### PR TITLE
docs: Update broken "Multiple Projects" link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ for OS X):
 }
 ```
 
-If you want to use a specific project (see [Multiple Projects](#multiple-projects) below), update your Claude Desktop
+If you want to use a specific project (see [Multiple Projects](docs/User%20Guide.md#multiple-projects)), update your Claude Desktop
 config:
 
 ```json


### PR DESCRIPTION
Thank you for building this! Exactly what I was looking for. 

Noticed a broken link in the readme. Not sure if you prefer the links to go to https://memory.basicmachines.co/docs/user-guide#Multiple+Projects or internally in the docs within the repo. 