### PR TITLE
feat: add watch to mcp process

### DIFF
--- a/src/basic_memory/api/app.py
+++ b/src/basic_memory/api/app.py
@@ -1,5 +1,6 @@
 """FastAPI application for basic-memory knowledge graph API."""
 
+import asyncio
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException
@@ -7,16 +8,54 @@ from fastapi.exception_handlers import http_exception_handler
 from loguru import logger
 
 from basic_memory import db
-from basic_memory.config import config as app_config
-from basic_memory.api.routers import knowledge, search, memory, resource, project_info
+from basic_memory.api.routers import knowledge, memory, project_info, resource, search
+from basic_memory.config import config as project_config
+from basic_memory.config import config_manager
+from basic_memory.sync import SyncService, WatchService
+
+
+async def run_background_sync(sync_service: SyncService, watch_service: WatchService):
+    logger.info(f"Starting watch service to sync file changes in dir: {project_config.home}")
+    # full sync
+    await sync_service.sync(config.home, show_progress=False)
+
+    # watch changes
+    await watch_service.run()
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):  # pragma: no cover
     """Lifecycle manager for the FastAPI app."""
-    await db.run_migrations(app_config)
+    await db.run_migrations(project_config)
+
+    # app config
+    basic_memory_config = config_manager.load_config()
+    logger.info(f"Sync changes enabled: {basic_memory_config.sync_changes}")
+    logger.info(f"Update permalinks on move enabled: {basic_memory_config.update_permalinks_on_move}")
+
+    if basic_memory_config.sync_changes:
+        # import after migrations have run
+        from basic_memory.cli.commands.sync import get_sync_service
+        watch_task = None
+
+        sync_service = await get_sync_service()
+        watch_service = WatchService(
+            sync_service=sync_service,
+            file_service=sync_service.entity_service.file_service,
+            config=project_config,
+        )
+        watch_task = asyncio.create_task(run_background_sync(sync_service, watch_service))
+    else:
+        logger.info("Sync changes disabled. Skipping watch service.")
+
+
+    # proceed with startup
     yield
+
     logger.info("Shutting down Basic Memory API")
+    if watch_task:
+        watch_task.cancel()
+
     await db.shutdown_db()
 
 

--- a/src/basic_memory/api/app.py
+++ b/src/basic_memory/api/app.py
@@ -14,10 +14,12 @@ from basic_memory.config import config_manager
 from basic_memory.sync import SyncService, WatchService
 
 
-async def run_background_sync(sync_service: SyncService, watch_service: WatchService):
+async def run_background_sync(
+    sync_service: SyncService, watch_service: WatchService
+):  # pragma: no cover
     logger.info(f"Starting watch service to sync file changes in dir: {project_config.home}")
     # full sync
-    await sync_service.sync(config.home, show_progress=False)
+    await sync_service.sync(project_config.home, show_progress=False)
 
     # watch changes
     await watch_service.run()
@@ -31,12 +33,14 @@ async def lifespan(app: FastAPI):  # pragma: no cover
     # app config
     basic_memory_config = config_manager.load_config()
     logger.info(f"Sync changes enabled: {basic_memory_config.sync_changes}")
-    logger.info(f"Update permalinks on move enabled: {basic_memory_config.update_permalinks_on_move}")
+    logger.info(
+        f"Update permalinks on move enabled: {basic_memory_config.update_permalinks_on_move}"
+    )
 
+    watch_task = None
     if basic_memory_config.sync_changes:
         # import after migrations have run
         from basic_memory.cli.commands.sync import get_sync_service
-        watch_task = None
 
         sync_service = await get_sync_service()
         watch_service = WatchService(
@@ -47,7 +51,6 @@ async def lifespan(app: FastAPI):  # pragma: no cover
         watch_task = asyncio.create_task(run_background_sync(sync_service, watch_service))
     else:
         logger.info("Sync changes disabled. Skipping watch service.")
-
 
     # proceed with startup
     yield

--- a/src/basic_memory/api/app.py
+++ b/src/basic_memory/api/app.py
@@ -14,9 +14,7 @@ from basic_memory.config import config_manager
 from basic_memory.sync import SyncService, WatchService
 
 
-async def run_background_sync(
-    sync_service: SyncService, watch_service: WatchService
-):  # pragma: no cover
+async def run_background_sync(sync_service: SyncService, watch_service: WatchService): # pragma: no cover
     logger.info(f"Starting watch service to sync file changes in dir: {project_config.home}")
     # full sync
     await sync_service.sync(project_config.home, show_progress=False)
@@ -33,9 +31,7 @@ async def lifespan(app: FastAPI):  # pragma: no cover
     # app config
     basic_memory_config = config_manager.load_config()
     logger.info(f"Sync changes enabled: {basic_memory_config.sync_changes}")
-    logger.info(
-        f"Update permalinks on move enabled: {basic_memory_config.update_permalinks_on_move}"
-    )
+    logger.info(f"Update permalinks on move enabled: {basic_memory_config.update_permalinks_on_move}")
 
     watch_task = None
     if basic_memory_config.sync_changes:
@@ -51,6 +47,7 @@ async def lifespan(app: FastAPI):  # pragma: no cover
         watch_task = asyncio.create_task(run_background_sync(sync_service, watch_service))
     else:
         logger.info("Sync changes disabled. Skipping watch service.")
+
 
     # proceed with startup
     yield

--- a/src/basic_memory/cli/app.py
+++ b/src/basic_memory/cli/app.py
@@ -1,10 +1,6 @@
-import asyncio
 from typing import Optional
 
 import typer
-
-from basic_memory import db
-from basic_memory.config import config
 
 
 def version_callback(value: bool) -> None:

--- a/src/basic_memory/cli/app.py
+++ b/src/basic_memory/cli/app.py
@@ -58,9 +58,6 @@ def app_callback(
         config = new_config
 
 
-# Run database migrations
-asyncio.run(db.run_migrations(config))
-
 # Register sub-command groups
 import_app = typer.Typer(help="Import data from various sources")
 app.add_typer(import_app, name="import")

--- a/src/basic_memory/cli/commands/mcp.py
+++ b/src/basic_memory/cli/commands/mcp.py
@@ -4,7 +4,7 @@ from loguru import logger
 
 import basic_memory
 from basic_memory.cli.app import app
-from basic_memory.config import config
+from basic_memory.config import config, config_manager
 
 # Import mcp instance
 from basic_memory.mcp.server import mcp as mcp_server  # pragma: no cover
@@ -19,8 +19,15 @@ def mcp():  # pragma: no cover
     home_dir = config.home
     project_name = config.project
 
+    # app config
+    basic_memory_config = config_manager.load_config()
+
     logger.info(f"Starting Basic Memory MCP server {basic_memory.__version__}")
     logger.info(f"Project: {project_name}")
     logger.info(f"Project directory: {home_dir}")
+    logger.info(f"Sync changes enabled: {basic_memory_config.sync_changes}")
+    logger.info(
+        f"Update permalinks on move enabled: {basic_memory_config.update_permalinks_on_move}"
+    )
 
     mcp_server.run()

--- a/src/basic_memory/cli/main.py
+++ b/src/basic_memory/cli/main.py
@@ -1,20 +1,21 @@
 """Main CLI entry point for basic-memory."""  # pragma: no cover
 
-from basic_memory.cli.app import app  # pragma: no cover
 import typer
+
+from basic_memory.cli.app import app  # pragma: no cover
 
 # Register commands
 from basic_memory.cli.commands import (  # noqa: F401  # pragma: no cover
-    status,
-    sync,
     db,
-    import_memory_json,
-    mcp,
+    import_chatgpt,
     import_claude_conversations,
     import_claude_projects,
-    import_chatgpt,
-    tool,
+    import_memory_json,
+    mcp,
     project,
+    status,
+    sync,
+    tool,
 )
 
 
@@ -55,4 +56,9 @@ def main(
 
 
 if __name__ == "__main__":  # pragma: no cover
+
+    # Run database migrations
+    asyncio.run(db.run_migrations(config))
+
+    # start the app
     app()

--- a/src/basic_memory/cli/main.py
+++ b/src/basic_memory/cli/main.py
@@ -1,5 +1,7 @@
 """Main CLI entry point for basic-memory."""  # pragma: no cover
 
+import asyncio
+
 import typer
 
 from basic_memory.cli.app import app  # pragma: no cover
@@ -17,6 +19,8 @@ from basic_memory.cli.commands import (  # noqa: F401  # pragma: no cover
     sync,
     tool,
 )
+from basic_memory.config import config
+from basic_memory.db import run_migrations as db_run_migrations
 
 
 # Version command
@@ -56,9 +60,8 @@ def main(
 
 
 if __name__ == "__main__":  # pragma: no cover
-
     # Run database migrations
-    asyncio.run(db.run_migrations(config))
+    asyncio.run(db_run_migrations(config))
 
     # start the app
     app()

--- a/src/basic_memory/db.py
+++ b/src/basic_memory/db.py
@@ -146,7 +146,9 @@ async def engine_session_factory(
             _session_maker = None
 
 
-async def run_migrations(app_config: ProjectConfig, database_type=DatabaseType.FILESYSTEM):
+async def run_migrations(
+    app_config: ProjectConfig, database_type=DatabaseType.FILESYSTEM
+):  # pragma: no cover
     """Run any pending alembic migrations."""
     logger.info("Running database migrations...")
     try:


### PR DESCRIPTION
This PR adds automatic file synchronization capabilities to the Model Context Protocol (MCP) server, fixing issue #53.

## Changes
- Added `sync_changes` configuration option to enable/disable real-time file synchronization
- Implemented background watch service in the API server that:
  - Performs initial full sync of all files on startup
  - Continuously monitors for file changes (additions, modifications, moves, deletions)
  - Automatically indexes changes without requiring manual `basic-memory sync` commands
- Added proper lifecycle management for the watch service
- Updated configuration handling and logging for better visibility

This change creates a more seamless experience when using Basic Memory with Claude by ensuring all file changes are immediately available to the knowledge graph without manual intervention.