### PR TITLE
Update name of function search_notes in error output

### DIFF
--- a/src/basic_memory/mcp/tools/read_note.py
+++ b/src/basic_memory/mcp/tools/read_note.py
@@ -111,7 +111,7 @@ def format_not_found_message(identifier: str) -> str:
         ## Search Instead
         Try searching for related content:
         ```
-        search(query="{identifier}")
+        search_notes(query="{identifier}")
         ```
         
         ## Recent Activity
@@ -172,7 +172,7 @@ def format_related_results(identifier: str, results) -> str:
         ## Search For More Results
         To see more related content:
         ```
-        search(query="{identifier}")
+        search_notes(query="{identifier}")
         ```
         
         ## Create New Note

--- a/tests/mcp/test_tool_read_note.py
+++ b/tests/mcp/test_tool_read_note.py
@@ -267,7 +267,7 @@ async def test_read_note_text_search_fallback(mock_call_get, mock_search):
     assert "Related Note 1" in result
     assert "Related Note 2" in result
     assert 'read_note("notes/related-note-1")' in result
-    assert "search(query=" in result
+    assert "search_notes(query=" in result
     assert "write_note(" in result
 
 


### PR DESCRIPTION
The error output uses `search(query=` but the function is now called `search-notes`. 
Still using underscore notation to match style elsewhere in the output, but I'd be happy to update underscores to dashes