### PR TITLE
fix: correct spelling error "Chose" to "Choose" in continue_conversation prompt

### DIFF
--- a/src/basic_memory/templates/prompts/continue_conversation.hbs
+++ b/src/basic_memory/templates/prompts/continue_conversation.hbs
@@ -96,7 +96,7 @@ You can also:
 You can:
 - Explore more with: `search_notes("{{ topic }}")`
 - See what's changed: `recent_activity(timeframe="{{default timeframe "7d"}}")`
-- **Record new learnings or decisions from this conversation:** `write_note(folder="[Chose a folder]" title="[Create a meaningful title]", content="[Content with observations and relations]")`
+- **Record new learnings or decisions from this conversation:** `write_note(folder="[Choose a folder]" title="[Create a meaningful title]", content="[Content with observations and relations]")`
 
 ## Knowledge Capture Recommendation
 


### PR DESCRIPTION
Fixes #138 - Corrected spelling error in the continue_conversation prompt template.

Changed "Chose a folder" to "Choose a folder" on line 99 to use the correct imperative verb form.

Generated with [Claude Code](https://claude.ai/code)