### PR TITLE
fix: eliminate redundant database migration initialization

### DIFF
--- a/src/basic_memory/db.py
+++ b/src/basic_memory/db.py
@@ -23,6 +23,7 @@ from basic_memory.repository.search_repository import SearchRepository
 # Module level state
 _engine: Optional[AsyncEngine] = None
 _session_maker: Optional[async_sessionmaker[AsyncSession]] = None
+_migrations_completed: bool = False
 
 
 class DatabaseType(Enum):
@@ -72,18 +73,35 @@ async def scoped_session(
         await factory.remove()
 
 
+def _create_engine_and_session(
+    db_path: Path, db_type: DatabaseType = DatabaseType.FILESYSTEM
+) -> tuple[AsyncEngine, async_sessionmaker[AsyncSession]]:
+    """Internal helper to create engine and session maker."""
+    db_url = DatabaseType.get_db_url(db_path, db_type)
+    logger.debug(f"Creating engine for db_url: {db_url}")
+    engine = create_async_engine(db_url, connect_args={"check_same_thread": False})
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    return engine, session_maker
+
+
 async def get_or_create_db(
     db_path: Path,
     db_type: DatabaseType = DatabaseType.FILESYSTEM,
+    ensure_migrations: bool = True,
+    app_config: Optional["BasicMemoryConfig"] = None,
 ) -> tuple[AsyncEngine, async_sessionmaker[AsyncSession]]:  # pragma: no cover
     """Get or create database engine and session maker."""
     global _engine, _session_maker
 
     if _engine is None:
-        db_url = DatabaseType.get_db_url(db_path, db_type)
-        logger.debug(f"Creating engine for db_url: {db_url}")
-        _engine = create_async_engine(db_url, connect_args={"check_same_thread": False})
-        _session_maker = async_sessionmaker(_engine, expire_on_commit=False)
+        _engine, _session_maker = _create_engine_and_session(db_path, db_type)
+        
+        # Run migrations automatically unless explicitly disabled
+        if ensure_migrations:
+            if app_config is None:
+                from basic_memory.config import get_basic_memory_config
+                app_config = get_basic_memory_config()
+            await run_migrations(app_config, db_type)
 
     # These checks should never fail since we just created the engine and session maker
     # if they were None, but we'll check anyway for the type checker
@@ -100,12 +118,13 @@ async def get_or_create_db(
 
 async def shutdown_db() -> None:  # pragma: no cover
     """Clean up database connections."""
-    global _engine, _session_maker
+    global _engine, _session_maker, _migrations_completed
 
     if _engine:
         await _engine.dispose()
         _engine = None
         _session_maker = None
+        _migrations_completed = False
 
 
 @asynccontextmanager
@@ -119,7 +138,7 @@ async def engine_session_factory(
     for each test. For production use, use get_or_create_db() instead.
     """
 
-    global _engine, _session_maker
+    global _engine, _session_maker, _migrations_completed
 
     db_url = DatabaseType.get_db_url(db_path, db_type)
     logger.debug(f"Creating engine for db_url: {db_url}")
@@ -143,12 +162,20 @@ async def engine_session_factory(
             await _engine.dispose()
             _engine = None
             _session_maker = None
+            _migrations_completed = False
 
 
 async def run_migrations(
-    app_config: BasicMemoryConfig, database_type=DatabaseType.FILESYSTEM
+    app_config: BasicMemoryConfig, database_type=DatabaseType.FILESYSTEM, force: bool = False
 ):  # pragma: no cover
     """Run any pending alembic migrations."""
+    global _migrations_completed
+    
+    # Skip if migrations already completed unless forced
+    if _migrations_completed and not force:
+        logger.debug("Migrations already completed in this session, skipping")
+        return
+        
     logger.info("Running database migrations...")
     try:
         # Get the absolute path to the alembic directory relative to this file
@@ -170,11 +197,18 @@ async def run_migrations(
         command.upgrade(config, "head")
         logger.info("Migrations completed successfully")
 
-        _, session_maker = await get_or_create_db(app_config.database_path, database_type)
+        # Get session maker - ensure we don't trigger recursive migration calls
+        if _session_maker is None:
+            _, session_maker = _create_engine_and_session(app_config.database_path, database_type)
+        else:
+            session_maker = _session_maker
 
         # initialize the search Index schema
         # the project_id is not used for init_search_index, so we pass a dummy value
         await SearchRepository(session_maker, 1).init_search_index()
+        
+        # Mark migrations as completed
+        _migrations_completed = True
     except Exception as e:  # pragma: no cover
         logger.error(f"Error running migrations: {e}")
         raise

--- a/tests/services/test_initialization.py
+++ b/tests/services/test_initialization.py
@@ -17,20 +17,21 @@ from basic_memory.services.initialization import (
 
 
 @pytest.mark.asyncio
-@patch("basic_memory.services.initialization.db.run_migrations")
-async def test_initialize_database(mock_run_migrations, project_config):
+@patch("basic_memory.services.initialization.db.get_or_create_db")
+async def test_initialize_database(mock_get_or_create_db, app_config):
     """Test initializing the database."""
-    await initialize_database(project_config)
-    mock_run_migrations.assert_called_once_with(project_config)
+    mock_get_or_create_db.return_value = (MagicMock(), MagicMock())
+    await initialize_database(app_config)
+    mock_get_or_create_db.assert_called_once_with(app_config.database_path)
 
 
 @pytest.mark.asyncio
-@patch("basic_memory.services.initialization.db.run_migrations")
-async def test_initialize_database_error(mock_run_migrations, project_config):
+@patch("basic_memory.services.initialization.db.get_or_create_db")
+async def test_initialize_database_error(mock_get_or_create_db, app_config):
     """Test handling errors during database initialization."""
-    mock_run_migrations.side_effect = Exception("Test error")
-    await initialize_database(project_config)
-    mock_run_migrations.assert_called_once_with(project_config)
+    mock_get_or_create_db.side_effect = Exception("Test error")
+    await initialize_database(app_config)
+    mock_get_or_create_db.assert_called_once_with(app_config.database_path)
 
 
 @pytest.mark.asyncio

--- a/tests/test_db_migration_deduplication.py
+++ b/tests/test_db_migration_deduplication.py
@@ -1,0 +1,189 @@
+"""Tests for database migration deduplication functionality."""
+
+import pytest
+from pathlib import Path
+from unittest.mock import patch, AsyncMock, call, MagicMock
+
+from basic_memory.config import BasicMemoryConfig
+from basic_memory import db
+
+
+@pytest.fixture
+def mock_alembic_config():
+    """Mock Alembic config to avoid actual migration runs."""
+    with patch("basic_memory.db.Config") as mock_config_class:
+        mock_config = MagicMock()
+        mock_config_class.return_value = mock_config
+        yield mock_config
+
+
+@pytest.fixture
+def mock_alembic_command():
+    """Mock Alembic command to avoid actual migration runs."""
+    with patch("basic_memory.db.command") as mock_command:
+        yield mock_command
+
+
+@pytest.fixture
+def mock_search_repository():
+    """Mock SearchRepository to avoid database dependencies."""
+    with patch("basic_memory.db.SearchRepository") as mock_repo_class:
+        mock_repo = AsyncMock()
+        mock_repo_class.return_value = mock_repo
+        yield mock_repo
+
+
+# Use the app_config fixture from conftest.py
+
+
+@pytest.mark.asyncio
+async def test_migration_deduplication_single_call(
+    app_config, mock_alembic_config, mock_alembic_command, mock_search_repository
+):
+    """Test that migrations are only run once when called multiple times."""
+    # Reset module state
+    db._migrations_completed = False
+    db._engine = None
+    db._session_maker = None
+
+    # First call should run migrations
+    await db.run_migrations(app_config)
+    
+    # Verify migrations were called
+    mock_alembic_command.upgrade.assert_called_once_with(mock_alembic_config, "head")
+    mock_search_repository.init_search_index.assert_called_once()
+    
+    # Reset mocks for second call
+    mock_alembic_command.reset_mock()
+    mock_search_repository.reset_mock()
+    
+    # Second call should skip migrations
+    await db.run_migrations(app_config)
+    
+    # Verify migrations were NOT called again
+    mock_alembic_command.upgrade.assert_not_called()
+    mock_search_repository.init_search_index.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_migration_force_parameter(
+    app_config, mock_alembic_config, mock_alembic_command, mock_search_repository
+):
+    """Test that migrations can be forced to run even if already completed."""
+    # Reset module state
+    db._migrations_completed = False
+    db._engine = None
+    db._session_maker = None
+
+    # First call should run migrations
+    await db.run_migrations(app_config)
+    
+    # Verify migrations were called
+    mock_alembic_command.upgrade.assert_called_once_with(mock_alembic_config, "head")
+    mock_search_repository.init_search_index.assert_called_once()
+    
+    # Reset mocks for forced call
+    mock_alembic_command.reset_mock()
+    mock_search_repository.reset_mock()
+    
+    # Forced call should run migrations again
+    await db.run_migrations(app_config, force=True)
+    
+    # Verify migrations were called again
+    mock_alembic_command.upgrade.assert_called_once_with(mock_alembic_config, "head")
+    mock_search_repository.init_search_index.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_migration_state_reset_on_shutdown():
+    """Test that migration state is reset when database is shut down."""
+    # Set up completed state
+    db._migrations_completed = True
+    db._engine = AsyncMock()
+    db._session_maker = AsyncMock()
+    
+    # Shutdown should reset state
+    await db.shutdown_db()
+    
+    # Verify state was reset
+    assert db._migrations_completed is False
+    assert db._engine is None
+    assert db._session_maker is None
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_db_runs_migrations_automatically(
+    app_config, mock_alembic_config, mock_alembic_command, mock_search_repository
+):
+    """Test that get_or_create_db runs migrations automatically."""
+    # Reset module state
+    db._migrations_completed = False
+    db._engine = None
+    db._session_maker = None
+
+    # First call should create engine and run migrations
+    engine, session_maker = await db.get_or_create_db(
+        app_config.database_path, app_config=app_config
+    )
+    
+    # Verify we got valid objects
+    assert engine is not None
+    assert session_maker is not None
+    
+    # Verify migrations were called
+    mock_alembic_command.upgrade.assert_called_once_with(mock_alembic_config, "head")
+    mock_search_repository.init_search_index.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_db_skips_migrations_when_disabled(
+    app_config, mock_alembic_config, mock_alembic_command, mock_search_repository
+):
+    """Test that get_or_create_db can skip migrations when ensure_migrations=False."""
+    # Reset module state
+    db._migrations_completed = False
+    db._engine = None
+    db._session_maker = None
+
+    # Call with ensure_migrations=False should skip migrations
+    engine, session_maker = await db.get_or_create_db(
+        app_config.database_path, ensure_migrations=False
+    )
+    
+    # Verify we got valid objects
+    assert engine is not None
+    assert session_maker is not None
+    
+    # Verify migrations were NOT called
+    mock_alembic_command.upgrade.assert_not_called()
+    mock_search_repository.init_search_index.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_multiple_get_or_create_db_calls_deduplicated(
+    app_config, mock_alembic_config, mock_alembic_command, mock_search_repository
+):
+    """Test that multiple get_or_create_db calls only run migrations once."""
+    # Reset module state
+    db._migrations_completed = False
+    db._engine = None
+    db._session_maker = None
+
+    # First call should create engine and run migrations
+    await db.get_or_create_db(app_config.database_path, app_config=app_config)
+    
+    # Verify migrations were called
+    mock_alembic_command.upgrade.assert_called_once_with(mock_alembic_config, "head")
+    mock_search_repository.init_search_index.assert_called_once()
+    
+    # Reset mocks for subsequent calls
+    mock_alembic_command.reset_mock()
+    mock_search_repository.reset_mock()
+    
+    # Subsequent calls should not run migrations again
+    await db.get_or_create_db(app_config.database_path, app_config=app_config)
+    await db.get_or_create_db(app_config.database_path, app_config=app_config)
+    
+    # Verify migrations were NOT called again
+    mock_alembic_command.upgrade.assert_not_called()
+    mock_search_repository.init_search_index.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes the redundant database migration initialization issue that was causing MCP startup to trigger 3x database initialization sequences, potentially interfering with tool registration and causing "Method not found" errors.

### Root Cause Analysis
- Each MCP startup triggered multiple independent database initialization paths:
  1. MCP server lifespan initialization  
  2. Project reconciliation requiring database access
  3. Legacy project migration requiring database access
- Each path called `run_migrations()` independently, causing redundant overhead

### Solution
- **Migration State Tracking**: Added global `_migrations_completed` flag to track completion
- **Idempotent Migrations**: Enhanced `run_migrations()` to skip if already completed (with force override)
- **Centralized Handling**: Updated `get_or_create_db()` to manage migrations automatically
- **Service Cleanup**: Removed redundant migration calls from initialization services

### Changes
- `src/basic_memory/db.py`: Migration state tracking and centralized handling
- `src/basic_memory/services/initialization.py`: Simplified database initialization  
- `tests/test_db_migration_deduplication.py`: Comprehensive test coverage (6 tests)
- Updated existing tests to match new behavior

### Benefits
- ✅ Eliminates 3x migration overhead during startup
- ✅ More reliable MCP tool registration
- ✅ Faster startup times  
- ✅ Cleaner initialization flow

## Test Plan
- [x] All new migration deduplication tests pass
- [x] Existing initialization tests updated and passing
- [x] Migration state properly reset on database shutdown
- [x] Force migration option works correctly
- [x] Migrations can be disabled when needed

## Related Issues
Fixes #142

🤖 Generated with [Claude Code](https://claude.ai/code)