### PR TITLE
fix: handle None from_entity in Context API RelationSummary

### DIFF
--- a/src/basic_memory/api/routers/utils.py
+++ b/src/basic_memory/api/routers/utils.py
@@ -52,7 +52,7 @@ async def to_graph_context(
                     file_path=item.file_path,
                     permalink=item.permalink,  # pyright: ignore
                     relation_type=item.relation_type,  # pyright: ignore
-                    from_entity=from_entity.title,  # pyright: ignore
+                    from_entity=from_entity.title if from_entity else None,
                     to_entity=to_entity.title if to_entity else None,
                     created_at=item.created_at,
                 )

--- a/src/basic_memory/schemas/memory.py
+++ b/src/basic_memory/schemas/memory.py
@@ -134,7 +134,7 @@ class RelationSummary(BaseModel):
     file_path: str
     permalink: str
     relation_type: str
-    from_entity: str
+    from_entity: Optional[str] = None
     to_entity: Optional[str] = None
     created_at: datetime
 


### PR DESCRIPTION
Add null check before accessing from_entity.title to prevent AttributeError when relations exist but referenced entities are deleted or inconsistent.

Follows the same pattern already used for to_entity handling.

Fixes #165

Generated with [Claude Code](https://claude.ai/code)