### PR TITLE
fix: handle Boolean search syntax with hyphenated terms

### DIFF
--- a/tests/repository/test_search_repository.py
+++ b/tests/repository/test_search_repository.py
@@ -329,6 +329,21 @@ class TestSearchTermPreparation:
             == "(hello AND world) OR test"
         )
 
+    def test_hyphenated_terms_with_boolean_operators(self, search_repository):
+        """Hyphenated terms with Boolean operators should be properly quoted."""
+        # Test the specific case from the GitHub issue
+        result = search_repository._prepare_search_term("tier1-test AND unicode")
+        assert result == '"tier1-test" AND unicode'
+        
+        # Test other hyphenated Boolean combinations
+        assert search_repository._prepare_search_term("multi-word OR single") == '"multi-word" OR single'
+        assert search_repository._prepare_search_term("well-formed NOT badly-formed") == '"well-formed" NOT "badly-formed"'
+        assert search_repository._prepare_search_term("test-case AND (hello OR world)") == '"test-case" AND (hello OR world)'
+        
+        # Test mixed special characters with Boolean operators
+        assert search_repository._prepare_search_term("config.json AND test-file") == '"config.json" AND "test-file"'
+        assert search_repository._prepare_search_term("C++ OR python-script") == '"C++" OR "python-script"'
+
     def test_programming_terms_should_work(self, search_repository):
         """Programming-related terms with special chars should be searchable."""
         # These should be quoted to handle special characters safely


### PR DESCRIPTION
This PR fixes the Boolean search syntax SQL parsing error when using hyphenated terms with Boolean operators.

## Problem
Queries like `"tier1-test AND unicode"` were causing SQL errors because FTS5 was interpreting hyphenated terms as column references instead of search terms.

## Solution
- Added `_prepare_boolean_query()` method to parse Boolean queries and quote individual terms
- Added `_prepare_single_term()` method for single term preparation logic
- Updated search processing to handle both simple and complex Boolean queries
- Added comprehensive test coverage for hyphenated terms with Boolean operators

## Key Features
- Preserves Boolean operators (AND, OR, NOT) exactly as written
- Quotes terms with special characters to prevent FTS5 syntax errors
- Handles complex expressions with parentheses and nested Boolean logic
- Maintains backward compatibility with existing functionality
- Optimized for FTS5 performance

Fixes #178

Generated with [Claude Code](https://claude.ai/code)