### PR TITLE
fix: preserve permalink when editing notes without frontmatter permalink

### DIFF
--- a/src/basic_memory/markdown/utils.py
+++ b/src/basic_memory/markdown/utils.py
@@ -38,7 +38,9 @@ def entity_model_from_markdown(
     # Update basic fields
     model.title = markdown.frontmatter.title
     model.entity_type = markdown.frontmatter.type
-    model.permalink = markdown.frontmatter.permalink
+    # Only update permalink if it exists in frontmatter, otherwise preserve existing
+    if markdown.frontmatter.permalink is not None:
+        model.permalink = markdown.frontmatter.permalink
     model.file_path = str(file_path)
     model.content_type = "text/markdown"
     model.created_at = markdown.created

--- a/tests/mcp/test_tool_edit_note.py
+++ b/tests/mcp/test_tool_edit_note.py
@@ -359,3 +359,42 @@ async def test_edit_note_find_replace_empty_find_text(client):
     assert isinstance(result, str)
     assert "# Edit Failed" in result
     # Should contain helpful guidance about the error
+
+
+@pytest.mark.asyncio
+async def test_edit_note_preserves_permalink_when_frontmatter_missing(client):
+    """Test that editing a note preserves the permalink when frontmatter doesn't contain one.
+    
+    This is a regression test for issue #170 where edit_note would fail with a validation error
+    because the permalink was being set to None when the markdown file didn't have a permalink
+    in its frontmatter.
+    """
+    # Create initial note
+    await write_note.fn(
+        title="Test Note",
+        folder="test",
+        content="# Test Note\nOriginal content here.",
+    )
+
+    # Verify the note was created with a permalink
+    first_result = await edit_note.fn(
+        identifier="test/test-note",
+        operation="append",
+        content="\nFirst edit.",
+    )
+    
+    assert isinstance(first_result, str)
+    assert "permalink: test/test-note" in first_result
+    
+    # Perform another edit - this should preserve the permalink even if the 
+    # file doesn't have a permalink in its frontmatter
+    second_result = await edit_note.fn(
+        identifier="test/test-note",
+        operation="append", 
+        content="\nSecond edit.",
+    )
+
+    assert isinstance(second_result, str)
+    assert "Edited note (append)" in second_result
+    assert "permalink: test/test-note" in second_result
+    # The edit should succeed without validation errors


### PR DESCRIPTION
Fixes issue #170 where edit_note would fail with EntityResponse validation error
"Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]"
even though the edit operation succeeded.

Root cause: The entity_model_from_markdown function was unconditionally overwriting
the permalink field with markdown.frontmatter.permalink, even when it was None.
This caused existing entities to lose their permalinks when edited.

Changes:
- Only update permalink from frontmatter if it's not None, preserving existing permalink
- Add regression test to prevent this issue from recurring

Generated with [Claude Code](https://claude.ai/code)