### PR TITLE
fix: MCP Error with MCP-Hub #204

### DIFF
--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -5,6 +5,7 @@ and manage project context during conversations.
 """
 
 from textwrap import dedent
+from typing import Optional
 
 from fastmcp import Context
 from loguru import logger
@@ -19,7 +20,9 @@ from basic_memory.utils import generate_permalink
 
 
 @mcp.tool("list_memory_projects")
-async def list_memory_projects(ctx: Context | None = None) -> str:
+async def list_memory_projects(
+    ctx: Context | None = None, _compatibility: Optional[str] = None
+) -> str:
     """List all available projects with their status.
 
     Shows all Basic Memory projects that are available, indicating which one
@@ -159,7 +162,9 @@ async def switch_project(project_name: str, ctx: Context | None = None) -> str:
 
 
 @mcp.tool()
-async def get_current_project(ctx: Context | None = None) -> str:
+async def get_current_project(
+    ctx: Context | None = None, _compatibility: Optional[str] = None
+) -> str:
     """Show the currently active project and basic stats.
 
     Displays which project is currently active and provides basic information


### PR DESCRIPTION
The MCP Tools spec calls for accepting empty parameter objects, which these two tools did not. This fixes the problem, I have verified this by testing the container locally. 

```docker-compose.yml
services:
  basic-memory:
    image: basic-memory:test
    container_name: basic-memory-issue-204
    ports:
      - 9000:8000
    volumes:
      - ~/bm:/app/data:rw
      - ./basic-memory:/root/.basic-memory:rw
    environment:
      - BASIC_MEMORY_DEFAULT_PROJECT=main
      - BASIC_MEMORY_SYNC_CHANGES=true
      - BASIC_MEMORY_LOG_LEVEL=DEBUG
      - BASIC_MEMORY_SYNC_DELAY=1000
    restart: unless-stopped

  mcphub:
    image: samanhappy/mcphub:latest
    container_name: mcphub-issue-204
    ports:
      - 3002:3000
    volumes:
      - ./mcp_settings.json:/app/mcp_settings.json:rw
    restart: unless-stopped
```

```mcp_settings.json
{
  "mcpServers": {
    "basic-memory": {
      "name": "Basic Memory",
      "type": "stdio",
      "command": "uvx",
      "args": [
        "mcp-proxy",
        "http://host.docker.internal:9000/mcp"
      ],
      "env": {}
    }
  }
}
```


![Screenshot 2025-07-03 at 3 00 30 PM](https://github.com/user-attachments/assets/e388a954-338b-444a-b4fa-edfb76c5d89b)
![Screenshot 2025-07-03 at 3 00 55 PM](https://github.com/user-attachments/assets/e5db6a97-66a1-4022-bed8-d7e1785ae1ab)
