### PR TITLE
docs: improve virtual environment setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,12 @@ project and how to get started as a developer.
 
    > **Note**: Basic Memory uses [just](https://just.systems) as a modern command runner. Install with `brew install just` or `cargo install just`.
 
-3. **Run the Tests**:
+3. **Activate the Virtual Environment**
+   ```bash
+   source .venv/bin/activate
+   ```
+
+4. **Run the Tests**:
    ```bash
    # Run all tests
    just test

--- a/justfile
+++ b/justfile
@@ -3,6 +3,9 @@
 # Install dependencies
 install:
     pip install -e ".[dev]"
+    uv sync
+    @echo ""
+    @echo "💡 Remember to activate the virtual environment by running: source .venv/bin/activate"
 
 # Run unit tests in parallel
 test-unit:


### PR DESCRIPTION
- Add virtual environment activation step to CONTRIBUTING.md
- Update justfile install command to run uv sync and remind users to activate venv
- Fixes issue [#217](https://github.com/basicmachines-co/basic-memory/issues/217) where virtual environment was not created with just install

🤖 Generated with [Claude Code](https://claude.ai/code)

Test steps:

1. Clone repo into empty directory
2. Run `just install`
3. Activate the virtual environment: `source .venv/bin/activate`
4. Run all tests: `just test`
