### PR TITLE
fix(mcp): support --project flag

### DIFF
--- a/src/basic_memory/cli/commands/mcp.py
+++ b/src/basic_memory/cli/commands/mcp.py
@@ -35,12 +35,24 @@ def mcp(
     - sse: Server-Sent Events (for compatibility with existing clients)
     """
 
+    from basic_memory.config import get_project_config
+    from basic_memory.mcp.project_session import session
     from basic_memory.services.initialization import initialize_file_sync
 
     # Use unified thread-based sync approach for both transports
     import threading
 
+    if session.current_project:
+        project_config = get_project_config(session.current_project)
+    else:
+        project_config = get_project_config()
+
     app_config = ConfigManager().config
+
+    # Ensure the session is properly initialized with the project before starting MCP
+    # This will be picked up by the MCP server lifespan
+    session.initialize(app_config.default_project)
+    session.set_current_project(project_config.name)
 
     def run_file_sync():
         """Run file sync in a separate thread with its own event loop."""

--- a/src/basic_memory/mcp/project_session.py
+++ b/src/basic_memory/mcp/project_session.py
@@ -68,16 +68,22 @@ class ProjectSession:
     def refresh_from_config(self) -> None:
         """Refresh session state from current configuration.
 
-        This method reloads the default project from config and reinitializes
-        the session. This should be called when the default project is changed
-        via CLI or API to ensure MCP session stays in sync.
+        This method reloads the default project from config and updates
+        the default_project. It preserves the current_project if it was
+        explicitly set (e.g. via CLI --project flag).
         """
         # Reload config to get latest default project
         current_config = ConfigManager().config
         new_default = current_config.default_project
 
-        # Reinitialize with new default
-        self.initialize(new_default)
+        # Update default project without touching current project
+        old_default = self.default_project
+        self.default_project = new_default
+
+        # Only update current project if it was the same as the old default
+        if self.current_project == old_default:
+            self.current_project = new_default
+
         logger.info(f"Refreshed project session from config, new default: {new_default}")
 
 

--- a/src/basic_memory/mcp/server.py
+++ b/src/basic_memory/mcp/server.py
@@ -29,8 +29,10 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:  # pragma:
     # Initialize on startup (now returns migration_manager)
     migration_manager = await initialize_app(app_config)
 
-    # Initialize project session with default project
-    session.initialize(app_config.default_project)
+    # Initialize project session - preserve existing session if already set
+    if not session.current_project:
+        # Session not initialized by CLI, use default
+        session.initialize(app_config.default_project)
 
     try:
         yield AppContext(watch_task=None, migration_manager=migration_manager)


### PR DESCRIPTION
This PR makes it so that the `mcp` sub-command respects the `--project` flag.

For example you can now do `basic-memory --project foo mcp` and expect the MCP to start up with the current project already set to `foo`. 

I'm making use of this feature by having a wrapper script that Claude uses to launch the MCP automatically setting the `--project` flag to the correct name based on the git repo Claude was launched from. 

I find this much more reliable than hoping that Claude automatically switches to the right project (or remembering to explicitly tell it every time). 