### PR TITLE
feat: implement non-root Docker container to fix file ownership issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 # Create a group and user with the provided UID/GID
-RUN groupadd --gid ${GID} appgroup && \
+# Check if the GID already exists, if not create appgroup
+RUN (getent group ${GID} || groupadd --gid ${GID} appgroup) && \
     useradd --uid ${UID} --gid ${GID} --create-home --shell /bin/bash appuser
 
 # Copy the project into the image
@@ -24,7 +25,7 @@ RUN uv sync --locked
 
 # Create necessary directories and set ownership
 RUN mkdir -p /app/data /app/.basic-memory && \
-    chown -R appuser:appgroup /app
+    chown -R appuser:${GID} /app
 
 # Set default data directory and add venv to PATH
 ENV BASIC_MEMORY_HOME=/app/data \


### PR DESCRIPTION
Implements a non-root Docker container to fix file ownership issues when using basic-memory with Docker and Obsidian.

## Changes

- Add configurable UID/GID build arguments (defaults to 1000)
- Create non-root user (appuser) with proper directory ownership
- Switch container execution to non-root user for improved security
- Update all documentation references from /root/.basic-memory to /app/.basic-memory
- Add comprehensive examples for custom UID/GID usage
- Remove outdated chmod permission workarounds

Closes #276

Generated with [Claude Code](https://claude.ai/code)