### PR TITLE
fix: Sanitize folder names and properly join paths

### DIFF
--- a/src/basic_memory/file_utils.py
+++ b/src/basic_memory/file_utils.py
@@ -294,3 +294,31 @@ def sanitize_for_filename(text: str, replacement: str = "-") -> str:
     text = re.sub(f"{re.escape(replacement)}+", replacement, text)
 
     return text.strip(replacement)
+
+
+def sanitize_for_folder(folder: str) -> str:
+    """
+    Sanitize folder path to be safe for use in file system paths.
+    Removes leading/trailing whitespace, compresses multiple slashes,
+    and removes special characters except for /, -, and _.
+    """
+    if not folder:
+        return ""
+
+    sanitized = folder.strip()
+
+    if sanitized.startswith("./"):
+        sanitized = sanitized[2:]
+
+    # ensure no special characters (except for a few that are allowed)
+    sanitized = "".join(
+        c for c in sanitized if c.isalnum() or c in (".", " ", "-", "_", "\\", "/")
+    ).rstrip()
+
+    # compress multiple, repeated instances of path separators
+    sanitized = re.sub(r"[\\/]+", "/", sanitized)
+
+    # trim any leading/trailing path separators
+    sanitized = sanitized.strip("\\/")
+
+    return sanitized

--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -1,5 +1,6 @@
 """Tests for Pydantic schema validation and conversion."""
 
+import os
 import pytest
 from datetime import datetime, time, timedelta
 from pydantic import ValidationError, BaseModel
@@ -20,7 +21,7 @@ def test_entity_project_name():
     """Test creating EntityIn with minimal required fields."""
     data = {"title": "Test Entity", "folder": "test", "entity_type": "knowledge"}
     entity = Entity.model_validate(data)
-    assert entity.file_path == "test/Test Entity.md"
+    assert entity.file_path == os.path.join("test", "Test Entity.md")
     assert entity.permalink == "test/test-entity"
     assert entity.entity_type == "knowledge"
 
@@ -29,7 +30,7 @@ def test_entity_project_id():
     """Test creating EntityIn with minimal required fields."""
     data = {"project": 2, "title": "Test Entity", "folder": "test", "entity_type": "knowledge"}
     entity = Entity.model_validate(data)
-    assert entity.file_path == "test/Test Entity.md"
+    assert entity.file_path == os.path.join("test", "Test Entity.md")
     assert entity.permalink == "test/test-entity"
     assert entity.entity_type == "knowledge"
 
@@ -43,7 +44,7 @@ def test_entity_non_markdown():
         "content_type": "text/plain",
     }
     entity = Entity.model_validate(data)
-    assert entity.file_path == "test/Test Entity.txt"
+    assert entity.file_path == os.path.join("test", "Test Entity.txt")
     assert entity.permalink == "test/test-entity"
     assert entity.entity_type == "file"
 


### PR DESCRIPTION
Fix for https://github.com/basicmachines-co/basic-memory/issues/172 (probably)

- Sanitizes folder names when creating entities.
- Uses `os.path.join()` rather than an f-string that separates folder and filename by the `"/"` character.
- Adds tests for the folder sanitization and an integration test for invoking the `write_note` tool.