### PR TITLE
fix: remove .env file loading from BasicMemoryConfig

### DIFF
--- a/src/basic_memory/config.py
+++ b/src/basic_memory/config.py
@@ -159,8 +159,6 @@ class BasicMemoryConfig(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="BASIC_MEMORY_",
         extra="ignore",
-        env_file=".env",
-        env_file_encoding="utf-8",
     )
 
     def get_project_path(self, project_name: Optional[str] = None) -> Path:  # pragma: no cover


### PR DESCRIPTION
## Summary

Fixes #227 by removing automatic .env file loading from `BasicMemoryConfig`. This prevents basic-memory from being affected by environment variables in project .env files, which was causing LOG_LEVEL and other configuration conflicts.

## Changes

- Removed `env_file=".env"` from `BasicMemoryConfig.model_config`
- Removed `env_file_encoding="utf-8"` as it's no longer needed

## Impact

Users can still configure basic-memory via:
- Environment variables with `BASIC_MEMORY_` prefix
- `~/.basic-memory/config.json` file
- Command line arguments

This change ensures basic-memory doesn't interfere with or get confused by project-specific .env files when running in project directories.

## Testing

- All config tests pass
- No breaking changes to existing configuration methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>