### PR TITLE
ci: Add Python 3.13 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [ "3.12" ]
+        python-version: [ "3.12", "3.13" ]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
## Summary
Add Python 3.13 to the CI test matrix to catch compatibility issues early.

## Changes
- Added Python 3.13 to the test matrix alongside Python 3.12
- Tests will now run on both Python versions across Ubuntu and Windows

## Motivation
Users are running Basic Memory on Python 3.13 (issue #218), and we've seen deprecation warnings related to SQLite datetime handling. Adding Python 3.13 to CI will help us catch and fix these compatibility issues proactively.

Related to #218