### PR TITLE
feat: introduce BASIC_MEMORY_PROJECT_ROOT for path constraints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,12 @@ WORKDIR /app
 RUN uv sync --locked
 
 # Create necessary directories and set ownership
-RUN mkdir -p /app/data /app/.basic-memory && \
+RUN mkdir -p /app/data/basic-memory /app/.basic-memory && \
     chown -R appuser:${GID} /app
 
 # Set default data directory and add venv to PATH
-ENV BASIC_MEMORY_HOME=/app/data \
+ENV BASIC_MEMORY_HOME=/app/data/basic-memory \
+    BASIC_MEMORY_PROJECT_ROOT=/app/data \
     PATH="/app/.venv/bin:$PATH"
 
 # Switch to the non-root user

--- a/src/basic_memory/config.py
+++ b/src/basic_memory/config.py
@@ -232,6 +232,10 @@ class BasicMemoryConfig(BaseSettings):
         return Path.home() / DATA_DIR_NAME
 
 
+# Module-level cache for configuration
+_CONFIG_CACHE: Optional[BasicMemoryConfig] = None
+
+
 class ConfigManager:
     """Manages Basic Memory configuration."""
 
@@ -253,12 +257,45 @@ class ConfigManager:
         return self.load_config()
 
     def load_config(self) -> BasicMemoryConfig:
-        """Load configuration from file or create default."""
+        """Load configuration from file or create default.
+
+        Environment variables take precedence over file config values,
+        following Pydantic Settings best practices.
+
+        Uses module-level cache for performance across ConfigManager instances.
+        """
+        global _CONFIG_CACHE
+
+        # Return cached config if available
+        if _CONFIG_CACHE is not None:
+            return _CONFIG_CACHE
 
         if self.config_file.exists():
             try:
-                data = json.loads(self.config_file.read_text(encoding="utf-8"))
-                return BasicMemoryConfig(**data)
+                file_data = json.loads(self.config_file.read_text(encoding="utf-8"))
+
+                # First, create config from environment variables (Pydantic will read them)
+                # Then overlay with file data for fields that aren't set via env vars
+                # This ensures env vars take precedence
+
+                # Get env-based config fields that are actually set
+                env_config = BasicMemoryConfig()
+                env_dict = env_config.model_dump()
+
+                # Merge: file data as base, but only use it for fields not set by env
+                # We detect env-set fields by comparing to default values
+                merged_data = file_data.copy()
+
+                # For fields that have env var overrides, use those instead of file values
+                # The env_prefix is "BASIC_MEMORY_" so we check those
+                for field_name in BasicMemoryConfig.model_fields.keys():
+                    env_var_name = f"BASIC_MEMORY_{field_name.upper()}"
+                    if env_var_name in os.environ:
+                        # Environment variable is set, use it
+                        merged_data[field_name] = env_dict[field_name]
+
+                _CONFIG_CACHE = BasicMemoryConfig(**merged_data)
+                return _CONFIG_CACHE
             except Exception as e:  # pragma: no cover
                 logger.exception(f"Failed to load config: {e}")
                 raise e
@@ -268,8 +305,11 @@ class ConfigManager:
             return config
 
     def save_config(self, config: BasicMemoryConfig) -> None:
-        """Save configuration to file."""
+        """Save configuration to file and invalidate cache."""
+        global _CONFIG_CACHE
         save_basic_memory_config(self.config_file, config)
+        # Invalidate cache so next load_config() reads fresh data
+        _CONFIG_CACHE = None
 
     @property
     def projects(self) -> Dict[str, str]:

--- a/src/basic_memory/config.py
+++ b/src/basic_memory/config.py
@@ -103,6 +103,12 @@ class BasicMemoryConfig(BaseSettings):
         description="Skip expensive initialization synchronization. Useful for cloud/stateless deployments where project reconciliation is not needed.",
     )
 
+    # Project path constraints
+    project_root: Optional[str] = Field(
+        default=None,
+        description="If set, all projects must be created underneath this directory. Paths will be sanitized and constrained to this root. If not set, projects can be created anywhere (default behavior).",
+    )
+
     # API connection configuration
     api_url: Optional[str] = Field(
         default=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,11 @@ def app_config(config_home, tmp_path, monkeypatch) -> BasicMemoryConfig:
 def config_manager(
     app_config: BasicMemoryConfig, project_config: ProjectConfig, config_home: Path, monkeypatch
 ) -> ConfigManager:
+    # Invalidate config cache to ensure clean state for each test
+    from basic_memory import config as config_module
+
+    config_module._CONFIG_CACHE = None
+
     # Create a new ConfigManager that uses the test home directory
     config_manager = ConfigManager()
     # Update its paths to use the test directory


### PR DESCRIPTION
## Summary

Introduces `BASIC_MEMORY_PROJECT_ROOT` environment variable to replace cloud mode path coupling and fixes ConfigManager to properly respect environment variable overrides.

Fixes #333

## Problem

1. **BASIC_MEMORY_HOME had dual, conflicting semantics:**
   - Path to the "main" (default) project directory
   - Root directory where ALL projects must be created (in cloud mode)

2. **Environment variables didn't override config file values:**
   - ConfigManager loaded config from file with explicit values
   - This prevented Pydantic's env var override mechanism from working
   - Tests required complex mocking to set environment variables

3. **Cloud mode tightly coupled to path validation:**
   - Path constraints were tied to `BASIC_MEMORY_CLOUD_MODE`
   - Not flexible for other constrained environments (Docker, multi-tenant)

## Solution

### 1. ConfigManager Refactor (Commit 1)

**Fixed environment variable override behavior:**
- Added module-level `_CONFIG_CACHE` for performance across instances
- Env vars now properly override file config values (Pydantic best practices)
- Cache invalidated on `save_config()` to ensure consistency
- Follows proper Pydantic Settings design pattern

**Benefits:**
- ✅ Environment variables work as expected
- ✅ Better performance (cached config across `ConfigManager()` instances)
- ✅ Simplified testing (no complex mocking needed)

### 2. BASIC_MEMORY_PROJECT_ROOT (Commit 2)

**Introduced new environment variable:**
- `BASIC_MEMORY_PROJECT_ROOT`: If set, all projects must be underneath this directory
- `BASIC_MEMORY_HOME`: Location of the "main" project (unchanged, backward compatible)

**Implementation:**
- Added `project_root` field to `BasicMemoryConfig` (config.py:106-110)
- Updated `project_service.py` to check `project_root` instead of `cloud_mode_enabled`
- Same path sanitization logic (strips `/`, `~/`, `../`)
- Validates resolved paths stay within boundary
- Clear error messages reference `BASIC_MEMORY_PROJECT_ROOT`

**Tests:**
- Renamed cloud mode tests to project_root tests
- Simplified using improved ConfigManager (just set env var + invalidate cache)
- No complex mocking needed anymore
- All tests passing on Ubuntu (skipped on Windows - cloud runs on Linux only)

**Benefits:**
- ✅ Decouples path restriction from cloud mode
- ✅ Useful for any constrained environment (cloud, docker, multi-tenant)
- ✅ Backward compatible - existing users unaffected
- ✅ More explicit and clear naming
- ✅ BASIC_MEMORY_HOME keeps its original purpose

### 3. Dockerfile & Test Updates (Commit 3)

**Updated Dockerfile:**
```dockerfile
ENV BASIC_MEMORY_HOME=/app/data/basic-memory \
    BASIC_MEMORY_PROJECT_ROOT=/app/data
```

**Directory structure:**
```
/app/data/
  ├── basic-memory/  (main project)
  │   └── *.md
  └── other-project/ (optional additional projects)
```

**Test fixtures:**
- Added config cache invalidation in `config_manager` fixture
- Ensures each test starts with clean config state
- Prevents test pollution from cached config values

## Example Usage

### Cloud Mode
```bash
BASIC_MEMORY_HOME=/app/data/basic-memory  # main project
BASIC_MEMORY_PROJECT_ROOT=/app/data       # all projects under /app/data
```

**Results:**
- Input: `/tmp/test` → `/app/data/tmp/test` (sanitized)
- Input: `test` → `/app/data/test`
- Main project: `/app/data/basic-memory/` (unchanged)

### Local Mode with Constraints
```bash
BASIC_MEMORY_HOME=~/basic-memory          # main project
BASIC_MEMORY_PROJECT_ROOT=~/my-projects   # all projects under here
```

### Local Mode Unrestricted (Default)
```bash
BASIC_MEMORY_HOME=~/basic-memory          # main project
# BASIC_MEMORY_PROJECT_ROOT not set - projects can be anywhere
```

## Files Changed

- `src/basic_memory/config.py` - Added `project_root` field, module-level caching, env var override
- `src/basic_memory/services/project_service.py` - Use `project_root` instead of `cloud_mode_enabled`
- `tests/services/test_project_service.py` - Simplified cloud mode tests
- `tests/conftest.py` - Added cache invalidation
- `Dockerfile` - Set both env vars for clean project structure

## Test Plan

- [x] Run all tests: `make check`
- [x] Config tests pass: `pytest tests/test_config.py -v`
- [x] Project service tests pass: `pytest tests/services/test_project_service.py -v`
- [x] Project root tests pass (sanitization, security, backward compat)
- [x] Code formatted and linted
- [x] Type checking passes

## Migration Notes

**For existing users:**
- No changes needed - fully backward compatible
- `BASIC_MEMORY_HOME` continues to work as before

**For cloud deployments:**
- Update Dockerfile or deployment config to set `BASIC_MEMORY_PROJECT_ROOT=/app/data`
- `BASIC_MEMORY_CLOUD_MODE` can remain for other cloud-specific behaviors

**For basic-memory-cloud:**
- Related issue: https://github.com/basicmachines-co/basic-memory-cloud/issues/103
- Update tenant Dockerfile to set `BASIC_MEMORY_PROJECT_ROOT=/app/data`
- Remove or keep `BASIC_MEMORY_CLOUD_MODE` based on other usages

## Breaking Changes

None - this is fully backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>