### PR TITLE
fix: prevent nested project paths to avoid data conflicts

### DIFF
--- a/src/basic_memory/services/project_service.py
+++ b/src/basic_memory/services/project_service.py
@@ -88,6 +88,37 @@ class ProjectService:
             name
         )
 
+    def _check_nested_paths(self, path1: str, path2: str) -> bool:
+        """Check if two paths are nested (one is a prefix of the other).
+
+        Args:
+            path1: First path to compare
+            path2: Second path to compare
+
+        Returns:
+            True if one path is nested within the other, False otherwise
+        """
+        # Normalize paths to ensure proper comparison
+        p1 = Path(path1).resolve()
+        p2 = Path(path2).resolve()
+
+        # Check if either path is a parent of the other
+        try:
+            # Check if p2 is under p1
+            p2.relative_to(p1)
+            return True
+        except ValueError:
+            pass
+
+        try:
+            # Check if p1 is under p2
+            p1.relative_to(p2)
+            return True
+        except ValueError:
+            pass
+
+        return False
+
     async def add_project(self, name: str, path: str, set_default: bool = False) -> None:
         """Add a new project to the configuration and database.
 
@@ -141,6 +172,40 @@ class ProjectService:
                     )
         else:
             resolved_path = Path(os.path.abspath(os.path.expanduser(path))).as_posix()
+
+        # Check for nested paths with existing projects
+        existing_projects = await self.list_projects()
+        for existing in existing_projects:
+            if self._check_nested_paths(resolved_path, existing.path):
+                # Determine which path is nested within which
+                p_new = Path(resolved_path).resolve()
+                p_existing = Path(existing.path).resolve()
+
+                try:
+                    p_new.relative_to(p_existing)
+                    # New path is nested under existing project
+                    raise ValueError(
+                        f"Cannot create project at '{resolved_path}': "
+                        f"path is nested within existing project '{existing.name}' at '{existing.path}'. "
+                        f"Projects cannot share directory trees."
+                    )
+                except ValueError as e:
+                    # Re-raise if it's the error we just raised, otherwise try the other direction
+                    if "Cannot create project" in str(e):
+                        raise
+
+                try:
+                    p_existing.relative_to(p_new)
+                    # Existing project is nested under new path
+                    raise ValueError(
+                        f"Cannot create project at '{resolved_path}': "
+                        f"existing project '{existing.name}' at '{existing.path}' is nested within this path. "
+                        f"Projects cannot share directory trees."
+                    )
+                except ValueError as e:
+                    # Re-raise if it's the error we just raised
+                    if "Cannot create project" in str(e):
+                        raise
 
         # First add to config file (this will validate the project doesn't exist)
         project_config = self.config_manager.add_project(name, resolved_path)

--- a/src/basic_memory/services/project_service.py
+++ b/src/basic_memory/services/project_service.py
@@ -97,6 +97,11 @@ class ProjectService:
 
         Returns:
             True if one path is nested within the other, False otherwise
+
+        Examples:
+            _check_nested_paths("/foo", "/foo/bar")     # True (child under parent)
+            _check_nested_paths("/foo/bar", "/foo")     # True (parent over child)
+            _check_nested_paths("/foo", "/bar")         # False (siblings)
         """
         # Normalize paths to ensure proper comparison
         p1 = Path(path1).resolve()
@@ -108,16 +113,14 @@ class ProjectService:
             p2.relative_to(p1)
             return True
         except ValueError:
-            pass
-
-        try:
-            # Check if p1 is under p2
-            p1.relative_to(p2)
-            return True
-        except ValueError:
-            pass
-
-        return False
+            # Not nested in this direction, check the other
+            try:
+                # Check if p1 is under p2
+                p1.relative_to(p2)
+                return True
+            except ValueError:
+                # Not nested in either direction
+                return False
 
     async def add_project(self, name: str, path: str, set_default: bool = False) -> None:
         """Add a new project to the configuration and database.
@@ -177,35 +180,24 @@ class ProjectService:
         existing_projects = await self.list_projects()
         for existing in existing_projects:
             if self._check_nested_paths(resolved_path, existing.path):
-                # Determine which path is nested within which
+                # Determine which path is nested within which for appropriate error message
                 p_new = Path(resolved_path).resolve()
                 p_existing = Path(existing.path).resolve()
 
-                try:
-                    p_new.relative_to(p_existing)
-                    # New path is nested under existing project
+                # Check if new path is nested under existing project
+                if p_new.is_relative_to(p_existing):
                     raise ValueError(
                         f"Cannot create project at '{resolved_path}': "
                         f"path is nested within existing project '{existing.name}' at '{existing.path}'. "
                         f"Projects cannot share directory trees."
                     )
-                except ValueError as e:
-                    # Re-raise if it's the error we just raised, otherwise try the other direction
-                    if "Cannot create project" in str(e):
-                        raise
-
-                try:
-                    p_existing.relative_to(p_new)
+                else:
                     # Existing project is nested under new path
                     raise ValueError(
                         f"Cannot create project at '{resolved_path}': "
                         f"existing project '{existing.name}' at '{existing.path}' is nested within this path. "
                         f"Projects cannot share directory trees."
                     )
-                except ValueError as e:
-                    # Re-raise if it's the error we just raised
-                    if "Cannot create project" in str(e):
-                        raise
 
         # First add to config file (this will validate the project doesn't exist)
         project_config = self.config_manager.add_project(name, resolved_path)

--- a/tests/db/test_issue_254_foreign_key_constraints.py
+++ b/tests/db/test_issue_254_foreign_key_constraints.py
@@ -14,7 +14,9 @@ This test file verifies that the fix works correctly in production databases
 that have had the migration applied.
 """
 
+import tempfile
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
@@ -23,7 +25,7 @@ from basic_memory.services.project_service import ProjectService
 
 # @pytest.mark.skip(reason="Issue #254 not fully resolved yet - foreign key constraint errors still occur")
 @pytest.mark.asyncio
-async def test_issue_254_foreign_key_constraint_fix(project_service: ProjectService, tmp_path):
+async def test_issue_254_foreign_key_constraint_fix(project_service: ProjectService):
     """Test to verify issue #254 is fixed: project removal with foreign key constraints.
 
     This test reproduces the exact scenario from issue #254:
@@ -36,123 +38,133 @@ async def test_issue_254_foreign_key_constraint_fix(project_service: ProjectServ
     Once issue #254 is fully fixed, remove the @pytest.mark.skip decorator.
     """
     test_project_name = "issue-254-verification"
-    test_project_path = str(tmp_path / "issue-254-verification")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_project_path = str(test_root / "issue-254-verification")
 
-    # Step 1: Create test project
-    await project_service.add_project(test_project_name, test_project_path)
-    project = await project_service.get_project(test_project_name)
-    assert project is not None, "Project should be created successfully"
+        # Step 1: Create test project
+        await project_service.add_project(test_project_name, test_project_path)
+        project = await project_service.get_project(test_project_name)
+        assert project is not None, "Project should be created successfully"
 
-    # Step 2: Create related entities that would cause foreign key constraint issues
-    from basic_memory.repository.entity_repository import EntityRepository
-    from basic_memory.repository.observation_repository import ObservationRepository
-    from basic_memory.repository.relation_repository import RelationRepository
+        # Step 2: Create related entities that would cause foreign key constraint issues
+        from basic_memory.repository.entity_repository import EntityRepository
+        from basic_memory.repository.observation_repository import ObservationRepository
+        from basic_memory.repository.relation_repository import RelationRepository
 
-    entity_repo = EntityRepository(project_service.repository.session_maker, project_id=project.id)
-    obs_repo = ObservationRepository(
-        project_service.repository.session_maker, project_id=project.id
-    )
-    rel_repo = RelationRepository(project_service.repository.session_maker, project_id=project.id)
+        entity_repo = EntityRepository(
+            project_service.repository.session_maker, project_id=project.id
+        )
+        obs_repo = ObservationRepository(
+            project_service.repository.session_maker, project_id=project.id
+        )
+        rel_repo = RelationRepository(
+            project_service.repository.session_maker, project_id=project.id
+        )
 
-    # Create entity
-    entity_data = {
-        "title": "Issue 254 Test Entity",
-        "entity_type": "note",
-        "content_type": "text/markdown",
-        "project_id": project.id,
-        "permalink": "issue-254-entity",
-        "file_path": "issue-254-entity.md",
-        "checksum": "issue254test",
-        "created_at": datetime.now(timezone.utc),
-        "updated_at": datetime.now(timezone.utc),
-    }
-    entity = await entity_repo.create(entity_data)
+        # Create entity
+        entity_data = {
+            "title": "Issue 254 Test Entity",
+            "entity_type": "note",
+            "content_type": "text/markdown",
+            "project_id": project.id,
+            "permalink": "issue-254-entity",
+            "file_path": "issue-254-entity.md",
+            "checksum": "issue254test",
+            "created_at": datetime.now(timezone.utc),
+            "updated_at": datetime.now(timezone.utc),
+        }
+        entity = await entity_repo.create(entity_data)
 
-    # Create observation linked to entity
-    observation_data = {
-        "entity_id": entity.id,
-        "content": "This observation should be cascade deleted",
-        "category": "test",
-    }
-    observation = await obs_repo.create(observation_data)
+        # Create observation linked to entity
+        observation_data = {
+            "entity_id": entity.id,
+            "content": "This observation should be cascade deleted",
+            "category": "test",
+        }
+        observation = await obs_repo.create(observation_data)
 
-    # Create relation involving the entity
-    relation_data = {
-        "from_id": entity.id,
-        "to_name": "some-other-entity",
-        "relation_type": "relates-to",
-    }
-    relation = await rel_repo.create(relation_data)
+        # Create relation involving the entity
+        relation_data = {
+            "from_id": entity.id,
+            "to_name": "some-other-entity",
+            "relation_type": "relates-to",
+        }
+        relation = await rel_repo.create(relation_data)
 
-    # Step 3: Attempt to remove the project
-    # This is where issue #254 manifested - should NOT raise "FOREIGN KEY constraint failed"
-    try:
-        await project_service.remove_project(test_project_name)
-    except Exception as e:
-        if "FOREIGN KEY constraint failed" in str(e):
-            pytest.fail(
-                f"Issue #254 not fixed - foreign key constraint error still occurs: {e}. "
-                f"The migration a1b2c3d4e5f6 may not have been applied correctly or "
-                f"the CASCADE DELETE constraint is not working as expected."
-            )
-        else:
-            # Re-raise unexpected errors
-            raise
+        # Step 3: Attempt to remove the project
+        # This is where issue #254 manifested - should NOT raise "FOREIGN KEY constraint failed"
+        try:
+            await project_service.remove_project(test_project_name)
+        except Exception as e:
+            if "FOREIGN KEY constraint failed" in str(e):
+                pytest.fail(
+                    f"Issue #254 not fixed - foreign key constraint error still occurs: {e}. "
+                    f"The migration a1b2c3d4e5f6 may not have been applied correctly or "
+                    f"the CASCADE DELETE constraint is not working as expected."
+                )
+            else:
+                # Re-raise unexpected errors
+                raise
 
-    # Step 4: Verify project was successfully removed
-    removed_project = await project_service.get_project(test_project_name)
-    assert removed_project is None, "Project should have been removed"
+        # Step 4: Verify project was successfully removed
+        removed_project = await project_service.get_project(test_project_name)
+        assert removed_project is None, "Project should have been removed"
 
-    # Step 5: Verify related data was cascade deleted
-    remaining_entity = await entity_repo.find_by_id(entity.id)
-    assert remaining_entity is None, "Entity should have been cascade deleted"
+        # Step 5: Verify related data was cascade deleted
+        remaining_entity = await entity_repo.find_by_id(entity.id)
+        assert remaining_entity is None, "Entity should have been cascade deleted"
 
-    remaining_observation = await obs_repo.find_by_id(observation.id)
-    assert remaining_observation is None, "Observation should have been cascade deleted"
+        remaining_observation = await obs_repo.find_by_id(observation.id)
+        assert remaining_observation is None, "Observation should have been cascade deleted"
 
-    remaining_relation = await rel_repo.find_by_id(relation.id)
-    assert remaining_relation is None, "Relation should have been cascade deleted"
+        remaining_relation = await rel_repo.find_by_id(relation.id)
+        assert remaining_relation is None, "Relation should have been cascade deleted"
 
 
 @pytest.mark.asyncio
-async def test_issue_254_reproduction(project_service: ProjectService, tmp_path):
+async def test_issue_254_reproduction(project_service: ProjectService):
     """Test that reproduces issue #254 to document the current state.
 
     This test demonstrates the current behavior and will fail until the issue is fixed.
     It serves as documentation of what the problem was.
     """
     test_project_name = "issue-254-reproduction"
-    test_project_path = str(tmp_path / "issue-254-reproduction")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_project_path = str(test_root / "issue-254-reproduction")
 
-    # Create project and entity
-    await project_service.add_project(test_project_name, test_project_path)
-    project = await project_service.get_project(test_project_name)
+        # Create project and entity
+        await project_service.add_project(test_project_name, test_project_path)
+        project = await project_service.get_project(test_project_name)
 
-    from basic_memory.repository.entity_repository import EntityRepository
+        from basic_memory.repository.entity_repository import EntityRepository
 
-    entity_repo = EntityRepository(project_service.repository.session_maker, project_id=project.id)
+        entity_repo = EntityRepository(
+            project_service.repository.session_maker, project_id=project.id
+        )
 
-    entity_data = {
-        "title": "Reproduction Entity",
-        "entity_type": "note",
-        "content_type": "text/markdown",
-        "project_id": project.id,
-        "permalink": "reproduction-entity",
-        "file_path": "reproduction-entity.md",
-        "checksum": "repro123",
-        "created_at": datetime.now(timezone.utc),
-        "updated_at": datetime.now(timezone.utc),
-    }
-    await entity_repo.create(entity_data)
+        entity_data = {
+            "title": "Reproduction Entity",
+            "entity_type": "note",
+            "content_type": "text/markdown",
+            "project_id": project.id,
+            "permalink": "reproduction-entity",
+            "file_path": "reproduction-entity.md",
+            "checksum": "repro123",
+            "created_at": datetime.now(timezone.utc),
+            "updated_at": datetime.now(timezone.utc),
+        }
+        await entity_repo.create(entity_data)
 
-    # This should eventually work without errors once issue #254 is fixed
-    # with pytest.raises(Exception) as exc_info:
-    await project_service.remove_project(test_project_name)
+        # This should eventually work without errors once issue #254 is fixed
+        # with pytest.raises(Exception) as exc_info:
+        await project_service.remove_project(test_project_name)
 
-    # Document the current error for tracking
-    # error_message = str(exc_info.value)
-    # assert any(keyword in error_message for keyword in [
-    #     "FOREIGN KEY constraint failed",
-    #     "constraint",
-    #     "integrity"
-    # ]), f"Expected foreign key or integrity constraint error, got: {error_message}"
+        # Document the current error for tracking
+        # error_message = str(exc_info.value)
+        # assert any(keyword in error_message for keyword in [
+        #     "FOREIGN KEY constraint failed",
+        #     "constraint",
+        #     "integrity"
+        # ]), f"Expected foreign key or integrity constraint error, got: {error_message}"

--- a/tests/services/test_project_removal_bug.py
+++ b/tests/services/test_project_removal_bug.py
@@ -1,7 +1,9 @@
 """Test for project removal bug #254."""
 
 import os
+import tempfile
 from datetime import timezone, datetime
+from pathlib import Path
 
 import pytest
 
@@ -9,7 +11,7 @@ from basic_memory.services.project_service import ProjectService
 
 
 @pytest.mark.asyncio
-async def test_remove_project_with_related_entities(project_service: ProjectService, tmp_path):
+async def test_remove_project_with_related_entities(project_service: ProjectService):
     """Test removing a project that has related entities (reproduces issue #254).
 
     This test verifies that projects with related entities (entities, observations, relations)
@@ -19,116 +21,118 @@ async def test_remove_project_with_related_entities(project_service: ProjectServ
     the project table was recreated in migration 647e7a75e2cd.
     """
     test_project_name = f"test-remove-with-entities-{os.urandom(4).hex()}"
-    test_project_path = str(tmp_path / "test-remove-with-entities")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_project_path = str(test_root / "test-remove-with-entities")
 
-    # Make sure the test directory exists
-    os.makedirs(test_project_path, exist_ok=True)
+        # Make sure the test directory exists
+        os.makedirs(test_project_path, exist_ok=True)
 
-    try:
-        # Step 1: Add the test project
-        await project_service.add_project(test_project_name, test_project_path)
+        try:
+            # Step 1: Add the test project
+            await project_service.add_project(test_project_name, test_project_path)
 
-        # Verify project exists
-        project = await project_service.get_project(test_project_name)
-        assert project is not None
+            # Verify project exists
+            project = await project_service.get_project(test_project_name)
+            assert project is not None
 
-        # Step 2: Create related entities for this project
-        from basic_memory.repository.entity_repository import EntityRepository
+            # Step 2: Create related entities for this project
+            from basic_memory.repository.entity_repository import EntityRepository
 
-        entity_repo = EntityRepository(
-            project_service.repository.session_maker, project_id=project.id
-        )
-
-        entity_data = {
-            "title": "Test Entity for Deletion",
-            "entity_type": "note",
-            "content_type": "text/markdown",
-            "project_id": project.id,
-            "permalink": "test-deletion-entity",
-            "file_path": "test-deletion-entity.md",
-            "checksum": "test123",
-            "created_at": datetime.now(timezone.utc),
-            "updated_at": datetime.now(timezone.utc),
-        }
-        entity = await entity_repo.create(entity_data)
-        assert entity is not None
-
-        # Step 3: Create observations for the entity
-        from basic_memory.repository.observation_repository import ObservationRepository
-
-        obs_repo = ObservationRepository(
-            project_service.repository.session_maker, project_id=project.id
-        )
-
-        observation_data = {
-            "entity_id": entity.id,
-            "content": "This is a test observation",
-            "category": "note",
-        }
-        observation = await obs_repo.create(observation_data)
-        assert observation is not None
-
-        # Step 4: Create relations involving the entity
-        from basic_memory.repository.relation_repository import RelationRepository
-
-        rel_repo = RelationRepository(
-            project_service.repository.session_maker, project_id=project.id
-        )
-
-        relation_data = {
-            "from_id": entity.id,
-            "to_name": "some-target-entity",
-            "relation_type": "relates-to",
-        }
-        relation = await rel_repo.create(relation_data)
-        assert relation is not None
-
-        # Step 5: Attempt to remove the project
-        # This should work with proper cascade delete, or fail with foreign key constraint
-        await project_service.remove_project(test_project_name)
-
-        # Step 6: Verify everything was properly deleted
-
-        # Project should be gone
-        removed_project = await project_service.get_project(test_project_name)
-        assert removed_project is None, "Project should have been removed"
-
-        # Related entities should be cascade deleted
-        remaining_entity = await entity_repo.find_by_id(entity.id)
-        assert remaining_entity is None, "Entity should have been cascade deleted"
-
-        # Observations should be cascade deleted
-        remaining_obs = await obs_repo.find_by_id(observation.id)
-        assert remaining_obs is None, "Observation should have been cascade deleted"
-
-        # Relations should be cascade deleted
-        remaining_rel = await rel_repo.find_by_id(relation.id)
-        assert remaining_rel is None, "Relation should have been cascade deleted"
-
-    except Exception as e:
-        # Check if this is the specific foreign key constraint error from the bug report
-        if "FOREIGN KEY constraint failed" in str(e):
-            pytest.fail(
-                f"Bug #254 reproduced: {e}. "
-                "This indicates missing foreign key constraints with CASCADE DELETE. "
-                "Run migration a1b2c3d4e5f6_fix_project_foreign_keys.py to fix this."
+            entity_repo = EntityRepository(
+                project_service.repository.session_maker, project_id=project.id
             )
-        else:
-            # Re-raise other unexpected errors
-            raise e
 
-    finally:
-        # Clean up - remove project if it still exists
-        if test_project_name in project_service.projects:
-            try:
-                await project_service.remove_project(test_project_name)
-            except Exception:
-                # Manual cleanup if remove_project fails
+            entity_data = {
+                "title": "Test Entity for Deletion",
+                "entity_type": "note",
+                "content_type": "text/markdown",
+                "project_id": project.id,
+                "permalink": "test-deletion-entity",
+                "file_path": "test-deletion-entity.md",
+                "checksum": "test123",
+                "created_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(timezone.utc),
+            }
+            entity = await entity_repo.create(entity_data)
+            assert entity is not None
+
+            # Step 3: Create observations for the entity
+            from basic_memory.repository.observation_repository import ObservationRepository
+
+            obs_repo = ObservationRepository(
+                project_service.repository.session_maker, project_id=project.id
+            )
+
+            observation_data = {
+                "entity_id": entity.id,
+                "content": "This is a test observation",
+                "category": "note",
+            }
+            observation = await obs_repo.create(observation_data)
+            assert observation is not None
+
+            # Step 4: Create relations involving the entity
+            from basic_memory.repository.relation_repository import RelationRepository
+
+            rel_repo = RelationRepository(
+                project_service.repository.session_maker, project_id=project.id
+            )
+
+            relation_data = {
+                "from_id": entity.id,
+                "to_name": "some-target-entity",
+                "relation_type": "relates-to",
+            }
+            relation = await rel_repo.create(relation_data)
+            assert relation is not None
+
+            # Step 5: Attempt to remove the project
+            # This should work with proper cascade delete, or fail with foreign key constraint
+            await project_service.remove_project(test_project_name)
+
+            # Step 6: Verify everything was properly deleted
+
+            # Project should be gone
+            removed_project = await project_service.get_project(test_project_name)
+            assert removed_project is None, "Project should have been removed"
+
+            # Related entities should be cascade deleted
+            remaining_entity = await entity_repo.find_by_id(entity.id)
+            assert remaining_entity is None, "Entity should have been cascade deleted"
+
+            # Observations should be cascade deleted
+            remaining_obs = await obs_repo.find_by_id(observation.id)
+            assert remaining_obs is None, "Observation should have been cascade deleted"
+
+            # Relations should be cascade deleted
+            remaining_rel = await rel_repo.find_by_id(relation.id)
+            assert remaining_rel is None, "Relation should have been cascade deleted"
+
+        except Exception as e:
+            # Check if this is the specific foreign key constraint error from the bug report
+            if "FOREIGN KEY constraint failed" in str(e):
+                pytest.fail(
+                    f"Bug #254 reproduced: {e}. "
+                    "This indicates missing foreign key constraints with CASCADE DELETE. "
+                    "Run migration a1b2c3d4e5f6_fix_project_foreign_keys.py to fix this."
+                )
+            else:
+                # Re-raise other unexpected errors
+                raise e
+
+        finally:
+            # Clean up - remove project if it still exists
+            if test_project_name in project_service.projects:
                 try:
-                    project_service.config_manager.remove_project(test_project_name)
+                    await project_service.remove_project(test_project_name)
                 except Exception:
-                    pass
+                    # Manual cleanup if remove_project fails
+                    try:
+                        project_service.config_manager.remove_project(test_project_name)
+                    except Exception:
+                        pass
 
-                project = await project_service.get_project(test_project_name)
-                if project:
-                    await project_service.repository.delete(project.id)
+                    project = await project_service.get_project(test_project_name)
+                    if project:
+                        await project_service.repository.delete(project.id)

--- a/tests/services/test_project_service.py
+++ b/tests/services/test_project_service.py
@@ -1,6 +1,7 @@
 """Tests for ProjectService."""
 
 import os
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -66,7 +67,7 @@ def test_current_project_property(project_service: ProjectService):
 
 @pytest.mark.asyncio
 async def test_project_operations_sync_methods(
-    app_config, project_service: ProjectService, config_manager: ConfigManager, tmp_path
+    app_config, project_service: ProjectService, config_manager: ConfigManager
 ):
     """Test adding, switching, and removing a project using ConfigManager directly.
 
@@ -74,40 +75,42 @@ async def test_project_operations_sync_methods(
     """
     # Generate a unique project name for testing
     test_project_name = f"test-project-{os.urandom(4).hex()}"
-    test_project_path = (tmp_path / "test-project").as_posix()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_project_path = (test_root / "test-project").as_posix()
 
-    # Make sure the test directory exists
-    os.makedirs(test_project_path, exist_ok=True)
+        # Make sure the test directory exists
+        os.makedirs(test_project_path, exist_ok=True)
 
-    try:
-        # Test adding a project (using ConfigManager directly)
-        config_manager.add_project(test_project_name, test_project_path)
+        try:
+            # Test adding a project (using ConfigManager directly)
+            config_manager.add_project(test_project_name, test_project_path)
 
-        # Verify it was added
-        assert test_project_name in project_service.projects
-        assert project_service.projects[test_project_name] == test_project_path
+            # Verify it was added
+            assert test_project_name in project_service.projects
+            assert project_service.projects[test_project_name] == test_project_path
 
-        # Test setting as default
-        original_default = project_service.default_project
-        config_manager.set_default_project(test_project_name)
-        assert project_service.default_project == test_project_name
+            # Test setting as default
+            original_default = project_service.default_project
+            config_manager.set_default_project(test_project_name)
+            assert project_service.default_project == test_project_name
 
-        # Restore original default
-        if original_default:
-            config_manager.set_default_project(original_default)
+            # Restore original default
+            if original_default:
+                config_manager.set_default_project(original_default)
 
-        # Test removing the project
-        config_manager.remove_project(test_project_name)
-        assert test_project_name not in project_service.projects
+            # Test removing the project
+            config_manager.remove_project(test_project_name)
+            assert test_project_name not in project_service.projects
 
-    except Exception as e:
-        # Clean up in case of error
-        if test_project_name in project_service.projects:
-            try:
-                config_manager.remove_project(test_project_name)
-            except Exception:
-                pass
-        raise e
+        except Exception as e:
+            # Clean up in case of error
+            if test_project_name in project_service.projects:
+                try:
+                    config_manager.remove_project(test_project_name)
+                except Exception:
+                    pass
+            raise e
 
 
 @pytest.mark.asyncio
@@ -165,255 +168,277 @@ async def test_get_project_info(project_service: ProjectService, test_graph, tes
 
 
 @pytest.mark.asyncio
-async def test_add_project_async(project_service: ProjectService, tmp_path):
+async def test_add_project_async(project_service: ProjectService):
     """Test adding a project with the updated async method."""
     test_project_name = f"test-async-project-{os.urandom(4).hex()}"
-    test_project_path = (tmp_path / "test-async-project").as_posix()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_project_path = (test_root / "test-async-project").as_posix()
 
-    # Make sure the test directory exists
-    os.makedirs(test_project_path, exist_ok=True)
+        # Make sure the test directory exists
+        os.makedirs(test_project_path, exist_ok=True)
 
-    try:
-        # Test adding a project
-        await project_service.add_project(test_project_name, test_project_path)
+        try:
+            # Test adding a project
+            await project_service.add_project(test_project_name, test_project_path)
 
-        # Verify it was added to config
-        assert test_project_name in project_service.projects
-        assert project_service.projects[test_project_name] == test_project_path
+            # Verify it was added to config
+            assert test_project_name in project_service.projects
+            assert project_service.projects[test_project_name] == test_project_path
 
-        # Verify it was added to the database
-        project = await project_service.repository.get_by_name(test_project_name)
-        assert project is not None
-        assert project.name == test_project_name
-        assert project.path == test_project_path
+            # Verify it was added to the database
+            project = await project_service.repository.get_by_name(test_project_name)
+            assert project is not None
+            assert project.name == test_project_name
+            assert project.path == test_project_path
 
-    finally:
-        # Clean up
-        if test_project_name in project_service.projects:
-            await project_service.remove_project(test_project_name)
+        finally:
+            # Clean up
+            if test_project_name in project_service.projects:
+                await project_service.remove_project(test_project_name)
 
-        # Ensure it was removed from both config and DB
-        assert test_project_name not in project_service.projects
-        project = await project_service.repository.get_by_name(test_project_name)
-        assert project is None
+            # Ensure it was removed from both config and DB
+            assert test_project_name not in project_service.projects
+            project = await project_service.repository.get_by_name(test_project_name)
+            assert project is None
 
 
 @pytest.mark.asyncio
-async def test_set_default_project_async(project_service: ProjectService, tmp_path):
+async def test_set_default_project_async(project_service: ProjectService):
     """Test setting a project as default with the updated async method."""
     # First add a test project
     test_project_name = f"test-default-project-{os.urandom(4).hex()}"
-    test_project_path = str(tmp_path / "test-default-project")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_project_path = str(test_root / "test-default-project")
 
-    # Make sure the test directory exists
-    os.makedirs(test_project_path, exist_ok=True)
+        # Make sure the test directory exists
+        os.makedirs(test_project_path, exist_ok=True)
 
-    original_default = project_service.default_project
+        original_default = project_service.default_project
 
-    try:
-        # Add the test project
-        await project_service.add_project(test_project_name, test_project_path)
+        try:
+            # Add the test project
+            await project_service.add_project(test_project_name, test_project_path)
 
-        # Set as default
-        await project_service.set_default_project(test_project_name)
+            # Set as default
+            await project_service.set_default_project(test_project_name)
 
-        # Verify it's set as default in config
-        assert project_service.default_project == test_project_name
+            # Verify it's set as default in config
+            assert project_service.default_project == test_project_name
 
-        # Verify it's set as default in database
-        project = await project_service.repository.get_by_name(test_project_name)
-        assert project is not None
-        assert project.is_default is True
+            # Verify it's set as default in database
+            project = await project_service.repository.get_by_name(test_project_name)
+            assert project is not None
+            assert project.is_default is True
 
-        # Make sure old default is no longer default
-        old_default_project = await project_service.repository.get_by_name(original_default)
-        if old_default_project:
-            assert old_default_project.is_default is not True
+            # Make sure old default is no longer default
+            old_default_project = await project_service.repository.get_by_name(original_default)
+            if old_default_project:
+                assert old_default_project.is_default is not True
 
-    finally:
-        # Restore original default
-        if original_default:
-            await project_service.set_default_project(original_default)
+        finally:
+            # Restore original default
+            if original_default:
+                await project_service.set_default_project(original_default)
 
-        # Clean up test project
-        if test_project_name in project_service.projects:
-            await project_service.remove_project(test_project_name)
+            # Clean up test project
+            if test_project_name in project_service.projects:
+                await project_service.remove_project(test_project_name)
 
 
 @pytest.mark.asyncio
-async def test_get_project_method(project_service: ProjectService, tmp_path):
+async def test_get_project_method(project_service: ProjectService):
     """Test the get_project method directly."""
     test_project_name = f"test-get-project-{os.urandom(4).hex()}"
-    test_project_path = (tmp_path / "test-get-project").as_posix()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_project_path = (test_root / "test-get-project").as_posix()
 
-    # Make sure the test directory exists
-    os.makedirs(test_project_path, exist_ok=True)
+        # Make sure the test directory exists
+        os.makedirs(test_project_path, exist_ok=True)
 
-    try:
-        # Test getting a non-existent project
-        result = await project_service.get_project("non-existent-project")
-        assert result is None
+        try:
+            # Test getting a non-existent project
+            result = await project_service.get_project("non-existent-project")
+            assert result is None
 
-        # Add a project
-        await project_service.add_project(test_project_name, test_project_path)
+            # Add a project
+            await project_service.add_project(test_project_name, test_project_path)
 
-        # Test getting an existing project
-        result = await project_service.get_project(test_project_name)
-        assert result is not None
-        assert result.name == test_project_name
-        assert result.path == test_project_path
+            # Test getting an existing project
+            result = await project_service.get_project(test_project_name)
+            assert result is not None
+            assert result.name == test_project_name
+            assert result.path == test_project_path
 
-    finally:
-        # Clean up
-        if test_project_name in project_service.projects:
-            await project_service.remove_project(test_project_name)
+        finally:
+            # Clean up
+            if test_project_name in project_service.projects:
+                await project_service.remove_project(test_project_name)
 
 
 @pytest.mark.asyncio
 async def test_set_default_project_config_db_mismatch(
-    project_service: ProjectService, config_manager: ConfigManager, tmp_path
+    project_service: ProjectService, config_manager: ConfigManager
 ):
     """Test set_default_project when project exists in config but not in database."""
     test_project_name = f"test-mismatch-project-{os.urandom(4).hex()}"
-    test_project_path = str(tmp_path / "test-mismatch-project")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_project_path = str(test_root / "test-mismatch-project")
 
-    # Make sure the test directory exists
-    os.makedirs(test_project_path, exist_ok=True)
+        # Make sure the test directory exists
+        os.makedirs(test_project_path, exist_ok=True)
 
-    original_default = project_service.default_project
+        original_default = project_service.default_project
 
-    try:
-        # Add project to config only (not to database)
-        config_manager.add_project(test_project_name, test_project_path)
+        try:
+            # Add project to config only (not to database)
+            config_manager.add_project(test_project_name, test_project_path)
 
-        # Verify it's in config but not in database
-        assert test_project_name in project_service.projects
-        db_project = await project_service.repository.get_by_name(test_project_name)
-        assert db_project is None
+            # Verify it's in config but not in database
+            assert test_project_name in project_service.projects
+            db_project = await project_service.repository.get_by_name(test_project_name)
+            assert db_project is None
 
-        # Try to set as default - this should trigger the error log on line 142
-        await project_service.set_default_project(test_project_name)
+            # Try to set as default - this should trigger the error log on line 142
+            await project_service.set_default_project(test_project_name)
 
-        # Should still update config despite database mismatch
-        assert project_service.default_project == test_project_name
+            # Should still update config despite database mismatch
+            assert project_service.default_project == test_project_name
 
-    finally:
-        # Restore original default
-        if original_default:
-            config_manager.set_default_project(original_default)
+        finally:
+            # Restore original default
+            if original_default:
+                config_manager.set_default_project(original_default)
 
-        # Clean up
-        if test_project_name in project_service.projects:
-            config_manager.remove_project(test_project_name)
+            # Clean up
+            if test_project_name in project_service.projects:
+                config_manager.remove_project(test_project_name)
 
 
 @pytest.mark.asyncio
-async def test_add_project_with_set_default_true(project_service: ProjectService, tmp_path):
+async def test_add_project_with_set_default_true(project_service: ProjectService):
     """Test adding a project with set_default=True enforces single default."""
     test_project_name = f"test-default-true-{os.urandom(4).hex()}"
-    test_project_path = str(tmp_path / "test-default-true")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_project_path = str(test_root / "test-default-true")
 
-    # Make sure the test directory exists
-    os.makedirs(test_project_path, exist_ok=True)
+        # Make sure the test directory exists
+        os.makedirs(test_project_path, exist_ok=True)
 
-    original_default = project_service.default_project
+        original_default = project_service.default_project
 
-    try:
-        # Get original default project from database
-        original_default_project = await project_service.repository.get_by_name(original_default)
+        try:
+            # Get original default project from database
+            original_default_project = await project_service.repository.get_by_name(
+                original_default
+            )
 
-        # Add project with set_default=True
-        await project_service.add_project(test_project_name, test_project_path, set_default=True)
+            # Add project with set_default=True
+            await project_service.add_project(
+                test_project_name, test_project_path, set_default=True
+            )
 
-        # Verify new project is set as default in both config and database
-        assert project_service.default_project == test_project_name
+            # Verify new project is set as default in both config and database
+            assert project_service.default_project == test_project_name
 
-        new_project = await project_service.repository.get_by_name(test_project_name)
-        assert new_project is not None
-        assert new_project.is_default is True
+            new_project = await project_service.repository.get_by_name(test_project_name)
+            assert new_project is not None
+            assert new_project.is_default is True
 
-        # Verify original default is no longer default in database
-        if original_default_project:
-            refreshed_original = await project_service.repository.get_by_name(original_default)
-            assert refreshed_original.is_default is not True
+            # Verify original default is no longer default in database
+            if original_default_project:
+                refreshed_original = await project_service.repository.get_by_name(original_default)
+                assert refreshed_original.is_default is not True
 
-        # Verify only one project has is_default=True
-        all_projects = await project_service.repository.find_all()
-        default_projects = [p for p in all_projects if p.is_default is True]
-        assert len(default_projects) == 1
-        assert default_projects[0].name == test_project_name
+            # Verify only one project has is_default=True
+            all_projects = await project_service.repository.find_all()
+            default_projects = [p for p in all_projects if p.is_default is True]
+            assert len(default_projects) == 1
+            assert default_projects[0].name == test_project_name
 
-    finally:
-        # Restore original default
-        if original_default:
-            await project_service.set_default_project(original_default)
+        finally:
+            # Restore original default
+            if original_default:
+                await project_service.set_default_project(original_default)
 
-        # Clean up test project
-        if test_project_name in project_service.projects:
-            await project_service.remove_project(test_project_name)
+            # Clean up test project
+            if test_project_name in project_service.projects:
+                await project_service.remove_project(test_project_name)
 
 
 @pytest.mark.asyncio
-async def test_add_project_with_set_default_false(project_service: ProjectService, tmp_path):
+async def test_add_project_with_set_default_false(project_service: ProjectService):
     """Test adding a project with set_default=False doesn't change defaults."""
     test_project_name = f"test-default-false-{os.urandom(4).hex()}"
-    test_project_path = str(tmp_path / "test-default-false")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_project_path = str(test_root / "test-default-false")
 
-    # Make sure the test directory exists
-    os.makedirs(test_project_path, exist_ok=True)
+        # Make sure the test directory exists
+        os.makedirs(test_project_path, exist_ok=True)
 
-    original_default = project_service.default_project
+        original_default = project_service.default_project
 
-    try:
-        # Add project with set_default=False (explicit)
-        await project_service.add_project(test_project_name, test_project_path, set_default=False)
+        try:
+            # Add project with set_default=False (explicit)
+            await project_service.add_project(
+                test_project_name, test_project_path, set_default=False
+            )
 
-        # Verify default project hasn't changed
-        assert project_service.default_project == original_default
+            # Verify default project hasn't changed
+            assert project_service.default_project == original_default
 
-        # Verify new project is NOT set as default
-        new_project = await project_service.repository.get_by_name(test_project_name)
-        assert new_project is not None
-        assert new_project.is_default is not True
+            # Verify new project is NOT set as default
+            new_project = await project_service.repository.get_by_name(test_project_name)
+            assert new_project is not None
+            assert new_project.is_default is not True
 
-        # Verify original default is still default
-        original_default_project = await project_service.repository.get_by_name(original_default)
-        if original_default_project:
-            assert original_default_project.is_default is True
+            # Verify original default is still default
+            original_default_project = await project_service.repository.get_by_name(
+                original_default
+            )
+            if original_default_project:
+                assert original_default_project.is_default is True
 
-    finally:
-        # Clean up test project
-        if test_project_name in project_service.projects:
-            await project_service.remove_project(test_project_name)
+        finally:
+            # Clean up test project
+            if test_project_name in project_service.projects:
+                await project_service.remove_project(test_project_name)
 
 
 @pytest.mark.asyncio
-async def test_add_project_default_parameter_omitted(project_service: ProjectService, tmp_path):
+async def test_add_project_default_parameter_omitted(project_service: ProjectService):
     """Test adding a project without set_default parameter defaults to False behavior."""
     test_project_name = f"test-default-omitted-{os.urandom(4).hex()}"
-    test_project_path = str(tmp_path / "test-default-omitted")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_project_path = str(test_root / "test-default-omitted")
 
-    # Make sure the test directory exists
-    os.makedirs(test_project_path, exist_ok=True)
+        # Make sure the test directory exists
+        os.makedirs(test_project_path, exist_ok=True)
 
-    original_default = project_service.default_project
+        original_default = project_service.default_project
 
-    try:
-        # Add project without set_default parameter (should default to False)
-        await project_service.add_project(test_project_name, test_project_path)
+        try:
+            # Add project without set_default parameter (should default to False)
+            await project_service.add_project(test_project_name, test_project_path)
 
-        # Verify default project hasn't changed
-        assert project_service.default_project == original_default
+            # Verify default project hasn't changed
+            assert project_service.default_project == original_default
 
-        # Verify new project is NOT set as default
-        new_project = await project_service.repository.get_by_name(test_project_name)
-        assert new_project is not None
-        assert new_project.is_default is not True
+            # Verify new project is NOT set as default
+            new_project = await project_service.repository.get_by_name(test_project_name)
+            assert new_project is not None
+            assert new_project.is_default is not True
 
-    finally:
-        # Clean up test project
-        if test_project_name in project_service.projects:
-            await project_service.remove_project(test_project_name)
+        finally:
+            # Clean up test project
+            if test_project_name in project_service.projects:
+                await project_service.remove_project(test_project_name)
 
 
 @pytest.mark.asyncio
@@ -433,530 +458,727 @@ async def test_ensure_single_default_project_enforcement_logic(project_service: 
 
 
 @pytest.mark.asyncio
-async def test_synchronize_projects_calls_ensure_single_default(
-    project_service: ProjectService, tmp_path
-):
+async def test_synchronize_projects_calls_ensure_single_default(project_service: ProjectService):
     """Test that synchronize_projects calls _ensure_single_default_project."""
     test_project_name = f"test-sync-default-{os.urandom(4).hex()}"
-    test_project_path = str(tmp_path / "test-sync-default")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_project_path = str(test_root / "test-sync-default")
 
-    # Make sure the test directory exists
-    os.makedirs(test_project_path, exist_ok=True)
+        # Make sure the test directory exists
+        os.makedirs(test_project_path, exist_ok=True)
 
-    config_manager = ConfigManager()
-    try:
-        # Add project to config only (simulating unsynchronized state)
-        config_manager.add_project(test_project_name, test_project_path)
+        config_manager = ConfigManager()
+        try:
+            # Add project to config only (simulating unsynchronized state)
+            config_manager.add_project(test_project_name, test_project_path)
 
-        # Verify it's in config but not in database
-        assert test_project_name in project_service.projects
-        db_project = await project_service.repository.get_by_name(test_project_name)
-        assert db_project is None
+            # Verify it's in config but not in database
+            assert test_project_name in project_service.projects
+            db_project = await project_service.repository.get_by_name(test_project_name)
+            assert db_project is None
 
-        # Call synchronize_projects (this should call _ensure_single_default_project)
-        await project_service.synchronize_projects()
+            # Call synchronize_projects (this should call _ensure_single_default_project)
+            await project_service.synchronize_projects()
 
-        # Verify project is now in database
-        db_project = await project_service.repository.get_by_name(test_project_name)
-        assert db_project is not None
+            # Verify project is now in database
+            db_project = await project_service.repository.get_by_name(test_project_name)
+            assert db_project is not None
 
-        # Verify default project enforcement was applied
-        all_projects = await project_service.repository.find_all()
-        default_projects = [p for p in all_projects if p.is_default is True]
-        assert len(default_projects) <= 1  # Should be exactly 1 or 0
+            # Verify default project enforcement was applied
+            all_projects = await project_service.repository.find_all()
+            default_projects = [p for p in all_projects if p.is_default is True]
+            assert len(default_projects) <= 1  # Should be exactly 1 or 0
 
-    finally:
-        # Clean up test project
-        if test_project_name in project_service.projects:
-            await project_service.remove_project(test_project_name)
+        finally:
+            # Clean up test project
+            if test_project_name in project_service.projects:
+                await project_service.remove_project(test_project_name)
 
 
 @pytest.mark.asyncio
-async def test_synchronize_projects_normalizes_project_names(
-    project_service: ProjectService, tmp_path
-):
+async def test_synchronize_projects_normalizes_project_names(project_service: ProjectService):
     """Test that synchronize_projects normalizes project names in config to match database format."""
     # Use a project name that needs normalization (uppercase, spaces)
     unnormalized_name = "Test Project With Spaces"
     expected_normalized_name = "test-project-with-spaces"
-    test_project_path = str(tmp_path / "test-project-spaces")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_project_path = str(test_root / "test-project-spaces")
 
-    # Make sure the test directory exists
-    os.makedirs(test_project_path, exist_ok=True)
+        # Make sure the test directory exists
+        os.makedirs(test_project_path, exist_ok=True)
 
-    config_manager = ConfigManager()
-    try:
-        # Manually add the unnormalized project name to config
+        config_manager = ConfigManager()
+        try:
+            # Manually add the unnormalized project name to config
 
-        # Add project with unnormalized name directly to config
-        config = config_manager.load_config()
-        config.projects[unnormalized_name] = test_project_path
-        config_manager.save_config(config)
+            # Add project with unnormalized name directly to config
+            config = config_manager.load_config()
+            config.projects[unnormalized_name] = test_project_path
+            config_manager.save_config(config)
 
-        # Verify the unnormalized name is in config
-        assert unnormalized_name in project_service.projects
-        assert project_service.projects[unnormalized_name] == test_project_path
+            # Verify the unnormalized name is in config
+            assert unnormalized_name in project_service.projects
+            assert project_service.projects[unnormalized_name] == test_project_path
 
-        # Call synchronize_projects - this should normalize the project name
-        await project_service.synchronize_projects()
+            # Call synchronize_projects - this should normalize the project name
+            await project_service.synchronize_projects()
 
-        # Verify the config was updated with normalized name
-        assert expected_normalized_name in project_service.projects
-        assert unnormalized_name not in project_service.projects
-        assert project_service.projects[expected_normalized_name] == test_project_path
+            # Verify the config was updated with normalized name
+            assert expected_normalized_name in project_service.projects
+            assert unnormalized_name not in project_service.projects
+            assert project_service.projects[expected_normalized_name] == test_project_path
 
-        # Verify the project was added to database with normalized name
-        db_project = await project_service.repository.get_by_name(expected_normalized_name)
-        assert db_project is not None
-        assert db_project.name == expected_normalized_name
-        assert db_project.path == test_project_path
-        assert db_project.permalink == expected_normalized_name
+            # Verify the project was added to database with normalized name
+            db_project = await project_service.repository.get_by_name(expected_normalized_name)
+            assert db_project is not None
+            assert db_project.name == expected_normalized_name
+            assert db_project.path == test_project_path
+            assert db_project.permalink == expected_normalized_name
 
-        # Verify the unnormalized name is not in database
-        unnormalized_db_project = await project_service.repository.get_by_name(unnormalized_name)
-        assert unnormalized_db_project is None
+            # Verify the unnormalized name is not in database
+            unnormalized_db_project = await project_service.repository.get_by_name(
+                unnormalized_name
+            )
+            assert unnormalized_db_project is None
 
-    finally:
-        # Clean up - remove any test projects from both config and database
-        current_projects = project_service.projects.copy()
-        for name in [unnormalized_name, expected_normalized_name]:
-            if name in current_projects:
-                try:
-                    await project_service.remove_project(name)
-                except Exception:
-                    # Try to clean up manually if remove_project fails
+        finally:
+            # Clean up - remove any test projects from both config and database
+            current_projects = project_service.projects.copy()
+            for name in [unnormalized_name, expected_normalized_name]:
+                if name in current_projects:
                     try:
-                        config_manager.remove_project(name)
+                        await project_service.remove_project(name)
                     except Exception:
-                        pass
+                        # Try to clean up manually if remove_project fails
+                        try:
+                            config_manager.remove_project(name)
+                        except Exception:
+                            pass
 
-                    # Remove from database
-                    db_project = await project_service.repository.get_by_name(name)
-                    if db_project:
-                        await project_service.repository.delete(db_project.id)
+                        # Remove from database
+                        db_project = await project_service.repository.get_by_name(name)
+                        if db_project:
+                            await project_service.repository.delete(db_project.id)
 
 
 @pytest.mark.asyncio
-async def test_move_project(project_service: ProjectService, tmp_path):
+async def test_move_project(project_service: ProjectService):
     """Test moving a project to a new location."""
     test_project_name = f"test-move-project-{os.urandom(4).hex()}"
-    old_path = (tmp_path / "old-location").as_posix()
-    new_path = (tmp_path / "new-location").as_posix()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        old_path = (test_root / "old-location").as_posix()
+        new_path = (test_root / "new-location").as_posix()
 
-    # Create old directory
-    os.makedirs(old_path, exist_ok=True)
+        # Create old directory
+        os.makedirs(old_path, exist_ok=True)
 
-    try:
-        # Add project with initial path
-        await project_service.add_project(test_project_name, old_path)
+        try:
+            # Add project with initial path
+            await project_service.add_project(test_project_name, old_path)
 
-        # Verify initial state
-        assert test_project_name in project_service.projects
-        assert project_service.projects[test_project_name] == old_path
+            # Verify initial state
+            assert test_project_name in project_service.projects
+            assert project_service.projects[test_project_name] == old_path
 
-        project = await project_service.repository.get_by_name(test_project_name)
-        assert project is not None
-        assert project.path == old_path
+            project = await project_service.repository.get_by_name(test_project_name)
+            assert project is not None
+            assert project.path == old_path
 
-        # Move project to new location
-        await project_service.move_project(test_project_name, new_path)
-
-        # Verify config was updated
-        assert project_service.projects[test_project_name] == new_path
-
-        # Verify database was updated
-        updated_project = await project_service.repository.get_by_name(test_project_name)
-        assert updated_project is not None
-        assert updated_project.path == new_path
-
-        # Verify new directory was created
-        assert os.path.exists(new_path)
-
-    finally:
-        # Clean up
-        if test_project_name in project_service.projects:
-            await project_service.remove_project(test_project_name)
-
-
-@pytest.mark.asyncio
-async def test_move_project_nonexistent(project_service: ProjectService, tmp_path):
-    """Test moving a project that doesn't exist."""
-    new_path = str(tmp_path / "new-location")
-
-    with pytest.raises(ValueError, match="not found in configuration"):
-        await project_service.move_project("nonexistent-project", new_path)
-
-
-@pytest.mark.asyncio
-async def test_move_project_db_mismatch(project_service: ProjectService, tmp_path):
-    """Test moving a project that exists in config but not in database."""
-    test_project_name = f"test-move-mismatch-{os.urandom(4).hex()}"
-    old_path = (tmp_path / "old-location").as_posix()
-    new_path = (tmp_path / "new-location").as_posix()
-
-    # Create directories
-    os.makedirs(old_path, exist_ok=True)
-
-    config_manager = project_service.config_manager
-
-    try:
-        # Add project to config only (not to database)
-        config_manager.add_project(test_project_name, old_path)
-
-        # Verify it's in config but not in database
-        assert test_project_name in project_service.projects
-        db_project = await project_service.repository.get_by_name(test_project_name)
-        assert db_project is None
-
-        # Try to move project - should fail and restore config
-        with pytest.raises(ValueError, match="not found in database"):
+            # Move project to new location
             await project_service.move_project(test_project_name, new_path)
 
-        # Verify config was restored to original path
-        assert project_service.projects[test_project_name] == old_path
+            # Verify config was updated
+            assert project_service.projects[test_project_name] == new_path
 
-    finally:
-        # Clean up
-        if test_project_name in project_service.projects:
-            config_manager.remove_project(test_project_name)
+            # Verify database was updated
+            updated_project = await project_service.repository.get_by_name(test_project_name)
+            assert updated_project is not None
+            assert updated_project.path == new_path
+
+            # Verify new directory was created
+            assert os.path.exists(new_path)
+
+        finally:
+            # Clean up
+            if test_project_name in project_service.projects:
+                await project_service.remove_project(test_project_name)
 
 
 @pytest.mark.asyncio
-async def test_move_project_expands_path(project_service: ProjectService, tmp_path):
+async def test_move_project_nonexistent(project_service: ProjectService):
+    """Test moving a project that doesn't exist."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        new_path = str(test_root / "new-location")
+
+        with pytest.raises(ValueError, match="not found in configuration"):
+            await project_service.move_project("nonexistent-project", new_path)
+
+
+@pytest.mark.asyncio
+async def test_move_project_db_mismatch(project_service: ProjectService):
+    """Test moving a project that exists in config but not in database."""
+    test_project_name = f"test-move-mismatch-{os.urandom(4).hex()}"
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        old_path = (test_root / "old-location").as_posix()
+        new_path = (test_root / "new-location").as_posix()
+
+        # Create directories
+        os.makedirs(old_path, exist_ok=True)
+
+        config_manager = project_service.config_manager
+
+        try:
+            # Add project to config only (not to database)
+            config_manager.add_project(test_project_name, old_path)
+
+            # Verify it's in config but not in database
+            assert test_project_name in project_service.projects
+            db_project = await project_service.repository.get_by_name(test_project_name)
+            assert db_project is None
+
+            # Try to move project - should fail and restore config
+            with pytest.raises(ValueError, match="not found in database"):
+                await project_service.move_project(test_project_name, new_path)
+
+            # Verify config was restored to original path
+            assert project_service.projects[test_project_name] == old_path
+
+        finally:
+            # Clean up
+            if test_project_name in project_service.projects:
+                config_manager.remove_project(test_project_name)
+
+
+@pytest.mark.asyncio
+async def test_move_project_expands_path(project_service: ProjectService):
     """Test that move_project expands ~ and relative paths."""
     test_project_name = f"test-move-expand-{os.urandom(4).hex()}"
-    old_path = (tmp_path / "old-location").as_posix()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        old_path = (test_root / "old-location").as_posix()
 
-    # Create old directory
-    os.makedirs(old_path, exist_ok=True)
+        # Create old directory
+        os.makedirs(old_path, exist_ok=True)
 
-    try:
-        # Add project with initial path
-        await project_service.add_project(test_project_name, old_path)
+        try:
+            # Add project with initial path
+            await project_service.add_project(test_project_name, old_path)
 
-        # Use a relative path for the move
-        relative_new_path = "./new-location"
-        expected_absolute_path = Path(os.path.abspath(relative_new_path)).as_posix()
+            # Use a relative path for the move
+            relative_new_path = "./new-location"
+            expected_absolute_path = Path(os.path.abspath(relative_new_path)).as_posix()
 
-        # Move project using relative path
-        await project_service.move_project(test_project_name, relative_new_path)
+            # Move project using relative path
+            await project_service.move_project(test_project_name, relative_new_path)
 
-        # Verify the path was expanded to absolute
-        assert project_service.projects[test_project_name] == expected_absolute_path
+            # Verify the path was expanded to absolute
+            assert project_service.projects[test_project_name] == expected_absolute_path
 
-        updated_project = await project_service.repository.get_by_name(test_project_name)
-        assert updated_project is not None
-        assert updated_project.path == expected_absolute_path
+            updated_project = await project_service.repository.get_by_name(test_project_name)
+            assert updated_project is not None
+            assert updated_project.path == expected_absolute_path
 
-    finally:
-        # Clean up
-        if test_project_name in project_service.projects:
-            await project_service.remove_project(test_project_name)
+        finally:
+            # Clean up
+            if test_project_name in project_service.projects:
+                await project_service.remove_project(test_project_name)
 
 
 @pytest.mark.asyncio
-async def test_synchronize_projects_handles_case_sensitivity_bug(
-    project_service: ProjectService, tmp_path
-):
+async def test_synchronize_projects_handles_case_sensitivity_bug(project_service: ProjectService):
     """Test that synchronize_projects fixes the case sensitivity bug (Personal vs personal)."""
-    # Simulate the exact bug scenario: config has "Personal" but database expects "personal"
-    config_name = "Personal"
-    normalized_name = "personal"
-    test_project_path = str(tmp_path / "personal-project")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Simulate the exact bug scenario: config has "Personal" but database expects "personal"
+        config_name = "Personal"
+        normalized_name = "personal"
+        test_root = Path(temp_dir)
+        test_project_path = str(test_root / "personal-project")
 
-    # Make sure the test directory exists
-    os.makedirs(test_project_path, exist_ok=True)
+        # Make sure the test directory exists
+        os.makedirs(test_project_path, exist_ok=True)
 
-    config_manager = ConfigManager()
-    try:
-        # Add project with uppercase name to config (simulating the bug scenario)
-        config = config_manager.load_config()
-        config.projects[config_name] = test_project_path
-        config_manager.save_config(config)
+        config_manager = ConfigManager()
+        try:
+            # Add project with uppercase name to config (simulating the bug scenario)
+            config = config_manager.load_config()
+            config.projects[config_name] = test_project_path
+            config_manager.save_config(config)
 
-        # Verify the uppercase name is in config
-        assert config_name in project_service.projects
-        assert project_service.projects[config_name] == test_project_path
+            # Verify the uppercase name is in config
+            assert config_name in project_service.projects
+            assert project_service.projects[config_name] == test_project_path
 
-        # Call synchronize_projects - this should fix the case sensitivity issue
-        await project_service.synchronize_projects()
+            # Call synchronize_projects - this should fix the case sensitivity issue
+            await project_service.synchronize_projects()
 
-        # Verify the config was updated to use normalized case
-        assert normalized_name in project_service.projects
-        assert config_name not in project_service.projects
-        assert project_service.projects[normalized_name] == test_project_path
+            # Verify the config was updated to use normalized case
+            assert normalized_name in project_service.projects
+            assert config_name not in project_service.projects
+            assert project_service.projects[normalized_name] == test_project_path
 
-        # Verify the project exists in database with correct normalized name
-        db_project = await project_service.repository.get_by_name(normalized_name)
-        assert db_project is not None
-        assert db_project.name == normalized_name
-        assert db_project.path == test_project_path
+            # Verify the project exists in database with correct normalized name
+            db_project = await project_service.repository.get_by_name(normalized_name)
+            assert db_project is not None
+            assert db_project.name == normalized_name
+            assert db_project.path == test_project_path
 
-        # Verify we can now switch to this project without case sensitivity errors
-        # (This would have failed before the fix with "Personal" != "personal")
-        project_lookup = await project_service.get_project(normalized_name)
-        assert project_lookup is not None
-        assert project_lookup.name == normalized_name
+            # Verify we can now switch to this project without case sensitivity errors
+            # (This would have failed before the fix with "Personal" != "personal")
+            project_lookup = await project_service.get_project(normalized_name)
+            assert project_lookup is not None
+            assert project_lookup.name == normalized_name
 
-    finally:
-        # Clean up
-        for name in [config_name, normalized_name]:
-            if name in project_service.projects:
-                try:
-                    await project_service.remove_project(name)
-                except Exception:
-                    # Manual cleanup if needed
+        finally:
+            # Clean up
+            for name in [config_name, normalized_name]:
+                if name in project_service.projects:
                     try:
-                        config_manager.remove_project(name)
+                        await project_service.remove_project(name)
                     except Exception:
-                        pass
+                        # Manual cleanup if needed
+                        try:
+                            config_manager.remove_project(name)
+                        except Exception:
+                            pass
 
-                    db_project = await project_service.repository.get_by_name(name)
-                    if db_project:
-                        await project_service.repository.delete(db_project.id)
+                        db_project = await project_service.repository.get_by_name(name)
+                        if db_project:
+                            await project_service.repository.delete(db_project.id)
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Project root constraints only tested on POSIX systems")
 @pytest.mark.asyncio
 async def test_add_project_with_project_root_sanitizes_paths(
-    project_service: ProjectService, config_manager: ConfigManager, tmp_path, monkeypatch
+    project_service: ProjectService, config_manager: ConfigManager, monkeypatch
 ):
     """Test that BASIC_MEMORY_PROJECT_ROOT sanitizes and validates project paths."""
-    # Set up project root environment
-    project_root_path = tmp_path / "app" / "data"
-    project_root_path.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Set up project root environment
+        project_root_path = Path(temp_dir) / "app" / "data"
+        project_root_path.mkdir(parents=True, exist_ok=True)
 
-    monkeypatch.setenv("BASIC_MEMORY_PROJECT_ROOT", str(project_root_path))
+        monkeypatch.setenv("BASIC_MEMORY_PROJECT_ROOT", str(project_root_path))
 
-    # Invalidate config cache so it picks up the new env var
-    from basic_memory import config as config_module
+        # Invalidate config cache so it picks up the new env var
+        from basic_memory import config as config_module
 
-    config_module._CONFIG_CACHE = None
+        config_module._CONFIG_CACHE = None
 
-    test_cases = [
-        # (input_path, expected_result_path, should_succeed)
-        ("test", str(project_root_path / "test"), True),  # Simple relative path
-        ("~/Documents/test", str(project_root_path / "Documents" / "test"), True),  # Home directory
-        (
-            "/tmp/test",
-            str(project_root_path / "tmp" / "test"),
-            True,
-        ),  # Absolute path (sanitized to relative)
-        (
-            "../../../etc/passwd",
-            str(project_root_path),
-            True,
-        ),  # Path traversal (all ../ removed, results in project_root)
-        ("folder/subfolder", str(project_root_path / "folder" / "subfolder"), True),  # Nested path
-        (
-            "~/folder/../test",
-            str(project_root_path / "test"),
-            True,
-        ),  # Mixed patterns (sanitized to just 'test')
-    ]
+        test_cases = [
+            # (input_path, expected_result_path, should_succeed)
+            ("test", str(project_root_path / "test"), True),  # Simple relative path
+            (
+                "~/Documents/test",
+                str(project_root_path / "Documents" / "test"),
+                True,
+            ),  # Home directory
+            (
+                "/tmp/test",
+                str(project_root_path / "tmp" / "test"),
+                True,
+            ),  # Absolute path (sanitized to relative)
+            (
+                "../../../etc/passwd",
+                str(project_root_path),
+                True,
+            ),  # Path traversal (all ../ removed, results in project_root)
+            (
+                "folder/subfolder",
+                str(project_root_path / "folder" / "subfolder"),
+                True,
+            ),  # Nested path
+            (
+                "~/folder/../test",
+                str(project_root_path / "test"),
+                True,
+            ),  # Mixed patterns (sanitized to just 'test')
+        ]
 
-    for i, (input_path, expected_path, should_succeed) in enumerate(test_cases):
-        test_project_name = f"project-root-test-{i}"
+        for i, (input_path, expected_path, should_succeed) in enumerate(test_cases):
+            test_project_name = f"project-root-test-{i}"
 
-        try:
-            # Add the project
-            await project_service.add_project(test_project_name, input_path)
+            try:
+                # Add the project
+                await project_service.add_project(test_project_name, input_path)
 
-            if should_succeed:
-                # Verify the path was sanitized correctly
-                assert test_project_name in project_service.projects
-                actual_path = project_service.projects[test_project_name]
+                if should_succeed:
+                    # Verify the path was sanitized correctly
+                    assert test_project_name in project_service.projects
+                    actual_path = project_service.projects[test_project_name]
 
-                # The path should be under project_root
-                assert actual_path.startswith(str(project_root_path)), (
-                    f"Path {actual_path} should start with {project_root_path} for input {input_path}"
-                )
+                    # The path should be under project_root (resolve both to handle macOS /private/var)
+                    assert (
+                        Path(actual_path)
+                        .resolve()
+                        .is_relative_to(Path(project_root_path).resolve())
+                    ), (
+                        f"Path {actual_path} should be under {project_root_path} for input {input_path}"
+                    )
 
-                # Clean up
-                await project_service.remove_project(test_project_name)
-            else:
-                pytest.fail(f"Expected ValueError for input path: {input_path}")
+                    # Clean up
+                    await project_service.remove_project(test_project_name)
+                else:
+                    pytest.fail(f"Expected ValueError for input path: {input_path}")
 
-        except ValueError as e:
-            if should_succeed:
-                pytest.fail(f"Unexpected ValueError for input path {input_path}: {e}")
-            # Expected failure - continue to next test case
+            except ValueError as e:
+                if should_succeed:
+                    pytest.fail(f"Unexpected ValueError for input path {input_path}: {e}")
+                # Expected failure - continue to next test case
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Project root constraints only tested on POSIX systems")
 @pytest.mark.asyncio
 async def test_add_project_with_project_root_rejects_escape_attempts(
-    project_service: ProjectService, config_manager: ConfigManager, tmp_path, monkeypatch
+    project_service: ProjectService, config_manager: ConfigManager, monkeypatch
 ):
     """Test that BASIC_MEMORY_PROJECT_ROOT rejects paths that try to escape the project root."""
-    # Set up project root environment
-    project_root_path = tmp_path / "app" / "data"
-    project_root_path.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Set up project root environment
+        project_root_path = Path(temp_dir) / "app" / "data"
+        project_root_path.mkdir(parents=True, exist_ok=True)
 
-    # Create a directory outside project_root to verify it's not accessible
-    outside_dir = tmp_path / "outside"
-    outside_dir.mkdir(parents=True, exist_ok=True)
+        # Create a directory outside project_root to verify it's not accessible
+        outside_dir = Path(temp_dir) / "outside"
+        outside_dir.mkdir(parents=True, exist_ok=True)
 
-    monkeypatch.setenv("BASIC_MEMORY_PROJECT_ROOT", str(project_root_path))
+        monkeypatch.setenv("BASIC_MEMORY_PROJECT_ROOT", str(project_root_path))
 
-    # Invalidate config cache so it picks up the new env var
-    from basic_memory import config as config_module
+        # Invalidate config cache so it picks up the new env var
+        from basic_memory import config as config_module
 
-    config_module._CONFIG_CACHE = None
+        config_module._CONFIG_CACHE = None
 
-    # All of these should succeed by being sanitized to paths under project_root
-    # The sanitization removes dangerous patterns, so they don't escape
-    safe_after_sanitization = [
-        "../../../etc/passwd",
-        "../../.env",
-        "../../../home/user/.ssh/id_rsa",
-    ]
+        # All of these should succeed by being sanitized to paths under project_root
+        # The sanitization removes dangerous patterns, so they don't escape
+        safe_after_sanitization = [
+            "../../../etc/passwd",
+            "../../.env",
+            "../../../home/user/.ssh/id_rsa",
+        ]
 
-    for i, attack_path in enumerate(safe_after_sanitization):
-        test_project_name = f"project-root-attack-test-{i}"
+        for i, attack_path in enumerate(safe_after_sanitization):
+            test_project_name = f"project-root-attack-test-{i}"
 
-        try:
-            # Add the project
-            await project_service.add_project(test_project_name, attack_path)
+            try:
+                # Add the project
+                await project_service.add_project(test_project_name, attack_path)
 
-            # Verify it was sanitized to be under project_root
-            actual_path = project_service.projects[test_project_name]
-            assert actual_path.startswith(str(project_root_path)), (
-                f"Sanitized path {actual_path} should be under {project_root_path}"
-            )
+                # Verify it was sanitized to be under project_root (resolve to handle macOS /private/var)
+                actual_path = project_service.projects[test_project_name]
+                assert (
+                    Path(actual_path).resolve().is_relative_to(Path(project_root_path).resolve())
+                ), f"Sanitized path {actual_path} should be under {project_root_path}"
 
-            # Clean up
-            await project_service.remove_project(test_project_name)
+                # Clean up
+                await project_service.remove_project(test_project_name)
 
-        except ValueError:
-            # If it raises ValueError, that's also acceptable for security
-            pass
+            except ValueError:
+                # If it raises ValueError, that's also acceptable for security
+                pass
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Project root constraints only tested on POSIX systems")
 @pytest.mark.asyncio
 async def test_add_project_without_project_root_allows_arbitrary_paths(
-    project_service: ProjectService, config_manager: ConfigManager, tmp_path, monkeypatch
+    project_service: ProjectService, config_manager: ConfigManager, monkeypatch
 ):
     """Test that without BASIC_MEMORY_PROJECT_ROOT set, arbitrary paths are allowed."""
-    # Ensure project_root is not set
-    if "BASIC_MEMORY_PROJECT_ROOT" in os.environ:
-        monkeypatch.delenv("BASIC_MEMORY_PROJECT_ROOT")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Ensure project_root is not set
+        if "BASIC_MEMORY_PROJECT_ROOT" in os.environ:
+            monkeypatch.delenv("BASIC_MEMORY_PROJECT_ROOT")
 
-    # Force reload config without project_root
-    from basic_memory.services import project_service as ps_module
+        # Force reload config without project_root
+        from basic_memory.services import project_service as ps_module
 
-    monkeypatch.setattr(ps_module, "config", config_manager.load_config())
+        monkeypatch.setattr(ps_module, "config", config_manager.load_config())
 
-    # Create a test directory
-    test_dir = tmp_path / "arbitrary-location"
-    test_dir.mkdir(parents=True, exist_ok=True)
+        # Create a test directory
+        test_dir = Path(temp_dir) / "arbitrary-location"
+        test_dir.mkdir(parents=True, exist_ok=True)
 
-    test_project_name = "no-project-root-test"
+        test_project_name = "no-project-root-test"
 
-    try:
-        # Without project_root, we should be able to use arbitrary absolute paths
-        await project_service.add_project(test_project_name, str(test_dir))
+        try:
+            # Without project_root, we should be able to use arbitrary absolute paths
+            await project_service.add_project(test_project_name, str(test_dir))
 
-        # Verify the path was accepted as-is
-        assert test_project_name in project_service.projects
-        actual_path = project_service.projects[test_project_name]
-        assert actual_path == str(test_dir)
+            # Verify the path was accepted as-is
+            assert test_project_name in project_service.projects
+            actual_path = project_service.projects[test_project_name]
+            assert actual_path == str(test_dir)
 
-    finally:
-        # Clean up
-        if test_project_name in project_service.projects:
-            await project_service.remove_project(test_project_name)
+        finally:
+            # Clean up
+            if test_project_name in project_service.projects:
+                await project_service.remove_project(test_project_name)
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Project root constraints only tested on POSIX systems")
 @pytest.mark.asyncio
 async def test_add_project_with_project_root_normalizes_case(
-    project_service: ProjectService, config_manager: ConfigManager, tmp_path, monkeypatch
+    project_service: ProjectService, config_manager: ConfigManager, monkeypatch
 ):
     """Test that BASIC_MEMORY_PROJECT_ROOT normalizes paths to lowercase."""
-    # Set up project root environment
-    project_root_path = tmp_path / "app" / "data"
-    project_root_path.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Set up project root environment
+        project_root_path = Path(temp_dir) / "app" / "data"
+        project_root_path.mkdir(parents=True, exist_ok=True)
 
-    monkeypatch.setenv("BASIC_MEMORY_PROJECT_ROOT", str(project_root_path))
+        monkeypatch.setenv("BASIC_MEMORY_PROJECT_ROOT", str(project_root_path))
 
-    # Invalidate config cache so it picks up the new env var
-    from basic_memory import config as config_module
+        # Invalidate config cache so it picks up the new env var
+        from basic_memory import config as config_module
 
-    config_module._CONFIG_CACHE = None
+        config_module._CONFIG_CACHE = None
 
-    test_cases = [
-        # (input_path, expected_normalized_path)
-        ("Documents/my-project", str(project_root_path / "documents" / "my-project")),
-        ("UPPERCASE/PATH", str(project_root_path / "uppercase" / "path")),
-        ("MixedCase/Path", str(project_root_path / "mixedcase" / "path")),
-        ("documents/Test-TWO", str(project_root_path / "documents" / "test-two")),
-    ]
+        test_cases = [
+            # (input_path, expected_normalized_path)
+            ("Documents/my-project", str(project_root_path / "documents" / "my-project")),
+            ("UPPERCASE/PATH", str(project_root_path / "uppercase" / "path")),
+            ("MixedCase/Path", str(project_root_path / "mixedcase" / "path")),
+            ("documents/Test-TWO", str(project_root_path / "documents" / "test-two")),
+        ]
 
-    for i, (input_path, expected_path) in enumerate(test_cases):
-        test_project_name = f"case-normalize-test-{i}"
+        for i, (input_path, expected_path) in enumerate(test_cases):
+            test_project_name = f"case-normalize-test-{i}"
 
-        try:
-            # Add the project
-            await project_service.add_project(test_project_name, input_path)
+            try:
+                # Add the project
+                await project_service.add_project(test_project_name, input_path)
 
-            # Verify the path was normalized to lowercase
-            assert test_project_name in project_service.projects
-            actual_path = project_service.projects[test_project_name]
-            assert actual_path == expected_path, (
-                f"Expected path {expected_path} but got {actual_path} for input {input_path}"
-            )
+                # Verify the path was normalized to lowercase (resolve both to handle macOS /private/var)
+                assert test_project_name in project_service.projects
+                actual_path = project_service.projects[test_project_name]
+                assert Path(actual_path).resolve() == Path(expected_path).resolve(), (
+                    f"Expected path {expected_path} but got {actual_path} for input {input_path}"
+                )
 
-            # Clean up
-            await project_service.remove_project(test_project_name)
+                # Clean up
+                await project_service.remove_project(test_project_name)
 
-        except ValueError as e:
-            pytest.fail(f"Unexpected ValueError for input path {input_path}: {e}")
+            except ValueError as e:
+                pytest.fail(f"Unexpected ValueError for input path {input_path}: {e}")
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Project root constraints only tested on POSIX systems")
 @pytest.mark.asyncio
 async def test_add_project_with_project_root_detects_case_collisions(
-    project_service: ProjectService, config_manager: ConfigManager, tmp_path, monkeypatch
+    project_service: ProjectService, config_manager: ConfigManager, monkeypatch
 ):
     """Test that BASIC_MEMORY_PROJECT_ROOT detects case-insensitive path collisions."""
-    # Set up project root environment
-    project_root_path = tmp_path / "app" / "data"
-    project_root_path.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Set up project root environment
+        project_root_path = Path(temp_dir) / "app" / "data"
+        project_root_path.mkdir(parents=True, exist_ok=True)
 
-    monkeypatch.setenv("BASIC_MEMORY_PROJECT_ROOT", str(project_root_path))
+        monkeypatch.setenv("BASIC_MEMORY_PROJECT_ROOT", str(project_root_path))
 
-    # Invalidate config cache so it picks up the new env var
-    from basic_memory import config as config_module
+        # Invalidate config cache so it picks up the new env var
+        from basic_memory import config as config_module
 
-    config_module._CONFIG_CACHE = None
+        config_module._CONFIG_CACHE = None
 
-    # First, create a project with lowercase path
-    first_project = "documents-project"
-    await project_service.add_project(first_project, "documents/basic-memory")
+        # First, create a project with lowercase path
+        first_project = "documents-project"
+        await project_service.add_project(first_project, "documents/basic-memory")
 
-    # Verify it was created with normalized lowercase path
-    assert first_project in project_service.projects
-    first_path = project_service.projects[first_project]
-    assert first_path == str(project_root_path / "documents" / "basic-memory")
+        # Verify it was created with normalized lowercase path (resolve to handle macOS /private/var)
+        assert first_project in project_service.projects
+        first_path = project_service.projects[first_project]
+        assert (
+            Path(first_path).resolve()
+            == (project_root_path / "documents" / "basic-memory").resolve()
+        )
 
-    # Now try to create a project with the same path but different case
-    # This should be normalized to the same lowercase path and not cause a collision
-    # since both will be normalized to the same path
-    second_project = "documents-project-2"
-    try:
-        # This should succeed because both get normalized to the same lowercase path
-        await project_service.add_project(second_project, "documents/basic-memory")
-        # If we get here, both should have the exact same path
-        second_path = project_service.projects[second_project]
-        assert second_path == first_path
+        # Now try to create a project with the same path but different case
+        # This should be normalized to the same lowercase path and not cause a collision
+        # since both will be normalized to the same path
+        second_project = "documents-project-2"
+        try:
+            # This should succeed because both get normalized to the same lowercase path
+            await project_service.add_project(second_project, "documents/basic-memory")
+            # If we get here, both should have the exact same path
+            second_path = project_service.projects[second_project]
+            assert second_path == first_path
 
-        # Clean up second project
-        await project_service.remove_project(second_project)
-    except ValueError:
-        # This is expected if there's already a project with this exact path
-        pass
+            # Clean up second project
+            await project_service.remove_project(second_project)
+        except ValueError:
+            # This is expected if there's already a project with this exact path
+            pass
 
-    # Clean up
-    await project_service.remove_project(first_project)
+        # Clean up
+        await project_service.remove_project(first_project)
+
+
+@pytest.mark.asyncio
+async def test_add_project_rejects_nested_child_path(project_service: ProjectService):
+    """Test that adding a project nested under an existing project fails."""
+    parent_project_name = f"parent-project-{os.urandom(4).hex()}"
+    # Use a completely separate temp directory to avoid fixture conflicts
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        parent_path = (test_root / "parent").as_posix()
+
+        # Create parent directory
+        os.makedirs(parent_path, exist_ok=True)
+
+        try:
+            # Add parent project
+            await project_service.add_project(parent_project_name, parent_path)
+
+            # Try to add a child project nested under parent
+            child_project_name = f"child-project-{os.urandom(4).hex()}"
+            child_path = (test_root / "parent" / "child").as_posix()
+
+            with pytest.raises(ValueError, match="nested within existing project"):
+                await project_service.add_project(child_project_name, child_path)
+
+        finally:
+            # Clean up
+            if parent_project_name in project_service.projects:
+                await project_service.remove_project(parent_project_name)
+
+
+@pytest.mark.asyncio
+async def test_add_project_rejects_parent_path_over_existing_child(project_service: ProjectService):
+    """Test that adding a parent project over an existing nested project fails."""
+    child_project_name = f"child-project-{os.urandom(4).hex()}"
+    # Use a completely separate temp directory to avoid fixture conflicts
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        child_path = (test_root / "parent" / "child").as_posix()
+
+        # Create child directory
+        os.makedirs(child_path, exist_ok=True)
+
+        try:
+            # Add child project
+            await project_service.add_project(child_project_name, child_path)
+
+            # Try to add a parent project that contains the child
+            parent_project_name = f"parent-project-{os.urandom(4).hex()}"
+            parent_path = (test_root / "parent").as_posix()
+
+            with pytest.raises(ValueError, match="is nested within this path"):
+                await project_service.add_project(parent_project_name, parent_path)
+
+        finally:
+            # Clean up
+            if child_project_name in project_service.projects:
+                await project_service.remove_project(child_project_name)
+
+
+@pytest.mark.asyncio
+async def test_add_project_allows_sibling_paths(project_service: ProjectService):
+    """Test that adding sibling projects (same level, different directories) succeeds."""
+    project1_name = f"sibling-project-1-{os.urandom(4).hex()}"
+    project2_name = f"sibling-project-2-{os.urandom(4).hex()}"
+
+    # Use a completely separate temp directory to avoid fixture conflicts
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        project1_path = (test_root / "sibling1").as_posix()
+        project2_path = (test_root / "sibling2").as_posix()
+
+        # Create directories
+        os.makedirs(project1_path, exist_ok=True)
+        os.makedirs(project2_path, exist_ok=True)
+
+        try:
+            # Add first sibling project
+            await project_service.add_project(project1_name, project1_path)
+
+            # Add second sibling project (should succeed)
+            await project_service.add_project(project2_name, project2_path)
+
+            # Verify both exist
+            assert project1_name in project_service.projects
+            assert project2_name in project_service.projects
+
+        finally:
+            # Clean up
+            if project1_name in project_service.projects:
+                await project_service.remove_project(project1_name)
+            if project2_name in project_service.projects:
+                await project_service.remove_project(project2_name)
+
+
+@pytest.mark.asyncio
+async def test_add_project_rejects_deeply_nested_path(project_service: ProjectService):
+    """Test that deeply nested paths are also rejected."""
+    root_project_name = f"root-project-{os.urandom(4).hex()}"
+
+    # Use a completely separate temp directory to avoid fixture conflicts
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        root_path = (test_root / "root").as_posix()
+
+        # Create root directory
+        os.makedirs(root_path, exist_ok=True)
+
+        try:
+            # Add root project
+            await project_service.add_project(root_project_name, root_path)
+
+            # Try to add a deeply nested project
+            nested_project_name = f"nested-project-{os.urandom(4).hex()}"
+            nested_path = (test_root / "root" / "level1" / "level2" / "level3").as_posix()
+
+            with pytest.raises(ValueError, match="nested within existing project"):
+                await project_service.add_project(nested_project_name, nested_path)
+
+        finally:
+            # Clean up
+            if root_project_name in project_service.projects:
+                await project_service.remove_project(root_project_name)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Project root constraints only tested on POSIX systems")
+@pytest.mark.asyncio
+async def test_add_project_nested_validation_with_project_root(
+    project_service: ProjectService, config_manager: ConfigManager, monkeypatch
+):
+    """Test that nested path validation works with BASIC_MEMORY_PROJECT_ROOT set."""
+    # Use a completely separate temp directory to avoid fixture conflicts
+    with tempfile.TemporaryDirectory() as temp_dir:
+        project_root_path = Path(temp_dir) / "app" / "data"
+        project_root_path.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setenv("BASIC_MEMORY_PROJECT_ROOT", str(project_root_path))
+
+        # Invalidate config cache
+        from basic_memory import config as config_module
+
+        config_module._CONFIG_CACHE = None
+
+        parent_project_name = f"cloud-parent-{os.urandom(4).hex()}"
+        child_project_name = f"cloud-child-{os.urandom(4).hex()}"
+
+        try:
+            # Add parent project (normalized to lowercase)
+            await project_service.add_project(parent_project_name, "parent-folder")
+
+            # Verify it was created
+            assert parent_project_name in project_service.projects
+            parent_actual_path = project_service.projects[parent_project_name]
+            # Resolve both paths to handle macOS /private/var vs /var differences
+            assert (
+                Path(parent_actual_path).resolve()
+                == (project_root_path / "parent-folder").resolve()
+            )
+
+            # Try to add a child project nested under parent (should fail)
+            with pytest.raises(ValueError, match="nested within existing project"):
+                await project_service.add_project(child_project_name, "parent-folder/child-folder")
+
+        finally:
+            # Clean up
+            if parent_project_name in project_service.projects:
+                await project_service.remove_project(parent_project_name)

--- a/tests/services/test_project_service_operations.py
+++ b/tests/services/test_project_service_operations.py
@@ -1,6 +1,8 @@
 """Additional tests for ProjectService operations."""
 
 import os
+import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -9,95 +11,101 @@ from basic_memory.services.project_service import ProjectService
 
 
 @pytest.mark.asyncio
-async def test_get_project_from_database(project_service: ProjectService, tmp_path):
+async def test_get_project_from_database(project_service: ProjectService):
     """Test getting projects from the database."""
     # Generate unique project name for testing
     test_project_name = f"test-project-{os.urandom(4).hex()}"
-    test_path = str(tmp_path / "test-project")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_path = str(test_root / "test-project")
 
-    # Make sure directory exists
-    os.makedirs(test_path, exist_ok=True)
+        # Make sure directory exists
+        os.makedirs(test_path, exist_ok=True)
 
-    try:
-        # Add a project to the database
-        project_data = {
-            "name": test_project_name,
-            "path": test_path,
-            "permalink": test_project_name.lower().replace(" ", "-"),
-            "is_active": True,
-            "is_default": False,
-        }
-        await project_service.repository.create(project_data)
+        try:
+            # Add a project to the database
+            project_data = {
+                "name": test_project_name,
+                "path": test_path,
+                "permalink": test_project_name.lower().replace(" ", "-"),
+                "is_active": True,
+                "is_default": False,
+            }
+            await project_service.repository.create(project_data)
 
-        # Verify we can get the project
-        project = await project_service.repository.get_by_name(test_project_name)
-        assert project is not None
-        assert project.name == test_project_name
-        assert project.path == test_path
+            # Verify we can get the project
+            project = await project_service.repository.get_by_name(test_project_name)
+            assert project is not None
+            assert project.name == test_project_name
+            assert project.path == test_path
 
-    finally:
-        # Clean up
-        project = await project_service.repository.get_by_name(test_project_name)
-        if project:
-            await project_service.repository.delete(project.id)
+        finally:
+            # Clean up
+            project = await project_service.repository.get_by_name(test_project_name)
+            if project:
+                await project_service.repository.delete(project.id)
 
 
 @pytest.mark.asyncio
-async def test_add_project_to_config(project_service: ProjectService, tmp_path, config_manager):
+async def test_add_project_to_config(project_service: ProjectService, config_manager):
     """Test adding a project to the config manager."""
     # Generate unique project name for testing
     test_project_name = f"config-project-{os.urandom(4).hex()}"
-    test_path = (tmp_path / "config-project").as_posix()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        test_path = (test_root / "config-project").as_posix()
 
-    # Make sure directory exists
-    os.makedirs(test_path, exist_ok=True)
+        # Make sure directory exists
+        os.makedirs(test_path, exist_ok=True)
 
-    try:
-        # Add a project to config only (using ConfigManager directly)
-        config_manager.add_project(test_project_name, test_path)
+        try:
+            # Add a project to config only (using ConfigManager directly)
+            config_manager.add_project(test_project_name, test_path)
 
-        # Verify it's in the config
-        assert test_project_name in project_service.projects
-        assert project_service.projects[test_project_name] == test_path
+            # Verify it's in the config
+            assert test_project_name in project_service.projects
+            assert project_service.projects[test_project_name] == test_path
 
-    finally:
-        # Clean up
-        if test_project_name in project_service.projects:
-            config_manager.remove_project(test_project_name)
+        finally:
+            # Clean up
+            if test_project_name in project_service.projects:
+                config_manager.remove_project(test_project_name)
 
 
 @pytest.mark.asyncio
-async def test_update_project_path(project_service: ProjectService, tmp_path, config_manager):
+async def test_update_project_path(project_service: ProjectService, config_manager):
     """Test updating a project's path."""
     # Create a test project
     test_project = f"path-update-test-project-{os.urandom(4).hex()}"
-    original_path = (tmp_path / "original-path").as_posix()
-    new_path = (tmp_path / "new-path").as_posix()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_root = Path(temp_dir)
+        original_path = (test_root / "original-path").as_posix()
+        new_path = (test_root / "new-path").as_posix()
 
-    # Make sure directories exist
-    os.makedirs(original_path, exist_ok=True)
-    os.makedirs(new_path, exist_ok=True)
+        # Make sure directories exist
+        os.makedirs(original_path, exist_ok=True)
+        os.makedirs(new_path, exist_ok=True)
 
-    try:
-        # Add the project
-        await project_service.add_project(test_project, original_path)
+        try:
+            # Add the project
+            await project_service.add_project(test_project, original_path)
 
-        # Mock the update_project method to avoid issues with complex DB updates
-        with patch.object(project_service, "update_project"):
-            # Just check if the project exists
-            project = await project_service.repository.get_by_name(test_project)
-            assert project is not None
-            assert project.path == original_path
-
-        # Since we mock the update_project method, we skip verifying path updates
-
-    finally:
-        # Clean up
-        if test_project in project_service.projects:
-            try:
+            # Mock the update_project method to avoid issues with complex DB updates
+            with patch.object(project_service, "update_project"):
+                # Just check if the project exists
                 project = await project_service.repository.get_by_name(test_project)
-                if project:
-                    await project_service.repository.delete(project.id)
-                config_manager.remove_project(test_project)
-            except Exception:
-                pass
+                assert project is not None
+                assert project.path == original_path
+
+            # Since we mock the update_project method, we skip verifying path updates
+
+        finally:
+            # Clean up
+            if test_project in project_service.projects:
+                try:
+                    project = await project_service.repository.get_by_name(test_project)
+                    if project:
+                        await project_service.repository.delete(project.id)
+                    config_manager.remove_project(test_project)
+                except Exception:
+                    pass


### PR DESCRIPTION
## Summary

Implements validation to prevent creating projects where one is nested within another (e.g., `/some-project` and `/some-project/some-nested-project`). This addresses data isolation and file ownership conflicts.

## Changes

- **Core Implementation**: Added `_check_nested_paths()` helper method in `ProjectService` to detect nested paths using `Path.resolve()` and `relative_to()`
- **Validation**: Added nested path checking in `add_project()` that validates against all existing projects
- **Works in both modes**: Validation applies to both local and cloud modes (with `BASIC_MEMORY_PROJECT_ROOT`)
- **Comprehensive tests**: 
  - 5 new unit tests for nested path validation
  - MCP integration test for tool error messaging
  - Fixed test isolation issues in ~20 tests using `tempfile.TemporaryDirectory()`
  - Fixed macOS path resolution issues using `Path.resolve()` for symlinks

## Error Messages

Clear, actionable error messages:
```
Cannot create project at '/path/to/child': path is nested within existing project 
'parent-project' at '/path/to/parent'. Projects cannot share directory trees.
```

## Testing

- ✅ All unit tests pass (33 tests in test_project_service.py)
- ✅ All integration tests pass (MCP and CLI)
- ✅ macOS path resolution handled (/var → /private/var symlinks)
- ⏳ Windows tests pending (CI will verify)

## Fixes

Fixes basicmachines-co/basic-memory-cloud#107

🤖 Generated with [Claude Code](https://claude.com/claude-code)