### PR TITLE
fix: correct ProjectItem.home property to return path instead of name

### DIFF
--- a/src/basic_memory/schemas/project_info.py
+++ b/src/basic_memory/schemas/project_info.py
@@ -183,7 +183,7 @@ class ProjectItem(BaseModel):
 
     @property
     def home(self) -> Path:  # pragma: no cover
-        return Path(self.name)
+        return Path(self.path)
 
     @property
     def project_url(self) -> str:  # pragma: no cover


### PR DESCRIPTION
## Summary

Fixed a critical bug in `ProjectItem.home` property that was returning the project name instead of the project path. This caused path validation failures in MCP tools, resulting in notes being created outside of project directories.

## Changes

- Changed `ProjectItem.home` property in `src/basic_memory/schemas/project_info.py` to return `Path(self.path)` instead of `Path(self.name)`

## Impact

This fix affects all MCP tools that use `active_project.home` for path validation:
- `write_note` - validates folder paths when creating notes
- `read_note` - validates paths when reading notes
- `read_content` - validates paths when reading content
- `move_note` - validates paths when moving notes
- `sync_status` - displays project path in status

## Test Plan

1. Create a project with a path like `~/Documents/Test Project`
2. Create a note in that project with a folder path like `documents`
3. Verify the note is created within the project directory
4. Verify path validation still blocks traversal attempts

Fixes #340

Generated with [Claude Code](https://claude.ai/code)