### PR TITLE
fix: Handle None text values in Claude conversations importer

### DIFF
--- a/src/basic_memory/importers/claude_conversations_importer.py
+++ b/src/basic_memory/importers/claude_conversations_importer.py
@@ -153,7 +153,11 @@ class ClaudeConversationsImporter(Importer[ChatImportResult]):
             # Handle message content
             content = msg.get("text", "")
             if msg.get("content"):
-                content = " ".join(c.get("text", "") for c in msg["content"])
+                # Filter out None values before joining
+                content = " ".join(
+                    str(c.get("text", "")) for c in msg["content"]
+                    if c and c.get("text") is not None
+                )
             lines.append(content)
 
             # Handle attachments

--- a/tests/cli/test_import_claude_conversations.py
+++ b/tests/cli/test_import_claude_conversations.py
@@ -149,3 +149,55 @@ def test_import_conversation_with_attachments(tmp_path):
     assert "**Attachment: test.txt**" in content
     assert "```" in content
     assert "Test file content" in content
+
+
+def test_import_conversation_with_none_text_values(tmp_path):
+    """Test importing conversation with None text values in content array (issue #236)."""
+    # Create conversation with None text values
+    conversation = {
+        "uuid": "test-uuid",
+        "name": "Test With None Text",
+        "created_at": "2025-01-05T20:55:32.499880+00:00",
+        "updated_at": "2025-01-05T20:56:39.477600+00:00",
+        "chat_messages": [
+            {
+                "uuid": "msg-1",
+                "text": None,
+                "sender": "human",
+                "created_at": "2025-01-05T20:55:32.499880+00:00",
+                "content": [
+                    {"type": "text", "text": "Valid text here"},
+                    {"type": "text", "text": None},  # This caused the TypeError
+                    {"type": "text", "text": "More valid text"},
+                ],
+            },
+            {
+                "uuid": "msg-2",
+                "text": None,
+                "sender": "assistant",
+                "created_at": "2025-01-05T20:55:40.123456+00:00",
+                "content": [
+                    {"type": "text", "text": None},  # All None case
+                    {"type": "text", "text": None},
+                ],
+            },
+        ],
+    }
+
+    json_file = tmp_path / "with_none_text.json"
+    with open(json_file, "w", encoding="utf-8") as f:
+        json.dump([conversation], f)
+
+    config = get_project_config()
+    config.home = tmp_path
+
+    # Run import - should not fail with TypeError
+    result = runner.invoke(app, ["import", "claude", "conversations", str(json_file)])
+    assert result.exit_code == 0
+
+    # Check that valid text is preserved and None values are filtered out
+    conv_path = tmp_path / "conversations/20250105-Test_With_None_Text.md"
+    assert conv_path.exists()
+    content = conv_path.read_text(encoding="utf-8")
+    assert "Valid text here" in content
+    assert "More valid text" in content


### PR DESCRIPTION
### Description

This PR fixes the TypeError that occurs when importing Claude conversations containing None text values in the content array.

### Problem

The importer failed with `TypeError: sequence item 2: expected str instance, NoneType found` when trying to join text content that included None values. This affected approximately 10% of messages in exported Claude conversations.

### Solution

- Added robust handling to filter out None values before joining text content
- Ensures all text values are converted to strings
- Handles edge cases including all-None content arrays

### Testing

Added comprehensive test case `test_import_conversation_with_none_text_values()` that reproduces the exact scenario from issue #236 and verifies the fix works correctly.

Fixes #236

Generated with [Claude Code](https://claude.ai/code)