### PR TITLE
fix: Terminate sync immediately when project is deleted

### DIFF
--- a/src/basic_memory/services/exceptions.py
+++ b/src/basic_memory/services/exceptions.py
@@ -20,3 +20,18 @@ class DirectoryOperationError(Exception):
     """Raised when directory operations fail"""
 
     pass
+
+
+class SyncFatalError(Exception):
+    """Raised when sync encounters a fatal error that prevents continuation.
+
+    Fatal errors include:
+    - Project deleted during sync (FOREIGN KEY constraint)
+    - Database corruption
+    - Critical system failures
+
+    When this exception is raised, the entire sync operation should be terminated
+    immediately rather than attempting to continue with remaining files.
+    """
+
+    pass


### PR DESCRIPTION
## Summary
Fixes #188 where sync fails with FOREIGN KEY constraint violations when a project is deleted during sync operations.

## Problem
When a project is deleted mid-sync, every file fails with a FOREIGN KEY constraint error. The circuit breaker treats these as file-level errors and retries each file 3 times, wasting resources before eventually skipping them all.

## Solution
Introduced `SyncFatalError` exception to distinguish between:
- **Fatal errors** (project deleted, database corrupt) → terminate sync immediately
- **Recoverable errors** (bad markdown, parse errors) → circuit breaker handles normally

## Changes
- Added `SyncFatalError` exception in `services/exceptions.py`
- Modified `entity_repository.upsert_entity()` to detect FOREIGN KEY constraint failures and raise `SyncFatalError` with clear message
- Updated `sync_service.sync_file()` to check exception chain for `SyncFatalError` and re-raise immediately
- Added repository-level test in `test_entity_repository_upsert.py`
- Added integration test in `test_sync_service.py` to verify sync terminates immediately

## Behavior
**Before:**
- Project deleted during sync → every file fails with FOREIGN KEY error
- Circuit breaker tries 3 times per file → wastes time and resources
- Eventually skips all files after repeated failures

**After:**
- Project deleted during sync → first file fails with FOREIGN KEY error
- `SyncFatalError` is raised and propagates through exception chain
- Sync terminates immediately with clear error message
- No wasted retries on remaining files

## Test Plan
- ✅ Repository test verifies `SyncFatalError` is raised with correct message
- ✅ Integration test verifies sync terminates immediately without circuit breaker retry
- ✅ All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)