### PR TITLE
fix: Handle YAML parsing errors and missing entity_type in markdown files

### DIFF
--- a/tests/markdown/test_entity_parser_error_handling.py
+++ b/tests/markdown/test_entity_parser_error_handling.py
@@ -1,0 +1,216 @@
+"""Tests for entity parser error handling (issues #184 and #185)."""
+
+import pytest
+from pathlib import Path
+from textwrap import dedent
+
+from basic_memory.markdown.entity_parser import EntityParser
+
+
+@pytest.mark.asyncio
+async def test_parse_file_with_malformed_yaml_frontmatter(tmp_path):
+    """Test that files with malformed YAML frontmatter are parsed gracefully (issue #185).
+
+    This reproduces the production error where block sequence entries cause YAML parsing to fail.
+    The parser should handle the error gracefully and treat the file as plain markdown.
+    """
+    # Create a file with malformed YAML frontmatter
+    test_file = tmp_path / "malformed.md"
+    content = dedent(
+        """
+        ---
+        title: Group Chat Texts
+        tags:
+          - family    # Line 5, column 7 - this syntax can fail in certain YAML contexts
+          - messages
+        type: note
+        ---
+        # Group Chat Texts
+
+        Content here
+        """
+    ).strip()
+    test_file.write_text(content)
+
+    # Parse the file - should not raise YAMLError
+    parser = EntityParser(tmp_path)
+    result = await parser.parse_file(test_file)
+
+    # Should successfully parse, treating as plain markdown if YAML fails
+    assert result is not None
+    # If YAML parsing succeeded, verify expected values
+    # If it failed, it should have defaults
+    assert result.frontmatter.title is not None
+    assert result.frontmatter.type is not None
+
+
+@pytest.mark.asyncio
+async def test_parse_file_with_completely_invalid_yaml(tmp_path):
+    """Test that files with completely invalid YAML are handled gracefully (issue #185).
+
+    This tests the extreme case where YAML parsing completely fails.
+    """
+    # Create a file with completely broken YAML
+    test_file = tmp_path / "broken_yaml.md"
+    content = dedent(
+        """
+        ---
+        title: Invalid YAML
+        this is: [not, valid, yaml
+        missing: closing bracket
+        ---
+        # Content
+
+        This file has broken YAML frontmatter.
+        """
+    ).strip()
+    test_file.write_text(content)
+
+    # Parse the file - should not raise exception
+    parser = EntityParser(tmp_path)
+    result = await parser.parse_file(test_file)
+
+    # Should successfully parse with defaults
+    assert result is not None
+    assert result.frontmatter.title == "broken_yaml"  # Default from filename
+    assert result.frontmatter.type == "note"  # Default type
+    # Content should include the whole file since frontmatter parsing failed
+    assert "# Content" in result.content
+
+
+@pytest.mark.asyncio
+async def test_parse_file_without_entity_type(tmp_path):
+    """Test that files without entity_type get a default value (issue #184).
+
+    This reproduces the NOT NULL constraint error where entity_type was missing.
+    """
+    # Create a file without entity_type in frontmatter
+    test_file = tmp_path / "no_type.md"
+    content = dedent(
+        """
+        ---
+        title: The Invisible Weight of Mental Habits
+        ---
+        # The Invisible Weight of Mental Habits
+
+        An article about mental habits.
+        """
+    ).strip()
+    test_file.write_text(content)
+
+    # Parse the file
+    parser = EntityParser(tmp_path)
+    result = await parser.parse_file(test_file)
+
+    # Should have default entity_type
+    assert result is not None
+    assert result.frontmatter.type == "note"  # Default type applied
+    assert result.frontmatter.title == "The Invisible Weight of Mental Habits"
+
+
+@pytest.mark.asyncio
+async def test_parse_file_with_empty_frontmatter(tmp_path):
+    """Test that files with empty frontmatter get defaults (issue #184)."""
+    # Create a file with empty frontmatter
+    test_file = tmp_path / "empty_frontmatter.md"
+    content = dedent(
+        """
+        ---
+        ---
+        # Content
+
+        This file has empty frontmatter.
+        """
+    ).strip()
+    test_file.write_text(content)
+
+    # Parse the file
+    parser = EntityParser(tmp_path)
+    result = await parser.parse_file(test_file)
+
+    # Should have defaults
+    assert result is not None
+    assert result.frontmatter.type == "note"  # Default type
+    assert result.frontmatter.title == "empty_frontmatter"  # Default from filename
+
+
+@pytest.mark.asyncio
+async def test_parse_file_without_frontmatter(tmp_path):
+    """Test that files without any frontmatter get defaults (issue #184)."""
+    # Create a file with no frontmatter at all
+    test_file = tmp_path / "no_frontmatter.md"
+    content = dedent(
+        """
+        # Just Content
+
+        This file has no frontmatter at all.
+        """
+    ).strip()
+    test_file.write_text(content)
+
+    # Parse the file
+    parser = EntityParser(tmp_path)
+    result = await parser.parse_file(test_file)
+
+    # Should have defaults
+    assert result is not None
+    assert result.frontmatter.type == "note"  # Default type
+    assert result.frontmatter.title == "no_frontmatter"  # Default from filename
+
+
+@pytest.mark.asyncio
+async def test_parse_file_with_null_entity_type(tmp_path):
+    """Test that files with explicit null entity_type get default (issue #184)."""
+    # Create a file with null/None entity_type
+    test_file = tmp_path / "null_type.md"
+    content = dedent(
+        """
+        ---
+        title: Test File
+        type: null
+        ---
+        # Content
+        """
+    ).strip()
+    test_file.write_text(content)
+
+    # Parse the file
+    parser = EntityParser(tmp_path)
+    result = await parser.parse_file(test_file)
+
+    # Should have default type even when explicitly set to null
+    assert result is not None
+    assert result.frontmatter.type == "note"  # Default type applied
+    assert result.frontmatter.title == "Test File"
+
+
+@pytest.mark.asyncio
+async def test_parse_valid_file_still_works(tmp_path):
+    """Test that valid files with proper frontmatter still parse correctly."""
+    # Create a valid file
+    test_file = tmp_path / "valid.md"
+    content = dedent(
+        """
+        ---
+        title: Valid File
+        type: knowledge
+        tags:
+          - test
+          - valid
+        ---
+        # Valid File
+
+        This is a properly formatted file.
+        """
+    ).strip()
+    test_file.write_text(content)
+
+    # Parse the file
+    parser = EntityParser(tmp_path)
+    result = await parser.parse_file(test_file)
+
+    # Should parse correctly with all values
+    assert result is not None
+    assert result.frontmatter.title == "Valid File"
+    assert result.frontmatter.type == "knowledge"
+    assert result.frontmatter.tags == ["test", "valid"]


### PR DESCRIPTION
## Issues Fixed

Fixes basicmachines-co/basic-memory-cloud#184
Fixes basicmachines-co/basic-memory-cloud#185

### Issue #184: NOT NULL constraint on entity_type
**Problem**: Sync was failing with database constraint violations when markdown files were missing the `type` field in frontmatter or had it explicitly set to `null`.

**Error from production (41 occurrences in 24 hours)**:
```
NOT NULL constraint failed: entity.entity_type
Failed to upsert entity for Archive/articles published/The Invisible Weight of Mental Habits.md
```

**Root cause**: Files without `type` field or with `type: null` resulted in None being passed to the database, violating the NOT NULL constraint.

### Issue #185: YAML parsing errors causing sync failures  
**Problem**: Files with malformed YAML frontmatter caused sync to fail completely, leading to:
- **12+ minute sync operations** (for just 2 files - normally processes thousands in seconds)
- Infinite retry loops with circuit breaker
- Keepalive ping failures during extended operations
- Complete blocking of sync for entire knowledge base

**Error from production**:
```
Failed to sync file: path=family/mom/_archive/group-chat-texts-00601-01200-paste.md
error=block sequence entries are not allowed in this context 
in "<unicode string>", line 5, column 7
```

**Root cause**: Malformed YAML syntax (e.g., unexpected list syntax) caused python-frontmatter to raise YAMLError, which wasn't being caught, causing the entire sync to fail.

## Solution

### Changes to `src/basic_memory/markdown/entity_parser.py`

1. **Added YAML error handling** (Issue #185):
   - Wrapped `frontmatter.loads()` in try/catch for `yaml.YAMLError`
   - On parsing failure: log warning with file context, treat as plain markdown
   - Allows sync to continue processing other files

2. **Enhanced entity_type defaults** (Issue #184):
   - Explicitly check for `None` values (not just missing keys)
   - Always ensure entity_type is set to "note" when missing or null
   - Handles both `type:` (missing) and `type: null` (explicit null) cases

### New comprehensive tests

Created `tests/markdown/test_entity_parser_error_handling.py` with 7 tests:
- ✅ Malformed YAML frontmatter (Issue #185 reproduction)
- ✅ Completely invalid YAML (extreme case)
- ✅ Missing entity_type field (Issue #184 reproduction)
- ✅ Empty frontmatter
- ✅ No frontmatter at all
- ✅ Explicit `type: null` (edge case)
- ✅ Valid files still work correctly (regression check)

## Impact

### Robustness
- Files with YAML errors no longer block entire sync operation
- Graceful degradation: treat malformed files as plain markdown
- Better error messages with file context for debugging

### Performance
- Eliminates 12+ minute sync hangs from single bad files
- Prevents infinite retry loops on problematic files
- Works seamlessly with circuit breaker mechanism (#364)

### Data Integrity
- All files get synced with appropriate defaults
- No more silent failures or missing content in database
- Users can find and fix problematic files from logs

### Code Quality
- **Markdown parsing module now has 100% test coverage**
- All 43 markdown tests pass (7 new, 36 existing)
- No regressions in existing functionality

## Testing

```bash
$ uv run pytest tests/markdown/ -v
================================ 43 passed in 8.49s ================================

# Coverage for markdown module
src/basic_memory/markdown/entity_parser.py         68      0   100%
src/basic_memory/markdown/markdown_processor.py    49      0   100%
src/basic_memory/markdown/plugins.py              119      0   100%
src/basic_memory/markdown/schemas.py               43      0   100%
```

## Related

- Works with circuit breaker from #364
- Complements upsert fix from #367
- Addresses production issues from basic-memory-cloud repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)