### PR TITLE
fix: Prevent deleted projects from being recreated by background sync (#193)

### DIFF
--- a/src/basic_memory/sync/watch_service.py
+++ b/src/basic_memory/sync/watch_service.py
@@ -236,6 +236,17 @@ class WatchService:
         # avoid circular imports
         from basic_memory.sync.sync_service import get_sync_service
 
+        # Check if project still exists in configuration before processing
+        # This prevents deleted projects from being recreated by background sync
+        from basic_memory.config import ConfigManager
+        config_manager = ConfigManager()
+        if project.name not in config_manager.projects and project.permalink not in config_manager.projects:
+            logger.info(
+                f"Skipping sync for deleted project: {project.name}, "
+                f"change_count={len(changes)}"
+            )
+            return
+
         sync_service = await get_sync_service(project)
         file_service = sync_service.file_service
 


### PR DESCRIPTION
## Summary

Fixes issue #193 from basic-memory-cloud where deleted projects would reappear after being removed by the user. This issue affected both local and cloud deployments.

## Root Cause

When a project was deleted, the directory still existed on disk, and two different mechanisms would resurrect it:

1. **Background sync (watch_service)**: Would continue processing file changes in the deleted project's directory, causing database entries to be recreated
2. **Project synchronization**: Would re-add projects from the database back to the configuration file, treating the database as the source of truth when it should be the config file

## Evidence from Cloud

Timeline from Logfire for tenant `0a20eb58-970f-ab05-ff49-25a9cdb2179c`:
- 09:01:10 - DELETE /projects/chris-ledoux-personal-info → 200 OK (deleted successfully)
- 10:21:40 - DELETE /projects/chris-ledoux-personal-info → 400 Bad Request (project exists again!)
- 10:22:01 - DELETE /projects/chris-ledoux-personal-info → 200 OK (deleted again)

The cloud sync worker runs `reconcile_projects_with_config()` every 30 seconds, which was calling `synchronize_projects()` and re-adding the deleted project back to config from the database.

## Changes Made

**`src/basic_memory/sync/watch_service.py`** (lines 241-251):
- Added configuration check in `handle_changes()` before processing file changes
- If project doesn't exist in config, skip sync to prevent recreation
- Logs: "Skipping sync for deleted project"

**`src/basic_memory/services/project_service.py`** (lines 363-371):
- Changed `synchronize_projects()` behavior for DB-only projects
- **Before**: Added projects from DB to config (bidirectional sync)
- **After**: Removes projects from DB that don't exist in config (config is source of truth)
- Logs: "Removing project '{name}' from database (deleted from config, source of truth)"

**Tests Added**:
- `test_handle_changes_skips_deleted_project` in `tests/sync/test_watch_service.py`
- `test_synchronize_projects_removes_db_only_projects` in `tests/services/test_project_service.py`

## Impact

This fix ensures that:
1. Config file is the single source of truth for project existence
2. Deleted projects stay deleted even when their directories remain on disk
3. Background sync workers in the cloud won't resurrect deleted projects
4. The `reconcile_projects_with_config()` function now properly cleans up orphaned DB entries

## Test Plan

- [x] Both new tests pass
- [x] All existing watch service tests pass (15 tests)
- [x] All existing project service tests pass (35+ tests)
- [x] Fix validates config as source of truth for both local and cloud scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)