### PR TITLE
fix: Handle YAML parsing errors gracefully in update_frontmatter (#378)

### DIFF
--- a/src/basic_memory/file_utils.py
+++ b/src/basic_memory/file_utils.py
@@ -210,11 +210,20 @@ async def update_frontmatter(path: FilePath, updates: Dict[str, Any]) -> str:
         # Read current content
         content = path_obj.read_text(encoding="utf-8")
 
-        # Parse current frontmatter
+        # Parse current frontmatter with proper error handling for malformed YAML
         current_fm = {}
         if has_frontmatter(content):
-            current_fm = parse_frontmatter(content)
-            content = remove_frontmatter(content)
+            try:
+                current_fm = parse_frontmatter(content)
+                content = remove_frontmatter(content)
+            except (ParseError, yaml.YAMLError) as e:
+                # Log warning and treat as plain markdown without frontmatter
+                logger.warning(
+                    f"Failed to parse YAML frontmatter in {path_obj}: {e}. "
+                    "Treating file as plain markdown without frontmatter."
+                )
+                # Keep full content, treat as having no frontmatter
+                current_fm = {}
 
         # Update frontmatter
         new_fm = {**current_fm, **updates}
@@ -229,11 +238,13 @@ async def update_frontmatter(path: FilePath, updates: Dict[str, Any]) -> str:
         return await compute_checksum(final_content)
 
     except Exception as e:  # pragma: no cover
-        logger.error(
-            "Failed to update frontmatter",
-            path=str(path) if isinstance(path, (str, Path)) else "<unknown>",
-            error=str(e),
-        )
+        # Only log real errors (not YAML parsing, which is handled above)
+        if not isinstance(e, (ParseError, yaml.YAMLError)):
+            logger.error(
+                "Failed to update frontmatter",
+                path=str(path) if isinstance(path, (str, Path)) else "<unknown>",
+                error=str(e),
+            )
         raise FileError(f"Failed to update frontmatter: {e}")
 
 

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -260,6 +260,37 @@ async def test_update_frontmatter_errors(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_update_frontmatter_handles_malformed_yaml(tmp_path: Path):
+    """Test that update_frontmatter handles malformed YAML gracefully (issue #378)."""
+    test_file = tmp_path / "test.md"
+
+    # Create file with malformed YAML frontmatter (colon in title breaks YAML)
+    content = """---
+title: KB: Something
+---
+
+# Test Content
+
+Some content here"""
+    test_file.write_text(content)
+
+    # Should handle gracefully and treat as having no frontmatter
+    updates = {"title": "Fixed Title", "type": "note"}
+    await update_frontmatter(test_file, updates)
+
+    # Verify file was updated successfully
+    updated = test_file.read_text(encoding="utf-8")
+    assert "title: Fixed Title" in updated
+    assert "type: note" in updated
+    assert "Test Content" in updated
+    assert "Some content here" in updated
+
+    # Verify new frontmatter is valid
+    fm = parse_frontmatter(updated)
+    assert fm == updates
+
+
+@pytest.mark.asyncio
 def test_sanitize_for_filename_removes_invalid_characters():
     # Test all invalid characters listed in the regex
     invalid_chars = '<>:"|?*'


### PR DESCRIPTION
## Summary

Fixes #378 - `update_frontmatter()` now handles malformed YAML frontmatter gracefully instead of logging errors.

## Problem

The `update_frontmatter()` function was logging ERROR (level 17) for malformed YAML frontmatter, even though the system should handle these gracefully. This caused **1,112+ errors per 3 hours** in production from files with titles like `KB: Something` where the second colon breaks YAML parsing.

PR #368 fixed this issue in the entity parser (reading), but `update_frontmatter()` (writing) has a separate code path that wasn't updated.

## Solution

Applied the same error handling pattern from PR #368's `entity_parser.py`:

1. Catch `ParseError` and `yaml.YAMLError` when parsing frontmatter
2. Log as **WARNING (level 13)** instead of ERROR
3. Treat file as having no frontmatter
4. Proceed with update using new valid frontmatter
5. Only log ERROR for actual file operation failures

## Changes

- **`src/basic_memory/file_utils.py:213-248`**: Added graceful YAML error handling
- **`tests/utils/test_file_utils.py:262-290`**: Added test for malformed YAML handling

## Test Coverage

New test `test_update_frontmatter_handles_malformed_yaml` verifies:
- Files with malformed YAML (e.g., `title: KB: Something`) are handled gracefully
- Frontmatter is updated successfully with valid YAML
- Content is preserved

## Expected Impact

- ✅ Error count drops from 1,112/3hrs to ~0 in production
- ✅ YAML parsing errors logged as WARNING instead of ERROR
- ✅ Files with malformed frontmatter get updated successfully  
- ✅ Real file operation errors still logged as ERROR

## Related

- Issue #378
- PR #368 - Fixed similar issue in entity parser
- Issue basicmachines-co/basic-memory-cloud#185 - Original YAML parsing errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)