### PR TITLE
fix: Optimize sync memory usage to prevent OOM on large projects

### DIFF
--- a/src/basic_memory/config.py
+++ b/src/basic_memory/config.py
@@ -84,7 +84,13 @@ class BasicMemoryConfig(BaseSettings):
 
     sync_thread_pool_size: int = Field(
         default=4,
-        description="Size of thread pool for file I/O operations in sync service",
+        description="Size of thread pool for file I/O operations in sync service. Default of 4 is optimized for cloud deployments with 1-2GB RAM.",
+        gt=0,
+    )
+
+    sync_max_concurrent_files: int = Field(
+        default=10,
+        description="Maximum number of files to process concurrently during sync. Limits memory usage on large projects (2000+ files). Lower values reduce memory consumption.",
         gt=0,
     )
 


### PR DESCRIPTION
## Summary

Implements P1 and P2 memory optimization fixes from basicmachines-co/basic-memory-cloud#198 to prevent OOM kills on large projects.

## Changes

### P1: Semaphore for Concurrent File Processing
- Added `asyncio.Semaphore` to limit concurrent file operations (default: 10 files)
- Wrapped `_read_file_async()` and `_compute_checksum_async()` with semaphore
- Added `sync_max_concurrent_files` configuration option

### P2: LRU Cache for File Failure Tracking
- Changed `_file_failures` from `Dict` to `OrderedDict` for LRU behavior
- Added max size limit of 100 entries with automatic eviction
- Updated `_record_failure()` to enforce cache size and maintain LRU ordering

### Documentation
- Updated `sync_thread_pool_size` description to note optimization for 1-2GB cloud deployments
- Added documentation for new `sync_max_concurrent_files` parameter

## Impact

**Memory Reduction:**
- Before: 2,621 files could all load into memory simultaneously
- After: Maximum 10 files in memory at once (configurable)
- Expected reduction: 90%+ on large projects

**OOM Prevention:**
- Tenant with 2,621 files previously consumed 1.36GB and got OOM killed on 1GB machine
- With these changes, should stay under 800MB on 1GB machines

**Configuration:**
Users can tune memory usage via config:
```json
{
  "sync_thread_pool_size": 4,           // Thread pool workers (default: 4)
  "sync_max_concurrent_files": 10       // Max concurrent files (default: 10)
}
```

For very constrained environments, `sync_max_concurrent_files` can be lowered to 5.

## Test Plan

- [x] All existing tests pass
- [ ] Deploy to tenant-6d2ff1a3 (2,621 files) and verify memory stays under 1GB
- [ ] Monitor sync performance to ensure semaphore doesn't significantly impact speed

## Related Issues

- Fixes basicmachines-co/basic-memory-cloud#198
- Related to #184, #185 (YAML parsing errors during sync)
- Related to #189 (Circuit breaker implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)