### PR TITLE
feat: Add delete_notes parameter to remove project endpoint

### DIFF
--- a/src/basic_memory/api/routers/project_router.py
+++ b/src/basic_memory/api/routers/project_router.py
@@ -1,7 +1,7 @@
 """Router for project management."""
 
 import os
-from fastapi import APIRouter, HTTPException, Path, Body, BackgroundTasks, Response
+from fastapi import APIRouter, HTTPException, Path, Body, BackgroundTasks, Response, Query
 from typing import Optional
 from loguru import logger
 
@@ -247,11 +247,15 @@ async def add_project(
 async def remove_project(
     project_service: ProjectServiceDep,
     name: str = Path(..., description="Name of the project to remove"),
+    delete_notes: bool = Query(
+        False, description="If True, delete project directory from filesystem"
+    ),
 ) -> ProjectStatusResponse:
     """Remove a project from configuration and database.
 
     Args:
         name: The name of the project to remove
+        delete_notes: If True, delete the project directory from the filesystem
 
     Returns:
         Response confirming the project was removed
@@ -276,7 +280,7 @@ async def remove_project(
                 detail += "This is the only project in your configuration."
             raise HTTPException(status_code=400, detail=detail)
 
-        await project_service.remove_project(name)
+        await project_service.remove_project(name, delete_notes=delete_notes)
 
         return ProjectStatusResponse(
             message=f"Project '{name}' removed successfully",


### PR DESCRIPTION
## Summary
Add optional `delete_notes` parameter to project removal endpoint to allow deleting project directories when removing projects.

## Problem
Fixes basic-memory-cloud #[200](https://github.com/basicmachines-co/basic-memory-cloud/issues/200) - Users in basic-memory-cloud cannot recreate projects because the note directories remain on disk after project deletion, even though the project is removed from the configuration and database.

## Solution
Added an optional `delete_notes` parameter (default `False`) to the remove project endpoint that deletes the project directory from the filesystem when set to `True`.

## Changes
**API Router** (`src/basic_memory/api/routers/project_router.py`)
- Added `delete_notes: bool = Query(False, ...)` parameter to `remove_project()` endpoint
- Updated docstring and passes parameter to service

**Project Service** (`src/basic_memory/services/project_service.py`)
- Added `delete_notes: bool = False` parameter to `remove_project()` method
- Retrieves project path before deletion
- Uses `await asyncio.to_thread(shutil.rmtree, project_path)` for async directory deletion
- Graceful error handling with logging (warnings, not failures)
- Validates path exists and is a directory before deletion

**CLI Command** (`src/basic_memory/cli/commands/project.py`)
- Added `--delete-notes` flag option
- Passes query parameter to DELETE request
- Conditionally shows warning message only when `delete_notes=False`

**Tests**
- Added 3 API router tests for delete_notes functionality
- Added 3 service-level tests for delete_notes functionality
- All existing tests continue to pass

## Key Features
- **Backward compatible**: Default is `False`, maintaining existing behavior
- **Safe**: Only deletes when explicitly requested
- **Async**: Uses `asyncio.to_thread()` for non-blocking directory deletion
- **Resilient**: Handles missing directories gracefully with warnings, not failures
- **Well-tested**: All 26 API router tests pass (97% coverage), 3 new service tests pass

## Usage Examples

**API:**
```bash
DELETE /projects/my-project?delete_notes=true
```

**CLI:**
```bash
basic-memory project remove my-project --delete-notes
```

## Test Results
```bash
# API Router tests
pytest tests/api/test_project_router.py -v
# 26 passed (including 3 new tests)

# Service tests  
pytest tests/services/test_project_service.py::test_remove_project_with_delete_notes_false -v
pytest tests/services/test_project_service.py::test_remove_project_with_delete_notes_true -v
pytest tests/services/test_project_service.py::test_remove_project_delete_notes_missing_directory -v
# 3 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)