### PR TITLE
fix: Strip duplicate headers in edit_note replace_section

### DIFF
--- a/src/basic_memory/services/entity_service.py
+++ b/src/basic_memory/services/entity_service.py
@@ -623,7 +623,7 @@ class EntityService(BaseService[EntityModel]):
         Args:
             current_content: The current markdown content
             section_header: The section header to find and replace (e.g., "## Section Name")
-            new_content: The new content to replace the section with
+            new_content: The new content to replace the section with (should not include the header itself)
 
         Returns:
             The updated content with the section replaced
@@ -634,6 +634,13 @@ class EntityService(BaseService[EntityModel]):
         # Normalize the section header (ensure it starts with #)
         if not section_header.startswith("#"):
             section_header = "## " + section_header
+
+        # Strip duplicate header from new_content if present (fix for issue #390)
+        # LLMs sometimes include the section header in their content, which would create duplicates
+        new_content_lines = new_content.lstrip().split("\n")
+        if new_content_lines and new_content_lines[0].strip() == section_header.strip():
+            # Remove the duplicate header line
+            new_content = "\n".join(new_content_lines[1:]).lstrip()
 
         # First pass: count matching sections to check for duplicates
         lines = current_content.split("\n")


### PR DESCRIPTION
## Summary

Fixes #390 - Prevents duplicate section headers when using edit_note with replace_section operation.

When LLMs include the section header in the content parameter (which they shouldn't, but sometimes do), the operation now detects and strips the duplicate header before appending the content.

## Changes

- Modified `replace_section_content()` in `entity_service.py` to strip duplicate headers
- Added regression test `test_edit_entity_replace_section_strips_duplicate_header()`
- Updated docstring to clarify expected behavior

## Test Plan

- [ ] Existing tests pass
- [ ] New regression test passes
- [ ] Manual testing with LLM confirms fix

Generated with [Claude Code](https://claude.ai/code)