### PR TITLE
fix: Replace Unicode arrows with ASCII for Windows compatibility

### DIFF
--- a/src/basic_memory/cli/commands/project.py
+++ b/src/basic_memory/cli/commands/project.py
@@ -422,7 +422,7 @@ def sync_project_command(
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview changes without syncing"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output"),
 ) -> None:
-    """One-way sync: local → cloud (make cloud identical to local).
+    """One-way sync: local -> cloud (make cloud identical to local).
 
     Example:
       bm project sync --name research
@@ -471,7 +471,7 @@ def sync_project_command(
         )
 
         # Run sync
-        console.print(f"[blue]Syncing {name} (local → cloud)...[/blue]")
+        console.print(f"[blue]Syncing {name} (local -> cloud)...[/blue]")
         success = project_sync(sync_project, bucket_name, dry_run=dry_run, verbose=verbose)
 
         if success:


### PR DESCRIPTION
## Summary

Fixes  on Windows when running sync commands by replacing Unicode arrow characters with ASCII equivalents.

## Problem

When running `bm project sync` or `bm project bisync` commands on Windows, users encounter:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\u2192' in position 6: character maps to <undefined>
```

**Root cause:** Windows console uses cp1252 encoding which cannot display the Unicode rightward arrow (→) character.

**Location:** `src/basic_memory/cli/commands/project.py` lines 425 and 474

## Solution

Replace Unicode arrows with ASCII equivalents:
- `local → cloud` → `local -> cloud`
- Maintains readability
- Ensures Windows compatibility

## Changes

- Line 425: Docstring updated
- Line 474: Console output updated

## Testing

✅ Verified on Windows 11 ARM64:
- All sync commands execute without encoding errors
- Tested as part of comprehensive SPEC-20 validation (PR #405)
- Both `bm project sync` and `bm project bisync` working correctly

## Related

- PR #405 - SPEC-20 testing revealed this issue
- PR #411 - Incomplete Windows Unicode fix (this provides working solution)

## Impact

- **Low risk** - Simple character replacement
- **High value** - Unblocks Windows users from using sync features
- **Backward compatible** - ASCII arrows work on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>