### PR TITLE
fix: Handle dict objects in write_resource endpoint

### DIFF
--- a/src/basic_memory/api/routers/resource_router.py
+++ b/src/basic_memory/api/routers/resource_router.py
@@ -151,6 +151,20 @@ async def write_resource(
     try:
         # Get content from request body
 
+        # Defensive type checking: ensure content is a string
+        # FastAPI should validate this, but if a dict somehow gets through
+        # (e.g., via JSON body parsing), we need to catch it here
+        if isinstance(content, dict):
+            logger.error(
+                f"Error writing resource {file_path}: "
+                f"content is a dict, expected string. Keys: {list(content.keys())}"
+            )
+            raise HTTPException(
+                status_code=400,
+                detail="content must be a string, not a dict. "
+                "Ensure request body is sent as raw string content, not JSON object.",
+            )
+
         # Ensure it's UTF-8 string content
         if isinstance(content, bytes):  # pragma: no cover
             content_str = content.decode("utf-8")

--- a/src/basic_memory/mcp/tools/canvas.py
+++ b/src/basic_memory/mcp/tools/canvas.py
@@ -110,7 +110,14 @@ async def canvas(
 
         # Write the file using the resource API
         logger.info(f"Creating canvas file: {file_path} in project {project}")
-        response = await call_put(client, f"{project_url}/resource/{file_path}", json=canvas_json)
+        # Send canvas_json as content string, not as json parameter
+        # The resource endpoint expects Body() string content, not JSON-encoded data
+        response = await call_put(
+            client,
+            f"{project_url}/resource/{file_path}",
+            content=canvas_json,
+            headers={"Content-Type": "text/plain"},
+        )
 
         # Parse response
         result = response.json()


### PR DESCRIPTION
Fixes #412 - 'dict' object has no attribute 'strip' error

### Problem
Production tenant was experiencing 52 errors in 48 hours when writing resources via the API. The error occurred when dict objects were passed to the write_resource endpoint instead of strings, causing AttributeError when file_utils tried to call .strip() on the content.

### Changes
- **resource_router.py**: Added defensive type checking to catch dict inputs early and return helpful 400 error
- **canvas.py**: Fixed to use content= parameter with text/plain content type instead of json= parameter

### Testing
The fix prevents dict objects from reaching code that expects strings. Manual testing recommended for canvas creation.

Generated with [Claude Code](https://claude.ai/code)