### PR TITLE
feat: Add run_in_background parameter to sync endpoint with tests

### DIFF
--- a/src/basic_memory/api/routers/project_router.py
+++ b/src/basic_memory/api/routers/project_router.py
@@ -124,9 +124,10 @@ async def sync_project(
         sync_service: Sync service for this project
         project_config: Project configuration
         force_full: If True, force a full scan even if watermark exists
+        run_in_background: If True, run sync in background and return immediately
 
     Returns:
-        Response confirming sync was initiated
+        Response confirming sync was initiated (background) or SyncReportResponse (foreground)
     """
     if run_in_background:
         background_tasks.add_task(
@@ -141,13 +142,11 @@ async def sync_project(
             "message": f"Filesystem sync initiated for project '{project_config.name}'",
         }
     else:
-        print("running in foreground")
         report = await sync_service.sync(project_config.home, project_config.name, force_full=force_full)
-        print(report.__dict__)
         logger.info(
             f"Filesystem sync completed for project: {project_config.name} (force_full={force_full})"
         )
-        return report
+        return SyncReportResponse.from_sync_report(report)
 
 
 @project_router.post("/status", response_model=SyncReportResponse)


### PR DESCRIPTION
## Summary

- Add `run_in_background` query parameter to the `/project/sync` endpoint (defaults to `true` for backward compatibility)
- When `run_in_background=false`, the sync runs synchronously and returns a complete `SyncReportResponse`
- Add comprehensive test coverage for the new functionality
- Fix bug where foreground sync returned raw dataclass instead of properly serialized response

## Changes

### API Changes
- **project_router.py**: Add `run_in_background` query parameter to `sync_project` endpoint
  - Default: `true` (maintains backward compatibility)
  - When `false`: Runs sync synchronously and returns `SyncReportResponse` with detailed change information
  - When `true`: Runs in background and returns status message (existing behavior)
  - Fixed conversion to use `SyncReportResponse.from_sync_report()` for proper serialization

### Tests Added
Three new comprehensive tests in `test_project_router.py`:
1. `test_sync_project_endpoint_foreground` - Verifies sync report structure when running in foreground
2. `test_sync_project_endpoint_foreground_with_force_full` - Tests foreground sync with `force_full=true`
3. `test_sync_project_endpoint_foreground_with_changes` - Tests that foreground sync detects actual file changes

## Test Plan

- [x] All existing tests pass (31/31 tests in test_project_router.py)
- [x] New foreground sync tests pass
- [x] Background sync (default) still works as expected
- [x] Foreground sync returns proper SyncReportResponse with all fields including `total`
- [x] Force_full parameter works with both background and foreground modes
- [x] Coverage for project_router.py: 97% (up from previous coverage)

## Benefits

- Enables synchronous sync operations for scenarios requiring immediate feedback
- Provides detailed sync report with counts of new/modified/deleted files
- Maintains full backward compatibility with existing API clients
- Comprehensive test coverage ensures reliability

🤖 Generated with [Claude Code](https://claude.com/claude-code)