### PR TITLE
fix: Handle Windows line endings in rclone bisync

### DIFF
--- a/src/basic_memory/cli/commands/cloud/rclone_commands.py
+++ b/src/basic_memory/cli/commands/cloud/rclone_commands.py
@@ -166,6 +166,7 @@ def project_bisync(
     Uses rclone bisync with balanced defaults:
     - conflict_resolve: newer (auto-resolve to most recent)
     - max_delete: 25 (safety limit)
+    - compare: modtime (ignore size differences from line ending conversions)
     - check_access: false (skip for performance)
 
     Args:
@@ -201,6 +202,7 @@ def project_bisync(
         "--resilient",
         "--conflict-resolve=newer",
         "--max-delete=25",
+        "--compare=modtime",  # Ignore size differences from line ending conversions
         "--filter-from",
         str(filter_path),
         "--workdir",


### PR DESCRIPTION
## Summary

Fixes rclone bisync failures on Windows caused by line ending conversions (LF→CRLF).

## Problem

Customer reported bisync failing with "corrupted on transfer: sizes differ src 5163 vs dst 5632" error. The 469-byte difference exactly matches the number of line breaks in the file, indicating LF (1 byte) to CRLF (2 bytes) conversion on Windows.

## Solution

Added `--compare=modtime` flag to rclone bisync command. This makes bisync compare only modification times instead of size+modtime, preventing line ending conversions from being treated as file corruption.

## Changes

- Modified `src/basic_memory/cli/commands/cloud/rclone_commands.py:205`
- Added `--compare=modtime` flag to bisync command
- Updated docstring to document this behavior

## Testing

- All existing tests pass
- Fix specifically addresses Windows text file handling
- Users will need to run `--resync` once after updating to establish new baseline

## Customer Impact

Resolves the reported issue where editing files in the cloud web interface on Windows causes bisync to fail. The fix allows Windows to use CRLF endings without triggering false corruption warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>