### PR TITLE
draft: Add batch processing for Postgres sync optimization

### DIFF
--- a/src/basic_memory/config.py
+++ b/src/basic_memory/config.py
@@ -132,6 +132,12 @@ class BasicMemoryConfig(BaseSettings):
         gt=0,
     )
 
+    sync_batch_size: int = Field(
+        default=100,
+        description="Number of files to process in a single database transaction during sync. Higher values improve performance with remote databases (Postgres) but increase memory usage. Typical values: 100 (conservative), 500 (balanced), 1000 (aggressive).",
+        gt=0,
+    )
+
     kebab_filenames: bool = Field(
         default=False,
         description="Format for generated filenames. False preserves spaces and special chars, True converts them to hyphens for consistency with permalinks",

--- a/src/basic_memory/sync/utils.py
+++ b/src/basic_memory/sync/utils.py
@@ -1,0 +1,23 @@
+"""Utilities for sync operations."""
+
+from typing import Iterator, List, TypeVar
+
+T = TypeVar("T")
+
+
+def chunks(items: List[T], size: int) -> Iterator[List[T]]:
+    """Split a list into chunks of specified size.
+
+    Args:
+        items: List of items to chunk
+        size: Size of each chunk
+
+    Yields:
+        Lists of items, each of specified size (last chunk may be smaller)
+
+    Example:
+        >>> list(chunks([1, 2, 3, 4, 5], 2))
+        [[1, 2], [3, 4], [5]]
+    """
+    for i in range(0, len(items), size):
+        yield items[i : i + size]


### PR DESCRIPTION
## Summary

Implements streaming batch processing to dramatically reduce database roundtrips for Postgres sync operations. Reduces queries from 50,000-80,000 down to 4,000-6,000 for large projects (10K files).

### Problem

Remote Postgres databases (like NeonDB) showed severe performance degradation:
- **Before**: 103 files in 20.6 minutes (~34 queries/file)
- **Root cause**: N+1 query patterns causing individual database queries per file
- Network latency (10-50ms per query) × thousands of queries = massive overhead

### Solution

Three-phase optimization approach:

**Phase 1: Scan Optimization**
- Batch fetch all entities in 1 query instead of N queries
- Impact: 427 files scanned with 2 queries (vs 427 before)

**Phase 2: Batch Infrastructure**
- Add `sync_batch_size` config (default: 100 files per batch)
- Streaming batch processing with `chunks()` utility
- Bulk repository operations: `upsert_entities()`, `delete_by_entity_ids()`, `delete_outgoing_relations_from_entities()`

**Phase 3: Sync Phase Optimization**  
- New `sync_markdown_batch()` method:
  1. Parse all files in batch (no DB operations)
  2. Bulk upsert entities in single transaction
  3. Post-process relations, checksums, search indexing per file
- Handles both initial bulk imports AND incremental syncs
- Preserves circuit breaker functionality and fatal error handling

### Performance Impact

**Expected improvement:**
- Initial bulk import: ~10-15 queries/file (vs 43 before) = ~67% reduction
- Incremental sync: Massive scan optimization + batch upsert benefits
- Configurable batch size for tuning based on project size

### Test Coverage

- ✅ All existing tests passing
- ✅ Updated circuit breaker tests for batch architecture
- ✅ Fatal error handling preserved
- ✅ Type checking passes

## Test Plan

- [x] Run full test suite locally - all passing
- [x] Type checker passes
- [ ] Test with local Postgres to measure performance gains
- [ ] Test with NeonDB in cloud repo to validate real-world improvement
- [ ] Monitor for any regressions in circuit breaker behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)