### PR TITLE
fix: handle null titles in ChatGPT import

### DIFF
--- a/src/basic_memory/importers/utils.py
+++ b/src/basic_memory/importers/utils.py
@@ -5,15 +5,18 @@ from datetime import datetime
 from typing import Any
 
 
-def clean_filename(name: str) -> str:  # pragma: no cover
+def clean_filename(name: str | None) -> str:  # pragma: no cover
     """Clean a string to be used as a filename.
 
     Args:
-        name: The string to clean.
+        name: The string to clean (can be None).
 
     Returns:
         A cleaned string suitable for use as a filename.
     """
+    # Handle None or empty input
+    if not name:
+        return "untitled"
     # Replace common punctuation and whitespace with underscores
     name = re.sub(r"[\s\-,.:/\\\[\]\(\)]+", "_", name)
     # Remove any non-alphanumeric or underscore characters

--- a/tests/importers/test_importer_utils.py
+++ b/tests/importers/test_importer_utils.py
@@ -23,6 +23,9 @@ def test_clean_filename():
     # Test with empty string
     assert clean_filename("") == "untitled"
 
+    # Test with None (fixes #451 - ChatGPT null titles)
+    assert clean_filename(None) == "untitled"
+
     # Test with only special characters
     # Some implementations may return empty string or underscore
     result = clean_filename("!@#$%^&*()")


### PR DESCRIPTION
## Summary

Update `clean_filename()` to handle `None` input by returning `"untitled"`. This prevents the ChatGPT importer from crashing when conversations have null titles in the exported JSON.

## Changes

- `src/basic_memory/importers/utils.py`: Add null check at start of `clean_filename()`
- `tests/importers/test_importer_utils.py`: Add test case for `None` input

## Test plan

- [x] Unit test for `clean_filename(None)` returns `"untitled"`
- [x] Existing tests pass
- [x] Type checking passes

Fixes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)