### PR TITLE
fix: only set BASIC_MEMORY_ENV=test during pytest runs

### DIFF
--- a/src/basic_memory/alembic/env.py
+++ b/src/basic_memory/alembic/env.py
@@ -21,8 +21,12 @@ from alembic import context
 
 from basic_memory.config import ConfigManager
 
-# set config.env to "test" for pytest to prevent logging to file in utils.setup_logging()
-os.environ["BASIC_MEMORY_ENV"] = "test"
+# Trigger: only set test env when actually running under pytest
+# Why: alembic/env.py is imported during normal operations (MCP server startup, migrations)
+#      but we only want test behavior during actual test runs
+# Outcome: prevents is_test_env from returning True in production, enabling watch service
+if os.getenv("PYTEST_CURRENT_TEST") is not None:
+    os.environ["BASIC_MEMORY_ENV"] = "test"
 
 # Import after setting environment variable  # noqa: E402
 from basic_memory.models import Base  # noqa: E402


### PR DESCRIPTION
Fixes #481

## Problem
The alembic/env.py module was unconditionally setting `BASIC_MEMORY_ENV='test'` at import time, which caused `config.is_test_env` to always return True. This prevented the MCP server from starting the file watch service, breaking file sync for external changes.

## Solution
Only set the env var when `PYTEST_CURRENT_TEST` is set, indicating an actual pytest run. This preserves test behavior while enabling watch service in production.

## Testing
- Tests remain safe because `PYTEST_CURRENT_TEST` is always set during pytest runs
- `tests/__init__.py` also sets the env var for additional safety
- `config.is_test_env` checks `PYTEST_CURRENT_TEST` directly as a third condition

———
Generated with [Claude Code](https://claude.ai/code)