### PR TITLE
fix: set_default_project skips config file update in cloud mode

### DIFF
--- a/tests/mcp/test_project_context.py
+++ b/tests/mcp/test_project_context.py
@@ -17,9 +17,7 @@ class TestResolveProjectParameter:
         mock_config = MagicMock()
         mock_config.cloud_mode = True
 
-        with patch(
-            "basic_memory.mcp.project_context.ConfigManager"
-        ) as mock_config_manager:
+        with patch("basic_memory.mcp.project_context.ConfigManager") as mock_config_manager:
             mock_config_manager.return_value.config = mock_config
 
             with pytest.raises(ValueError) as exc_info:
@@ -36,9 +34,7 @@ class TestResolveProjectParameter:
         mock_config = MagicMock()
         mock_config.cloud_mode = True
 
-        with patch(
-            "basic_memory.mcp.project_context.ConfigManager"
-        ) as mock_config_manager:
+        with patch("basic_memory.mcp.project_context.ConfigManager") as mock_config_manager:
             mock_config_manager.return_value.config = mock_config
 
             result = await resolve_project_parameter(project=None, allow_discovery=True)
@@ -53,9 +49,7 @@ class TestResolveProjectParameter:
         mock_config = MagicMock()
         mock_config.cloud_mode = True
 
-        with patch(
-            "basic_memory.mcp.project_context.ConfigManager"
-        ) as mock_config_manager:
+        with patch("basic_memory.mcp.project_context.ConfigManager") as mock_config_manager:
             mock_config_manager.return_value.config = mock_config
 
             result = await resolve_project_parameter(project="my-project")
@@ -70,9 +64,7 @@ class TestResolveProjectParameter:
         mock_config = MagicMock()
         mock_config.cloud_mode = False
 
-        with patch(
-            "basic_memory.mcp.project_context.ConfigManager"
-        ) as mock_config_manager:
+        with patch("basic_memory.mcp.project_context.ConfigManager") as mock_config_manager:
             mock_config_manager.return_value.config = mock_config
 
             with patch.dict(os.environ, {"BASIC_MEMORY_MCP_PROJECT": "env-project"}):
@@ -90,9 +82,7 @@ class TestResolveProjectParameter:
         mock_config.cloud_mode = False
         mock_config.default_project_mode = False
 
-        with patch(
-            "basic_memory.mcp.project_context.ConfigManager"
-        ) as mock_config_manager:
+        with patch("basic_memory.mcp.project_context.ConfigManager") as mock_config_manager:
             mock_config_manager.return_value.config = mock_config
 
             with patch.dict(os.environ, {}, clear=True):
@@ -112,9 +102,7 @@ class TestResolveProjectParameter:
         mock_config.default_project_mode = True
         mock_config.default_project = "default-project"
 
-        with patch(
-            "basic_memory.mcp.project_context.ConfigManager"
-        ) as mock_config_manager:
+        with patch("basic_memory.mcp.project_context.ConfigManager") as mock_config_manager:
             mock_config_manager.return_value.config = mock_config
 
             with patch.dict(os.environ, {}, clear=True):
@@ -132,9 +120,7 @@ class TestResolveProjectParameter:
         mock_config.cloud_mode = False
         mock_config.default_project_mode = False
 
-        with patch(
-            "basic_memory.mcp.project_context.ConfigManager"
-        ) as mock_config_manager:
+        with patch("basic_memory.mcp.project_context.ConfigManager") as mock_config_manager:
             mock_config_manager.return_value.config = mock_config
 
             with patch.dict(os.environ, {}, clear=True):

--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -106,7 +106,11 @@ def test_relation_response_with_null_permalink():
         "permalink": "test/relation/123",
         "relation_type": "relates_to",
         "from_entity": {"permalink": None, "file_path": "notes/source-note.md"},
-        "to_entity": {"permalink": None, "file_path": "notes/target-note.md", "title": "Target Note"},
+        "to_entity": {
+            "permalink": None,
+            "file_path": "notes/target-note.md",
+            "title": "Target Note",
+        },
     }
     relation = RelationResponse.model_validate(data)
     # Falls back to file_path directly (not converted to permalink)


### PR DESCRIPTION
## Summary
- Validate project exists in database before updating (fail-fast approach)
- Only update config file in local mode; cloud mode uses database as source of truth
- Raise `ValueError` if project not found instead of just logging error

## Test plan
- [x] Unit tests updated to expect `ValueError` for non-existent projects
- [x] Verified existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)