### PR TITLE
fix: check config default_project only in local mode for remove_project

### DIFF
--- a/src/basic_memory/services/project_service.py
+++ b/src/basic_memory/services/project_service.py
@@ -241,8 +241,13 @@ class ProjectService:
 
         project_path = project.path
 
-        # Check if project is default (in cloud mode, check database; in local mode, check config)
-        if project.is_default or name == self.config_manager.config.default_project:
+        # Check if project is default
+        # In cloud mode: database is source of truth
+        # In local mode: also check config file
+        is_default = project.is_default
+        if not self.config_manager.config.cloud_mode:
+            is_default = is_default or name == self.config_manager.config.default_project
+        if is_default:
             raise ValueError(f"Cannot remove the default project '{name}'")  # pragma: no cover
 
         # Remove from config if it exists there (may not exist in cloud mode)


### PR DESCRIPTION
## Summary
- Fixed `remove_project()` in `project_service.py` to only check config file in local mode
- In cloud mode, database is the source of truth for default project status
- Config file can become stale when users set default project via the v2 API

## The Bug
The code checked BOTH the database (`project.is_default`) AND the config file (`config.default_project`). In cloud mode, the config file is never updated when users set a new default project via the v2 API, causing deletion to fail even after successfully setting a different project as default.

## Fix
```python
# Before (checked both in all modes)
if project.is_default or name == self.config_manager.config.default_project:

# After (only check config in local mode)
is_default = project.is_default
if not self.config_manager.config.cloud_mode:
    is_default = is_default or name == self.config_manager.config.default_project
if is_default:
```

## Test plan
- [x] Added `test_remove_project_cloud_mode_uses_database_not_config` - verifies cloud mode ignores stale config
- [x] Added `test_remove_project_local_mode_checks_both_config_and_database` - verifies local mode checks both
- [x] Added `test_remove_project_rejects_database_default_in_both_modes` - verifies DB default blocked in both modes
- [x] All 38 project service tests pass

Unblocks basic-memory-cloud PR #398.

🤖 Generated with [Claude Code](https://claude.ai/code)