### PR TITLE
fix: resolve MCP prompt rendering errors

### DIFF
--- a/src/basic_memory/mcp/prompts/continue_conversation.py
+++ b/src/basic_memory/mcp/prompts/continue_conversation.py
@@ -13,7 +13,6 @@ from basic_memory.config import get_project_config
 from basic_memory.mcp.async_client import get_client
 from basic_memory.mcp.server import mcp
 from basic_memory.mcp.tools.utils import call_post
-from basic_memory.schemas.base import TimeFrame
 from basic_memory.schemas.prompt import ContinueConversationRequest
 
 
@@ -24,7 +23,7 @@ from basic_memory.schemas.prompt import ContinueConversationRequest
 async def continue_conversation(
     topic: Annotated[Optional[str], Field(description="Topic or keyword to search for")] = None,
     timeframe: Annotated[
-        Optional[TimeFrame],
+        Optional[str],
         Field(description="How far back to look for activity (e.g. '1d', '1 week')"),
     ] = None,
 ) -> str:

--- a/src/basic_memory/mcp/prompts/recent_activity.py
+++ b/src/basic_memory/mcp/prompts/recent_activity.py
@@ -3,17 +3,14 @@
 These prompts help users see what has changed in their knowledge base recently.
 """
 
+from textwrap import dedent
 from typing import Annotated, Optional
 
 from loguru import logger
 from pydantic import Field
 
-from basic_memory.mcp.prompts.utils import format_prompt_context, PromptContext, PromptContextItem
 from basic_memory.mcp.server import mcp
 from basic_memory.mcp.tools.recent_activity import recent_activity
-from basic_memory.schemas.base import TimeFrame
-from basic_memory.schemas.memory import GraphContext, ProjectActivitySummary
-from basic_memory.schemas.search import SearchItemType
 
 
 @mcp.prompt(
@@ -22,7 +19,7 @@ from basic_memory.schemas.search import SearchItemType
 )
 async def recent_activity_prompt(
     timeframe: Annotated[
-        TimeFrame,
+        str,
         Field(description="How far back to look for activity (e.g. '1d', '1 week')"),
     ] = "7d",
     project: Annotated[
@@ -47,142 +44,57 @@ async def recent_activity_prompt(
     """
     logger.info(f"Getting recent activity, timeframe: {timeframe}, project: {project}")
 
-    recent = await recent_activity.fn(
-        project=project, timeframe=timeframe, type=[SearchItemType.ENTITY]
+    # Call the tool function - it returns a well-formatted string
+    # Pass type as string values (not enum) to match the tool's expected input
+    activity_summary = await recent_activity.fn(
+        project=project, timeframe=timeframe, type="entity"
     )
 
-    # Extract primary results from the hierarchical structure
-    primary_results = []
-    related_results = []
+    # Build the prompt response
+    # The tool already returns formatted markdown, so we use it directly
+    # and add prompt-specific guidance
+    target = project if project else "all projects"
 
-    if isinstance(recent, ProjectActivitySummary):
-        # Discovery mode - extract results from all projects
-        for _, project_activity in recent.projects.items():
-            if project_activity.activity.results:
-                # Take up to 2 primary results per project
-                for item in project_activity.activity.results[:2]:
-                    primary_results.append(item.primary_result)
-                    # Add up to 1 related result per primary item
-                    if item.related_results:
-                        related_results.extend(item.related_results[:1])  # pragma: no cover
+    prompt_guidance = dedent(f"""
+        # Recent Activity Context
 
-        # Limit total results for readability
-        primary_results = primary_results[:8]
-        related_results = related_results[:6]
+        This is a memory retrieval session showing recent activity from {target}.
 
-    elif isinstance(recent, GraphContext):
-        # Project-specific mode - use existing logic
-        if recent.results:
-            # Take up to 5 primary results
-            for item in recent.results[:5]:
-                primary_results.append(item.primary_result)
-                # Add up to 2 related results per primary item
-                if item.related_results:
-                    related_results.extend(item.related_results[:2])  # pragma: no cover
+        {activity_summary}
 
-    # Set topic based on mode
-    if project:
-        topic = f"Recent Activity in {project} ({timeframe})"
-    else:
-        topic = f"Recent Activity Across All Projects ({timeframe})"
+        ---
 
-    prompt_context = format_prompt_context(
-        PromptContext(
-            topic=topic,
-            timeframe=timeframe,
-            results=[
-                PromptContextItem(
-                    primary_results=primary_results,
-                    related_results=related_results[:10],  # Limit total related results
-                )
-            ],
+        ## Next Steps
+
+        Based on this activity, you can:
+
+        1. **Explore specific items** - Use `read_note("permalink")` to dive deeper into any item
+        2. **Search for related content** - Use `search_notes("topic")` to find connected knowledge
+        3. **Build context** - Use `build_context("memory://path")` to see relationships
+
+        ## Capture Opportunity
+
+        If you notice patterns or insights from this activity, consider documenting them:
+
+        ```python
+        write_note(
+            title="Activity Insights - {timeframe}",
+            content='''
+            # Activity Insights
+
+            ## Patterns Observed
+            - [trend] [Pattern you noticed in the activity]
+
+            ## Key Developments
+            - [insight] [Important development worth tracking]
+
+            ## Relations
+            - summarizes [[Recent Work]]
+            ''',
+            folder="insights",
+            project="{project or 'default'}"
         )
-    )
+        ```
+    """)
 
-    # Add mode-specific suggestions
-    first_title = "Recent Topic"
-    if primary_results and len(primary_results) > 0:
-        first_title = primary_results[0].title
-
-    if project:
-        # Project-specific suggestions
-        capture_suggestions = f"""
-    ## Opportunity to Capture Activity Summary
-
-    Consider creating a summary note of recent activity in {project}:
-
-    ```python
-    await write_note(
-        "{project}",
-        title="Activity Summary {timeframe}",
-        content='''
-        # Activity Summary for {project} ({timeframe})
-
-        ## Overview
-        [Summary of key changes and developments in this project over this period]
-
-        ## Key Updates
-        [List main updates and their significance within this project]
-
-        ## Observations
-        - [trend] [Observation about patterns in recent activity]
-        - [insight] [Connection between different activities]
-
-        ## Relations
-        - summarizes [[{first_title}]]
-        - relates_to [[{project} Overview]]
-        ''',
-        folder="summaries"
-    )
-    ```
-
-    Summarizing periodic activity helps create high-level insights and connections within the project.
-    """
-    else:
-        # Discovery mode suggestions
-        project_count = len(recent.projects) if isinstance(recent, ProjectActivitySummary) else 0
-        most_active = (
-            getattr(recent.summary, "most_active_project", "Unknown")
-            if isinstance(recent, ProjectActivitySummary)
-            else "Unknown"
-        )
-
-        capture_suggestions = f"""
-    ## Cross-Project Activity Discovery
-
-    Found activity across {project_count} projects. Most active: **{most_active}**
-
-    Consider creating a cross-project summary:
-
-    ```python
-    await write_note(
-        "{most_active if most_active != "Unknown" else "main"}",
-        title="Cross-Project Activity Summary {timeframe}",
-        content='''
-        # Cross-Project Activity Summary ({timeframe})
-
-        ## Overview
-        Activity found across {project_count} projects, with {most_active} showing the most activity.
-
-        ## Key Developments
-        [Summarize important changes across all projects]
-
-        ## Project Insights
-        [Note patterns or connections between projects]
-
-        ## Observations
-        - [trend] [Cross-project patterns observed]
-        - [insight] [Connections between different project activities]
-
-        ## Relations
-        - summarizes [[{first_title}]]
-        - relates_to [[Project Portfolio Overview]]
-        ''',
-        folder="summaries"
-    )
-    ```
-
-    Cross-project summaries help identify broader trends and project interconnections.
-    """
-
-    return prompt_context + capture_suggestions
+    return prompt_guidance

--- a/src/basic_memory/mcp/prompts/search.py
+++ b/src/basic_memory/mcp/prompts/search.py
@@ -12,7 +12,6 @@ from basic_memory.config import get_project_config
 from basic_memory.mcp.async_client import get_client
 from basic_memory.mcp.server import mcp
 from basic_memory.mcp.tools.utils import call_post
-from basic_memory.schemas.base import TimeFrame
 from basic_memory.schemas.prompt import SearchPromptRequest
 
 
@@ -23,7 +22,7 @@ from basic_memory.schemas.prompt import SearchPromptRequest
 async def search_prompt(
     query: str,
     timeframe: Annotated[
-        Optional[TimeFrame],
+        Optional[str],
         Field(description="How far back to search (e.g. '1d', '1 week')"),
     ] = None,
 ) -> str:

--- a/src/basic_memory/mcp/prompts/utils.py
+++ b/src/basic_memory/mcp/prompts/utils.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from textwrap import dedent
 from typing import List
 
-from basic_memory.schemas.base import TimeFrame
 from basic_memory.schemas.memory import (
     normalize_memory_url,
     EntitySummary,
@@ -25,7 +24,7 @@ class PromptContextItem:
 
 @dataclass
 class PromptContext:
-    timeframe: TimeFrame
+    timeframe: str
     topic: str
     results: List[PromptContextItem]
 

--- a/tests/mcp/test_prompts.py
+++ b/tests/mcp/test_prompts.py
@@ -153,8 +153,9 @@ async def test_recent_activity_prompt_discovery_mode(client, test_project, test_
     result = await recent_activity_prompt.fn(timeframe="1w")  # pyright: ignore [reportGeneralTypeIssues]
 
     # Check the response contains expected discovery mode content
-    assert "Recent Activity Across All Projects" in result  # pyright: ignore [reportOperatorIssue]
-    assert "Cross-Project Activity Discovery" in result  # pyright: ignore [reportOperatorIssue]
+    assert "Recent Activity Context" in result  # pyright: ignore [reportOperatorIssue]
+    assert "all projects" in result  # pyright: ignore [reportOperatorIssue]
+    assert "Next Steps" in result  # pyright: ignore [reportOperatorIssue]
     assert "write_note" in result  # pyright: ignore [reportOperatorIssue]
 
 
@@ -165,9 +166,9 @@ async def test_recent_activity_prompt_project_specific(client, test_project, tes
     result = await recent_activity_prompt.fn(timeframe="1w", project=test_project.name)  # pyright: ignore [reportGeneralTypeIssues]
 
     # Check the response contains expected project-specific content
-    assert f"Recent Activity in {test_project.name}" in result  # pyright: ignore [reportOperatorIssue]
-    assert "Opportunity to Capture Activity Summary" in result  # pyright: ignore [reportOperatorIssue]
-    assert f"recent activity in {test_project.name}" in result  # pyright: ignore [reportOperatorIssue]
+    assert "Recent Activity Context" in result  # pyright: ignore [reportOperatorIssue]
+    assert test_project.name in result  # pyright: ignore [reportOperatorIssue]
+    assert "Next Steps" in result  # pyright: ignore [reportOperatorIssue]
     assert "write_note" in result  # pyright: ignore [reportOperatorIssue]
 
 
@@ -178,4 +179,5 @@ async def test_recent_activity_prompt_with_custom_timeframe(client, test_project
     result = await recent_activity_prompt.fn(timeframe="1d")  # pyright: ignore [reportGeneralTypeIssues]
 
     # Check the response includes the custom timeframe
-    assert "Recent Activity Across All Projects (1d)" in result  # pyright: ignore [reportOperatorIssue]
+    assert "1d" in result  # pyright: ignore [reportOperatorIssue]
+    assert "Recent Activity Context" in result  # pyright: ignore [reportOperatorIssue]

--- a/tests/mcp/test_recent_activity_prompt_modes.py
+++ b/tests/mcp/test_recent_activity_prompt_modes.py
@@ -1,111 +1,91 @@
-from datetime import UTC, datetime
+"""Tests for recent_activity_prompt with different modes.
+
+The prompt delegates to the recent_activity tool which returns a formatted string.
+These tests verify the prompt correctly uses the tool output and adds guidance.
+"""
 
 import pytest
 
 from basic_memory.mcp.prompts.recent_activity import recent_activity_prompt
-from basic_memory.schemas.memory import (
-    ActivityStats,
-    ContextResult,
-    GraphContext,
-    MemoryMetadata,
-    ProjectActivity,
-    ProjectActivitySummary,
-    EntitySummary,
-)
-from basic_memory.schemas.search import SearchItemType
-
-
-def _entity(title: str, entity_id: int = 1) -> EntitySummary:
-    return EntitySummary(
-        entity_id=entity_id,
-        permalink=title.lower().replace(" ", "-"),
-        title=title,
-        content=None,
-        file_path=f"{title}.md",
-        created_at=datetime.now(UTC),
-    )
 
 
 @pytest.mark.asyncio
 async def test_recent_activity_prompt_discovery_mode(monkeypatch):
-    recent = ProjectActivitySummary(
-        projects={
-            "p1": ProjectActivity(
-                project_name="p1",
-                project_path="/tmp/p1",
-                activity=GraphContext(
-                    results=[
-                        ContextResult(
-                            primary_result=_entity("A"), observations=[], related_results=[]
-                        )
-                    ],
-                    metadata=MemoryMetadata(
-                        uri=None,
-                        types=[SearchItemType.ENTITY],
-                        depth=1,
-                        timeframe="7d",
-                        generated_at=datetime.now(UTC),
-                    ),
-                ),
-                item_count=1,
-            ),
-            "p2": ProjectActivity(
-                project_name="p2",
-                project_path="/tmp/p2",
-                activity=GraphContext(
-                    results=[
-                        ContextResult(
-                            primary_result=_entity("B", 2), observations=[], related_results=[]
-                        )
-                    ],
-                    metadata=MemoryMetadata(
-                        uri=None,
-                        types=[SearchItemType.ENTITY],
-                        depth=1,
-                        timeframe="7d",
-                        generated_at=datetime.now(UTC),
-                    ),
-                ),
-                item_count=1,
-            ),
-        },
-        summary=ActivityStats(
-            total_projects=2, active_projects=2, most_active_project="p1", total_items=2
-        ),
-        timeframe="7d",
-        generated_at=datetime.now(UTC),
-    )
+    """Test prompt in discovery mode (no project specified)."""
+    # The tool returns a formatted string in discovery mode
+    tool_output = """## Recent Activity Summary (7d)
+
+**Most Active Project:** project-alpha (5 items)
+- 🔧 **Latest:** API Design Decision (2 hours ago)
+- 📋 **Focus areas:** decisions, specs
+
+**Other Active Projects:**
+- **project-beta** (3 items)
+
+**Summary:** 2 active projects, 8 recent items
+"""
 
     async def fake_fn(**_kwargs):
-        return recent
+        return tool_output
 
     monkeypatch.setattr("basic_memory.mcp.prompts.recent_activity.recent_activity.fn", fake_fn)
 
     out = await recent_activity_prompt.fn(timeframe="7d", project=None)  # pyright: ignore[reportGeneralTypeIssues]
-    assert "Recent Activity Across All Projects" in out
-    assert "Cross-Project Activity Discovery" in out
+
+    # Should contain the tool output
+    assert "Recent Activity Summary (7d)" in out
+    assert "Most Active Project" in out
+
+    # Should contain prompt guidance
+    assert "Recent Activity Context" in out
+    assert "Next Steps" in out
+    assert "Capture Opportunity" in out
 
 
 @pytest.mark.asyncio
 async def test_recent_activity_prompt_project_mode(monkeypatch):
-    recent = GraphContext(
-        results=[
-            ContextResult(primary_result=_entity("Only"), observations=[], related_results=[])
-        ],
-        metadata=MemoryMetadata(
-            uri=None,
-            types=[SearchItemType.ENTITY],
-            depth=1,
-            timeframe="1d",
-            generated_at=datetime.now(UTC),
-        ),
-    )
+    """Test prompt in project-specific mode."""
+    # The tool returns a formatted string for a specific project
+    tool_output = """## Recent Activity: my-project (1d)
+
+**📄 Recent Notes & Documents (3):**
+  • API Design Decision
+  • User Authentication Spec
+  • Database Schema
+
+**Activity Summary:** 3 items found
+"""
 
     async def fake_fn(**_kwargs):
-        return recent
+        return tool_output
 
     monkeypatch.setattr("basic_memory.mcp.prompts.recent_activity.recent_activity.fn", fake_fn)
 
-    out = await recent_activity_prompt.fn(timeframe="1d", project="proj")  # pyright: ignore[reportGeneralTypeIssues]
-    assert "Recent Activity in proj" in out
-    assert "Opportunity to Capture Activity Summary" in out
+    out = await recent_activity_prompt.fn(timeframe="1d", project="my-project")  # pyright: ignore[reportGeneralTypeIssues]
+
+    # Should contain the tool output
+    assert "Recent Activity: my-project" in out
+    assert "Recent Notes & Documents" in out
+
+    # Should contain prompt guidance
+    assert "Recent Activity Context" in out
+    assert "my-project" in out  # Project mentioned in guidance
+    assert "Next Steps" in out
+
+
+@pytest.mark.asyncio
+async def test_recent_activity_prompt_passes_correct_params(monkeypatch):
+    """Test that prompt passes correct parameters to the tool."""
+    captured_kwargs = {}
+
+    async def fake_fn(**kwargs):
+        captured_kwargs.update(kwargs)
+        return "## Recent Activity"
+
+    monkeypatch.setattr("basic_memory.mcp.prompts.recent_activity.recent_activity.fn", fake_fn)
+
+    await recent_activity_prompt.fn(timeframe="2d", project="test-proj")  # pyright: ignore[reportGeneralTypeIssues]
+
+    assert captured_kwargs["timeframe"] == "2d"
+    assert captured_kwargs["project"] == "test-proj"
+    assert captured_kwargs["type"] == "entity"


### PR DESCRIPTION
## Summary

- Fix MCP prompt "Error rendering prompt recent_activity" error
- Change `TimeFrame` to `str` in prompt type annotations for FastMCP JSON schema compatibility
- Fix `recent_activity_prompt` architecture - it was checking `isinstance(result, ProjectActivitySummary)` on a string

## Problem

The `recent_activity` MCP prompt was failing with "Error rendering prompt recent_activity" because:

1. **Type annotation issue**: `TimeFrame = Annotated[str, BeforeValidator(...)]` could cause issues with FastMCP's JSON schema generation for prompt parameters

2. **Architecture bug**: The prompt called `recent_activity.fn()` which returns a **formatted string**, but then checked `isinstance(recent, ProjectActivitySummary)` which was always `False`

## Solution

1. Changed all prompt `timeframe` parameters from `TimeFrame` to `str`
2. Rewrote `recent_activity_prompt` to use the tool's string output directly and add helpful guidance
3. Updated `PromptContext` dataclass to use `str` instead of `TimeFrame`
4. Pass `type="entity"` as string instead of enum `[SearchItemType.ENTITY]`

## Test plan

- [x] All existing prompt tests pass
- [x] New test verifies correct parameters are passed to tool
- [ ] Manual test: Call `/basic-memory-cloud:recent_activity (MCP)` in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)