### PR TITLE
fix: prevent spurious 'metadata: {}' in frontmatter output

### DIFF
--- a/src/basic_memory/markdown/entity_parser.py
+++ b/src/basic_memory/markdown/entity_parser.py
@@ -241,7 +241,9 @@ class EntityParser:
                 f"Failed to parse YAML frontmatter in {file_path}: {e}. "
                 f"Treating file as plain markdown without frontmatter."
             )
-            post = frontmatter.Post(content, metadata={})
+            # Use Post(content) not Post(content, metadata={})
+            # The latter creates {"metadata": {}} in the metadata dict (issue #528)
+            post = frontmatter.Post(content)
 
         # Normalize frontmatter values
         metadata = normalize_frontmatter_metadata(post.metadata)


### PR DESCRIPTION
## Summary

Fixes #528 - Cloud sync prepends duplicate frontmatter to files that already have YAML frontmatter

This PR fixes a bug where files with invalid YAML frontmatter would get a spurious `metadata: {}` key added to their frontmatter output.

### Root Cause

When YAML frontmatter parsing failed, the code used:
```python
post = frontmatter.Post(content, metadata={})
```

The `frontmatter.Post()` constructor uses `**kwargs` for metadata, so `metadata={}` becomes a KEY in the metadata dict:
```python
post.metadata = {"metadata": {}}  # Bug!
```

The fix changes this to:
```python
post = frontmatter.Post(content)  # Creates empty metadata dict correctly
```

Which correctly creates:
```python
post.metadata = {}  # Correct!
```

### Impact

This was causing files with invalid/malformed YAML to get `metadata: {}` appearing in their frontmatter output, which contributed to the duplicate frontmatter issue reported in #528.

## Test plan

- [x] Added `test_invalid_yaml_does_not_add_metadata_key` - Verifies the bug fix
- [x] Added `test_frontmatter_roundtrip_preserves_user_metadata` - Ensures user custom fields like 'citekey' and 'type: litnote' are preserved
- [x] All 61 markdown tests pass
- [x] All 12 entity parser error handling tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)