### PR TITLE
fix: add X-Tigris-Consistent headers to all rclone commands

### DIFF
--- a/src/basic_memory/cli/commands/cloud/rclone_commands.py
+++ b/src/basic_memory/cli/commands/cloud/rclone_commands.py
@@ -27,6 +27,14 @@ console = Console()
 # Minimum rclone version for --create-empty-src-dirs support
 MIN_RCLONE_VERSION_EMPTY_DIRS = (1, 64, 0)
 
+# Tigris edge caching returns stale data for users outside the origin region (iad).
+# These headers bypass edge cache and force reads/writes against the origin.
+# See: https://www.tigrisdata.com/docs/objects/consistency/
+TIGRIS_CONSISTENCY_HEADERS = [
+    "--header-download", "X-Tigris-Consistent: true",
+    "--header-upload", "X-Tigris-Consistent: true",
+]
+
 
 class RunResult(Protocol):
     returncode: int
@@ -210,6 +218,7 @@ def project_sync(
         "sync",
         str(local_path),
         remote_path,
+        *TIGRIS_CONSISTENCY_HEADERS,
         "--filter-from",
         str(filter_path),
     ]
@@ -279,6 +288,7 @@ def project_bisync(
         "bisync",
         str(local_path),
         remote_path,
+        *TIGRIS_CONSISTENCY_HEADERS,
         "--resilient",
         "--conflict-resolve=newer",
         "--max-delete=25",
@@ -354,6 +364,7 @@ def project_check(
         "check",
         str(local_path),
         remote_path,
+        *TIGRIS_CONSISTENCY_HEADERS,
         "--filter-from",
         str(filter_path),
     ]
@@ -393,6 +404,6 @@ def project_ls(
     if path:
         remote_path = f"{remote_path}/{path}"
 
-    cmd = ["rclone", "ls", remote_path]
+    cmd = ["rclone", "ls", *TIGRIS_CONSISTENCY_HEADERS, remote_path]
     result = run(cmd, capture_output=True, text=True, check=True)
     return result.stdout.splitlines()


### PR DESCRIPTION
## Summary

- Adds `X-Tigris-Consistent: true` download/upload headers to all rclone commands (`project_sync`, `project_bisync`, `project_check`, `project_ls`)
- Fixes stale reads for users outside the US caused by Tigris edge cache returning eventual-consistency data
- First reported by a user in Germany getting 2048 bytes while origin returned 8257 bytes for the same file

## Test plan

- [x] All 39 existing rclone command tests pass with header assertions added
- [ ] Verify bisync works correctly for a non-US user after upgrade

Closes #557