### PR TITLE
fix: use VIRTUAL instead of STORED columns in SQLite migration

### DIFF
--- a/src/basic_memory/alembic/versions/d7e8f9a0b1c2_add_structured_metadata_indexes.py
+++ b/src/basic_memory/alembic/versions/d7e8f9a0b1c2_add_structured_metadata_indexes.py
@@ -94,13 +94,15 @@ def upgrade() -> None:
         return
 
     # SQLite: add generated columns for common frontmatter fields
+    # Constraint: SQLite ALTER TABLE ADD COLUMN only supports VIRTUAL generated columns,
+    # not STORED. json_extract is deterministic so VIRTUAL columns can still be indexed.
     if not column_exists(connection, "entity", "tags_json"):
         op.add_column(
             "entity",
             sa.Column(
                 "tags_json",
                 sa.Text(),
-                sa.Computed("json_extract(entity_metadata, '$.tags')", persisted=True),
+                sa.Computed("json_extract(entity_metadata, '$.tags')", persisted=False),
             ),
         )
     if not column_exists(connection, "entity", "frontmatter_status"):
@@ -109,7 +111,7 @@ def upgrade() -> None:
             sa.Column(
                 "frontmatter_status",
                 sa.Text(),
-                sa.Computed("json_extract(entity_metadata, '$.status')", persisted=True),
+                sa.Computed("json_extract(entity_metadata, '$.status')", persisted=False),
             ),
         )
     if not column_exists(connection, "entity", "frontmatter_type"):
@@ -118,7 +120,7 @@ def upgrade() -> None:
             sa.Column(
                 "frontmatter_type",
                 sa.Text(),
-                sa.Computed("json_extract(entity_metadata, '$.type')", persisted=True),
+                sa.Computed("json_extract(entity_metadata, '$.type')", persisted=False),
             ),
         )
 


### PR DESCRIPTION
## Summary
- SQLite's `ALTER TABLE ADD COLUMN` only supports VIRTUAL generated columns, not STORED
- The `d7e8f9a0b1c2` migration was failing on startup with `cannot add a STORED column` for the `tags_json`, `frontmatter_status`, and `frontmatter_type` columns
- Changed `persisted=True` (STORED) to `persisted=False` (VIRTUAL) — `json_extract` is deterministic so VIRTUAL columns can still be indexed

## Test plan
- [x] Verified fix via local logs: migration errors on Feb 9 (`STORED`), clean migrations on Feb 10+ (`VIRTUAL`)
- [ ] `just test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)