### PR TITLE
feat: isolate default sqlite db by config dir

### DIFF
--- a/src/basic_memory/config.py
+++ b/src/basic_memory/config.py
@@ -364,8 +364,11 @@ class BasicMemoryConfig(BaseSettings):
 
         This is the single database that will store all knowledge data
         across all projects.
+
+        Uses BASIC_MEMORY_CONFIG_DIR when set so each process/worktree can
+        isolate both config and database state.
         """
-        database_path = Path.home() / DATA_DIR_NAME / APP_DATABASE_NAME
+        database_path = self.data_dir_path / APP_DATABASE_NAME
         if not database_path.exists():  # pragma: no cover
             database_path.parent.mkdir(parents=True, exist_ok=True)
             database_path.touch()
@@ -411,8 +414,13 @@ class BasicMemoryConfig(BaseSettings):
         return self
 
     @property
-    def data_dir_path(self):
-        return Path.home() / DATA_DIR_NAME
+    def data_dir_path(self) -> Path:
+        """Get app state directory for config and default SQLite database."""
+        if config_dir := os.getenv("BASIC_MEMORY_CONFIG_DIR"):
+            return Path(config_dir)
+
+        home = os.getenv("HOME", Path.home())
+        return Path(home) / DATA_DIR_NAME
 
 
 # Module-level cache for configuration

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -97,6 +97,25 @@ class TestBasicMemoryConfig:
         # Note: This tests the current behavior where default_factory takes precedence
         assert config.projects["main"] == original_path
 
+    def test_app_database_path_uses_custom_config_dir(self, tmp_path, monkeypatch):
+        """Default SQLite DB should live under BASIC_MEMORY_CONFIG_DIR when set."""
+        custom_config_dir = tmp_path / "instance-a" / "state"
+        monkeypatch.setenv("BASIC_MEMORY_CONFIG_DIR", str(custom_config_dir))
+
+        config = BasicMemoryConfig(projects={"main": str(tmp_path / "project")})
+
+        assert config.data_dir_path == custom_config_dir
+        assert config.app_database_path == custom_config_dir / "memory.db"
+        assert config.app_database_path.exists()
+
+    def test_app_database_path_defaults_to_home_data_dir(self, config_home, monkeypatch):
+        """Without BASIC_MEMORY_CONFIG_DIR, default DB stays at ~/.basic-memory/memory.db."""
+        monkeypatch.delenv("BASIC_MEMORY_CONFIG_DIR", raising=False)
+        config = BasicMemoryConfig()
+
+        assert config.data_dir_path == config_home / ".basic-memory"
+        assert config.app_database_path == config_home / ".basic-memory" / "memory.db"
+
 
 class TestConfigManager:
     """Test ConfigManager functionality."""


### PR DESCRIPTION
## Summary

This keeps the solution simple: when `BASIC_MEMORY_CONFIG_DIR` is set, Basic Memory now stores the default SQLite index DB (`memory.db`) in that same directory.

- `app_database_path` now derives from `data_dir_path`
- `data_dir_path` now respects `BASIC_MEMORY_CONFIG_DIR` (falls back to `~/.basic-memory`)
- Added focused tests for both custom-config-dir and default behavior

## Why

This enables separate config+db state per worktree/process/MCP instance without introducing new URL parsing or Postgres schema logic.

## Scope

- Solves per-instance SQLite isolation
- Does **not** change Postgres schema/search_path behavior

## Tests

- `uv run pytest tests/test_config.py -q`
- `uv run ruff check src/basic_memory/config.py tests/test_config.py`

Supersedes #540.
