### PR TITLE
feat: CLI analytics via Umami event collector

### DIFF
--- a/src/basic_memory/cli/analytics.py
+++ b/src/basic_memory/cli/analytics.py
@@ -1,0 +1,103 @@
+"""Lightweight CLI analytics via Umami event collector.
+
+Sends anonymous, non-blocking usage events to help understand how the
+CLI-to-cloud conversion funnel performs. No PII, no fingerprinting,
+no cookies. Respects the same opt-out mechanisms as promo messaging.
+
+Events are fire-and-forget — analytics never blocks or breaks the CLI.
+
+Setup:
+    Set these environment variables (or leave unset to disable):
+        BASIC_MEMORY_UMAMI_HOST     — Umami instance URL (e.g. https://analytics.basicmemory.com)
+        BASIC_MEMORY_UMAMI_SITE_ID  — Website ID from Umami dashboard
+"""
+
+import json
+import os
+import threading
+import urllib.request
+from typing import Optional
+
+import basic_memory
+
+
+# ---------------------------------------------------------------------------
+# Configuration — read from environment so nothing is hard-coded in source
+# ---------------------------------------------------------------------------
+
+def _umami_host() -> Optional[str]:
+    return os.getenv("BASIC_MEMORY_UMAMI_HOST", "").strip() or None
+
+
+def _umami_site_id() -> Optional[str]:
+    return os.getenv("BASIC_MEMORY_UMAMI_SITE_ID", "").strip() or None
+
+
+def _analytics_disabled() -> bool:
+    """True when analytics should not fire."""
+    value = os.getenv("BASIC_MEMORY_NO_PROMOS", "").strip().lower()
+    return value in {"1", "true", "yes"}
+
+
+def _is_configured() -> bool:
+    """True when both host and site ID are available."""
+    return _umami_host() is not None and _umami_site_id() is not None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+# Well-known event names for the promo/cloud funnel
+EVENT_PROMO_SHOWN = "cli-promo-shown"
+EVENT_PROMO_OPTED_OUT = "cli-promo-opted-out"
+EVENT_CLOUD_LOGIN_STARTED = "cli-cloud-login-started"
+EVENT_CLOUD_LOGIN_SUCCESS = "cli-cloud-login-success"
+EVENT_CLOUD_LOGIN_SUB_REQUIRED = "cli-cloud-login-sub-required"
+
+
+def track(event_name: str, data: Optional[dict] = None) -> None:
+    """Send an analytics event to Umami. Non-blocking, silent on failure.
+
+    Parameters
+    ----------
+    event_name:
+        Short kebab-case name (e.g. "cli-promo-shown").
+    data:
+        Optional dict of event properties (all values should be strings/numbers).
+    """
+    if _analytics_disabled() or not _is_configured():
+        return
+
+    host = _umami_host()
+    site_id = _umami_site_id()
+
+    payload = {
+        "payload": {
+            "hostname": "cli.basicmemory.com",
+            "language": "en",
+            "url": f"/cli/{event_name}",
+            "website": site_id,
+            "name": event_name,
+            "data": {
+                "version": basic_memory.__version__,
+                **(data or {}),
+            },
+        }
+    }
+
+    def _send():
+        try:
+            req = urllib.request.Request(
+                f"{host}/api/send",
+                data=json.dumps(payload).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": f"basic-memory-cli/{basic_memory.__version__}",
+                },
+            )
+            urllib.request.urlopen(req, timeout=3)
+        except Exception:
+            pass  # Never break the CLI for analytics
+
+    threading.Thread(target=_send, daemon=True).start()

--- a/src/basic_memory/cli/promo.py
+++ b/src/basic_memory/cli/promo.py
@@ -7,10 +7,14 @@ from rich.console import Console
 from rich.panel import Panel
 
 import basic_memory
+from basic_memory.cli.analytics import track, EVENT_PROMO_SHOWN, EVENT_PROMO_OPTED_OUT
 from basic_memory.config import ConfigManager
 
 OSS_DISCOUNT_CODE = "BMFOSS"
-CLOUD_LEARN_MORE_URL = "https://basicmemory.com"
+CLOUD_LEARN_MORE_URL = (
+    "https://basicmemory.com"
+    "?utm_source=bm-cli&utm_medium=promo&utm_campaign=cloud-upsell"
+)
 
 
 def _promos_disabled_by_env() -> bool:
@@ -112,6 +116,9 @@ def maybe_show_cloud_promo(
     )
     out.print(f"Learn more at [link={CLOUD_LEARN_MORE_URL}]{CLOUD_LEARN_MORE_URL}[/link]")
     out.print("[dim]Disable with: bm cloud promo --off[/dim]")
+
+    trigger = "first_run" if show_first_run else "version_bump"
+    track(EVENT_PROMO_SHOWN, {"trigger": trigger})
 
     config.cloud_promo_first_run_shown = True
     config.cloud_promo_last_version_shown = basic_memory.__version__

--- a/tests/cli/test_analytics.py
+++ b/tests/cli/test_analytics.py
@@ -1,0 +1,157 @@
+"""Tests for CLI analytics module."""
+
+import json
+import threading
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from basic_memory.cli.analytics import (
+    track,
+    _analytics_disabled,
+    _is_configured,
+    EVENT_PROMO_SHOWN,
+    EVENT_CLOUD_LOGIN_STARTED,
+    EVENT_CLOUD_LOGIN_SUCCESS,
+    EVENT_CLOUD_LOGIN_SUB_REQUIRED,
+    EVENT_PROMO_OPTED_OUT,
+)
+
+
+class TestAnalyticsDisabled:
+    def test_disabled_when_env_set(self, monkeypatch):
+        monkeypatch.setenv("BASIC_MEMORY_NO_PROMOS", "1")
+        assert _analytics_disabled() is True
+
+    def test_disabled_when_env_true(self, monkeypatch):
+        monkeypatch.setenv("BASIC_MEMORY_NO_PROMOS", "true")
+        assert _analytics_disabled() is True
+
+    def test_not_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("BASIC_MEMORY_NO_PROMOS", raising=False)
+        assert _analytics_disabled() is False
+
+
+class TestIsConfigured:
+    def test_configured_when_both_set(self, monkeypatch):
+        monkeypatch.setenv("BASIC_MEMORY_UMAMI_HOST", "https://analytics.example.com")
+        monkeypatch.setenv("BASIC_MEMORY_UMAMI_SITE_ID", "abc-123")
+        assert _is_configured() is True
+
+    def test_not_configured_when_host_missing(self, monkeypatch):
+        monkeypatch.delenv("BASIC_MEMORY_UMAMI_HOST", raising=False)
+        monkeypatch.setenv("BASIC_MEMORY_UMAMI_SITE_ID", "abc-123")
+        assert _is_configured() is False
+
+    def test_not_configured_when_site_id_missing(self, monkeypatch):
+        monkeypatch.setenv("BASIC_MEMORY_UMAMI_HOST", "https://analytics.example.com")
+        monkeypatch.delenv("BASIC_MEMORY_UMAMI_SITE_ID", raising=False)
+        assert _is_configured() is False
+
+    def test_not_configured_when_empty_strings(self, monkeypatch):
+        monkeypatch.setenv("BASIC_MEMORY_UMAMI_HOST", "")
+        monkeypatch.setenv("BASIC_MEMORY_UMAMI_SITE_ID", "")
+        assert _is_configured() is False
+
+
+class TestTrack:
+    def test_no_op_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("BASIC_MEMORY_NO_PROMOS", "1")
+        with patch("basic_memory.cli.analytics.threading.Thread") as mock_thread:
+            track("test-event")
+            mock_thread.assert_not_called()
+
+    def test_no_op_when_not_configured(self, monkeypatch):
+        monkeypatch.delenv("BASIC_MEMORY_NO_PROMOS", raising=False)
+        monkeypatch.delenv("BASIC_MEMORY_UMAMI_HOST", raising=False)
+        monkeypatch.delenv("BASIC_MEMORY_UMAMI_SITE_ID", raising=False)
+        with patch("basic_memory.cli.analytics.threading.Thread") as mock_thread:
+            track("test-event")
+            mock_thread.assert_not_called()
+
+    def test_sends_event_when_configured(self, monkeypatch):
+        monkeypatch.delenv("BASIC_MEMORY_NO_PROMOS", raising=False)
+        monkeypatch.setenv("BASIC_MEMORY_UMAMI_HOST", "https://analytics.example.com")
+        monkeypatch.setenv("BASIC_MEMORY_UMAMI_SITE_ID", "test-site-id")
+
+        captured_target = None
+
+        def fake_thread(target, daemon):
+            nonlocal captured_target
+            captured_target = target
+            mock = MagicMock()
+            return mock
+
+        with patch("basic_memory.cli.analytics.threading.Thread", side_effect=fake_thread):
+            track(EVENT_PROMO_SHOWN, {"trigger": "first_run"})
+
+        assert captured_target is not None
+
+    def test_send_hits_correct_url(self, monkeypatch):
+        monkeypatch.delenv("BASIC_MEMORY_NO_PROMOS", raising=False)
+        monkeypatch.setenv("BASIC_MEMORY_UMAMI_HOST", "https://analytics.example.com")
+        monkeypatch.setenv("BASIC_MEMORY_UMAMI_SITE_ID", "test-site-id")
+
+        captured_request = None
+
+        def fake_urlopen(req, timeout=None):
+            nonlocal captured_request
+            captured_request = req
+            return MagicMock()
+
+        # Run the send function directly instead of in a thread
+        with patch("basic_memory.cli.analytics.urllib.request.urlopen", fake_urlopen):
+            with patch("basic_memory.cli.analytics.threading.Thread") as mock_thread:
+                # Capture the target function and call it directly
+                def run_target(target, daemon):
+                    target()  # Execute synchronously
+                    return MagicMock()
+
+                mock_thread.side_effect = run_target
+                track(EVENT_CLOUD_LOGIN_STARTED)
+
+        assert captured_request is not None
+        assert captured_request.full_url == "https://analytics.example.com/api/send"
+        body = json.loads(captured_request.data)
+        assert body["payload"]["name"] == "cli-cloud-login-started"
+        assert body["payload"]["website"] == "test-site-id"
+        assert body["payload"]["hostname"] == "cli.basicmemory.com"
+        assert "version" in body["payload"]["data"]
+
+    def test_send_failure_is_silent(self, monkeypatch):
+        monkeypatch.delenv("BASIC_MEMORY_NO_PROMOS", raising=False)
+        monkeypatch.setenv("BASIC_MEMORY_UMAMI_HOST", "https://analytics.example.com")
+        monkeypatch.setenv("BASIC_MEMORY_UMAMI_SITE_ID", "test-site-id")
+
+        def fake_urlopen(req, timeout=None):
+            raise ConnectionError("Network down")
+
+        with patch("basic_memory.cli.analytics.urllib.request.urlopen", fake_urlopen):
+            with patch("basic_memory.cli.analytics.threading.Thread") as mock_thread:
+                def run_target(target, daemon):
+                    target()  # Should not raise
+                    return MagicMock()
+
+                mock_thread.side_effect = run_target
+                # Should not raise
+                track("test-event")
+
+
+class TestEventConstants:
+    """Verify event name constants exist and are kebab-case strings."""
+
+    @pytest.mark.parametrize(
+        "event",
+        [
+            EVENT_PROMO_SHOWN,
+            EVENT_PROMO_OPTED_OUT,
+            EVENT_CLOUD_LOGIN_STARTED,
+            EVENT_CLOUD_LOGIN_SUCCESS,
+            EVENT_CLOUD_LOGIN_SUB_REQUIRED,
+        ],
+    )
+    def test_event_names_are_kebab_case(self, event):
+        assert isinstance(event, str)
+        assert event == event.lower()
+        assert " " not in event
+        assert event.startswith("cli-")


### PR DESCRIPTION
## What

Lightweight, non-blocking analytics for the CLI-to-cloud conversion funnel. Tracks promo impressions, opt-outs, and cloud login attempts/successes via Umami's event collector API.

## Events Tracked

| Event | When |
|-------|------|
| `cli-promo-shown` | Promo panel displayed (first run or version bump) |
| `cli-promo-opted-out` | User ran `bm cloud promo --off` |
| `cli-cloud-login-started` | User initiated `bm cloud login` |
| `cli-cloud-login-success` | Login + subscription verified |
| `cli-cloud-login-sub-required` | Login hit subscription paywall |

## Also

- Learn-more URL now includes UTM tags (`utm_source=bm-cli&utm_medium=promo&utm_campaign=cloud-upsell`) for web attribution in Umami

## Design

- **Zero new dependencies** — stdlib only (`urllib.request` + `threading`)
- **Fire-and-forget** — daemon thread, 3s timeout, silent on any failure
- **Respects opt-out** — honors `BASIC_MEMORY_NO_PROMOS` env var
- **No-op by default** — requires `BASIC_MEMORY_UMAMI_HOST` and `BASIC_MEMORY_UMAMI_SITE_ID` env vars to activate. Existing installs see zero change.
- **No PII** — only event name, BM version, and trigger type

## Umami Setup Instructions

After merging, you need to configure Umami to receive these events:

### 1. Get your Umami website ID

- Log in to your Umami dashboard
- Go to **Settings → Websites**
- Click the website for basicmemory.com
- Copy the **Website ID** (UUID format)

### 2. Set environment variables

Wherever the `bm` CLI runs (or in your deployment/build config):

```bash
export BASIC_MEMORY_UMAMI_HOST="https://your-umami-instance.com"
export BASIC_MEMORY_UMAMI_SITE_ID="your-website-uuid-here"
```

For testing locally: set these in your shell before running `bm status` etc.

For production/distribution: these would go in the release build config or be baked into a future config file. Users without these vars set get zero analytics (the module is a complete no-op).

### 3. Create custom events dashboard in Umami

- Go to your website dashboard → **Events** tab
- After the first events flow in, you'll see them listed automatically
- Set up **Goals** for the conversion funnel:
  - Goal 1: Event `cli-promo-shown` (top of funnel)
  - Goal 2: Event `cli-cloud-login-started` (intent)
  - Goal 3: Event `cli-cloud-login-success` (conversion)
- Set up a **Funnel** insight:
  - Step 1: Event `cli-promo-shown`
  - Step 2: Event `cli-cloud-login-started`
  - Step 3: Event `cli-cloud-login-success`

### 4. UTM attribution

The learn-more URL now points to:
```
https://basicmemory.com?utm_source=bm-cli&utm_medium=promo&utm_campaign=cloud-upsell
```

Check **Insights → UTM** in Umami to see CLI-sourced web traffic.

### 5. Verify it works

```bash
export BASIC_MEMORY_UMAMI_HOST="https://your-umami-instance.com"
export BASIC_MEMORY_UMAMI_SITE_ID="your-website-uuid"

# This should trigger a promo-shown event (if promo conditions are met)
bm status

# Check your Umami dashboard → Events tab within a few seconds
```

## Tests

32 tests pass including new analytics tests covering:
- Disabled/unconfigured no-op behavior
- Correct URL and payload construction
- Silent failure on network errors
- Event name constants validation
