### PR TITLE
feat: Let stdio MCP honor per-project cloud routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,8 @@ basic-memory project ls --name main --cloud
 
 No-flag behavior defaults to local when no project context is present.
 
-The local MCP server (`basic-memory mcp`) always uses local routing (including `--transport stdio`).
+The local MCP server routes per transport: `--transport stdio` honors per-project routing
+(local or cloud), while `--transport streamable-http` and `--transport sse` always route locally.
 
 **CLI Note Editing (`tool edit-note`):**
 

--- a/src/basic_memory/cli/analytics.py
+++ b/src/basic_memory/cli/analytics.py
@@ -25,6 +25,7 @@ import basic_memory
 # Configuration — read from environment so nothing is hard-coded in source
 # ---------------------------------------------------------------------------
 
+
 def _umami_host() -> Optional[str]:
     return os.getenv("BASIC_MEMORY_UMAMI_HOST", "").strip() or None
 

--- a/src/basic_memory/cli/promo.py
+++ b/src/basic_memory/cli/promo.py
@@ -7,13 +7,12 @@ from rich.console import Console
 from rich.panel import Panel
 
 import basic_memory
-from basic_memory.cli.analytics import track, EVENT_PROMO_SHOWN, EVENT_PROMO_OPTED_OUT
+from basic_memory.cli.analytics import track, EVENT_PROMO_SHOWN
 from basic_memory.config import ConfigManager
 
 OSS_DISCOUNT_CODE = "BMFOSS"
 CLOUD_LEARN_MORE_URL = (
-    "https://basicmemory.com"
-    "?utm_source=bm-cli&utm_medium=promo&utm_campaign=cloud-upsell"
+    "https://basicmemory.com?utm_source=bm-cli&utm_medium=promo&utm_campaign=cloud-upsell"
 )
 
 

--- a/src/basic_memory/config.py
+++ b/src/basic_memory/config.py
@@ -42,7 +42,9 @@ class DatabaseBackend(str, Enum):
 def _default_semantic_search_enabled() -> bool:
     """Enable semantic search by default when required local semantic dependencies exist."""
     required_modules = ("fastembed", "sqlite_vec")
-    return all(importlib.util.find_spec(module_name) is not None for module_name in required_modules)
+    return all(
+        importlib.util.find_spec(module_name) is not None for module_name in required_modules
+    )
 
 
 @dataclass

--- a/tests/cli/test_analytics.py
+++ b/tests/cli/test_analytics.py
@@ -1,7 +1,6 @@
 """Tests for CLI analytics module."""
 
 import json
-import threading
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -128,6 +127,7 @@ class TestTrack:
 
         with patch("basic_memory.cli.analytics.urllib.request.urlopen", fake_urlopen):
             with patch("basic_memory.cli.analytics.threading.Thread") as mock_thread:
+
                 def run_target(target, daemon):
                     target()  # Should not raise
                     return MagicMock()


### PR DESCRIPTION
## Summary

- Stdio transport (`bm mcp`) no longer forces local routing, allowing per-project cloud routing to work (local projects stay local, cloud projects route to cloud)
- HTTP/SSE transports continue to force local routing since they serve as local API endpoints
- Externally-set env vars (e.g. `BASIC_MEMORY_FORCE_CLOUD=true`) are honored for stdio, preserving escape hatches

## Test plan

- [x] 4 new transport-specific routing tests (stdio no-force, stdio honors external env, streamable-http forces local, sse forces local)
- [x] Existing routing unit tests pass (`tests/cli/test_routing.py`, `tests/mcp/test_async_client_modes.py`)
- [x] Full `just fast-check` passes (2171 tests, lint, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)