### PR TITLE
feat: Fix bm CLI runtime defects and audit regressions

### DIFF
--- a/src/basic_memory/cli/commands/cloud/api_client.py
+++ b/src/basic_memory/cli/commands/cloud/api_client.py
@@ -52,7 +52,7 @@ async def get_authenticated_headers(auth: CLIAuth | None = None) -> dict[str, st
     auth_obj = auth or CLIAuth(client_id=client_id, authkit_domain=domain)
     token = await auth_obj.get_valid_token()
     if not token:
-        console.print("[red]Not authenticated. Please run 'basic-memory cloud login' first.[/red]")
+        console.print("[red]Not authenticated. Please run 'bm cloud login' first.[/red]")
         raise typer.Exit(1)
 
     return {"Authorization": f"Bearer {token}"}

--- a/src/basic_memory/cli/commands/cloud/core_commands.py
+++ b/src/basic_memory/cli/commands/cloud/core_commands.py
@@ -151,7 +151,7 @@ def setup() -> None:
     """Set up cloud sync by installing rclone and configuring credentials.
 
     After setup, use project commands for syncing:
-      bm project add <name> <path> --local-path ~/projects/<name>
+      bm project add <name> --cloud --local-path ~/projects/<name>
       bm project bisync --name <name> --resync  # First time
       bm project bisync --name <name>            # Subsequent syncs
     """
@@ -183,7 +183,7 @@ def setup() -> None:
         console.print("\n[bold green]Cloud setup completed successfully![/bold green]")
         console.print("\n[bold]Next steps:[/bold]")
         console.print("1. Add a project with local sync path:")
-        console.print("   bm project add research --local-path ~/Documents/research")
+        console.print("   bm project add research --cloud --local-path ~/Documents/research")
         console.print("\n   Or configure sync for an existing project:")
         console.print("   bm project sync-setup research ~/Documents/research")
         console.print("\n2. Preview the initial sync (recommended):")

--- a/src/basic_memory/cli/commands/cloud/upload_command.py
+++ b/src/basic_memory/cli/commands/cloud/upload_command.py
@@ -13,6 +13,7 @@ from basic_memory.cli.commands.cloud.cloud_utils import (
     sync_project,
 )
 from basic_memory.cli.commands.cloud.upload import upload_path
+from basic_memory.mcp.async_client import get_cloud_control_plane_client
 
 console = Console()
 
@@ -86,7 +87,7 @@ def upload(
                 console.print(
                     f"[red]Project '{project}' does not exist.[/red]\n"
                     f"[yellow]Options:[/yellow]\n"
-                    f"  1. Create it first: bm project add {project}\n"
+                    f"  1. Create it first: bm project add {project} --cloud\n"
                     f"  2. Use --create-project flag to create automatically"
                 )
                 raise typer.Exit(1)
@@ -100,7 +101,12 @@ def upload(
             console.print(f"[blue]Uploading {path} to project '{project}'...[/blue]")
 
         success = await upload_path(
-            path, project, verbose=verbose, use_gitignore=not no_gitignore, dry_run=dry_run
+            path,
+            project,
+            verbose=verbose,
+            use_gitignore=not no_gitignore,
+            dry_run=dry_run,
+            client_cm_factory=get_cloud_control_plane_client,
         )
         if not success:
             console.print("[red]Upload failed[/red]")

--- a/src/basic_memory/cli/commands/command_utils.py
+++ b/src/basic_memory/cli/commands/command_utils.py
@@ -97,5 +97,19 @@ async def get_project_info(project: str):
             response = await call_get(client, f"/v2/projects/{project_item.external_id}/info")
             return ProjectInfoResponse.model_validate(response.json())
     except (ToolError, ValueError) as e:
-        console.print(f"[red]Sync failed: {e}[/red]")
+        error_text = str(e)
+        if "internal proxy error" in error_text.lower() and "not found in configuration" in (
+            error_text.lower()
+        ):
+            console.print(
+                "[red]Project info failed: cloud returned an internal configuration error for "
+                "this project.[/red]"
+            )
+            console.print(
+                "[yellow]This is a cloud backend issue for detailed info lookups. "
+                "Use `bm project list --cloud` for project metadata until the service is updated."
+                "[/yellow]"
+            )
+        else:
+            console.print(f"[red]Project info failed: {e}[/red]")
         raise typer.Exit(1)

--- a/src/basic_memory/cli/commands/format.py
+++ b/src/basic_memory/cli/commands/format.py
@@ -183,10 +183,10 @@ def format(
     By default, formats all .md, .json, and .canvas files in the current project.
 
     Examples:
-        basic-memory format                    # Format all files in current project
-        basic-memory format --project research # Format files in specific project
-        basic-memory format notes/meeting.md   # Format a specific file
-        basic-memory format notes/             # Format all files in directory
+        bm format                    # Format all files in current project
+        bm format --project research # Format files in specific project
+        bm format notes/meeting.md   # Format a specific file
+        bm format notes/             # Format all files in directory
     """
     try:
         run_with_cleanup(run_format(path, project))

--- a/src/basic_memory/cli/commands/import_chatgpt.py
+++ b/src/basic_memory/cli/commands/import_chatgpt.py
@@ -44,7 +44,7 @@ def import_chatgpt(
     2. Convert them to linear markdown conversations
     3. Save as clean, readable markdown files
 
-    After importing, run 'basic-memory sync' to index the new files.
+    After importing, run 'bm reindex --search' to index the new files.
     """
 
     try:
@@ -81,7 +81,7 @@ def import_chatgpt(
             )
         )
 
-        console.print("\nRun 'basic-memory sync' to index the new files.")
+        console.print("\nRun 'bm reindex --search' to index the new files.")
 
     except Exception as e:
         logger.error("Import failed")

--- a/src/basic_memory/cli/commands/import_claude_conversations.py
+++ b/src/basic_memory/cli/commands/import_claude_conversations.py
@@ -44,7 +44,7 @@ def import_claude(
     2. Create markdown files for each conversation
     3. Format content in clean, readable markdown
 
-    After importing, run 'basic-memory sync' to index the new files.
+    After importing, run 'bm reindex --search' to index the new files.
     """
 
     config = get_project_config()
@@ -84,7 +84,7 @@ def import_claude(
             )
         )
 
-        console.print("\nRun 'basic-memory sync' to index the new files.")
+        console.print("\nRun 'bm reindex --search' to index the new files.")
 
     except Exception as e:
         logger.error("Import failed")

--- a/src/basic_memory/cli/commands/import_claude_projects.py
+++ b/src/basic_memory/cli/commands/import_claude_projects.py
@@ -44,7 +44,7 @@ def import_projects(
     2. Store docs in a docs/ subdirectory
     3. Place prompt template in project root
 
-    After importing, run 'basic-memory sync' to index the new files.
+    After importing, run 'bm reindex --search' to index the new files.
     """
     config = get_project_config()
     try:
@@ -83,7 +83,7 @@ def import_projects(
             )
         )
 
-        console.print("\nRun 'basic-memory sync' to index the new files.")
+        console.print("\nRun 'bm reindex --search' to index the new files.")
 
     except Exception as e:
         logger.error("Import failed")

--- a/src/basic_memory/cli/commands/mcp.py
+++ b/src/basic_memory/cli/commands/mcp.py
@@ -36,7 +36,7 @@ def mcp(
     This command starts an MCP server using one of three transport options:
 
     - stdio: Standard I/O (good for local usage)
-    - streamable-http: Recommended for web deployments (default)
+    - streamable-http: Recommended for web deployments
     - sse: Server-Sent Events (for compatibility with existing clients)
 
     Initialization, file sync, and cleanup are handled by the MCP server's lifespan.

--- a/src/basic_memory/cli/commands/project.py
+++ b/src/basic_memory/cli/commands/project.py
@@ -1149,6 +1149,8 @@ def display_project_info(
             )
             console.print(f"\nTimestamp: [cyan]{current_time.strftime('%Y-%m-%d %H:%M:%S')}[/cyan]")
 
+    except typer.Exit:
+        raise
     except Exception as e:  # pragma: no cover
         typer.echo(f"Error getting project info: {e}", err=True)
         raise typer.Exit(1)

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -298,7 +298,7 @@ def write_note(
     content: Annotated[
         Optional[str],
         typer.Option(
-            help="The content of the note. If not provided, content will be read from stdin. This allows piping content from other commands, e.g.: cat file.md | basic-memory tools write-note"
+            help="The content of the note. If not provided, content will be read from stdin. This allows piping content from other commands, e.g.: cat file.md | bm tool write-note"
         ),
     ] = None,
     tags: Annotated[
@@ -322,13 +322,13 @@ def write_note(
     Examples:
 
     # Using content parameter
-    basic-memory tools write-note --title "My Note" --folder "notes" --content "Note content"
+    bm tool write-note --title "My Note" --folder "notes" --content "Note content"
 
     # Using stdin pipe
-    echo "# My Note Content" | basic-memory tools write-note --title "My Note" --folder "notes"
+    echo "# My Note Content" | bm tool write-note --title "My Note" --folder "notes"
 
     # Using heredoc
-    cat << EOF | basic-memory tools write-note --title "My Note" --folder "notes"
+    cat << EOF | bm tool write-note --title "My Note" --folder "notes"
     # My Document
 
     This is my document content.
@@ -338,10 +338,10 @@ def write_note(
     EOF
 
     # Reading from a file
-    cat document.md | basic-memory tools write-note --title "Document" --folder "docs"
+    cat document.md | bm tool write-note --title "Document" --folder "docs"
 
     # Force local routing in cloud mode
-    basic-memory tools write-note --title "My Note" --folder "notes" --content "..." --local
+    bm tool write-note --title "My Note" --folder "notes" --content "..." --local
     """
     try:
         validate_routing_flags(local, cloud)

--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -65,9 +65,7 @@ async def list_memory_projects(
         result = "Available projects:\n"
         for project in project_list.projects:
             label = (
-                f"{project.display_name} ({project.name})"
-                if project.display_name
-                else project.name
+                f"{project.display_name} ({project.name})" if project.display_name else project.name
             )
             result += f"• {label}\n"
 

--- a/src/basic_memory/repository/sqlite_search_repository.py
+++ b/src/basic_memory/repository/sqlite_search_repository.py
@@ -607,6 +607,7 @@ class SQLiteSearchRepository(SearchRepositoryBase):
 
         # --- FTS mode (SQLite-specific) ---
         conditions = []
+        match_conditions = []
         params = {}
         order_by_clause = ""
         from_clause = "search_index"
@@ -621,7 +622,7 @@ class SQLiteSearchRepository(SearchRepositoryBase):
                 # Use _prepare_search_term to handle both Boolean and non-Boolean queries
                 processed_text = self._prepare_search_term(search_text.strip())
                 params["text"] = processed_text
-                conditions.append(
+                match_conditions.append(
                     "(search_index.title MATCH :text OR search_index.content_stems MATCH :text)"
                 )
 
@@ -629,7 +630,7 @@ class SQLiteSearchRepository(SearchRepositoryBase):
         if title:
             title_text = self._prepare_search_term(title.strip(), is_prefix=False)
             params["title_text"] = title_text
-            conditions.append("search_index.title MATCH :title_text")
+            match_conditions.append("search_index.title MATCH :title_text")
 
         # Handle permalink exact search
         if permalink:
@@ -652,7 +653,7 @@ class SQLiteSearchRepository(SearchRepositoryBase):
                 else:
                     permalink_text = self._prepare_search_term(permalink_text, is_prefix=False)
                     params["permalink"] = permalink_text
-                    conditions.append("search_index.permalink MATCH :permalink")
+                    match_conditions.append("search_index.permalink MATCH :permalink")
 
         # Handle entity type filter
         if search_item_types:
@@ -755,6 +756,18 @@ class SQLiteSearchRepository(SearchRepositoryBase):
                         operator = {"gt": ">", "gte": ">=", "lt": "<", "lte": "<="}[filt.op]
                         conditions.append(f"{compare_expr} {operator} :{value_param}")
                     continue
+
+        # Trigger: SQLite FTS MATCH predicates combined with JOINs can fail with
+        # "unable to use function MATCH in the requested context".
+        # Why: MATCH needs to run in an FTS-valid context.
+        # Outcome: evaluate MATCH clauses in an FTS subquery and filter outer rows by rowid.
+        if metadata_filters and match_conditions:
+            match_where = " AND ".join(match_conditions)
+            conditions.append(
+                f"search_index.rowid IN (SELECT rowid FROM search_index WHERE {match_where})"
+            )
+        else:
+            conditions.extend(match_conditions)
 
         # Always filter by project_id
         params["project_id"] = self.project_id

--- a/test-int/cli/test_search_notes_meta_integration.py
+++ b/test-int/cli/test_search_notes_meta_integration.py
@@ -1,0 +1,71 @@
+"""Integration coverage for tool search-notes with metadata filters."""
+
+import json
+
+from typer.testing import CliRunner
+
+from basic_memory.cli.main import app as cli_app
+
+runner = CliRunner()
+
+
+def test_search_notes_query_plus_meta_filter(app, app_config, test_project, config_manager):
+    """`bm tool search-notes` should support query + metadata filter together."""
+    active_content = "---\nstatus: active\n---\n# Active Meta Note\n\nMetaFilterToken"
+    inactive_content = "---\nstatus: inactive\n---\n# Inactive Meta Note\n\nMetaFilterToken"
+
+    active_write = runner.invoke(
+        cli_app,
+        [
+            "tool",
+            "write-note",
+            "--title",
+            "Active Meta Note",
+            "--folder",
+            "meta-tests",
+            "--content",
+            active_content,
+            "--format",
+            "json",
+        ],
+    )
+    assert active_write.exit_code == 0, active_write.output
+    active_data = json.loads(active_write.stdout)
+
+    inactive_write = runner.invoke(
+        cli_app,
+        [
+            "tool",
+            "write-note",
+            "--title",
+            "Inactive Meta Note",
+            "--folder",
+            "meta-tests",
+            "--content",
+            inactive_content,
+            "--format",
+            "json",
+        ],
+    )
+    assert inactive_write.exit_code == 0, inactive_write.output
+    inactive_data = json.loads(inactive_write.stdout)
+
+    search = runner.invoke(
+        cli_app,
+        [
+            "tool",
+            "search-notes",
+            "MetaFilterToken",
+            "--meta",
+            "status=active",
+            "--local",
+            "--page-size",
+            "20",
+        ],
+    )
+    assert search.exit_code == 0, search.output
+
+    payload = json.loads(search.stdout)
+    permalinks = {item["permalink"] for item in payload["results"]}
+    assert active_data["permalink"] in permalinks
+    assert inactive_data["permalink"] not in permalinks

--- a/tests/cli/cloud/test_upload_command_routing.py
+++ b/tests/cli/cloud/test_upload_command_routing.py
@@ -1,0 +1,55 @@
+"""Tests for cloud upload command routing behavior."""
+
+from contextlib import asynccontextmanager
+
+import httpx
+from typer.testing import CliRunner
+
+from basic_memory.cli.app import app
+
+runner = CliRunner()
+
+
+def test_cloud_upload_uses_control_plane_client(monkeypatch, tmp_path):
+    """Upload command should use control-plane cloud client for WebDAV PUT operations."""
+    import basic_memory.cli.commands.cloud.upload_command as upload_command
+
+    upload_dir = tmp_path / "upload"
+    upload_dir.mkdir()
+    (upload_dir / "note.md").write_text("hello", encoding="utf-8")
+
+    seen: dict[str, str] = {}
+
+    async def fake_project_exists(_project_name: str) -> bool:
+        return True
+
+    @asynccontextmanager
+    async def fake_get_client():
+        async with httpx.AsyncClient(base_url="https://cloud.example.test") as client:
+            yield client
+
+    async def fake_upload_path(*args, **kwargs):
+        client_cm_factory = kwargs.get("client_cm_factory")
+        assert client_cm_factory is not None
+        async with client_cm_factory() as client:
+            seen["base_url"] = str(client.base_url).rstrip("/")
+        return True
+
+    monkeypatch.setattr(upload_command, "project_exists", fake_project_exists)
+    monkeypatch.setattr(upload_command, "get_cloud_control_plane_client", fake_get_client)
+    monkeypatch.setattr(upload_command, "upload_path", fake_upload_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "cloud",
+            "upload",
+            str(upload_dir),
+            "--project",
+            "routing-test",
+            "--no-sync",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen["base_url"] == "https://cloud.example.test"

--- a/tests/cli/test_db_reset_exit.py
+++ b/tests/cli/test_db_reset_exit.py
@@ -1,0 +1,56 @@
+"""Regression tests for bm reset command process exit behavior."""
+
+import os
+import platform
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+IS_WINDOWS = platform.system() == "Windows"
+skip_on_windows = pytest.mark.skipif(
+    IS_WINDOWS, reason="Subprocess cleanup tests are unreliable on Windows CI"
+)
+
+
+def _isolated_env(tmp_path: Path) -> dict[str, str]:
+    env = dict(os.environ)
+    env["HOME"] = str(tmp_path)
+    if os.name == "nt":
+        env["USERPROFILE"] = str(tmp_path)
+    env["BASIC_MEMORY_HOME"] = str(tmp_path / "basic-memory")
+    env["BASIC_MEMORY_CONFIG_DIR"] = str(tmp_path / ".basic-memory")
+    return env
+
+
+@skip_on_windows
+def test_bm_reset_exits_cleanly(tmp_path: Path):
+    """bm reset should finish and exit cleanly with non-interactive confirmation."""
+    result = subprocess.run(
+        ["uv", "run", "bm", "reset"],
+        input="y\n",
+        capture_output=True,
+        text=True,
+        timeout=20,
+        cwd=Path(__file__).parent.parent.parent,
+        env=_isolated_env(tmp_path),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Database reset complete" in result.stdout
+
+
+@skip_on_windows
+def test_bm_reset_reindex_exits_cleanly(tmp_path: Path):
+    """bm reset --reindex should finish and exit cleanly with non-interactive confirmation."""
+    result = subprocess.run(
+        ["uv", "run", "bm", "reset", "--reindex"],
+        input="y\n",
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=Path(__file__).parent.parent.parent,
+        env=_isolated_env(tmp_path),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Reindex complete" in result.stdout

--- a/tests/cli/test_project_info_errors.py
+++ b/tests/cli/test_project_info_errors.py
@@ -1,0 +1,58 @@
+"""Regression tests for project info error handling."""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import pytest
+import typer
+from mcp.server.fastmcp.exceptions import ToolError
+from typer.testing import CliRunner
+
+from basic_memory.cli.app import app
+import basic_memory.cli.commands.command_utils as command_utils
+import basic_memory.cli.commands.project as project_cmd  # noqa: F401
+
+runner = CliRunner()
+
+
+@pytest.mark.asyncio
+async def test_get_project_info_cloud_config_error_has_clear_message(monkeypatch, capsys):
+    """Cloud internal proxy config failures should surface actionable guidance."""
+
+    @asynccontextmanager
+    async def fake_get_client(project_name=None):
+        yield object()
+
+    async def fake_get_active_project(client, project, context):
+        return SimpleNamespace(external_id="proj-123")
+
+    async def fake_call_get(client, url):
+        raise ToolError("Internal proxy error: Project 'demo' not found in configuration")
+
+    monkeypatch.setattr(command_utils, "get_client", fake_get_client)
+    monkeypatch.setattr(command_utils, "get_active_project", fake_get_active_project)
+    monkeypatch.setattr(command_utils, "call_get", fake_call_get)
+
+    with pytest.raises(typer.Exit) as exc:
+        await command_utils.get_project_info("demo")
+
+    assert exc.value.exit_code == 1
+    captured = capsys.readouterr()
+    combined_output = captured.out + captured.err
+    assert "Project info failed: cloud returned an internal configuration error" in combined_output
+    assert "bm project list" in combined_output
+    assert "--cloud" in combined_output
+
+
+def test_project_info_does_not_print_wrapper_exit_code(monkeypatch):
+    """project info should not append a secondary 'Error getting project info: 1' line."""
+
+    async def fake_get_project_info(_project_name: str):
+        raise typer.Exit(1)
+
+    monkeypatch.setattr(project_cmd, "get_project_info", fake_get_project_info)
+
+    result = runner.invoke(app, ["project", "info", "demo"])
+
+    assert result.exit_code == 1
+    assert "Error getting project info" not in result.output

--- a/tests/mcp/test_tool_utils_cloud_auth.py
+++ b/tests/mcp/test_tool_utils_cloud_auth.py
@@ -1,0 +1,56 @@
+"""Cloud auth error translation tests for MCP tool HTTP helpers."""
+
+import pytest
+from httpx import HTTPStatusError
+from mcp.server.fastmcp.exceptions import ToolError
+
+from basic_memory.mcp.tools.utils import call_post
+
+
+class _MockResponse:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+        self.is_success = status_code < 400
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise HTTPStatusError(
+                message=f"HTTP Error {self.status_code}",
+                request=None,
+                response=self,
+            )
+
+
+class _PostClient:
+    def __init__(self, response: _MockResponse):
+        self._response = response
+
+    async def post(self, *args, **kwargs):
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_call_post_401_with_cloud_key_shows_actionable_remediation(config_manager):
+    """401 auth failures with configured cloud_api_key should provide clear remediation."""
+    config = config_manager.load_config()
+    config.cloud_api_key = "bmc_invalid_test_key"
+    config_manager.save_config(config)
+
+    client = _PostClient(
+        _MockResponse(
+            401,
+            {"detail": "Invalid JWT token. Authentication required."},
+        )
+    )
+
+    with pytest.raises(ToolError) as exc:
+        await call_post(client, "/v2/projects/", json={"name": "test"})
+
+    message = str(exc.value)
+    assert "configured cloud API key was rejected" in message
+    assert "bm cloud set-key <valid-key>" in message
+    assert "cloud_api_key" in message

--- a/tests/repository/test_search_text_with_metadata_filters.py
+++ b/tests/repository/test_search_text_with_metadata_filters.py
@@ -1,0 +1,65 @@
+"""Regression coverage for combined text + metadata filtering."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from basic_memory import db
+from basic_memory.models.knowledge import Entity
+from basic_memory.repository.search_index_row import SearchIndexRow
+from basic_memory.schemas.search import SearchItemType
+
+
+async def _index_entity(search_repository, session_maker, title: str, status: str) -> Entity:
+    slug = "-".join(title.lower().split())
+    now = datetime.now(timezone.utc)
+    file_path = f"notes/{slug}.md"
+    permalink = f"notes/{slug}"
+
+    async with db.scoped_session(session_maker) as session:
+        entity = Entity(
+            project_id=search_repository.project_id,
+            title=title,
+            entity_type="note",
+            permalink=permalink,
+            file_path=file_path,
+            content_type="text/markdown",
+            entity_metadata={"status": status},
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(entity)
+        await session.flush()
+
+    await search_repository.index_item(
+        SearchIndexRow(
+            project_id=search_repository.project_id,
+            id=entity.id,
+            type=SearchItemType.ENTITY.value,
+            title=entity.title,
+            content_stems="CLI metadata filter regression",
+            content_snippet="CLI metadata filter regression",
+            permalink=entity.permalink,
+            file_path=entity.file_path,
+            entity_id=entity.id,
+            metadata={"entity_type": entity.entity_type},
+            created_at=entity.created_at,
+            updated_at=entity.updated_at,
+        )
+    )
+
+    return entity
+
+
+@pytest.mark.asyncio
+async def test_search_text_and_metadata_filters_work_together(search_repository, session_maker):
+    """Combined text + metadata filters should work without MATCH context errors."""
+    active = await _index_entity(search_repository, session_maker, "CLI Active Result", "active")
+    await _index_entity(search_repository, session_maker, "CLI Inactive Result", "inactive")
+
+    results = await search_repository.search(
+        search_text="CLI",
+        metadata_filters={"status": "active"},
+    )
+
+    assert {row.id for row in results} == {active.id}

--- a/tests/services/test_project_service_cloud_info.py
+++ b/tests/services/test_project_service_cloud_info.py
@@ -1,0 +1,38 @@
+"""Regression tests for cloud-only project info handling."""
+
+import os
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_get_project_info_supports_db_only_project(
+    project_service,
+    project_repository,
+    config_manager,
+):
+    """Project info should work when project exists in DB but not local config."""
+    suffix = os.urandom(4).hex()
+    project_name = f"cloud-only-{suffix}"
+    project_path = f"/app/data/{project_name}"
+
+    # Ensure the project is not present in local config.
+    config = config_manager.load_config()
+    config.projects.pop(project_name, None)
+    config_manager.save_config(config)
+
+    await project_repository.create(
+        {
+            "name": project_name,
+            "path": project_path,
+            "is_active": True,
+            "is_default": False,
+        }
+    )
+
+    info = await project_service.get_project_info(project_name)
+
+    assert info.project_name == project_name
+    assert info.project_path == project_path
+    assert project_name in info.available_projects
+    assert info.available_projects[project_name]["path"] == project_path


### PR DESCRIPTION
## Summary
- Fixes `bm reset` shutdown hang in non-interactive flows
- Fixes SQLite `search-notes` query + metadata filter MATCH context error
- Fixes `bm cloud upload --no-sync` WebDAV routing path
- Improves cloud API-key auth failure remediation messaging
- Adds focused regressions across CLI/repository/service/tool layers (including Postgres coverage for search filters)

## Validation
- Targeted regression suite passes
- Postgres search regression slice passes
- Manual runtime verification completed for reset and upload paths

## Runtime notes (hang fixes)
- `bm reset` and `bm reset --reindex` previously hung after printing completion when run non-interactively (for example with piped `y`).
- Root cause was migration-time temporary engine/thread lifecycle not being disposed cleanly.
- Fixed in this PR and manually re-verified with:
  - `printf 'y\n' | uv run bm reset`
  - `printf 'y\n' | uv run bm reset --reindex`
- Both now exit cleanly with exit code `0`.

## Follow-up after cloud deploy
- `bm project info --cloud` must be re-verified after deploying corresponding cloud backend changes (proxy/API alignment).
- Current hosted cloud still returns: `Internal proxy error: Project '<name>' not found in configuration` for `/proxy/v2/projects/{id}/info`.
