### PR TITLE
docs: update v0.19.0 release notes with post-draft changes

### DIFF
--- a/docs/releases/v0.19.0.md
+++ b/docs/releases/v0.19.0.md
@@ -4,7 +4,7 @@
 
 v0.19.0 is a major release that introduces semantic vector search, a schema validation system,
 project-prefixed permalinks, per-project cloud routing, and a significant upgrade to FastMCP 3.0.
-It includes 66 commits since v0.18.0 spanning new features, architectural improvements, and
+It includes 80+ commits since v0.18.0 spanning new features, architectural improvements, and
 stability fixes across both SQLite and Postgres backends.
 
 ---
@@ -16,6 +16,7 @@ stability fixes across both SQLite and Postgres backends.
 Full vector and hybrid search for SQLite (via sqlite-vec) and Postgres (via pgvector).
 
 - **Hybrid search mode** combines full-text search (FTS) with vector similarity for best results
+- **Score-based fusion** replaces RRF for hybrid ranking — `max(vec, fts) + 0.3 * min(vec, fts)` preserves dominant signals and rewards dual-source agreement (#577)
 - **Default search mode** is now `hybrid` when semantic search is enabled, `text` when disabled
 - Embedding providers: FastEmbed (local, default) or OpenAI API
 - Configurable similarity threshold via `semantic_min_similarity` (default 0.55)
@@ -23,6 +24,7 @@ Full vector and hybrid search for SQLite (via sqlite-vec) and Postgres (via pgve
 - Auto-backfill: existing entities get embeddings generated on first startup
 - Backend-specific distance-to-similarity conversion (cosine for SQLite, inner product for Postgres)
 - FTS fallback: if semantic dependencies are missing, search gracefully degrades to text-only
+- sqlite-vec knn `k` parameter capped at 4096 to prevent backend errors
 
 **Configuration:**
 ```json
@@ -84,18 +86,19 @@ Cloud projects can target specific workspaces for multi-tenant environments.
 
 ## New Tools and Capabilities
 
-### JSON Output Mode
+### Dashboard (`bm project info`)
 
-All MCP tools now support `output_format="json"` for machine-readable responses.
+`bm project info` now displays an htop-inspired compact dashboard with:
 
-- Default remains `"text"` for human-readable output (no breaking changes)
-- `build_context` defaults to `"json"` with slimmed payloads (redundant fields stripped)
-- CLI tool commands support `--format json` flag
+- Horizontal bar charts for note types (top 5)
+- Embedding coverage bar with Unicode block characters
+- Colored status dots for at-a-glance health
+- `EmbeddingStatus` schema and `get_embedding_status()` service method for programmatic access
 
-### Structured Metadata Search
+### Unified Metadata Search
 
-`search_notes` now supports filter-only searches — `query` is optional, so you can search
-purely by frontmatter metadata without passing an empty string.
+`search_by_metadata` has been merged into `search_notes` — one tool for all searches.
+`query` is now optional, so you can search purely by frontmatter metadata.
 
 ```
 search_notes(metadata_filters={"status": "in-progress"})
@@ -105,6 +108,14 @@ search_notes(metadata_filters={"schema.confidence": {"$gt": 0.7}})
 search_notes(tags=["security"])  # convenience shorthand
 search_notes(status="draft")     # convenience shorthand
 ```
+
+### JSON Output Mode
+
+All MCP tools now support `output_format="json"` for machine-readable responses.
+
+- Default remains `"text"` for human-readable output (no breaking changes)
+- `build_context` defaults to `"json"` with slimmed payloads (redundant fields stripped)
+- CLI tool commands support `--format json` flag
 
 ### `tag:` Search Shorthand
 
@@ -119,13 +130,24 @@ search_notes("tag:coffee AND tag:brewing")
 
 Entities now track `created_by` and `last_updated_by` fields for attribution.
 
-### Matched Chunk Text in Search
+### Improved Search Result Content (#609)
 
-Search results now include `matched_chunk` field showing the specific text that matched.
+Search results now surface more relevant context:
+
+- `matched_chunk_text` populated for FTS-only hybrid results (no more fallback to truncated content)
+- `TOP_CHUNKS_PER_RESULT` increased from 3 to 5, catching answers deeper in large notes (~2700 → ~4500 chars)
+- `CONTENT_DISPLAY_LIMIT` doubled from 2000 to 4000 chars for results without matched chunks
 
 ---
 
 ## Architecture Changes
+
+### Score-Based Hybrid Fusion (#577)
+
+RRF (Reciprocal Rank Fusion) compressed all fused scores to ~0.016, destroying ranking
+differentiation. The new formula `max(vec, fts) + FUSION_BONUS * min(vec, fts)` preserves
+dominant signals and rewards dual-source agreement. Zero-score results now produce zero
+fused score instead of receiving a 0.1 weight floor.
 
 ### FastMCP 3.0 Upgrade
 
@@ -204,6 +226,7 @@ making all major CLI commands scriptable for CI pipelines and automation.
 
 ## Bug Fixes
 
+- **#577**: RRF fusion compressed all hybrid scores to ~0.016, destroying ranking differentiation
 - **#582**: build_context returns empty results on valid note identifiers
 - **#575**: Remove hardcoded "main" default from default_project
 - **#595**: recent_activity dedup and pagination across MCP tools
@@ -216,11 +239,22 @@ making all major CLI commands scriptable for CI pipelines and automation.
 - **#533**: Fix recent_activity prompt defaults
 - **#530**: Prevent spurious `metadata: {}` in frontmatter output
 - **#601**: Return matched chunk text in search results
+- **#606**: Accept `null` for `expected_replacements` in `edit_note`
+- **#579, #607**: Guard against closed streams in promo panel and missing vector tables on shutdown
+- **#609**: FTS-only hybrid results missing `matched_chunk_text`; content limits too conservative
+- Cap sqlite-vec knn `k` parameter at 4096 to prevent backend errors
 - Parameterize SQL queries in search repository type filters
 - Double-default display in project list
 - `ensure_frontmatter_on_sync` default changed to `True`
 - Status/doctor commands fail with cloud-mode projects (Docker path error)
 - Prompts return "0 projects" in discovery mode
+
+---
+
+## Security
+
+- Upgrade `cryptography` for CVE advisory
+- Upgrade `python-multipart` for security advisory
 
 ---
 
@@ -233,6 +267,8 @@ making all major CLI commands scriptable for CI pipelines and automation.
 - **#596**: Fix CLI runtime defects and audit regressions
 - CLI refactoring and workspace-aware cloud project listing
 - Split and speed up PR test matrix in CI
+- Fix CI: collect coverage from test jobs instead of re-running all tests
+- Create `search_vector_chunks` in test fixtures for Postgres compatibility
 
 ---
 
@@ -251,6 +287,10 @@ making all major CLI commands scriptable for CI pipelines and automation.
 - **Semantic search dependencies** are now included by default. If sqlite-vec fails to load,
   search gracefully falls back to FTS. Run `bm reindex --embeddings` to generate embeddings
   for existing content.
+- **Hybrid search scoring** has changed from RRF to score-based fusion. Search result ordering
+  may differ — results should be more accurate with better score differentiation.
+- **`search_by_metadata`** is removed as a standalone tool. Use `search_notes` with
+  `metadata_filters` instead (same parameters, same behavior).
 - **Project-prefixed permalinks** are enabled by default. Existing notes keep their current
   permalinks until modified. Set `permalinks_include_project: false` to disable.
 - **Frontmatter on sync** is now enabled by default. Files without frontmatter will have it


### PR DESCRIPTION
Updates release notes to cover everything merged after the initial draft was written.

**Added:**
- **#577**: Score-based fusion replacing RRF — the big search quality fix
- **#609**: Richer content context + improved hit rate in search results
- **#606**: Accept null for expected_replacements in edit_note
- **#579/#607**: Guard against closed streams in promo + missing vector tables
- **Dashboard**: htop-inspired `bm project info` with embedding coverage bars
- **Unified metadata search**: search_by_metadata merged into search_notes
- **sqlite-vec knn cap**: k parameter capped at 4096
- **Security section**: cryptography + python-multipart CVE upgrades
- **CI fixes**: coverage collection, Postgres test fixtures

**Upgrade Notes additions:**
- Hybrid search scoring change (RRF → score-based fusion)
- search_by_metadata removal notice

Commit count updated from 66 to 80+.