### PR TITLE
fix(cli): use resolved project path in doctor command

### DIFF
--- a/src/basic_memory/cli/commands/doctor.py
+++ b/src/basic_memory/cli/commands/doctor.py
@@ -54,6 +54,9 @@ async def run_doctor() -> None:
                 if not status.new_project:
                     raise ValueError("Failed to create doctor project")
                 project_id = status.new_project.external_id
+                # Use the resolved path from the server — when project_root is configured,
+                # the actual project directory differs from the requested temp_path
+                project_path = Path(status.new_project.path)
                 console.print(f"[green]OK[/green] Created doctor project: {project_name}")
 
                 # --- DB -> File: create an entity via API ---
@@ -68,7 +71,7 @@ async def run_doctor() -> None:
                 )
                 api_result = await knowledge_client.create_entity(api_note.model_dump(), fast=False)
 
-                api_file = temp_path / api_result.file_path
+                api_file = project_path / api_result.file_path
                 if not api_file.exists():
                     raise ValueError(f"API note file missing: {api_result.file_path}")
 
@@ -79,7 +82,7 @@ async def run_doctor() -> None:
                 console.print("[green]OK[/green] API write created file")
 
                 # --- File -> DB: write markdown file directly, then sync ---
-                parser = EntityParser(temp_path)
+                parser = EntityParser(project_path)
                 processor = MarkdownProcessor(parser)
                 manual_markdown = EntityMarkdown(
                     frontmatter=EntityFrontmatter(
@@ -93,7 +96,7 @@ async def run_doctor() -> None:
                     content=f"# {manual_note_title}\n\n- [note] File to DB check",
                 )
 
-                manual_path = temp_path / "doctor" / "manual-note.md"
+                manual_path = project_path / "doctor" / "manual-note.md"
                 await processor.write_file(manual_path, manual_markdown)
                 console.print("[green]OK[/green] Manual file written")
 

--- a/test-int/mcp/test_string_params_integration.py
+++ b/test-int/mcp/test_string_params_integration.py
@@ -148,9 +148,7 @@ async def test_canvas_nodes_edges_as_string(mcp_server, app, test_project):
             "height": 100,
         }
     ]
-    edges = [
-        {"id": "e1", "fromNode": "n1", "toNode": "n1", "label": "self"}
-    ]
+    edges = [{"id": "e1", "fromNode": "n1", "toNode": "n1", "label": "self"}]
 
     async with Client(mcp_server) as client:
         result = await client.call_tool(

--- a/tests/mcp/test_tool_edit_note.py
+++ b/tests/mcp/test_tool_edit_note.py
@@ -1,6 +1,5 @@
 """Tests for the edit_note MCP tool."""
 
-
 import pytest
 
 from basic_memory.mcp.tools.edit_note import edit_note

--- a/tests/test_coerce.py
+++ b/tests/test_coerce.py
@@ -3,7 +3,6 @@
 These must fail until the helpers are implemented in utils.py.
 """
 
-
 from basic_memory.utils import coerce_list, coerce_dict
 
 


### PR DESCRIPTION
## Summary
- When `project_root` is configured (e.g., Docker), `bm doctor` would falsely fail because it checked for files under the original `temp_path` instead of the resolved path under `project_root`
- Now uses `status.new_project.path` (the actual resolved path) for all file existence checks after project creation

Fixes #665

## Test plan
- [ ] `just fast-check` passes (lint, typecheck, impacted tests)
- [ ] `just doctor` passes locally (without `project_root` set)
- [ ] Verify with `project_root` configured that doctor no longer false-fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)