### PR TITLE
ci(core): reduce duplicate CI and normalize Windows assertions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,11 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  # Trigger: PR branch pushes already publish commit statuses that show up on the PR.
+  # Why: running the full matrix on both push and pull_request doubles CI time for the
+  #      exact same branch head commit.
+  # Outcome: each branch push runs the test suite once, including PR updates.
   push:
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   static-checks:

--- a/tests/indexing/test_batch_indexer.py
+++ b/tests/indexing/test_batch_indexer.py
@@ -734,4 +734,4 @@ async def test_batch_indexer_does_not_inject_frontmatter_when_sync_enforcement_i
     assert entity.permalink == existing_permalink
     assert frontmatter_writer.await_count == 0
     assert indexed.markdown_content == persisted_content
-    assert await file_service.read_file_content(path) == persisted_content
+    assert (await file_service.read_file_bytes(path)).decode("utf-8") == persisted_content

--- a/tests/sync/test_sync_one_markdown_file.py
+++ b/tests/sync/test_sync_one_markdown_file.py
@@ -153,7 +153,7 @@ async def test_sync_one_markdown_file_returns_original_content_when_no_rewrite_n
 
     assert frontmatter_writer.await_count == 0
     assert result.markdown_content == persisted_content
-    assert file_path.read_text(encoding="utf-8") == persisted_content
+    assert file_path.read_bytes().decode("utf-8") == persisted_content
     assert result.checksum == await sync_service.file_service.compute_checksum(
         "notes/no-rewrite.md"
     )
@@ -248,7 +248,7 @@ async def test_sync_one_markdown_file_indexes_thematic_break_content_without_fro
     persisted_content = file_path.read_bytes().decode("utf-8")
 
     assert result.markdown_content == persisted_content
-    assert file_path.read_text(encoding="utf-8") == persisted_content
+    assert file_path.read_bytes().decode("utf-8") == persisted_content
     index_entity_data.assert_awaited_once_with(
         result.entity,
         content=persisted_content,


### PR DESCRIPTION
## Summary
- carry the Windows newline assertion follow-up onto `main` without reopening the whole merged branch
- run the test matrix on branch pushes only so PR updates do not execute the same workflow twice

## Testing
- not rerun in this follow-up branch
- carries forward fixes that were already validated locally on the original branch