### PR TITLE
fix(mcp): report cloud projects as source=cloud in factory mode

### DIFF
--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -199,7 +199,7 @@ async def list_memory_projects(
     # Why: there is no local ASGI server; the factory IS the cloud source
     # Outcome: single fetch, projects reported as source="cloud" with workspace metadata
     if is_factory_mode():
-        async with get_client() as client:
+        async with get_client(workspace=workspace) as client:
             project_client = ProjectClient(client)
             project_list = await project_client.list_projects()
 

--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -196,14 +196,42 @@ async def list_memory_projects(
 
     # --- Factory mode (cloud app) ---
     # Trigger: set_client_factory() was called (e.g., basic-memory-cloud)
-    # Why: there is no local ASGI server; the factory IS the only source
-    # Outcome: single fetch, no merge needed
+    # Why: there is no local ASGI server; the factory IS the cloud source
+    # Outcome: single fetch, projects reported as source="cloud" with workspace metadata
     if is_factory_mode():
         async with get_client() as client:
             project_client = ProjectClient(client)
             project_list = await project_client.list_projects()
 
-        merged = _merge_projects(project_list, None)
+        # Resolve workspace metadata so cloud projects carry their workspace info
+        cloud_ws_name: str | None = None
+        cloud_ws_type: str | None = None
+        cloud_ws_tenant_id: str | None = None
+        try:
+            from basic_memory.mcp.project_context import get_available_workspaces
+
+            workspaces = await get_available_workspaces(context)
+            if workspaces:
+                # In factory mode the user is authenticated to a single workspace;
+                # use the explicit workspace param or fall back to the first available.
+                matched = None
+                if workspace:
+                    matched = next((ws for ws in workspaces if ws.tenant_id == workspace), None)
+                if matched is None:
+                    matched = workspaces[0]
+                cloud_ws_name = matched.name
+                cloud_ws_type = matched.workspace_type
+                cloud_ws_tenant_id = matched.tenant_id
+        except Exception:
+            pass  # workspace lookup is best-effort
+
+        merged = _merge_projects(
+            None,
+            project_list,
+            cloud_workspace_name=cloud_ws_name,
+            cloud_workspace_type=cloud_ws_type,
+            cloud_workspace_tenant_id=cloud_ws_tenant_id,
+        )
         if output_format == "json":
             return _format_project_list_json(
                 merged, project_list.default_project, constrained_project

--- a/tests/mcp/test_tool_project_management.py
+++ b/tests/mcp/test_tool_project_management.py
@@ -214,7 +214,74 @@ async def test_list_memory_projects_cloud_failure_graceful(app, test_project):
 
 @pytest.mark.asyncio
 async def test_list_memory_projects_factory_mode(app, test_project):
-    """In factory mode (cloud app), only the factory client is used — no cloud merge."""
+    """In factory mode (cloud app), projects are reported as cloud-sourced with workspace metadata."""
+    factory_project = _make_project("cloud-proj", "/cloud-proj", is_default=True)
+    factory_list = _make_list([factory_project], default="cloud-proj")
+
+    ws = _make_workspace("tenant-abc", "Personal", "personal")
+
+    with (
+        patch(
+            "basic_memory.mcp.tools.project_management.is_factory_mode",
+            return_value=True,
+        ),
+        patch(
+            "basic_memory.mcp.clients.project.ProjectClient.list_projects",
+            new_callable=AsyncMock,
+            return_value=factory_list,
+        ),
+        patch(
+            "basic_memory.mcp.project_context.get_available_workspaces",
+            new_callable=AsyncMock,
+            return_value=[ws],
+        ),
+    ):
+        result = await list_memory_projects()
+
+    assert "• cloud-proj (cloud)" in result
+
+
+@pytest.mark.asyncio
+async def test_list_memory_projects_factory_mode_json_includes_workspace(app, test_project):
+    """In factory mode, JSON output includes workspace metadata for cloud projects."""
+    factory_project = _make_project("cloud-proj", "/cloud-proj", is_default=True)
+    factory_list = _make_list([factory_project], default="cloud-proj")
+
+    ws = _make_workspace("tenant-abc", "My Org", "organization")
+
+    with (
+        patch(
+            "basic_memory.mcp.tools.project_management.is_factory_mode",
+            return_value=True,
+        ),
+        patch(
+            "basic_memory.mcp.clients.project.ProjectClient.list_projects",
+            new_callable=AsyncMock,
+            return_value=factory_list,
+        ),
+        patch(
+            "basic_memory.mcp.project_context.get_available_workspaces",
+            new_callable=AsyncMock,
+            return_value=[ws],
+        ),
+    ):
+        result = await list_memory_projects(output_format="json")
+
+    assert isinstance(result, dict)
+    projects = result["projects"]
+    assert len(projects) == 1
+    proj = projects[0]
+    assert proj["source"] == "cloud"
+    assert proj["cloud_path"] == "/cloud-proj"
+    assert proj["local_path"] is None
+    assert proj["workspace_name"] == "My Org"
+    assert proj["workspace_type"] == "organization"
+    assert proj["workspace_tenant_id"] == "tenant-abc"
+
+
+@pytest.mark.asyncio
+async def test_list_memory_projects_factory_mode_workspace_lookup_failure(app, test_project):
+    """In factory mode, workspace lookup failure still returns projects as cloud-sourced."""
     factory_project = _make_project("cloud-proj", "/cloud-proj", is_default=True)
     factory_list = _make_list([factory_project], default="cloud-proj")
 
@@ -228,12 +295,49 @@ async def test_list_memory_projects_factory_mode(app, test_project):
             new_callable=AsyncMock,
             return_value=factory_list,
         ),
+        patch(
+            "basic_memory.mcp.project_context.get_available_workspaces",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("no user context"),
+        ),
     ):
         result = await list_memory_projects()
 
-    assert "• cloud-proj (local)" in result
-    # has_cloud_credentials should not be called in factory mode
-    # (no cloud merge attempt)
+    # Still reported as cloud even without workspace metadata
+    assert "• cloud-proj (cloud)" in result
+
+
+@pytest.mark.asyncio
+async def test_list_memory_projects_factory_mode_explicit_workspace(app, test_project):
+    """In factory mode, explicit workspace param selects the matching workspace."""
+    factory_project = _make_project("cloud-proj", "/cloud-proj", is_default=True)
+    factory_list = _make_list([factory_project], default="cloud-proj")
+
+    personal_ws = _make_workspace("tenant-personal", "Personal", "personal")
+    org_ws = _make_workspace("tenant-org", "Acme Corp", "organization")
+
+    with (
+        patch(
+            "basic_memory.mcp.tools.project_management.is_factory_mode",
+            return_value=True,
+        ),
+        patch(
+            "basic_memory.mcp.clients.project.ProjectClient.list_projects",
+            new_callable=AsyncMock,
+            return_value=factory_list,
+        ),
+        patch(
+            "basic_memory.mcp.project_context.get_available_workspaces",
+            new_callable=AsyncMock,
+            return_value=[personal_ws, org_ws],
+        ),
+    ):
+        result = await list_memory_projects(output_format="json", workspace="tenant-org")
+
+    proj = result["projects"][0]
+    assert proj["workspace_name"] == "Acme Corp"
+    assert proj["workspace_type"] == "organization"
+    assert proj["workspace_tenant_id"] == "tenant-org"
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_tool_project_management.py
+++ b/tests/mcp/test_tool_project_management.py
@@ -334,6 +334,7 @@ async def test_list_memory_projects_factory_mode_explicit_workspace(app, test_pr
     ):
         result = await list_memory_projects(output_format="json", workspace="tenant-org")
 
+    assert isinstance(result, dict)
     proj = result["projects"][0]
     assert proj["workspace_name"] == "Acme Corp"
     assert proj["workspace_type"] == "organization"
@@ -467,7 +468,11 @@ def test_merge_projects_overlap():
 
 
 def _make_workspace(
-    tenant_id: str, name: str, workspace_type: str = "personal", role: str = "owner"
+    tenant_id: str,
+    name: str,
+    workspace_type: str = "personal",
+    role: str = "owner",
+    organization_id: str | None = None,
 ):
     """Create a WorkspaceInfo for testing."""
     from basic_memory.schemas.cloud import WorkspaceInfo
@@ -477,6 +482,7 @@ def _make_workspace(
         name=name,
         workspace_type=workspace_type,
         role=role,
+        organization_id=organization_id,
         has_active_subscription=True,
     )
 


### PR DESCRIPTION
## Summary

- Fix `list_memory_projects` reporting `source: "local"` for all projects when called via cloud MCP server
- In factory mode, projects are now correctly passed as `cloud_list` (not `local_list`) to `_merge_projects()`
- Workspace metadata (`workspace_name`, `workspace_type`, `workspace_tenant_id`) is resolved via the existing workspace provider



## Test plan

- [x] Updated `test_list_memory_projects_factory_mode` to assert `source: "cloud"`
- [x] Added `test_list_memory_projects_factory_mode_json_includes_workspace` — verifies JSON output has workspace fields
- [x] Added `test_list_memory_projects_factory_mode_workspace_lookup_failure` — graceful degradation when workspace provider fails
- [x] Added `test_list_memory_projects_factory_mode_explicit_workspace` — explicit workspace param selects correct workspace
- [x] All 21 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)