### PR TITLE
fix(mcp): remove no-op pagination params from read_note and view_note

### DIFF
--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -128,8 +128,6 @@ def read_note(
     include_frontmatter: bool = typer.Option(
         False, "--include-frontmatter", help="Include YAML frontmatter in output"
     ),
-    page: int = typer.Option(1, "--page", help="Page number for pagination"),
-    page_size: int = typer.Option(10, "--page-size", help="Number of results per page"),
     project: Annotated[
         Optional[str],
         typer.Option(help="The project to use. If not provided, the default project will be used."),
@@ -149,7 +147,6 @@ def read_note(
 
     bm tool read-note my-note
     bm tool read-note my-note --include-frontmatter
-    bm tool read-note my-note --page 2 --page-size 5
     """
     try:
         validate_routing_flags(local, cloud)
@@ -160,8 +157,6 @@ def read_note(
                     identifier=identifier,
                     project=project,
                     workspace=workspace,
-                    page=page,
-                    page_size=page_size,
                     include_frontmatter=include_frontmatter,
                     output_format="json",
                 )

--- a/src/basic_memory/mcp/clients/resource.py
+++ b/src/basic_memory/mcp/clients/resource.py
@@ -3,8 +3,6 @@
 Encapsulates all /v2/projects/{project_id}/resource/* endpoints.
 """
 
-from typing import Optional
-
 from httpx import AsyncClient, Response
 
 import logfire
@@ -39,19 +37,11 @@ class ResourceClient:
         self.project_id = project_id
         self._base_path = f"/v2/projects/{project_id}/resource"
 
-    async def read(
-        self,
-        entity_id: str,
-        *,
-        page: Optional[int] = None,
-        page_size: Optional[int] = None,
-    ) -> Response:
+    async def read(self, entity_id: str) -> Response:
         """Read a resource by entity ID.
 
         Args:
             entity_id: Entity external_id (UUID)
-            page: Optional page number for paginated content
-            page_size: Optional page size for paginated content
 
         Returns:
             Raw HTTP Response (caller handles text/binary content)
@@ -59,23 +49,14 @@ class ResourceClient:
         Raises:
             ToolError: If the resource is not found or request fails
         """
-        params: dict = {}
-        if page is not None:
-            params["page"] = page
-        if page_size is not None:
-            params["page_size"] = page_size
-
         with logfire.span(
             "mcp.client.resource.read",
             client_name="resource",
             operation="read",
-            page=page,
-            page_size=page_size,
         ):
             return await call_get(
                 self.http_client,
                 f"{self._base_path}/{entity_id}",
-                params=params if params else None,
                 client_name="resource",
                 operation="read",
                 path_template="/v2/projects/{project_id}/resource/{entity_id}",

--- a/src/basic_memory/mcp/tools/chatgpt_tools.py
+++ b/src/basic_memory/mcp/tools/chatgpt_tools.py
@@ -181,8 +181,6 @@ async def fetch(
         content = str(
             await read_note(
                 identifier=id,
-                page=1,
-                page_size=10,
                 context=context,
             )
         )

--- a/src/basic_memory/mcp/tools/read_note.py
+++ b/src/basic_memory/mcp/tools/read_note.py
@@ -1,14 +1,13 @@
 """Read note tool for Basic Memory MCP server."""
 
 from textwrap import dedent
-from typing import Annotated, Optional, Literal, cast
+from typing import Optional, Literal, cast
 
 import logfire
 import yaml
 
 from loguru import logger
 from fastmcp import Context
-from pydantic import AliasChoices, Field
 
 from basic_memory.config import ConfigManager
 from basic_memory.mcp.project_context import (
@@ -72,20 +71,6 @@ async def read_note(
     identifier: str,
     project: Optional[str] = None,
     workspace: Optional[str] = None,
-    # Accept common pagination aliases models reach for from training data
-    # (page_number/limit/per_page). Schema still advertises only the canonical
-    # names; aliases are silently mapped at validation time.
-    # Why no `offset` alias: `offset` is item-indexed (skip N items) while `page`
-    # is 1-indexed page-number, so direct aliasing returns the wrong slice
-    # (e.g. offset=20,limit=10 should mean items 21-30, not page 20).
-    page: Annotated[
-        int,
-        Field(default=1, validation_alias=AliasChoices("page", "page_number")),
-    ] = 1,
-    page_size: Annotated[
-        int,
-        Field(default=10, validation_alias=AliasChoices("page_size", "limit", "per_page")),
-    ] = 10,
     output_format: Literal["text", "json"] = "text",
     include_frontmatter: bool = False,
     context: Context | None = None,
@@ -111,8 +96,6 @@ async def read_note(
                 available projects.
         identifier: The title or permalink of the note to read
                    Can be a full memory:// URL, a permalink, a title, or search text
-        page: Page number for paginated results (default: 1)
-        page_size: Number of items per page (default: 10)
         output_format: "text" returns markdown content or guidance text.
             "json" returns a structured object with title/permalink/file_path/content/frontmatter.
         include_frontmatter: When output_format="json", whether content should include the
@@ -132,9 +115,6 @@ async def read_note(
 
         # Read with memory URL
         read_note("my-research", "memory://specs/search-spec")
-
-        # Read with pagination
-        read_note("work-project", "Project Updates", page=2, page_size=5)
 
         # Read recent meeting notes
         read_note("team-docs", "Weekly Standup")
@@ -160,8 +140,6 @@ async def read_note(
         requested_project=project,
         workspace_id=workspace,
         output_format=output_format,
-        page=page,
-        page_size=page_size,
         include_frontmatter=include_frontmatter,
     ):
         async with get_project_client(project, workspace, context) as (client, active_project):
@@ -217,7 +195,7 @@ async def read_note(
                     phase="shape_response",
                 ):
                     entity = await knowledge_client.get_entity(entity_id)
-                    response = await resource_client.read(entity_id, page=page, page_size=page_size)
+                    response = await resource_client.read(entity_id)
                     content_text = response.text
                     body_content, parsed_frontmatter = _parse_opening_frontmatter(content_text)
                     return {
@@ -263,8 +241,6 @@ async def read_note(
                     workspace=workspace,
                     query=identifier_text,
                     search_type=search_type,
-                    page=page,
-                    page_size=page_size,
                     output_format="json",
                     context=context,
                 )
@@ -286,7 +262,7 @@ async def read_note(
                 entity_id = await knowledge_client.resolve_entity(entity_path, strict=True)
 
                 # Fetch content using entity ID
-                response = await resource_client.read(entity_id, page=page, page_size=page_size)
+                response = await resource_client.read(entity_id)
 
                 # If successful, return the content
                 if response.status_code == 200:
@@ -327,9 +303,7 @@ async def read_note(
                         )
 
                         # Fetch content using the entity ID
-                        response = await resource_client.read(
-                            entity_id, page=page, page_size=page_size
-                        )
+                        response = await resource_client.read(entity_id)
 
                         if response.status_code == 200:
                             logger.info(

--- a/src/basic_memory/mcp/tools/ui_sdk.py
+++ b/src/basic_memory/mcp/tools/ui_sdk.py
@@ -97,16 +97,12 @@ async def search_notes_ui(
 async def read_note_ui(
     identifier: str,
     project: Optional[str] = None,
-    page: int = 1,
-    page_size: int = 10,
     context: Context | None = None,
 ) -> List[ContentBlock]:
     """Return a note preview UI as an embedded MCP-UI resource."""
     content = await read_note(
         identifier=identifier,
         project=project,
-        page=page,
-        page_size=page_size,
         output_format="text",
         context=context,
     )
@@ -114,8 +110,6 @@ async def read_note_ui(
     render_data = {
         "toolInput": {
             "identifier": identifier,
-            "page": page,
-            "page_size": page_size,
         },
         "toolOutput": content,
     }

--- a/src/basic_memory/mcp/tools/view_note.py
+++ b/src/basic_memory/mcp/tools/view_note.py
@@ -1,11 +1,10 @@
 """View note tool for Basic Memory MCP server."""
 
 from textwrap import dedent
-from typing import Annotated, Optional
+from typing import Optional
 
 from loguru import logger
 from fastmcp import Context
-from pydantic import AliasChoices, Field
 
 from basic_memory.mcp.server import mcp
 from basic_memory.mcp.tools.read_note import read_note
@@ -19,16 +18,6 @@ async def view_note(
     identifier: str,
     project: Optional[str] = None,
     workspace: Optional[str] = None,
-    # `offset` is intentionally NOT aliased: it has different semantics
-    # (item-indexed vs. 1-indexed page-number).
-    page: Annotated[
-        int,
-        Field(default=1, validation_alias=AliasChoices("page", "page_number")),
-    ] = 1,
-    page_size: Annotated[
-        int,
-        Field(default=10, validation_alias=AliasChoices("page_size", "limit", "per_page")),
-    ] = 10,
     context: Context | None = None,
 ) -> str:
     """View a markdown note as a formatted artifact.
@@ -41,8 +30,6 @@ async def view_note(
         identifier: The title or permalink of the note to view
         project: Project name to read from. Optional - server will resolve using hierarchy.
                 If unknown, use list_memory_projects() to discover available projects.
-        page: Page number for paginated results (default: 1)
-        page_size: Number of items per page (default: 10)
         context: Optional FastMCP context for performance caching.
 
     Returns:
@@ -54,9 +41,6 @@ async def view_note(
 
         # View a note by permalink
         view_note("meetings/weekly-standup")
-
-        # View with pagination
-        view_note("large-document", page=2, page_size=5)
 
         # Explicit project specification
         view_note("Meeting Notes", project="my-project")
@@ -73,8 +57,6 @@ async def view_note(
             identifier=identifier,
             project=project,
             workspace=workspace,
-            page=page,
-            page_size=page_size,
             context=context,
         )
     )

--- a/test-int/mcp/test_param_aliases_integration.py
+++ b/test-int/mcp/test_param_aliases_integration.py
@@ -13,123 +13,9 @@ import pytest
 from fastmcp import Client
 
 
-# --- read_note: page / page_size aliases ---
-
-
-@pytest.mark.asyncio
-async def test_read_note_accepts_limit_alias_for_page_size(mcp_server, app, test_project):
-    """`limit` should be accepted in place of `page_size` (true synonym — both mean
-    "max items per response"). Note: `offset` is intentionally NOT aliased to `page`
-    because offset is item-indexed while page is 1-indexed page-number — silently
-    aliasing would return the wrong slice. See test_offset_is_rejected below.
-    """
-    async with Client(mcp_server) as client:
-        await client.call_tool(
-            "write_note",
-            {
-                "project": test_project.name,
-                "title": "Pagination Note",
-                "directory": "test",
-                "content": "# Pagination Note\n\nBody.",
-            },
-        )
-
-        result = await client.call_tool(
-            "read_note",
-            {
-                "project": test_project.name,
-                "identifier": "Pagination Note",
-                "limit": 5,
-            },
-        )
-
-        assert len(result.content) == 1
-        assert "# Pagination Note" in result.content[0].text
-
-
-@pytest.mark.asyncio
-async def test_offset_is_not_aliased_to_page(mcp_server, app, test_project):
-    """`offset` must NOT be silently mapped to `page` — they have different
-    semantics (item-index vs. 1-indexed page number). Locks in the deliberate
-    omission so a future contributor doesn't add it back thinking it's harmless.
-    """
-    async with Client(mcp_server) as client:
-        await client.call_tool(
-            "write_note",
-            {
-                "project": test_project.name,
-                "title": "Offset Reject Note",
-                "directory": "test",
-                "content": "# Offset Reject Note\n\nBody.",
-            },
-        )
-
-        # FastMCP wraps unknown kwargs in a ToolError; just assert it raises.
-        with pytest.raises(Exception):
-            await client.call_tool(
-                "read_note",
-                {
-                    "project": test_project.name,
-                    "identifier": "Offset Reject Note",
-                    "offset": 0,
-                },
-            )
-
-
-@pytest.mark.asyncio
-async def test_read_note_accepts_page_number_per_page_aliases(mcp_server, app, test_project):
-    """`page_number` and `per_page` should also map to `page` / `page_size`."""
-    async with Client(mcp_server) as client:
-        await client.call_tool(
-            "write_note",
-            {
-                "project": test_project.name,
-                "title": "Per Page Note",
-                "directory": "test",
-                "content": "# Per Page Note\n\nBody.",
-            },
-        )
-
-        result = await client.call_tool(
-            "read_note",
-            {
-                "project": test_project.name,
-                "identifier": "Per Page Note",
-                "page_number": 1,
-                "per_page": 10,
-            },
-        )
-
-        assert len(result.content) == 1
-        assert "# Per Page Note" in result.content[0].text
-
-
-@pytest.mark.asyncio
-async def test_read_note_canonical_names_still_work(mcp_server, app, test_project):
-    """Canonical names must keep working — aliases are additive, not a rename."""
-    async with Client(mcp_server) as client:
-        await client.call_tool(
-            "write_note",
-            {
-                "project": test_project.name,
-                "title": "Canonical Note",
-                "directory": "test",
-                "content": "# Canonical Note\n\nBody.",
-            },
-        )
-
-        result = await client.call_tool(
-            "read_note",
-            {
-                "project": test_project.name,
-                "identifier": "Canonical Note",
-                "page": 1,
-                "page_size": 10,
-            },
-        )
-
-        assert len(result.content) == 1
-        assert "# Canonical Note" in result.content[0].text
+# --- read_note: pagination params removed in #693 (were no-ops) ---
+# The `page` / `page_size` parameters were removed because the API endpoint
+# silently dropped them. Search-fallback pagination is unrelated to read_note.
 
 
 # --- edit_note: find_text / content / section aliases ---
@@ -534,35 +420,7 @@ async def test_build_context_accepts_url_aliases(mcp_server, app, test_project):
         assert result.content or result.structured_content
 
 
-# --- view_note aliases (mirrors read_note pagination) ---
-
-
-@pytest.mark.asyncio
-async def test_view_note_accepts_pagination_aliases(mcp_server, app, test_project):
-    """`page_number`/`limit`/`per_page` should map through view_note to read_note."""
-    async with Client(mcp_server) as client:
-        await client.call_tool(
-            "write_note",
-            {
-                "project": test_project.name,
-                "title": "View Alias Note",
-                "directory": "test",
-                "content": "# View Alias Note\n\nBody.",
-            },
-        )
-
-        result = await client.call_tool(
-            "view_note",
-            {
-                "project": test_project.name,
-                "identifier": "View Alias Note",
-                "page_number": 1,
-                "limit": 10,
-            },
-        )
-
-        assert len(result.content) == 1
-        assert "# View Alias Note" in result.content[0].text
+# --- view_note: pagination params removed in #693 (delegates to read_note) ---
 
 
 # --- delete_note aliases ---
@@ -618,9 +476,12 @@ async def test_aliases_not_advertised_in_schema(mcp_server, app):
 
         # tool_name -> (must_have_canonical, must_not_have_aliases)
         checks = {
+            # read_note has no pagination params (#693 — they were no-ops; removed).
+            # The must_not_have list still includes the rejected aliases so future
+            # contributors don't reintroduce them.
             "read_note": (
-                ["page", "page_size"],
-                ["offset", "limit", "page_number", "per_page"],
+                [],
+                ["page", "page_size", "offset", "limit", "page_number", "per_page"],
             ),
             "edit_note": (
                 ["find_text", "section", "content"],
@@ -648,9 +509,10 @@ async def test_aliases_not_advertised_in_schema(mcp_server, app):
             ),
             "delete_note": (["is_directory"], ["is_dir"]),
             "read_content": (["path"], ["file_path", "filepath", "file"]),
+            # view_note pagination params removed in #693 (delegates to read_note).
             "view_note": (
-                ["page", "page_size"],
-                ["offset", "limit", "page_number", "per_page"],
+                [],
+                ["page", "page_size", "offset", "limit", "page_number", "per_page"],
             ),
             "build_context": (
                 ["url", "timeframe", "page", "page_size", "max_related"],

--- a/tests/cli/test_cli_tool_json_output.py
+++ b/tests/cli/test_cli_tool_json_output.py
@@ -199,23 +199,6 @@ def test_read_note_include_frontmatter(mock_mcp_read):
     assert mock_mcp_read.call_args.kwargs["include_frontmatter"] is True
 
 
-@patch(
-    "basic_memory.cli.commands.tool.mcp_read_note",
-    new_callable=AsyncMock,
-    return_value=READ_NOTE_RESULT,
-)
-def test_read_note_pagination(mock_mcp_read):
-    """read-note --page and --page-size are passed through."""
-    result = runner.invoke(
-        cli_app,
-        ["tool", "read-note", "test-note", "--page", "2", "--page-size", "5"],
-    )
-
-    assert result.exit_code == 0, f"CLI failed: {result.output}"
-    assert mock_mcp_read.call_args.kwargs["page"] == 2
-    assert mock_mcp_read.call_args.kwargs["page_size"] == 5
-
-
 # --- edit-note ---
 
 

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -55,8 +55,6 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "identifier",
         "project",
         "workspace",
-        "page",
-        "page_size",
         "output_format",
         "include_frontmatter",
     ],
@@ -91,7 +89,7 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "status",
         "min_similarity",
     ],
-    "view_note": ["identifier", "project", "workspace", "page", "page_size"],
+    "view_note": ["identifier", "project", "workspace"],
     "write_note": [
         "title",
         "content",

--- a/tests/mcp/test_tool_read_note.py
+++ b/tests/mcp/test_tool_read_note.py
@@ -201,9 +201,8 @@ async def test_multiple_notes(app, test_project):
 
 
 @pytest.mark.asyncio
-async def test_multiple_notes_pagination(app, test_project):
-    """Test reading individual notes (pagination applies to single note content)"""
-    # Create several notes
+async def test_read_multiple_notes_individually(app, test_project):
+    """Test reading several notes back individually after writing them."""
     notes_data = [
         ("test/note-1", "Note 1", "test", "Content 1", ["tag1"]),
         ("test/note-2", "Note 2", "test", "Content 2", ["tag1", "tag2"]),
@@ -215,10 +214,8 @@ async def test_multiple_notes_pagination(app, test_project):
             project=test_project.name, title=title, directory=folder, content=content, tags=tags
         )
 
-    # Should be able to read each one individually with pagination
-    # Note: pagination now applies to single note content, not multiple notes
     for permalink, title, folder, content, _ in notes_data:
-        note = await read_note(permalink, page=1, page_size=10, project=test_project.name)
+        note = await read_note(permalink, project=test_project.name)
         assert content in note
 
     # Note: v2 API does not support glob patterns in read_note
@@ -517,8 +514,6 @@ class TestReadNoteSecurityValidation:
         result = await read_note(
             project=test_project.name,
             identifier="../../../etc/malicious",
-            page=1,
-            page_size=5,
         )
 
         assert isinstance(result, str)

--- a/tests/mcp/test_tool_telemetry.py
+++ b/tests/mcp/test_tool_telemetry.py
@@ -110,8 +110,6 @@ async def test_read_note_emits_root_operation_and_project_context(
             "requested_project": test_project.name,
             "workspace_id": None,
             "output_format": "json",
-            "page": 1,
-            "page_size": 10,
             "include_frontmatter": True,
         },
     )

--- a/tests/mcp/test_tool_view_note.py
+++ b/tests/mcp/test_tool_view_note.py
@@ -149,25 +149,6 @@ async def test_view_note_not_found(app, test_project):
 
 
 @pytest.mark.asyncio
-async def test_view_note_pagination(app, test_project):
-    """Test viewing a note with pagination parameters."""
-    await write_note(
-        project=test_project.name,
-        title="Pagination Test",
-        directory="test",
-        content="Content for pagination test.",
-    )
-
-    # View with pagination
-    result = await view_note("Pagination Test", page=1, page_size=5, project=test_project.name)
-
-    # Should work with pagination
-    assert 'Note retrieved: "Pagination Test"' in result
-    assert "Content for pagination test." in result
-    assert "Display this note as a markdown artifact for the user" in result
-
-
-@pytest.mark.asyncio
 async def test_view_note_project_parameter(app, test_project):
     """Test viewing a note with project parameter."""
     await write_note(


### PR DESCRIPTION
## Summary
- The `page`/`page_size` parameters on `read_note` (and the delegating `view_note`) had no effect — the v2 resource endpoint takes no query params and returns the full file contents regardless.
- Honest fix: remove the params from the tool schema and CLI rather than implement pagination. "Page" of a single-file read has no obvious semantics (chunked by chars? lines? markdown sections?) and adding it should be a deliberate feature with a real shape, not a backfill of a broken contract.
- Schema-sanity test still lists `page`/`page_size` in `must_not_have` as a regression guard.

## Test plan
- [x] `pytest tests/mcp/test_tool_read_note.py tests/mcp/test_tool_view_note.py tests/mcp/test_tool_contracts.py test-int/mcp/test_param_aliases_integration.py test-int/mcp/test_read_note_integration.py --no-cov` — 57 passed
- [x] `ruff check` and `ty check` clean
- [x] Manual: `bm tool read-note <some-note>` still works without the dropped flags

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)