### PR TITLE
fix(core): skip Obsidian callouts in observation parser

### DIFF
--- a/src/basic_memory/markdown/plugins.py
+++ b/src/basic_memory/markdown/plugins.py
@@ -180,12 +180,27 @@ def observation_plugin(md: MarkdownIt) -> None:
     def observation_rule(state: Any) -> None:
         """Process observations in token stream."""
         tokens = state.tokens
+        # Track blockquote nesting so Obsidian callouts (`> [!info] Title`)
+        # don't get parsed as observations with category `!info`.
+        blockquote_depth = 0
 
         for idx in range(len(tokens)):
             token = tokens[idx]
 
             # Initialize meta for all tokens
             token.meta = token.meta or {}
+
+            if token.type == "blockquote_open":
+                blockquote_depth += 1
+                continue
+            if token.type == "blockquote_close":
+                blockquote_depth -= 1
+                continue
+
+            # Skip parsing inside blockquotes — that's Obsidian callout
+            # territory, not Basic Memory observation syntax.
+            if blockquote_depth > 0:
+                continue
 
             # Parse observations in list items
             if token.type == "inline" and is_observation(token):

--- a/tests/markdown/test_markdown_plugins.py
+++ b/tests/markdown/test_markdown_plugins.py
@@ -159,6 +159,78 @@ def test_observation_excludes_html_color_codes():
     assert is_observation(token), "Real hashtag with color code should still be observation"
 
 
+def test_observation_skips_obsidian_callouts():
+    """Test that Obsidian callout syntax is NOT parsed as observations (issue #738).
+
+    Callouts use `> [!type] title` which previously matched the bracket-content
+    regex and produced spurious observations with categories like `!info`,
+    `!warning`, `!quote`. The blockquote prefix (`>`) is the distinguishing
+    feature — Basic Memory observations are list items, not blockquote lines.
+    """
+    md = MarkdownIt().use(observation_plugin)
+
+    callout_doc = dedent("""
+        > [!info] Information title
+        > Body of the info callout.
+
+        > [!warning] Heads up
+        > Body of the warning.
+
+        > [!quote] Citation
+        > Quoted text here.
+
+        - [design] Real observation outside the callout
+        """)
+
+    tokens = md.parse(callout_doc)
+
+    # No callout content should produce an observation
+    callout_observations = [
+        t.meta.get("observation")
+        for t in tokens
+        if t.type == "inline" and t.meta and t.meta.get("observation")
+        if t.meta["observation"]["category"]
+        and t.meta["observation"]["category"].startswith("!")
+    ]
+    assert callout_observations == [], (
+        f"Obsidian callouts should not produce observations, got: {callout_observations}"
+    )
+
+    # Real observation outside the blockquote must still parse
+    real_observations = [
+        t.meta["observation"]
+        for t in tokens
+        if t.type == "inline" and t.meta and t.meta.get("observation")
+    ]
+    assert len(real_observations) == 1
+    assert real_observations[0]["category"] == "design"
+    assert real_observations[0]["content"] == "Real observation outside the callout"
+
+
+def test_observation_skipped_inside_any_blockquote():
+    """Even non-callout `[bracket]` content in a blockquote should not be
+    treated as an observation — blockquote contents are quoted/aside text,
+    not knowledge graph observations.
+    """
+    md = MarkdownIt().use(observation_plugin)
+
+    quoted_doc = dedent("""
+        > [design] This looks like an observation but lives in a blockquote.
+
+        - [design] Real observation
+        """)
+
+    tokens = md.parse(quoted_doc)
+    observations = [
+        t.meta["observation"]
+        for t in tokens
+        if t.type == "inline" and t.meta and t.meta.get("observation")
+    ]
+    # Only the bullet observation should be picked up.
+    assert len(observations) == 1
+    assert observations[0]["content"] == "Real observation"
+
+
 def test_relation_plugin():
     """Test relation plugin."""
     md = MarkdownIt().use(relation_plugin)


### PR DESCRIPTION
## Summary
- Obsidian callout syntax `> [!info] Title` was being parsed as Basic Memory observations with categories like `!info`/`!warning`/`!quote`, polluting the knowledge graph for any user indexing an Obsidian vault.
- The fix tracks blockquote depth in `observation_rule` (mirroring the existing `in_list_item` tracking in `relation_rule`) and skips observation parsing while inside a blockquote.
- Broader than just suppressing leading-`!` brackets: blockquotes are quoted/aside content by definition, so anything inside `> ...` is now skipped — Obsidian callouts, normal citations, all of it.

## Test plan
- [x] `pytest tests/markdown/ --no-cov` — 68 passed
- [x] Two new tests cover (1) Obsidian callouts produce no observations and (2) any `[bracket]` content inside any blockquote is skipped while real bullet observations still parse
- [x] `ruff check` and `ty check` clean

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)