### PR TITLE
test(core): regression guard for vector-row cleanup on entity delete (#764)

### DIFF
--- a/tests/services/test_search_service.py
+++ b/tests/services/test_search_service.py
@@ -278,9 +278,7 @@ async def test_handle_delete_clears_entity_vectors(
 
     # Force the cleanup path even if the test repo is configured without
     # semantic enabled — we're asserting the wiring, not embedding behavior.
-    monkeypatch.setattr(
-        search_service.repository, "_semantic_enabled", True, raising=False
-    )
+    monkeypatch.setattr(search_service.repository, "_semantic_enabled", True)
     monkeypatch.setattr(
         search_service.repository,
         "delete_entity_vector_rows",

--- a/tests/services/test_search_service.py
+++ b/tests/services/test_search_service.py
@@ -259,6 +259,43 @@ async def test_delete_entity_without_permalink(search_service, sample_entity):
 
 
 @pytest.mark.asyncio
+async def test_handle_delete_clears_entity_vectors(
+    search_service, sample_entity, monkeypatch
+):
+    """Regression guard for #764: handle_delete must drive vector-row cleanup
+    so deleting an entity doesn't leave orphaned rows in `search_vector_chunks`
+    or `search_vector_embeddings`.
+
+    Verified by spying on the repository's `delete_entity_vector_rows`. The
+    short-circuit path inside `_clear_entity_vectors` (semantic disabled) is
+    bypassed by forcing `_semantic_enabled=True` so we exercise the real
+    delegation, not the no-op branch.
+    """
+    calls: list[int] = []
+
+    async def spy_delete_entity_vector_rows(entity_id: int) -> None:
+        calls.append(entity_id)
+
+    # Force the cleanup path even if the test repo is configured without
+    # semantic enabled — we're asserting the wiring, not embedding behavior.
+    monkeypatch.setattr(
+        search_service.repository, "_semantic_enabled", True, raising=False
+    )
+    monkeypatch.setattr(
+        search_service.repository,
+        "delete_entity_vector_rows",
+        spy_delete_entity_vector_rows,
+    )
+
+    await search_service.handle_delete(sample_entity)
+
+    assert calls == [sample_entity.id], (
+        f"handle_delete must call delete_entity_vector_rows({sample_entity.id}); "
+        f"got calls={calls}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_no_criteria(search_service, test_graph):
     """Test search with no criteria returns empty list."""
     results = await search_service.search(SearchQuery())


### PR DESCRIPTION
## Summary
- The delete-path cleanup the reporter asked for already shipped in #733 ("clean up delete vectors and cloud sync", merged 2026-04-10): `handle_delete` → `_clear_entity_vectors` → `repository.delete_entity_vector_rows`.
- Issue #764 was filed two weeks later (2026-04-24) without referencing #733. This PR locks the wiring in with a regression test so a future change can't silently remove the cleanup call.

## What the test does
Spies on `repository.delete_entity_vector_rows` via monkeypatch, calls `handle_delete`, asserts the spy was called with the entity id. Forces `_semantic_enabled=True` so we exercise the real delegation rather than the no-op short-circuit.

## Out of scope (filed in the issue, will land separately)
- **pavelasm**: project info doesn't surface orphaned `search_vector_embeddings` rows from pre-fix DBs. Reporting gap, not a correctness bug.
- **natedev**: the watch service single-file sync path doesn't refresh vectors on UPDATE. Different code path (`sync_service.sync_file`), unrelated to the delete-path issue.

I'll recommend in the issue comment that those land as separate issues so they get individual triage.

## Test plan
- [x] `pytest tests/services/test_search_service.py::test_handle_delete_clears_entity_vectors --no-cov` — passes
- [x] Existing `test_delete_entity_without_permalink` still passes
- [x] `ruff check` clean

Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)