### PR TITLE
fix(installer): mount docker-compose config volume to appuser home

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,9 @@ services:
     volumes:
 
       # Persistent storage for configuration and database
-      - basic-memory-config:/root/.basic-memory:rw
+      # Container runs as `appuser` (Dockerfile USER directive), so the CLI
+      # config dir lives under /home/appuser, not /root.
+      - basic-memory-config:/home/appuser/.basic-memory:rw
 
       # Mount your knowledge directory (required)
       # Change './knowledge' to your actual Obsidian vault or knowledge directory


### PR DESCRIPTION
## Summary
- The Dockerfile creates `appuser` (UID/GID 1000) and switches to it before launching basic-memory.
- `docker-compose.yml` mounts the persistent config volume at `/root/.basic-memory` — a directory `appuser` has no write access to.
- Result: every container start, basic-memory silently re-initializes config + the index DB under `/home/appuser/.basic-memory` (in the writable layer), and that state is wiped on restart.

This PR moves the mount target to `/home/appuser/.basic-memory` so the volume actually persists.

## Test plan
- [x] Verified `Dockerfile:42` runs as `appuser` and `Dockerfile:22` creates `--create-home` for that user.
- [x] Confirmed `BASIC_MEMORY_HOME=/app/data/basic-memory` only sets the project-data root, not the CLI config dir, so the CLI default of `~/.basic-memory` resolves to `/home/appuser/.basic-memory` for `appuser`.
- [ ] Manual: `docker compose up -d`, run `basic-memory project add ...`, `docker compose down && up`, confirm config + db persist.

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)