### PR TITLE
fix(cli): clear default_workspace on cloud logout

### DIFF
--- a/src/basic_memory/cli/commands/cloud/core_commands.py
+++ b/src/basic_memory/cli/commands/cloud/core_commands.py
@@ -76,10 +76,22 @@ def login():
 
 @cloud_app.command()
 def logout():
-    """Remove stored OAuth tokens."""
-    config = ConfigManager().config
+    """Remove stored OAuth tokens and clear cached workspace selection."""
+    config_manager = ConfigManager()
+    config = config_manager.config
     auth = CLIAuth(client_id=config.cloud_client_id, authkit_domain=config.cloud_domain)
     auth.logout()
+
+    # Trigger: ending a session must invalidate the cached workspace.
+    # Why: a follow-up `bm cloud login` (often as a different user, or returning
+    #      from an org workspace to personal) inherits the previous selection
+    #      and silently routes everything through the wrong tenant. See #755.
+    # Outcome: re-login starts from a clean slate; the user picks again via
+    #      `bm cloud workspace set-default` or per-project --workspace.
+    if config.default_workspace is not None:
+        config.default_workspace = None
+        config_manager.save_config(config)
+
     console.print("[dim]API key (if configured) remains available for cloud project routing.[/dim]")
 
 

--- a/tests/cli/test_cloud_authentication.py
+++ b/tests/cli/test_cloud_authentication.py
@@ -199,3 +199,68 @@ class TestLoginCommand:
         result = runner.invoke(app, ["cloud", "login"])
         assert result.exit_code == 1
         assert "Login failed" in result.stdout
+
+
+class TestLogoutCommand:
+    """Tests for `bm cloud logout`."""
+
+    @staticmethod
+    def _patch(monkeypatch, default_workspace):
+        class FakeConfig:
+            cloud_client_id = "cid"
+            cloud_domain = "https://auth.example.com"
+
+            def __init__(self):
+                self.default_workspace = default_workspace
+
+        saved: list[FakeConfig] = []
+        config_instance = FakeConfig()
+        logout_called = {"value": False}
+
+        class FakeConfigManager:
+            config = config_instance
+
+            def save_config(self, cfg):
+                saved.append(cfg)
+
+        class FakeAuth:
+            def __init__(self, **_kwargs):
+                pass
+
+            def logout(self):
+                logout_called["value"] = True
+
+        monkeypatch.setattr(
+            "basic_memory.cli.commands.cloud.core_commands.ConfigManager", FakeConfigManager
+        )
+        monkeypatch.setattr("basic_memory.cli.commands.cloud.core_commands.CLIAuth", FakeAuth)
+        return config_instance, saved, logout_called
+
+    def test_logout_clears_default_workspace(self, monkeypatch):
+        """Regression for #755: logout must invalidate the cached workspace."""
+        config_instance, saved, logout_called = self._patch(
+            monkeypatch, default_workspace="tenant-org-123"
+        )
+        runner = CliRunner()
+
+        result = runner.invoke(app, ["cloud", "logout"])
+
+        assert result.exit_code == 0
+        assert logout_called["value"] is True
+        assert config_instance.default_workspace is None
+        # Save was called once because a non-None value needed clearing.
+        assert len(saved) == 1
+        assert saved[0].default_workspace is None
+
+    def test_logout_skips_save_when_no_default_workspace(self, monkeypatch):
+        """If nothing was cached, logout shouldn't rewrite the config file."""
+        config_instance, saved, logout_called = self._patch(monkeypatch, default_workspace=None)
+        runner = CliRunner()
+
+        result = runner.invoke(app, ["cloud", "logout"])
+
+        assert result.exit_code == 0
+        assert logout_called["value"] is True
+        assert config_instance.default_workspace is None
+        # No save: avoid touching the file when there's nothing to clear.
+        assert saved == []


### PR DESCRIPTION
## Summary
- `bm cloud logout` only invalidated OAuth tokens — it left `config.default_workspace` pointing at the previously selected tenant.
- A subsequent `bm cloud login` (e.g. switching from an org workspace back to personal) inherited that stale selection and silently routed every cloud-mode project through the wrong tenant. The user had no signal that the active workspace hadn't reset.
- Reporter (#755) hit this while migrating a project out of a Teams workspace; only `bm cloud workspace set-default <personal>` recovered.

## Change
- `cli/commands/cloud/core_commands.py` — `logout()` now clears `config.default_workspace` and saves the config when a non-None value was cleared. Skips the write when there's nothing to clear, so we don't touch the file unnecessarily.

## Out of scope
- The reporter also suggested `login` should prompt to pick a default workspace when multiple are available. That's a UX enhancement (needs to fetch workspaces, render a chooser, validate selection) and worth a separate PR. This change focuses on the smaller invariant: ending a session must invalidate the cached selection.

## Test plan
- [x] New `TestLogoutCommand` class in `tests/cli/test_cloud_authentication.py`:
  - `test_logout_clears_default_workspace` — confirms the value goes from set → None and config is saved exactly once
  - `test_logout_skips_save_when_no_default_workspace` — confirms no save call when there was nothing to clear
- [x] `uv run pytest tests/cli/test_cloud_authentication.py --no-cov` — green

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)