### PR TITLE
fix(cli): point bm cloud setup hint at bm cloud sync-setup

### DIFF
--- a/docs/cloud-cli.md
+++ b/docs/cloud-cli.md
@@ -113,7 +113,7 @@ bm project add research --cloud
 bm project add research --cloud --local-path ~/Documents/research
 
 # Or configure sync for existing project
-bm project sync-setup research ~/Documents/research
+bm cloud sync-setup research ~/Documents/research
 ```
 
 **What happens under the covers:**
@@ -236,7 +236,7 @@ bm project add research --cloud --local-path ~/Documents/research
 
 ```bash
 # Project already exists on cloud
-bm project sync-setup research ~/Documents/research
+bm cloud sync-setup research ~/Documents/research
 ```
 
 **What this does:**
@@ -739,7 +739,7 @@ bm project sync --name research
 **Solution:**
 
 ```bash
-bm project sync-setup research ~/Documents/research
+bm cloud sync-setup research ~/Documents/research
 bm project bisync --name research --resync
 ```
 
@@ -795,7 +795,7 @@ bm project list --local                   # Local project list
 bm project list --cloud                   # Cloud project list
 bm project add <name> --cloud             # Create cloud project (no sync)
 bm project add <name> --cloud --local-path <path> # Create with local sync
-bm project sync-setup <name> <path>       # Add sync to existing project
+bm cloud sync-setup <name> <path>       # Add sync to existing project
 bm project rm <name>                      # Delete project
 ```
 

--- a/src/basic_memory/cli/commands/cloud/core_commands.py
+++ b/src/basic_memory/cli/commands/cloud/core_commands.py
@@ -179,7 +179,7 @@ def setup() -> None:
         console.print("1. Add a project with local sync path:")
         console.print("   bm project add research --cloud --local-path ~/Documents/research")
         console.print("\n   Or configure sync for an existing project:")
-        console.print("   bm project sync-setup research ~/Documents/research")
+        console.print("   bm cloud sync-setup research ~/Documents/research")
         console.print("\n2. Preview the initial sync (recommended):")
         console.print("   bm project bisync --name research --resync --dry-run")
         console.print("\n3. If all looks good, run the actual sync:")


### PR DESCRIPTION
## Summary

- `bm cloud setup` printed `bm project sync-setup ...` in its "Next steps", but the command is registered under the `cloud` Typer app (`@cloud_app.command("sync-setup")` in `cli/commands/cloud/project_sync.py:275`). Following the hint produced `No such command 'sync-setup'`.
- Replaced the bad command in the post-setup output (`cli/commands/cloud/core_commands.py:182`) and in `docs/cloud-cli.md` (4 occurrences) with the correct `bm cloud sync-setup`.

Closes #779

## Test plan

- [ ] `bm cloud setup` "Next steps" output now shows `bm cloud sync-setup <name> <path>`
- [ ] `bm cloud sync-setup --help` resolves (sanity check the command path is unchanged)
- [ ] `docs/cloud-cli.md` no longer references `bm project sync-setup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)