### PR TITLE
fix(mcp): add workspace routing to delete_project

### DIFF
--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -369,11 +369,11 @@ def _format_constrained_text(constrained_project: str) -> str:
     return result
 
 
-async def _resolve_create_project_workspace(
+async def _resolve_workspace_routing(
     workspace: str | None,
     context: Context | None,
 ) -> str | None:
-    """Resolve the create-project workspace selector to the routing tenant id."""
+    """Resolve an optional workspace selector to the routing tenant id."""
     if workspace is None:
         return None
 
@@ -389,7 +389,8 @@ async def _resolve_create_project_workspace(
     #   a friendly selector such as a slug, name, or tenant id.
     # Why: MCP callers should not need to paste UUIDs, but the transport still
     #   uses X-Workspace-ID with the tenant id as its routing authority.
-    # Outcome: resolve once at create time and pass only the tenant id downstream.
+    # Outcome: resolve once before the project-management request and pass only
+    #   the tenant id downstream.
     resolved_workspace = await resolve_workspace_parameter(workspace=workspace, context=context)
     return resolved_workspace.tenant_id
 
@@ -432,7 +433,7 @@ async def create_memory_project(
         create_memory_project("work-notes", "/home/user/work", set_default=True)
         create_memory_project("team-notes", "/team/notes", workspace="team-paul")
     """
-    workspace_id = await _resolve_create_project_workspace(workspace, context)
+    workspace_id = await _resolve_workspace_routing(workspace, context)
 
     # workspace targets a non-default cloud workspace at create time.
     # Trigger: caller passed workspace (e.g. a slug discovered via list_workspaces).
@@ -536,7 +537,11 @@ async def create_memory_project(
 @mcp.tool(
     annotations={"destructiveHint": True, "openWorldHint": False},
 )
-async def delete_project(project_name: str, context: Context | None = None) -> str:
+async def delete_project(
+    project_name: str,
+    workspace: str | None = None,
+    context: Context | None = None,
+) -> str:
     """Delete a Basic Memory project.
 
     Removes a project from the configuration and database. This does NOT delete
@@ -545,18 +550,25 @@ async def delete_project(project_name: str, context: Context | None = None) -> s
 
     Args:
         project_name: Name of the project to delete
+        workspace: Optional cloud workspace selector to delete the project from.
+            Slug is preferred for AI callers, but tenant_id and unique name are
+            also accepted. When omitted, the connection's default workspace is
+            used. Only meaningful in cloud mode; ignored for local projects.
 
     Returns:
         Confirmation message about project deletion
 
     Example:
         delete_project("old-project")
+        delete_project("team-project", workspace="team-paul")
 
     Warning:
         This action cannot be undone. The project will need to be re-added
         to access its content through Basic Memory again.
     """
-    async with get_client() as client:
+    workspace_id = await _resolve_workspace_routing(workspace, context)
+
+    async with get_client(workspace=workspace_id) as client:
         # Check if server is constrained to a specific project
         constrained_project = os.environ.get("BASIC_MEMORY_MCP_PROJECT")
         if constrained_project:

--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -553,7 +553,8 @@ async def delete_project(
         workspace: Optional cloud workspace selector to delete the project from.
             Slug is preferred for AI callers, but tenant_id and unique name are
             also accepted. When omitted, the connection's default workspace is
-            used. Only meaningful in cloud mode; ignored for local projects.
+            used. In local mode the selector is passed through without slug
+            resolution, matching create_memory_project behavior.
 
     Returns:
         Confirmation message about project deletion
@@ -566,14 +567,16 @@ async def delete_project(
         This action cannot be undone. The project will need to be re-added
         to access its content through Basic Memory again.
     """
+    # Trigger: MCP server is constrained to a single project.
+    # Why: constrained sessions cannot delete projects, and workspace selectors
+    # may be invalid or unavailable in that locked context.
+    # Outcome: return the existing disabled message before opening a routed client.
+    constrained_project = os.environ.get("BASIC_MEMORY_MCP_PROJECT")
+    if constrained_project:
+        return f"# Error\n\nProject deletion disabled - MCP server is constrained to project '{constrained_project}'.\nUse the CLI to delete projects: `basic-memory project remove \"{project_name}\"`"
+
     workspace_id = await _resolve_workspace_routing(workspace, context)
-
     async with get_client(workspace=workspace_id) as client:
-        # Check if server is constrained to a specific project
-        constrained_project = os.environ.get("BASIC_MEMORY_MCP_PROJECT")
-        if constrained_project:
-            return f"# Error\n\nProject deletion disabled - MCP server is constrained to project '{constrained_project}'.\nUse the CLI to delete projects: `basic-memory project remove \"{project_name}\"`"
-
         if context:  # pragma: no cover
             await context.info(f"Deleting project: {project_name}")
 

--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -419,8 +419,8 @@ async def create_memory_project(
         workspace: Optional cloud workspace selector to create the project in. Slug is
             preferred for AI callers, but tenant_id and unique name are also accepted.
             When omitted, the connection's default workspace is used. Discover values
-            via `list_workspaces`. Only meaningful in cloud mode; ignored for local
-            projects.
+            via `list_workspaces`. In local mode the selector is passed through
+            without slug resolution.
         output_format: "text" returns the existing human-readable result text.
             "json" returns structured project creation metadata.
         context: Optional FastMCP context for progress/status logging.
@@ -433,6 +433,27 @@ async def create_memory_project(
         create_memory_project("work-notes", "/home/user/work", set_default=True)
         create_memory_project("team-notes", "/team/notes", workspace="team-paul")
     """
+    # Trigger: MCP server is constrained to a single project.
+    # Why: constrained sessions cannot create projects, and workspace selectors
+    # may be invalid or unavailable in that locked context.
+    # Outcome: return the existing disabled response before opening a routed client.
+    constrained_project = os.environ.get("BASIC_MEMORY_MCP_PROJECT")
+    if constrained_project:
+        if output_format == "json":
+            return {
+                "name": project_name,
+                "path": project_path,
+                "is_default": False,
+                "created": False,
+                "already_exists": False,
+                "error": "PROJECT_CONSTRAINED",
+                "message": (
+                    f"Project creation disabled - MCP server is constrained to project "
+                    f"'{constrained_project}'."
+                ),
+            }
+        return f'# Error\n\nProject creation disabled - MCP server is constrained to project \'{constrained_project}\'.\nUse the CLI to create projects: `basic-memory project add "{project_name}" "{project_path}"`'
+
     workspace_id = await _resolve_workspace_routing(workspace, context)
 
     # workspace targets a non-default cloud workspace at create time.
@@ -440,24 +461,6 @@ async def create_memory_project(
     # Why: there is no project_id yet for per-project routing — the project doesn't exist.
     # Outcome: cloud factory routes the create request to the resolved workspace tenant id.
     async with get_client(workspace=workspace_id) as client:
-        # Check if server is constrained to a specific project
-        constrained_project = os.environ.get("BASIC_MEMORY_MCP_PROJECT")
-        if constrained_project:
-            if output_format == "json":
-                return {
-                    "name": project_name,
-                    "path": project_path,
-                    "is_default": False,
-                    "created": False,
-                    "already_exists": False,
-                    "error": "PROJECT_CONSTRAINED",
-                    "message": (
-                        f"Project creation disabled - MCP server is constrained to project "
-                        f"'{constrained_project}'."
-                    ),
-                }
-            return f'# Error\n\nProject creation disabled - MCP server is constrained to project \'{constrained_project}\'.\nUse the CLI to create projects: `basic-memory project add "{project_name}" "{project_path}"`'
-
         if context:  # pragma: no cover
             await context.info(f"Creating project: {project_name} at {project_path}")
 

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -31,7 +31,7 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "output_format",
     ],
     "delete_note": ["identifier", "is_directory", "project", "project_id", "output_format"],
-    "delete_project": ["project_name"],
+    "delete_project": ["project_name", "workspace"],
     "edit_note": [
         "identifier",
         "operation",

--- a/tests/mcp/test_tool_project_management.py
+++ b/tests/mcp/test_tool_project_management.py
@@ -322,6 +322,36 @@ async def test_create_memory_project_default_workspace_is_none(app, tmp_path_fac
 
 
 @pytest.mark.asyncio
+async def test_create_memory_project_constrained_with_workspace_returns_disabled_message(
+    monkeypatch, tmp_path_factory
+):
+    """A constrained MCP session rejects creation before resolving a workspace selector."""
+    monkeypatch.setenv("BASIC_MEMORY_MCP_PROJECT", "locked-project")
+    project_root = tmp_path_factory.mktemp("constrained-create-project-home")
+
+    with (
+        patch(
+            "basic_memory.mcp.tools.project_management.is_factory_mode",
+            return_value=True,
+        ),
+        patch(
+            "basic_memory.mcp.tools.project_management.resolve_workspace_parameter",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("bad workspace"),
+        ) as mock_resolve_workspace,
+    ):
+        result = await create_memory_project(
+            project_name="Any Project",
+            project_path=str(project_root),
+            workspace="missing-team",
+        )
+
+    mock_resolve_workspace.assert_not_awaited()
+    assert "Project creation disabled" in result
+    assert "locked-project" in result
+
+
+@pytest.mark.asyncio
 async def test_delete_project_resolves_workspace_slug(app):
     """A friendly workspace slug resolves to the tenant id used for delete routing."""
     from basic_memory.mcp.clients import ProjectClient

--- a/tests/mcp/test_tool_project_management.py
+++ b/tests/mcp/test_tool_project_management.py
@@ -328,6 +328,204 @@ async def test_create_memory_project_default_workspace_is_none(app, tmp_path_fac
     assert captured["workspace"] is None
 
 
+@pytest.mark.asyncio
+async def test_delete_project_resolves_workspace_slug(app):
+    """A friendly workspace slug resolves to the tenant id used for delete routing."""
+    from contextlib import asynccontextmanager
+    import httpx
+
+    from basic_memory.mcp.clients import ProjectClient
+    from basic_memory.schemas.project_info import ProjectStatusResponse
+
+    target_project = _make_project(
+        "WS Project",
+        "/ws-project",
+        external_id="project-uuid",
+    )
+    captured: dict[str, str | None] = {}
+
+    @asynccontextmanager
+    async def fake_get_client(*, workspace=None, project_name=None):
+        captured["workspace"] = workspace
+        async with httpx.AsyncClient(base_url="http://testserver") as client:
+            yield client
+
+    fake_status = ProjectStatusResponse(
+        message="Project deleted",
+        status="success",
+        default=False,
+        old_project=target_project,
+    )
+
+    with (
+        patch(
+            "basic_memory.mcp.tools.project_management.get_client",
+            new=fake_get_client,
+        ),
+        patch(
+            "basic_memory.mcp.tools.project_management.is_factory_mode",
+            return_value=True,
+        ),
+        patch(
+            "basic_memory.mcp.tools.project_management.resolve_workspace_parameter",
+            new_callable=AsyncMock,
+            return_value=_make_workspace(
+                "tenant-abc-123",
+                "Team Paul",
+                workspace_type="organization",
+                slug="team-paul",
+            ),
+        ) as mock_resolve_workspace,
+        patch.object(
+            ProjectClient,
+            "list_projects",
+            new_callable=AsyncMock,
+            return_value=_make_list([target_project], default=None),
+        ),
+        patch.object(
+            ProjectClient,
+            "delete_project",
+            new_callable=AsyncMock,
+            return_value=fake_status,
+        ) as mock_delete_project,
+        patch(
+            "basic_memory.mcp.project_context.invalidate_workspace_project_index",
+            new_callable=AsyncMock,
+        ),
+    ):
+        result = await delete_project("WS Project", workspace="team-paul")
+
+    mock_resolve_workspace.assert_awaited_once_with(workspace="team-paul", context=None)
+    assert captured["workspace"] == "tenant-abc-123"
+    mock_delete_project.assert_awaited_once_with("project-uuid")
+    assert result.startswith("✓")
+
+
+@pytest.mark.asyncio
+async def test_delete_project_workspace_is_local_noop(app):
+    """Local delete accepts workspace without requiring cloud workspace discovery."""
+    from contextlib import asynccontextmanager
+    import httpx
+
+    from basic_memory.mcp.clients import ProjectClient
+    from basic_memory.schemas.project_info import ProjectStatusResponse
+
+    target_project = _make_project(
+        "Local WS Project",
+        "/local-ws-project",
+        external_id="local-project-uuid",
+    )
+    captured: dict[str, str | None] = {}
+
+    @asynccontextmanager
+    async def fake_get_client(*, workspace=None, project_name=None):
+        captured["workspace"] = workspace
+        async with httpx.AsyncClient(base_url="http://testserver") as client:
+            yield client
+
+    fake_status = ProjectStatusResponse(
+        message="Project deleted",
+        status="success",
+        default=False,
+        old_project=target_project,
+    )
+
+    with (
+        patch(
+            "basic_memory.mcp.tools.project_management.get_client",
+            new=fake_get_client,
+        ),
+        patch(
+            "basic_memory.mcp.tools.project_management.is_factory_mode",
+            return_value=False,
+        ),
+        patch(
+            "basic_memory.mcp.tools.project_management.has_cloud_credentials",
+            return_value=False,
+        ),
+        patch(
+            "basic_memory.mcp.tools.project_management.resolve_workspace_parameter",
+            new_callable=AsyncMock,
+        ) as mock_resolve_workspace,
+        patch.object(
+            ProjectClient,
+            "list_projects",
+            new_callable=AsyncMock,
+            return_value=_make_list([target_project], default=None),
+        ),
+        patch.object(
+            ProjectClient,
+            "delete_project",
+            new_callable=AsyncMock,
+            return_value=fake_status,
+        ),
+        patch(
+            "basic_memory.mcp.project_context.invalidate_workspace_project_index",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await delete_project("Local WS Project", workspace="team-paul")
+
+    mock_resolve_workspace.assert_not_awaited()
+    assert captured["workspace"] == "team-paul"
+
+
+@pytest.mark.asyncio
+async def test_delete_project_default_workspace_is_none(app):
+    """When workspace is omitted, delete_project routes through the default workspace."""
+    from contextlib import asynccontextmanager
+    import httpx
+
+    from basic_memory.mcp.clients import ProjectClient
+    from basic_memory.schemas.project_info import ProjectStatusResponse
+
+    target_project = _make_project(
+        "Default WS Project",
+        "/default-ws-project",
+        external_id="default-project-uuid",
+    )
+    captured: dict[str, str | None] = {"workspace": "sentinel"}
+
+    @asynccontextmanager
+    async def fake_get_client(*, workspace=None, project_name=None):
+        captured["workspace"] = workspace
+        async with httpx.AsyncClient(base_url="http://testserver") as client:
+            yield client
+
+    fake_status = ProjectStatusResponse(
+        message="Project deleted",
+        status="success",
+        default=False,
+        old_project=target_project,
+    )
+
+    with (
+        patch(
+            "basic_memory.mcp.tools.project_management.get_client",
+            new=fake_get_client,
+        ),
+        patch.object(
+            ProjectClient,
+            "list_projects",
+            new_callable=AsyncMock,
+            return_value=_make_list([target_project], default=None),
+        ),
+        patch.object(
+            ProjectClient,
+            "delete_project",
+            new_callable=AsyncMock,
+            return_value=fake_status,
+        ),
+        patch(
+            "basic_memory.mcp.project_context.invalidate_workspace_project_index",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await delete_project("Default WS Project")
+
+    assert captured["workspace"] is None
+
+
 # --- Cloud merge tests ---
 
 

--- a/tests/mcp/test_tool_project_management.py
+++ b/tests/mcp/test_tool_project_management.py
@@ -1,7 +1,9 @@
 """Tests for MCP project management tools."""
 
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from sqlalchemy import select
 
@@ -136,9 +138,6 @@ async def test_create_and_delete_project_and_name_match_branch(
 @pytest.mark.asyncio
 async def test_create_memory_project_resolves_workspace_slug(app, tmp_path_factory):
     """A friendly workspace slug resolves to the tenant id used for cloud routing."""
-    from contextlib import asynccontextmanager
-    import httpx
-
     from basic_memory.mcp.clients import ProjectClient
     from basic_memory.schemas.project_info import ProjectStatusResponse
 
@@ -207,9 +206,6 @@ async def test_create_memory_project_resolves_workspace_slug(app, tmp_path_facto
 @pytest.mark.asyncio
 async def test_create_memory_project_workspace_is_local_noop(app, tmp_path_factory):
     """Local create accepts workspace without requiring cloud workspace discovery."""
-    from contextlib import asynccontextmanager
-    import httpx
-
     from basic_memory.mcp.clients import ProjectClient
     from basic_memory.schemas.project_info import ProjectStatusResponse
 
@@ -276,9 +272,6 @@ async def test_create_memory_project_workspace_is_local_noop(app, tmp_path_facto
 @pytest.mark.asyncio
 async def test_create_memory_project_default_workspace_is_none(app, tmp_path_factory):
     """When workspace is omitted, get_client receives workspace=None (default workspace)."""
-    from contextlib import asynccontextmanager
-    import httpx
-
     from basic_memory.mcp.clients import ProjectClient
     from basic_memory.schemas.project_info import ProjectStatusResponse
 
@@ -331,9 +324,6 @@ async def test_create_memory_project_default_workspace_is_none(app, tmp_path_fac
 @pytest.mark.asyncio
 async def test_delete_project_resolves_workspace_slug(app):
     """A friendly workspace slug resolves to the tenant id used for delete routing."""
-    from contextlib import asynccontextmanager
-    import httpx
-
     from basic_memory.mcp.clients import ProjectClient
     from basic_memory.schemas.project_info import ProjectStatusResponse
 
@@ -404,9 +394,6 @@ async def test_delete_project_resolves_workspace_slug(app):
 @pytest.mark.asyncio
 async def test_delete_project_workspace_is_local_noop(app):
     """Local delete accepts workspace without requiring cloud workspace discovery."""
-    from contextlib import asynccontextmanager
-    import httpx
-
     from basic_memory.mcp.clients import ProjectClient
     from basic_memory.schemas.project_info import ProjectStatusResponse
 
@@ -473,9 +460,6 @@ async def test_delete_project_workspace_is_local_noop(app):
 @pytest.mark.asyncio
 async def test_delete_project_default_workspace_is_none(app):
     """When workspace is omitted, delete_project routes through the default workspace."""
-    from contextlib import asynccontextmanager
-    import httpx
-
     from basic_memory.mcp.clients import ProjectClient
     from basic_memory.schemas.project_info import ProjectStatusResponse
 
@@ -524,6 +508,29 @@ async def test_delete_project_default_workspace_is_none(app):
         await delete_project("Default WS Project")
 
     assert captured["workspace"] is None
+
+
+@pytest.mark.asyncio
+async def test_delete_project_constrained_with_workspace_returns_disabled_message(monkeypatch):
+    """A constrained MCP session rejects deletion before resolving a workspace selector."""
+    monkeypatch.setenv("BASIC_MEMORY_MCP_PROJECT", "locked-project")
+
+    with (
+        patch(
+            "basic_memory.mcp.tools.project_management.is_factory_mode",
+            return_value=True,
+        ),
+        patch(
+            "basic_memory.mcp.tools.project_management.resolve_workspace_parameter",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("bad workspace"),
+        ) as mock_resolve_workspace,
+    ):
+        result = await delete_project("Any Project", workspace="missing-team")
+
+    mock_resolve_workspace.assert_not_awaited()
+    assert "Project deletion disabled" in result
+    assert "locked-project" in result
 
 
 # --- Cloud merge tests ---


### PR DESCRIPTION
## Summary
- Add an optional workspace selector to delete_project.
- Reuse the create-project workspace routing resolver so friendly workspace slugs resolve to tenant ids in cloud/factory mode.
- Add unit, tool-contract, and integration coverage for the MCP project-management path.

Closes #800

## Tests
- BASIC_MEMORY_LOGFIRE_ENABLED=false uv run ruff check src tests test-int
- BASIC_MEMORY_LOGFIRE_ENABLED=false uv run ty check src tests test-int
- BASIC_MEMORY_LOGFIRE_ENABLED=false uv run pytest tests/mcp/test_tool_project_management.py tests/mcp/test_tool_contracts.py test-int/mcp/test_project_management_integration.py -q
- BASIC_MEMORY_LOGFIRE_ENABLED=false just doctor
