### PR TITLE
fix(mcp): centralize workspace permalink routing

### DIFF
--- a/src/basic_memory/mcp/async_client.py
+++ b/src/basic_memory/mcp/async_client.py
@@ -37,8 +37,13 @@ def _build_timeout() -> Timeout:
 
 def _asgi_client(timeout: Timeout) -> AsyncClient:
     """Create a local ASGI client."""
+    from basic_memory.workspace_context import workspace_permalink_headers
+
     return AsyncClient(
-        transport=ASGITransport(app=fastapi_app), base_url="http://test", timeout=timeout
+        transport=ASGITransport(app=fastapi_app),
+        base_url="http://test",
+        timeout=timeout,
+        headers=workspace_permalink_headers(),
     )
 
 

--- a/src/basic_memory/mcp/async_client.py
+++ b/src/basic_memory/mcp/async_client.py
@@ -43,6 +43,8 @@ def _asgi_client(timeout: Timeout) -> AsyncClient:
         transport=ASGITransport(app=fastapi_app),
         base_url="http://test",
         timeout=timeout,
+        # Local ASGI calls still cross the HTTP boundary, so request handlers need
+        # the same workspace permalink metadata that cloud proxy calls receive.
         headers=workspace_permalink_headers(),
     )
 

--- a/src/basic_memory/mcp/project_context.py
+++ b/src/basic_memory/mcp/project_context.py
@@ -29,7 +29,11 @@ from basic_memory.schemas.cloud import WorkspaceInfo, WorkspaceListResponse
 from basic_memory.schemas.project_info import ProjectItem, ProjectList
 from basic_memory.schemas.v2 import ProjectResolveResponse
 from basic_memory.schemas.memory import memory_url_path
-from basic_memory.utils import generate_permalink, normalize_project_reference
+from basic_memory.utils import (
+    build_qualified_permalink_reference,
+    generate_permalink,
+    normalize_project_reference,
+)
 from basic_memory.workspace_context import (
     current_workspace_permalink_context,
     workspace_permalink_context,
@@ -417,12 +421,15 @@ def _unqualified_project_identifier(identifier: str) -> str:
     return project_identifier
 
 
-def _split_workspace_memory_url_segments(identifier: str) -> tuple[str, str, str] | None:
-    """Split ``memory://<workspace>/<project>/<path>`` into route segments."""
-    if not identifier.strip().startswith("memory://"):
-        return None
+def _identifier_path(identifier: str) -> str:
+    """Return the routable path portion of a raw identifier or memory URL."""
+    stripped = identifier.strip()
+    return memory_url_path(stripped) if stripped.startswith("memory://") else stripped
 
-    normalized = normalize_project_reference(memory_url_path(identifier))
+
+def _split_workspace_identifier_segments(identifier: str) -> tuple[str, str, str] | None:
+    """Split ``<workspace>/<project>/<path>`` identifiers into route segments."""
+    normalized = normalize_project_reference(_identifier_path(identifier)).strip("/")
     parts = normalized.split("/", 2)
     if len(parts) != 3:
         return None
@@ -431,6 +438,14 @@ def _split_workspace_memory_url_segments(identifier: str) -> tuple[str, str, str
     if not workspace_slug or not project_identifier or not remainder:
         return None
     return workspace_slug, project_identifier, remainder
+
+
+def _split_workspace_memory_url_segments(identifier: str) -> tuple[str, str, str] | None:
+    """Split ``memory://<workspace>/<project>/<path>`` into route segments."""
+    if not identifier.strip().startswith("memory://"):
+        return None
+
+    return _split_workspace_identifier_segments(identifier)
 
 
 def _canonical_memory_path_for_workspace(
@@ -448,10 +463,14 @@ def _canonical_memory_path_for_workspace(
     # Trigger: a caller supplied a workspace-qualified memory URL.
     # Why: the first two path segments are the global route, even for Personal.
     # Outcome: lookups preserve the complete workspace/project canonical permalink.
-    prefix = f"{generate_permalink(workspace_slug)}/{project_permalink}"
     if not normalized_remainder:
-        return prefix
-    return f"{prefix}/{normalized_remainder}"
+        normalized_remainder = project_permalink
+    return build_qualified_permalink_reference(
+        project_permalink,
+        normalized_remainder,
+        include_project=True,
+        workspace_permalink=workspace_slug,
+    )
 
 
 def _canonical_memory_path_for_active_route(
@@ -528,6 +547,27 @@ async def resolve_workspace_qualified_memory_url(
     if segments is None:
         return None
 
+    return await _resolve_workspace_segments(identifier, segments, context=context)
+
+
+async def resolve_workspace_qualified_identifier(
+    identifier: str,
+    context: Optional[Context] = None,
+) -> WorkspaceMemoryUrlResolution | None:
+    """Resolve a workspace-qualified permalink or memory URL against accessible workspaces."""
+    segments = _split_workspace_identifier_segments(identifier)
+    if segments is None:
+        return None
+
+    return await _resolve_workspace_segments(identifier, segments, context=context)
+
+
+async def _resolve_workspace_segments(
+    identifier: str,
+    segments: tuple[str, str, str],
+    context: Optional[Context] = None,
+) -> WorkspaceMemoryUrlResolution | None:
+    """Resolve parsed workspace/project/path segments against accessible workspaces."""
     workspace_slug, project_identifier, remainder = segments
     index = await _ensure_workspace_project_index(context=context)
     workspace = next(
@@ -1278,17 +1318,44 @@ async def detect_project_from_memory_url_prefix(
     if not identifier.strip().startswith("memory://"):
         return None
 
+    return await detect_project_from_identifier_prefix(identifier, config, context=context)
+
+
+async def detect_project_from_identifier_prefix(
+    identifier: str,
+    config: BasicMemoryConfig,
+    context: Optional[Context] = None,
+) -> Optional[str]:
+    """Resolve a project from a plain permalink, memory URL, or workspace route prefix."""
     local_project = detect_project_from_url_prefix(identifier, config)
     if local_project is not None:
         return local_project
 
     if _cloud_workspace_discovery_available(config):
-        resolution = await resolve_workspace_qualified_memory_url(
+        workspace_resolution = await resolve_workspace_qualified_identifier(
             identifier,
             context=context,
         )
-        if resolution is not None:
-            return resolution.project_identifier
+        if workspace_resolution is not None:
+            return workspace_resolution.project_identifier
+
+        normalized = normalize_project_reference(_identifier_path(identifier))
+        project_prefix, _ = _split_project_prefix(normalized)
+        if project_prefix is None:
+            return None
+
+        try:
+            project_resolution = await resolve_workspace_project_identifier(
+                project_prefix,
+                context=context,
+            )
+        except ValueError as exc:
+            message = str(exc).lower()
+            if "not found" in message or "no accessible workspaces" in message:
+                return None
+            raise
+
+        return project_resolution.qualified_name
 
     return None
 

--- a/src/basic_memory/mcp/project_context.py
+++ b/src/basic_memory/mcp/project_context.py
@@ -432,6 +432,9 @@ def _split_workspace_identifier_segments(identifier: str) -> tuple[str, str, str
     normalized = normalize_project_reference(_identifier_path(identifier)).strip("/")
     parts = normalized.split("/", 2)
     if len(parts) != 3:
+        # Trigger: two-segment identifiers such as `workspace/project` or `project/path`.
+        # Why: without a remainder, the shape is ambiguous with existing project-prefix routing.
+        # Outcome: fall through so the normal project-prefix/default-project resolver decides.
         return None
 
     workspace_slug, project_identifier, remainder = parts
@@ -1331,6 +1334,14 @@ async def detect_project_from_identifier_prefix(
     if local_project is not None:
         return local_project
 
+    normalized_identifier = normalize_project_reference(_identifier_path(identifier)).strip("/")
+    if "/" not in normalized_identifier:
+        # Trigger: plain text search query or single-segment title/permalink.
+        # Why: cloud project discovery can build a workspace index; only path-shaped
+        #   identifiers carry enough structure to justify that cost.
+        # Outcome: keep unqualified search/title input on the active/default project route.
+        return None
+
     if _cloud_workspace_discovery_available(config):
         workspace_resolution = await resolve_workspace_qualified_identifier(
             identifier,
@@ -1339,8 +1350,7 @@ async def detect_project_from_identifier_prefix(
         if workspace_resolution is not None:
             return workspace_resolution.project_identifier
 
-        normalized = normalize_project_reference(_identifier_path(identifier))
-        project_prefix, _ = _split_project_prefix(normalized)
+        project_prefix, _ = _split_project_prefix(normalized_identifier)
         if project_prefix is None:
             return None
 

--- a/src/basic_memory/mcp/tools/read_note.py
+++ b/src/basic_memory/mcp/tools/read_note.py
@@ -11,15 +11,14 @@ from fastmcp import Context
 
 from basic_memory.config import ConfigManager
 from basic_memory.mcp.project_context import (
-    detect_project_from_memory_url_prefix,
+    detect_project_from_identifier_prefix,
     get_project_client,
     resolve_project_and_path,
 )
 from basic_memory.mcp.server import mcp
 from basic_memory.mcp.tools.search import search_notes
 from basic_memory.schemas.memory import memory_url_path
-from basic_memory.utils import generate_permalink, validate_project_path
-from basic_memory.workspace_context import current_workspace_permalink_context
+from basic_memory.utils import validate_project_path
 
 
 def _is_exact_title_match(identifier: str, title: str) -> bool:
@@ -131,10 +130,10 @@ async def read_note(
         If the exact note isn't found, this tool provides helpful suggestions
         including related notes, search commands, and note creation templates.
     """
-    # Detect project from memory URL prefix before routing.
+    # Detect project from a memory URL or permalink prefix before routing.
     # project_id routes by external UUID, so it bypasses URL discovery entirely.
     if project is None and project_id is None:
-        detected = await detect_project_from_memory_url_prefix(
+        detected = await detect_project_from_identifier_prefix(
             identifier,
             ConfigManager().config,
             context=context,
@@ -278,51 +277,25 @@ async def read_note(
                 value = item.get("file_path")
                 return str(value) if value else None
 
-            def _legacy_workspace_unqualified_path(path: str) -> str | None:
-                workspace_context = current_workspace_permalink_context()
-                if workspace_context is None:
-                    return None
+            try:
+                # Try to resolve identifier to entity ID
+                entity_id = await knowledge_client.resolve_entity(entity_path, strict=True)
 
-                workspace_prefix = generate_permalink(workspace_context.workspace_slug)
-                project_prefix = active_project.permalink
-                qualified_prefix = f"{workspace_prefix}/{project_prefix}"
-                normalized_path = path.strip("/")
-                if normalized_path == qualified_prefix:
-                    return project_prefix
-                if normalized_path.startswith(f"{qualified_prefix}/"):
-                    return f"{project_prefix}/{normalized_path.removeprefix(f'{qualified_prefix}/')}"
-                return None
+                # Fetch content using entity ID
+                response = await resource_client.read(entity_id)
 
-            direct_lookup_paths = [entity_path]
-            legacy_path = _legacy_workspace_unqualified_path(entity_path)
-            if legacy_path and legacy_path not in direct_lookup_paths:
-                # Trigger: existing cloud rows may still use project-prefixed permalinks.
-                # Why: new workspace-qualified IDs should read old notes without a re-sync.
-                # Outcome: try the legacy path after the canonical workspace path misses.
-                direct_lookup_paths.append(legacy_path)
-
-            for direct_lookup_path in direct_lookup_paths:
-                try:
-                    # Try to resolve identifier to entity ID
-                    entity_id = await knowledge_client.resolve_entity(
-                        direct_lookup_path, strict=True
+                # If successful, return the content
+                if response.status_code == 200:
+                    logger.info(
+                        "Returning read_note result from resource: {path}",
+                        path=entity_path,
                     )
-
-                    # Fetch content using entity ID
-                    response = await resource_client.read(entity_id)
-
-                    # If successful, return the content
-                    if response.status_code == 200:
-                        logger.info(
-                            "Returning read_note result from resource: {path}",
-                            path=direct_lookup_path,
-                        )
-                        if output_format == "json":
-                            return await _read_json_payload(entity_id)
-                        return response.text
-                except Exception as e:  # pragma: no cover
-                    logger.info(f"Direct lookup failed for '{direct_lookup_path}': {e}")
-                    # Continue to alternate direct lookup paths, then fallback methods
+                    if output_format == "json":
+                        return await _read_json_payload(entity_id)
+                    return response.text
+            except Exception as e:  # pragma: no cover
+                logger.info(f"Direct lookup failed for '{entity_path}': {e}")
+                # Continue to fallback methods
 
             # Fallback 1: Try title search via API
             logger.info(f"Search title for: {identifier}")

--- a/src/basic_memory/mcp/tools/search.py
+++ b/src/basic_memory/mcp/tools/search.py
@@ -11,10 +11,10 @@ from fastmcp import Context
 from pydantic import AliasChoices, BeforeValidator, Field
 
 from basic_memory.config import ConfigManager
-from basic_memory.utils import coerce_dict, coerce_list
+from basic_memory.utils import build_canonical_permalink, coerce_dict, coerce_list
 from basic_memory.mcp.container import get_container
 from basic_memory.mcp.project_context import (
-    detect_project_from_memory_url_prefix,
+    detect_project_from_identifier_prefix,
     get_project_client,
     resolve_project_and_path,
 )
@@ -402,11 +402,12 @@ def _qualify_permalink_for_project(permalink: object, project: str | None) -> ob
         return normalized_permalink
 
     workspace_slug, project_permalink = qualified_project.split("/", 1)
-    if normalized_permalink == project_permalink or normalized_permalink.startswith(
-        f"{project_permalink}/"
-    ):
-        return f"{workspace_slug}/{normalized_permalink}"
-    return f"{qualified_project}/{normalized_permalink}"
+    return build_canonical_permalink(
+        project_permalink,
+        normalized_permalink,
+        include_project=True,
+        workspace_permalink=workspace_slug,
+    )
 
 
 def _qualify_results_for_project(
@@ -805,10 +806,10 @@ async def search_notes(
             remainder = re.sub(r"\b(AND|OR|NOT)\b", "", remainder).strip()
             query = remainder or None
 
-    # Detect project from memory URL prefix before routing.
+    # Detect project from a memory URL or permalink prefix before routing.
     # project_id routes by external UUID, so it bypasses URL discovery entirely.
     if project is None and project_id is None and query is not None:
-        detected = await detect_project_from_memory_url_prefix(
+        detected = await detect_project_from_identifier_prefix(
             query,
             ConfigManager().config,
             context=context,

--- a/src/basic_memory/mcp/tools/utils.py
+++ b/src/basic_memory/mcp/tools/utils.py
@@ -8,7 +8,7 @@ import typing
 from typing import Any, Optional
 
 import logfire
-from httpx import Response, URL, AsyncClient, HTTPStatusError
+from httpx import Response, URL, AsyncClient, HTTPStatusError, Headers
 from httpx._client import UseClientDefault, USE_CLIENT_DEFAULT
 from httpx._types import (
     RequestContent,
@@ -56,6 +56,22 @@ def _transport_error_span_attrs(exc: Exception) -> dict[str, Any]:
         "outcome": "transport_error",
         "error_type": type(exc).__name__,
     }
+
+
+def _request_headers(headers: HeaderTypes | None) -> HeaderTypes | None:
+    """Merge request-local workspace permalink headers into outbound API calls."""
+    from basic_memory.workspace_context import workspace_permalink_headers
+
+    workspace_headers = workspace_permalink_headers()
+    if not workspace_headers:
+        return headers
+
+    if headers is None:
+        return workspace_headers
+
+    merged_headers = Headers(headers)
+    merged_headers.update(workspace_headers)
+    return merged_headers
 
 
 def get_error_message(
@@ -224,7 +240,7 @@ async def call_get(
             response = await client.get(
                 url,
                 params=params,
-                headers=headers,
+                headers=_request_headers(headers),
                 cookies=cookies,
                 auth=auth,
                 follow_redirects=follow_redirects,
@@ -328,7 +344,7 @@ async def call_put(
                 files=files,
                 json=json,
                 params=params,
-                headers=headers,
+                headers=_request_headers(headers),
                 cookies=cookies,
                 auth=auth,
                 follow_redirects=follow_redirects,
@@ -432,7 +448,7 @@ async def call_patch(
                 files=files,
                 json=json,
                 params=params,
-                headers=headers,
+                headers=_request_headers(headers),
                 cookies=cookies,
                 auth=auth,
                 follow_redirects=follow_redirects,
@@ -542,7 +558,7 @@ async def call_post(
                 files=files,
                 json=json,
                 params=params,
-                headers=headers,
+                headers=_request_headers(headers),
                 cookies=cookies,
                 auth=auth,
                 follow_redirects=follow_redirects,
@@ -667,7 +683,7 @@ async def call_delete(
             response = await client.delete(
                 url=url,
                 params=params,
-                headers=headers,
+                headers=_request_headers(headers),
                 cookies=cookies,
                 auth=auth,
                 follow_redirects=follow_redirects,

--- a/src/basic_memory/services/link_resolver.py
+++ b/src/basic_memory/services/link_resolver.py
@@ -13,10 +13,11 @@ from basic_memory.repository.search_repository import create_search_repository
 from basic_memory.schemas.search import SearchQuery, SearchItemType
 from basic_memory.services.search_service import SearchService
 from basic_memory.utils import (
-    build_canonical_permalink,
+    build_permalink_resolution_candidates,
     generate_permalink,
     normalize_project_reference,
 )
+from basic_memory.workspace_context import current_workspace_permalink_context
 
 
 class LinkResolver:
@@ -189,25 +190,25 @@ class LinkResolver:
         """Resolve a link within a specific project scope."""
         clean_text = link_text
         include_project = self._include_project_permalinks()
+        workspace_context = current_workspace_permalink_context()
+        workspace_permalink = (
+            workspace_context.workspace_slug
+            if workspace_context and workspace_context.should_prefix_permalinks
+            else None
+        )
 
-        canonical_permalink: Optional[str] = None
-        legacy_permalink: Optional[str] = None
-        # Trigger: permalinks include project slug and project permalink is known
-        # Why: support globally addressable permalinks while keeping legacy links resolvable
-        # Outcome: include canonical and legacy candidates for resolution
-        if include_project and project_permalink:
-            canonical_permalink = build_canonical_permalink(
-                project_permalink, clean_text, include_project=True
-            )
-            if clean_text.startswith(f"{project_permalink}/"):
-                legacy_candidate = clean_text.removeprefix(f"{project_permalink}/")
-                if legacy_candidate:
-                    legacy_permalink = legacy_candidate
-
-        permalink_candidates = []
-        for candidate in (clean_text, canonical_permalink, legacy_permalink):
-            if candidate and candidate not in permalink_candidates:
-                permalink_candidates.append(candidate)
+        # Trigger: callers can pass title, short permalink, project/path, or
+        #   workspace/project/path identifiers to the same resolver.
+        # Why: search results and memory:// URLs should stay usable across read,
+        #   edit, delete, move, and API-level entity resolution.
+        # Outcome: resolve canonical workspace IDs and legacy project-prefixed rows
+        #   through one shared candidate builder.
+        permalink_candidates = build_permalink_resolution_candidates(
+            clean_text,
+            project_permalink,
+            include_project=include_project,
+            workspace_permalink=workspace_permalink,
+        )
 
         # --- Path Resolution ---
         # Note: All paths in Basic Memory are stored as POSIX strings (forward slashes)

--- a/src/basic_memory/utils.py
+++ b/src/basic_memory/utils.py
@@ -276,6 +276,119 @@ def build_canonical_permalink(
     return project_path
 
 
+def build_qualified_permalink_reference(
+    project_permalink: Optional[str],
+    identifier: Union[Path, str, PathLike],
+    include_project: bool = True,
+    *,
+    workspace_permalink: Optional[str] = None,
+) -> str:
+    """Add workspace/project route prefixes while preserving lookup syntax.
+
+    Unlike ``build_canonical_permalink()``, this helper does not run the identifier
+    through permalink generation. It is for inbound references that may contain
+    lookup-only syntax such as ``.md`` extensions or ``*`` glob patterns.
+    """
+    normalized_path = normalize_project_reference(str(identifier)).strip("/")
+    normalized_workspace = generate_permalink(workspace_permalink) if workspace_permalink else None
+    normalized_project = generate_permalink(project_permalink) if project_permalink else None
+
+    if normalized_workspace:
+        if not normalized_project:
+            raise ValueError("workspace_permalink requires project_permalink")
+
+        workspace_project_prefix = f"{normalized_workspace}/{normalized_project}"
+        if not normalized_path:
+            return workspace_project_prefix
+        if normalized_path == workspace_project_prefix or normalized_path.startswith(
+            f"{workspace_project_prefix}/"
+        ):
+            return normalized_path
+        if normalized_path == normalized_project or normalized_path.startswith(
+            f"{normalized_project}/"
+        ):
+            return f"{normalized_workspace}/{normalized_path}"
+        return f"{workspace_project_prefix}/{normalized_path}"
+
+    if not include_project or not normalized_project:
+        return normalized_path
+
+    if not normalized_path:
+        return normalized_project
+    if normalized_path == normalized_project or normalized_path.startswith(
+        f"{normalized_project}/"
+    ):
+        return normalized_path
+    return f"{normalized_project}/{normalized_path}"
+
+
+def build_permalink_resolution_candidates(
+    identifier: Union[Path, str, PathLike],
+    project_permalink: Optional[str],
+    include_project: bool = True,
+    *,
+    workspace_permalink: Optional[str] = None,
+) -> list[str]:
+    """Return permalink candidates from most caller-specific to broadest legacy form.
+
+    The first candidate preserves the normalized identifier the caller supplied. Follow-up
+    candidates add the active workspace/project route and legacy project/path forms so
+    all resolver callers share the same compatibility behavior.
+    """
+    exact_path = normalize_project_reference(str(identifier)).strip("/")
+    normalized_path = generate_permalink(exact_path).strip("/")
+    normalized_project = generate_permalink(project_permalink) if project_permalink else None
+    normalized_workspace = generate_permalink(workspace_permalink) if workspace_permalink else None
+    candidates: list[str] = []
+
+    def add_candidate(value: str | None) -> None:
+        if value and value not in candidates:
+            candidates.append(value)
+
+    add_candidate(exact_path)
+    add_candidate(normalized_path)
+    if not normalized_project:
+        return candidates
+
+    workspace_project_prefix = (
+        f"{normalized_workspace}/{normalized_project}" if normalized_workspace else None
+    )
+    workspace_qualified = False
+    if workspace_project_prefix:
+        add_candidate(
+            build_canonical_permalink(
+                normalized_project,
+                normalized_path,
+                include_project=include_project,
+                workspace_permalink=normalized_workspace,
+            )
+        )
+        if normalized_path == workspace_project_prefix:
+            workspace_qualified = True
+            add_candidate(normalized_project)
+        elif normalized_path.startswith(f"{workspace_project_prefix}/"):
+            workspace_qualified = True
+            remainder = normalized_path.removeprefix(f"{workspace_project_prefix}/")
+            add_candidate(f"{normalized_project}/{remainder}")
+            add_candidate(remainder)
+
+    if include_project and not workspace_qualified:
+        add_candidate(
+            build_canonical_permalink(
+                normalized_project,
+                normalized_path,
+                include_project=True,
+            )
+        )
+        if normalized_path == normalized_project:
+            return candidates
+        if normalized_path.startswith(f"{normalized_project}/"):
+            remainder = normalized_path.removeprefix(f"{normalized_project}/")
+            add_candidate(remainder)
+
+    return candidates
+
+
 def setup_logging(
     log_level: str = "INFO",
     log_to_file: bool = False,

--- a/src/basic_memory/utils.py
+++ b/src/basic_memory/utils.py
@@ -386,6 +386,12 @@ def build_permalink_resolution_candidates(
             remainder = normalized_path.removeprefix(f"{normalized_project}/")
             add_candidate(remainder)
 
+    if not include_project and normalized_path.startswith(f"{normalized_project}/"):
+        # Trigger: caller supplied `project/path` while legacy short permalinks are stored.
+        # Why: routing uses the project prefix, but strict lookup still needs the short row.
+        # Outcome: try `path` after the exact project-qualified candidate.
+        add_candidate(normalized_path.removeprefix(f"{normalized_project}/"))
+
     return candidates
 
 

--- a/src/basic_memory/utils.py
+++ b/src/basic_memory/utils.py
@@ -372,6 +372,18 @@ def build_permalink_resolution_candidates(
             add_candidate(f"{normalized_project}/{remainder}")
             add_candidate(remainder)
 
+    if workspace_project_prefix and not include_project and not workspace_qualified:
+        # Trigger: short lookup in a workspace where new canonical links omit project prefixes.
+        # Why: older rows in that same workspace may still be stored as `project/path`.
+        # Outcome: try the project-prefixed legacy form after the workspace-qualified form.
+        add_candidate(
+            build_canonical_permalink(
+                normalized_project,
+                normalized_path,
+                include_project=True,
+            )
+        )
+
     if include_project and not workspace_qualified:
         add_candidate(
             build_canonical_permalink(

--- a/test-int/conftest.py
+++ b/test-int/conftest.py
@@ -138,6 +138,17 @@ async def cleanup_global_db_after_test() -> AsyncGenerator[None, None]:
     await db.shutdown_db()
 
 
+@pytest.fixture(autouse=True)
+def clean_routing_env(monkeypatch) -> None:
+    """Keep CLI routing env mutations from leaking between integration tests."""
+    # Trigger: CLI integration tests exercise long-running MCP entrypoints that set routing env.
+    # Why: those commands normally own the process lifetime, but pytest keeps reusing it.
+    # Outcome: every integration test starts from neutral routing unless it opts in explicitly.
+    monkeypatch.delenv("BASIC_MEMORY_FORCE_LOCAL", raising=False)
+    monkeypatch.delenv("BASIC_MEMORY_FORCE_CLOUD", raising=False)
+    monkeypatch.delenv("BASIC_MEMORY_EXPLICIT_ROUTING", raising=False)
+
+
 POSTGRES_EPHEMERAL_TABLES = [
     "search_vector_embeddings",
     "search_vector_chunks",

--- a/test-int/mcp/test_workspace_permalink_integration.py
+++ b/test-int/mcp/test_workspace_permalink_integration.py
@@ -1,0 +1,463 @@
+"""Integration coverage for local, cloud, and team permalink routing."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from contextlib import asynccontextmanager, contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastmcp import Client
+from httpx import ASGITransport, AsyncClient as HttpxAsyncClient
+
+from basic_memory.config import BasicMemoryConfig, ConfigManager, ProjectEntry
+from basic_memory.mcp import async_client
+from basic_memory.mcp import project_context
+from basic_memory.models import Project
+from basic_memory.repository.project_repository import ProjectRepository
+from basic_memory.schemas.cloud import WorkspaceInfo
+from basic_memory.workspace_context import workspace_permalink_headers
+
+
+def _json_content(tool_result) -> Any:
+    """Parse a FastMCP tool result content block into JSON."""
+    assert len(tool_result.content) == 1
+    assert tool_result.content[0].type == "text"
+    return json.loads(tool_result.content[0].text)  # pyright: ignore [reportAttributeAccessIssue]
+
+
+def _workspace(
+    *,
+    tenant_id: str,
+    slug: str,
+    workspace_type: str,
+    is_default: bool = True,
+) -> WorkspaceInfo:
+    return WorkspaceInfo(
+        tenant_id=tenant_id,
+        name=slug.replace("-", " ").title(),
+        workspace_type=workspace_type,
+        slug=slug,
+        role="owner",
+        organization_id=None,
+        is_default=is_default,
+        has_active_subscription=True,
+    )
+
+
+@pytest.fixture
+def personal_workspace() -> WorkspaceInfo:
+    return _workspace(
+        tenant_id="personal-tenant",
+        slug="personal",
+        workspace_type="personal",
+    )
+
+
+@pytest.fixture
+def team_workspace() -> WorkspaceInfo:
+    return _workspace(
+        tenant_id="team-tenant",
+        slug="team-paul",
+        workspace_type="organization",
+        is_default=False,
+    )
+
+
+@pytest.fixture
+def route_workspaces(app):
+    @contextmanager
+    def route(*workspaces: WorkspaceInfo):
+        with _workspace_routing(app, workspaces):
+            yield
+
+    return route
+
+
+@pytest_asyncio.fixture
+async def alternate_project(
+    config_home,
+    engine_factory,
+    app_config: BasicMemoryConfig,
+    config_manager: ConfigManager,
+) -> Project:
+    """Create a second project so no-project lookups cannot pass via the default."""
+    alternate_path = Path(config_home) / "alternate-project"
+    alternate_path.mkdir(parents=True, exist_ok=True)
+
+    _, session_maker = engine_factory
+    project_repository = ProjectRepository(session_maker)
+    project = await project_repository.create(
+        {
+            "name": "alternate-project",
+            "description": "Non-default project for prefix routing tests",
+            "path": str(alternate_path),
+            "is_active": True,
+            "is_default": False,
+        }
+    )
+
+    app_config.projects[project.name] = ProjectEntry(path=str(alternate_path))
+    config_manager.save_config(app_config)
+    return project
+
+
+def _save_permalink_config(
+    app_config: BasicMemoryConfig,
+    *,
+    include_project: bool,
+    default_project: str | None,
+) -> None:
+    app_config.permalinks_include_project = include_project
+    app_config.default_project = default_project
+    ConfigManager().save_config(app_config)
+
+
+@contextmanager
+def _workspace_routing(app, workspaces: Iterable[WorkspaceInfo]):
+    """Route MCP tool HTTP calls through an ASGI-backed cloud workspace seam."""
+    workspace_list = tuple(workspaces)
+    workspace_ids = {workspace.tenant_id for workspace in workspace_list}
+
+    async def workspace_provider():
+        return list(workspace_list)
+
+    @asynccontextmanager
+    async def factory(workspace: str | None = None):
+        assert workspace is None or workspace in workspace_ids
+        async with HttpxAsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            headers=workspace_permalink_headers(),
+        ) as inner:
+            yield inner
+
+    original_factory = async_client._client_factory
+    original_workspace_provider = project_context._workspace_provider
+    async_client.set_client_factory(factory)
+    project_context.set_workspace_provider(workspace_provider)
+    try:
+        yield
+    finally:
+        async_client._client_factory = original_factory
+        project_context._workspace_provider = original_workspace_provider
+
+
+async def _call_json(mcp_server, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(tool_name, arguments)
+
+    payload = _json_content(result)
+    assert isinstance(payload, dict)
+    return payload
+
+
+async def _write_json(
+    mcp_server,
+    *,
+    project: str,
+    title: str,
+    directory: str = "permalink-suite",
+) -> dict[str, Any]:
+    return await _call_json(
+        mcp_server,
+        "write_note",
+        {
+            "project": project,
+            "title": title,
+            "directory": directory,
+            "content": f"# {title}\n\nUnique body for {title}.",
+            "output_format": "json",
+        },
+    )
+
+
+async def _read_json(
+    mcp_server,
+    *,
+    identifier: str,
+    project: str | None = None,
+) -> dict[str, Any]:
+    arguments = {
+        "identifier": identifier,
+        "output_format": "json",
+    }
+    if project is not None:
+        arguments["project"] = project
+    return await _call_json(mcp_server, "read_note", arguments)
+
+
+async def _search_single_permalink(
+    mcp_server,
+    *,
+    title: str,
+    project: str | None = None,
+) -> str:
+    arguments = {
+        "query": title,
+        "search_type": "text",
+        "output_format": "json",
+    }
+    if project is not None:
+        arguments["project"] = project
+
+    payload = await _call_json(mcp_server, "search_notes", arguments)
+    matching_results = [
+        item for item in payload["results"] if isinstance(item, dict) and item.get("title") == title
+    ]
+    assert len(matching_results) == 1
+    permalink = matching_results[0].get("permalink")
+    assert isinstance(permalink, str)
+    return permalink
+
+
+async def _search_permalink_exact(
+    mcp_server,
+    *,
+    permalink: str,
+    title: str,
+    project: str | None = None,
+) -> str:
+    arguments = {
+        "query": permalink,
+        "search_type": "permalink",
+        "output_format": "json",
+    }
+    if project is not None:
+        arguments["project"] = project
+
+    payload = await _call_json(mcp_server, "search_notes", arguments)
+    matching_results = [
+        item for item in payload["results"] if isinstance(item, dict) and item.get("title") == title
+    ]
+    assert len(matching_results) == 1
+    result_permalink = matching_results[0].get("permalink")
+    assert isinstance(result_permalink, str)
+    return result_permalink
+
+
+@pytest.mark.asyncio
+async def test_local_short_permalink_round_trips_when_project_is_supplied(
+    mcp_server,
+    test_project,
+    app_config,
+):
+    """Local short IDs need the project argument for write/search/read routing."""
+    _save_permalink_config(app_config, include_project=False, default_project=None)
+
+    title = "Local Short Permalink"
+    expected_permalink = "permalink-suite/local-short-permalink"
+
+    write_payload = await _write_json(mcp_server, project=test_project.name, title=title)
+    assert write_payload["permalink"] == expected_permalink
+
+    assert (
+        await _search_single_permalink(mcp_server, project=test_project.name, title=title)
+        == expected_permalink
+    )
+
+    short_read = await _read_json(
+        mcp_server,
+        project=test_project.name,
+        identifier=expected_permalink,
+    )
+    assert short_read["permalink"] == expected_permalink
+
+
+@pytest.mark.asyncio
+async def test_local_project_permalink_routes_without_project_argument(
+    mcp_server,
+    alternate_project,
+    app_config,
+):
+    """Local project-qualified IDs carry enough route context for search/read."""
+    _save_permalink_config(app_config, include_project=True, default_project=None)
+
+    title = "Local Project Permalink"
+    short_permalink = "permalink-suite/local-project-permalink"
+    expected_permalink = f"{alternate_project.name}/{short_permalink}"
+
+    write_payload = await _write_json(mcp_server, project=alternate_project.name, title=title)
+    assert write_payload["permalink"] == expected_permalink
+
+    assert (
+        await _search_permalink_exact(
+            mcp_server,
+            permalink=expected_permalink,
+            title=title,
+        )
+        == expected_permalink
+    )
+
+    project_read = await _read_json(mcp_server, identifier=expected_permalink)
+    assert project_read["permalink"] == expected_permalink
+
+
+@pytest.mark.asyncio
+async def test_personal_cloud_short_permalink_round_trips_when_project_is_supplied(
+    mcp_server,
+    test_project,
+    app_config,
+    personal_workspace,
+    route_workspaces,
+):
+    """Legacy short IDs remain readable/searchable in a personal cloud workspace."""
+    _save_permalink_config(app_config, include_project=False, default_project=None)
+
+    title = "Personal Cloud Short Permalink"
+    expected_permalink = "permalink-suite/personal-cloud-short-permalink"
+
+    write_payload = await _write_json(mcp_server, project=test_project.name, title=title)
+    assert write_payload["permalink"] == expected_permalink
+
+    with route_workspaces(personal_workspace):
+        assert (
+            await _search_single_permalink(
+                mcp_server,
+                project=test_project.name,
+                title=title,
+            )
+            == expected_permalink
+        )
+
+        short_read = await _read_json(
+            mcp_server,
+            project=test_project.name,
+            identifier=expected_permalink,
+        )
+        assert short_read["permalink"] == expected_permalink
+
+
+@pytest.mark.asyncio
+async def test_personal_cloud_project_permalink_routes_without_project_argument(
+    mcp_server,
+    alternate_project,
+    app_config,
+    personal_workspace,
+    route_workspaces,
+):
+    """Legacy project-qualified cloud IDs carry enough route context."""
+    _save_permalink_config(app_config, include_project=True, default_project=None)
+
+    title = "Personal Cloud Project Permalink"
+    short_permalink = "permalink-suite/personal-cloud-project-permalink"
+    expected_permalink = f"{alternate_project.name}/{short_permalink}"
+
+    write_payload = await _write_json(mcp_server, project=alternate_project.name, title=title)
+    assert write_payload["permalink"] == expected_permalink
+
+    with route_workspaces(personal_workspace):
+        assert (
+            await _search_permalink_exact(
+                mcp_server,
+                permalink=expected_permalink,
+                title=title,
+            )
+            == expected_permalink
+        )
+
+        project_read = await _read_json(mcp_server, identifier=expected_permalink)
+        assert project_read["permalink"] == expected_permalink
+
+
+@pytest.mark.asyncio
+async def test_team_short_permalink_round_trips_when_project_is_supplied(
+    mcp_server,
+    test_project,
+    app_config,
+    team_workspace,
+    route_workspaces,
+):
+    """Team short IDs need the qualified project argument for search/read routing."""
+    team_project = f"{team_workspace.slug}/{test_project.name}"
+
+    _save_permalink_config(app_config, include_project=False, default_project=None)
+    title = "Team Short Permalink"
+    expected_permalink = "permalink-suite/team-short-permalink"
+
+    write_payload = await _write_json(mcp_server, project=test_project.name, title=title)
+    assert write_payload["permalink"] == expected_permalink
+
+    with route_workspaces(team_workspace):
+        assert (
+            await _search_single_permalink(
+                mcp_server,
+                project=team_project,
+                title=title,
+            )
+            == expected_permalink
+        )
+        short_read = await _read_json(
+            mcp_server,
+            project=team_project,
+            identifier=expected_permalink,
+        )
+        assert short_read["permalink"] == expected_permalink
+
+
+@pytest.mark.asyncio
+async def test_team_project_permalink_routes_without_project_argument(
+    mcp_server,
+    alternate_project,
+    app_config,
+    team_workspace,
+    route_workspaces,
+):
+    """Team project-qualified IDs carry enough route context for search/read."""
+    _save_permalink_config(app_config, include_project=True, default_project=None)
+
+    title = "Team Project Permalink"
+    short_permalink = "permalink-suite/team-project-permalink"
+    expected_permalink = f"{alternate_project.name}/{short_permalink}"
+
+    write_payload = await _write_json(mcp_server, project=alternate_project.name, title=title)
+    assert write_payload["permalink"] == expected_permalink
+
+    with route_workspaces(team_workspace):
+        assert (
+            await _search_permalink_exact(
+                mcp_server,
+                permalink=expected_permalink,
+                title=title,
+            )
+            == expected_permalink
+        )
+        project_read = await _read_json(mcp_server, identifier=expected_permalink)
+        assert project_read["permalink"] == expected_permalink
+
+
+@pytest.mark.asyncio
+async def test_team_workspace_permalink_routes_to_specific_workspace(
+    mcp_server,
+    test_project,
+    app_config,
+    personal_workspace,
+    team_workspace,
+    route_workspaces,
+):
+    """Workspace-qualified IDs route to the project in that workspace."""
+    _save_permalink_config(app_config, include_project=True, default_project=None)
+    team_project = f"{team_workspace.slug}/{test_project.name}"
+
+    title = "Team Workspace Permalink"
+    short_permalink = "permalink-suite/team-workspace-permalink"
+    expected_permalink = f"{team_workspace.slug}/{test_project.name}/{short_permalink}"
+
+    with route_workspaces(personal_workspace, team_workspace):
+        write_payload = await _write_json(mcp_server, project=team_project, title=title)
+        assert write_payload["permalink"] == expected_permalink
+
+        assert (
+            await _search_permalink_exact(
+                mcp_server,
+                permalink=expected_permalink,
+                title=title,
+            )
+            == expected_permalink
+        )
+
+        workspace_read = await _read_json(mcp_server, identifier=expected_permalink)
+        assert workspace_read["permalink"] == expected_permalink

--- a/tests/mcp/test_tool_read_note.py
+++ b/tests/mcp/test_tool_read_note.py
@@ -292,7 +292,7 @@ async def test_read_note_skips_url_detection_when_project_id_provided(
     import importlib
 
     read_note_module = importlib.import_module("basic_memory.mcp.tools.read_note")
-    monkeypatch.setattr(read_note_module, "detect_project_from_memory_url_prefix", fail_if_called)
+    monkeypatch.setattr(read_note_module, "detect_project_from_identifier_prefix", fail_if_called)
 
     result = await read_note(
         f"memory://{test_project.name}/test/project-id-memory-url-read",

--- a/tests/mcp/test_tool_utils.py
+++ b/tests/mcp/test_tool_utils.py
@@ -13,6 +13,11 @@ from basic_memory.mcp.tools.utils import (
     call_put,
     get_error_message,
 )
+from basic_memory.workspace_context import (
+    WORKSPACE_SLUG_HEADER,
+    WORKSPACE_TYPE_HEADER,
+    workspace_permalink_context,
+)
 
 
 @pytest.fixture
@@ -168,6 +173,26 @@ async def test_call_get_with_params(mock_response):
     method, _args, kwargs = client.calls[0]
     assert method == "get"
     assert kwargs["params"] == params
+
+
+@pytest.mark.asyncio
+async def test_call_post_adds_workspace_permalink_headers_at_request_time(mock_response):
+    client = _Client()
+    client.set_response("post", mock_response())
+
+    with workspace_permalink_context("team-paul", "organization"):
+        await call_post(
+            _client(client),
+            "http://test.com",
+            headers={"X-Existing": "value"},
+        )
+
+    assert len(client.calls) == 1
+    _, _args, kwargs = client.calls[0]
+    request_headers = kwargs["headers"]
+    assert request_headers["X-Existing"] == "value"
+    assert request_headers[WORKSPACE_SLUG_HEADER] == "team-paul"
+    assert request_headers[WORKSPACE_TYPE_HEADER] == "organization"
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_workspace_permalink_resolution.py
+++ b/tests/mcp/test_workspace_permalink_resolution.py
@@ -1,0 +1,102 @@
+"""Regression tests for workspace-qualified permalink resolution."""
+
+import pytest
+
+from basic_memory.mcp.tools.delete_note import delete_note
+from basic_memory.mcp.tools.edit_note import edit_note
+from basic_memory.mcp.tools.read_note import read_note
+from basic_memory.mcp.tools.write_note import write_note
+from basic_memory.workspace_context import workspace_permalink_context
+
+
+@pytest.mark.asyncio
+async def test_link_resolver_strictly_finds_legacy_project_permalink_from_workspace_url(
+    link_resolver,
+    test_project,
+    entity_service,
+):
+    """Workspace/project IDs should resolve legacy project-prefixed rows centrally."""
+    await write_note(
+        project=test_project.name,
+        title="Resolver Legacy Workspace Note",
+        directory="personal",
+        content="Resolver legacy content",
+    )
+
+    legacy_permalink = f"{test_project.name}/personal/resolver-legacy-workspace-note"
+
+    with workspace_permalink_context(workspace_slug="personal", workspace_type="personal"):
+        resolved = await link_resolver.resolve_link(
+            f"personal/{legacy_permalink}",
+            strict=True,
+        )
+
+    assert resolved is not None
+    assert resolved.permalink == legacy_permalink
+
+
+@pytest.mark.asyncio
+async def test_edit_note_workspace_qualified_url_edits_legacy_project_permalink(
+    app,
+    test_project,
+):
+    """IDs returned from multi-project search should be editable even for legacy rows."""
+    legacy_permalink = f"{test_project.name}/personal/edit-legacy-workspace-note"
+    qualified_permalink = f"personal/{legacy_permalink}"
+
+    await write_note(
+        project=test_project.name,
+        title="Edit Legacy Workspace Note",
+        directory="personal",
+        content="# Edit Legacy Workspace Note\n\nstatus: draft",
+    )
+
+    with workspace_permalink_context(workspace_slug="personal", workspace_type="personal"):
+        edit_result = await edit_note(
+            identifier=f"memory://{qualified_permalink}",
+            project=test_project.name,
+            operation="find_replace",
+            find_text="status: draft",
+            content="status: done",
+            output_format="json",
+        )
+
+    assert isinstance(edit_result, dict)
+    assert edit_result["fileCreated"] is False
+    assert edit_result["permalink"] == legacy_permalink
+
+    read_result = await read_note(
+        legacy_permalink,
+        project=test_project.name,
+        output_format="json",
+    )
+    assert isinstance(read_result, dict)
+    assert "status: done" in read_result["content"]
+
+
+@pytest.mark.asyncio
+async def test_delete_note_workspace_qualified_url_deletes_legacy_project_permalink(
+    app,
+    test_project,
+):
+    """IDs returned from multi-project search should be deletable even for legacy rows."""
+    legacy_permalink = f"{test_project.name}/personal/delete-legacy-workspace-note"
+    qualified_permalink = f"personal/{legacy_permalink}"
+
+    await write_note(
+        project=test_project.name,
+        title="Delete Legacy Workspace Note",
+        directory="personal",
+        content="Delete legacy content",
+    )
+
+    with workspace_permalink_context(workspace_slug="personal", workspace_type="personal"):
+        delete_result = await delete_note(
+            identifier=f"memory://{qualified_permalink}",
+            project=test_project.name,
+            output_format="json",
+        )
+
+    assert isinstance(delete_result, dict)
+    assert delete_result["deleted"] is True
+    assert delete_result["permalink"] == legacy_permalink

--- a/tests/test_permalink_utils.py
+++ b/tests/test_permalink_utils.py
@@ -47,6 +47,21 @@ def test_short_permalink_candidates_include_workspace_and_project_forms():
     ]
 
 
+def test_short_workspace_candidate_keeps_project_legacy_when_project_prefix_disabled():
+    candidates = build_permalink_resolution_candidates(
+        "notes/example",
+        "main",
+        include_project=False,
+        workspace_permalink="personal",
+    )
+
+    assert candidates == [
+        "notes/example",
+        "personal/main/notes/example",
+        "main/notes/example",
+    ]
+
+
 def test_qualified_permalink_reference_preserves_lookup_syntax():
     assert (
         build_qualified_permalink_reference(

--- a/tests/test_permalink_utils.py
+++ b/tests/test_permalink_utils.py
@@ -20,6 +20,19 @@ def test_workspace_qualified_permalink_candidates_include_legacy_without_rewrapp
     ]
 
 
+def test_project_prefixed_candidate_includes_short_legacy_when_project_prefix_disabled():
+    candidates = build_permalink_resolution_candidates(
+        "main/notes/example",
+        "main",
+        include_project=False,
+    )
+
+    assert candidates == [
+        "main/notes/example",
+        "notes/example",
+    ]
+
+
 def test_short_permalink_candidates_include_workspace_and_project_forms():
     candidates = build_permalink_resolution_candidates(
         "notes/example",

--- a/tests/test_permalink_utils.py
+++ b/tests/test_permalink_utils.py
@@ -1,0 +1,62 @@
+"""Tests for canonical permalink utility helpers."""
+
+from basic_memory.utils import (
+    build_permalink_resolution_candidates,
+    build_qualified_permalink_reference,
+)
+
+
+def test_workspace_qualified_permalink_candidates_include_legacy_without_rewrapping():
+    candidates = build_permalink_resolution_candidates(
+        "personal/main/notes/example",
+        "main",
+        workspace_permalink="personal",
+    )
+
+    assert candidates == [
+        "personal/main/notes/example",
+        "main/notes/example",
+        "notes/example",
+    ]
+
+
+def test_short_permalink_candidates_include_workspace_and_project_forms():
+    candidates = build_permalink_resolution_candidates(
+        "notes/example",
+        "main",
+        workspace_permalink="personal",
+    )
+
+    assert candidates == [
+        "notes/example",
+        "personal/main/notes/example",
+        "main/notes/example",
+    ]
+
+
+def test_qualified_permalink_reference_preserves_lookup_syntax():
+    assert (
+        build_qualified_permalink_reference(
+            "main",
+            "notes/roadmap.md",
+            include_project=False,
+        )
+        == "notes/roadmap.md"
+    )
+    assert (
+        build_qualified_permalink_reference(
+            "main",
+            "patterns/*",
+            include_project=True,
+        )
+        == "main/patterns/*"
+    )
+    assert (
+        build_qualified_permalink_reference(
+            "main",
+            "patterns/*",
+            include_project=True,
+            workspace_permalink="personal",
+        )
+        == "personal/main/patterns/*"
+    )


### PR DESCRIPTION
Follow-up to #807.

## Summary
- Centralizes qualified permalink construction and resolution candidates so write/read/search paths share one workspace/project permalink model.
- Routes project-prefixed identifiers like `project/some-note` without requiring a separate `project` argument.
- Routes workspace-qualified identifiers like `workspace-slug/project/some-note` to the matching workspace/project before default-project fallback.
- Keeps short permalinks scoped: callers still need an explicit project when there is no route/default context.
- Preserves existing cloud notes stored with legacy short or project-prefixed permalinks by resolving those forms inside the routed workspace.
- Adds explicit scenario integration tests, using fixtures/helpers instead of table-driven cases, for local, personal cloud, and team workspace permalink write/search/read behavior.

## Validation
- `BASIC_MEMORY_LOGFIRE_ENABLED=false uv run pytest tests/test_permalink_utils.py tests/mcp/test_workspace_permalink_resolution.py test-int/mcp/test_workspace_permalink_integration.py tests/mcp/test_tool_read_note.py tests/mcp/test_project_context.py::test_resolve_project_and_path_uses_cached_project_for_memory_url_prefix tests/mcp/test_project_context.py::test_resolve_project_and_path_keeps_workspace_qualified_canonical_path tests/mcp/test_project_context.py::test_resolve_project_and_path_preserves_personal_workspace_prefix tests/mcp/test_project_context.py::test_resolve_project_and_path_preserves_existing_project_prefixed_memory_url tests/mcp/test_project_context.py::test_detect_project_from_memory_url_prefix_resolves_workspace_slug tests/mcp/test_project_context.py::test_detect_project_from_memory_url_prefix_prefers_local_project_prefix tests/mcp/test_project_context.py::test_detect_project_from_memory_url_prefix_skips_workspace_discovery_for_local_config tests/mcp/test_project_context.py::test_detect_project_from_memory_url_prefix_ignores_plain_paths tests/mcp/test_tool_search.py test-int/mcp/test_build_context_validation.py::test_build_context_pattern_matching_works test-int/mcp/test_build_context_underscore.py::test_build_context_complex_underscore_paths test-int/mcp/test_build_context_underscore.py::test_build_context_underscore_normalization -q` (`106 passed`)
- `BASIC_MEMORY_LOGFIRE_ENABLED=false uv run pytest tests/mcp/test_async_client_modes.py tests/mcp/tools/test_search_notes_multi_project.py tests/mcp/test_tool_read_note.py::test_read_note_workspace_qualified_personal_url_finds_legacy_short_permalink tests/mcp/test_tool_read_note.py::test_read_note_workspace_qualified_memory_url_uses_complete_permalink tests/mcp/test_tool_delete_note.py::test_delete_directory_workspace_memory_url_strips_route_prefix -q` (`31 passed`)
- `uv run ruff check src/basic_memory/utils.py src/basic_memory/mcp/project_context.py src/basic_memory/mcp/async_client.py src/basic_memory/mcp/tools/read_note.py src/basic_memory/mcp/tools/search.py src/basic_memory/services/link_resolver.py tests/test_permalink_utils.py tests/mcp/test_workspace_permalink_resolution.py test-int/mcp/test_workspace_permalink_integration.py tests/mcp/test_tool_read_note.py`
- `uv run ruff format --check src/basic_memory/utils.py src/basic_memory/mcp/project_context.py src/basic_memory/mcp/async_client.py src/basic_memory/mcp/tools/read_note.py src/basic_memory/mcp/tools/search.py src/basic_memory/services/link_resolver.py tests/test_permalink_utils.py tests/mcp/test_workspace_permalink_resolution.py test-int/mcp/test_workspace_permalink_integration.py tests/mcp/test_tool_read_note.py`
- `git diff --check --cached`
- `BASIC_MEMORY_LOGFIRE_ENABLED=false just doctor`
