### PR TITLE
fix(core): don't capture prose prefix before wikilink as relation type

### DIFF
--- a/src/basic_memory/markdown/plugins.py
+++ b/src/basic_memory/markdown/plugins.py
@@ -85,14 +85,39 @@ def parse_observation(token: Token) -> Dict[str, Any]:
 
 
 # Relation handling functions
+
+# A relation type is a short label ("relates_to", "depends on"), never a
+# sentence of prose. A list item can legitimately contain a [[wikilink]] inside
+# ordinary prose ("- I read about this in [[Some Note]] last week") -- that is
+# an inline link, not an explicit `type [[target]]` relation. The bound below
+# is what separates the two: anything longer before the [[ is treated as prose.
+# Why a bound is needed: without it, the entire prose prefix is captured as the
+# relation type (see parse_relation), producing meaningless edges -- and, while
+# RelationType still carried a MaxLen, failing the whole note write.
+MAX_RELATION_TYPE_LENGTH = 100
+
+
 def is_explicit_relation(token: Token) -> bool:
-    """Check if token looks like our relation format."""
+    """Check if token looks like our relation format.
+
+    An explicit relation is `relation_type [[target]] (context)` where
+    relation_type is a short label. A list item whose [[wikilink]] is preceded
+    by a long prose prefix is NOT an explicit relation -- returning False here
+    lets relation_rule fall through to parse_inline_relations, which records it
+    as an inline "links_to" relation instead.
+    """
     if token.type != "inline":  # pragma: no cover
         return False
 
     # Use token.tag which contains the actual content for test tokens, fallback to content
     content = (token.tag or token.content).strip()
-    return "[[" in content and "]]" in content
+    if "[[" not in content or "]]" not in content:
+        return False
+
+    # The text before the first [[ is the candidate relation type. A prose-
+    # length prefix is prose, not a label -- defer to inline link handling.
+    before = content[: content.find("[[")].strip()
+    return len(before) <= MAX_RELATION_TYPE_LENGTH
 
 
 def parse_relation(token: Token) -> Dict[str, Any] | None:
@@ -113,6 +138,12 @@ def parse_relation(token: Token) -> Dict[str, Any] | None:
         # Get text before link as relation type
         before = content[:start].strip()
         if before:
+            # Defense-in-depth: is_explicit_relation already filters prose-
+            # length prefixes out before relation_rule calls us, but guard
+            # directly too so a prose prefix can never become a relation type
+            # regardless of caller.
+            if len(before) > MAX_RELATION_TYPE_LENGTH:
+                return None
             rel_type = before
 
         # Get target

--- a/tests/markdown/test_relation_edge_cases.py
+++ b/tests/markdown/test_relation_edge_cases.py
@@ -2,7 +2,12 @@
 
 from markdown_it import MarkdownIt
 
-from basic_memory.markdown.plugins import relation_plugin, parse_relation, parse_inline_relations
+from basic_memory.markdown.plugins import (
+    MAX_RELATION_TYPE_LENGTH,
+    relation_plugin,
+    parse_relation,
+    parse_inline_relations,
+)
 from basic_memory.markdown.schemas import Relation
 
 
@@ -128,3 +133,47 @@ def test_unicode_targets():
     assert relation.type == "type"
     assert relation.target == "Target"
     assert relation.context == "测试"
+
+
+def test_prose_prefix_not_captured_as_relation_type():
+    """A long prose prefix before a [[wikilink]] is prose, not a relation type.
+
+    A list item can legitimately mention a [[wikilink]] inside ordinary prose.
+    Without a length bound, the whole sentence before the [[ was captured as
+    the relation type -- a meaningless edge that (while RelationType carried a
+    MaxLen) failed the entire note write. Such a list item must instead fall
+    through to inline handling and be recorded as a generic "links_to".
+    """
+    md = MarkdownIt().use(relation_plugin)
+
+    prose = (
+        "This is a long bullet describing something in detail, going on well "
+        "past a hundred characters so the text before the wikilink is clearly "
+        "prose and not a relation type, and only at the very end does it cite "
+    )
+    assert len(prose) > MAX_RELATION_TYPE_LENGTH  # guard: prefix exceeds the bound
+
+    tokens = md.parse(f"- {prose}[[Some Target Note]]\n")
+    token = next(t for t in tokens if t.type == "inline")
+
+    # relation_rule routes it to parse_inline_relations: generic "links_to",
+    # target preserved, prose not captured as the type.
+    rels = token.meta["relations"]
+    assert len(rels) == 1
+    assert rels[0]["type"] == "links_to"
+    assert rels[0]["target"] == "Some Target Note"
+
+    # parse_relation itself also refuses to mint a prose-length type.
+    assert parse_relation(token) is None
+
+
+def test_short_relation_type_still_parses():
+    """A genuine short relation type is unaffected by the prose-prefix guard."""
+    md = MarkdownIt().use(relation_plugin)
+
+    tokens = md.parse("- relates_to [[Some Target Note]]")
+    token = next(t for t in tokens if t.type == "inline")
+    rel = parse_relation(token)
+    assert rel is not None
+    assert rel["type"] == "relates_to"
+    assert rel["target"] == "Some Target Note"


### PR DESCRIPTION
## Problem

`is_explicit_relation()` treats **any** list item containing `[[...]]` anywhere in it as an explicit `relation_type [[target]]` relation. `parse_relation()` then captures *everything before the `[[`* as the relation type.

So a list item that just mentions a wikilink inside ordinary prose:

```markdown
- After a long discussion we eventually decided to revisit [[Some Note]]
```

produces a relation whose `type` is the entire prose sentence. That's a meaningless edge in the knowledge graph — and while `RelationType` still carried `MaxLen(200)`, a prose prefix over 200 chars failed Pydantic validation and **rejected the whole note write**. One prose bullet poisoned the entire document.

This is the bug reported in #721. #770 fixed the *crash* by removing `MaxLen` from `RelationType`, but explicitly left the parsing heuristic out of scope — so on `main` today, prose with a wikilink no longer errors, but is still silently ingested as an explicit relation typed with a whole sentence.

## Fix

A relation type is a short label (`relates_to`, `depends on`) — never a sentence. This adds a `MAX_RELATION_TYPE_LENGTH = 100` bound:

- `is_explicit_relation()` returns `False` when the text before `[[` exceeds that bound. The token then falls through `relation_rule`'s existing `else` branch to `parse_inline_relations()` and is correctly recorded as a generic `links_to` relation — the wikilink is preserved, the prose is not captured as a type.
- `parse_relation()` guards the same bound directly as defense-in-depth, so a prose prefix can never become a relation type regardless of caller.

Two regression tests added in `tests/markdown/test_relation_edge_cases.py`: a long-prose bullet routes to `links_to` (and `parse_relation` returns `None`), and a genuine short `relates_to [[...]]` is unaffected.

## Scope / deliberately deferred

This is intentionally the **minimal** fix — a single length bound. The explicit/inline distinction is fundamentally ambiguous under the current syntax (`- saw this in [[X]]` is indistinguishable from a real short relation type), and `100` is a conservative threshold that cleanly catches prose sentences without touching any plausible real label. Two follow-ups were considered and left out to keep this reviewable:

1. **Tighter heuristics** — also reject prefixes with sentence punctuation or many words. Shrinks the ambiguous middle zone but adds individually-debatable rules.
2. **A syntax-level marker** for explicit relations (e.g. `relation:: [[X]]`) — the only thing that makes the distinction *truly* decidable, but backward-incompatible and a maintainer call.

Happy to fold either in if you'd prefer a different scope.
