### PR TITLE
fix(core): parse prose wikilinks as inline links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- Relation parsing no longer treats unquoted multi-word text before a wikilink as a
+  custom relation type. Use single-token relation types like `relates_to [[Target]]`,
+  or quote multi-word relation types like `"relates to" [[Target]]` or
+  `'relates to' [[Target]]`.
+  - Bare list wikilinks like `- [[Target]]` now index as `links_to`.
+  - Prose list items like `- some other thing [[Target]]` now index as `links_to`.
+  - To preserve existing multi-word relation types on re-sync, quote them before upgrading.
+
 ## v0.20.3 (2026-03-26)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -285,7 +285,12 @@ Markdown format:
 
 ```markdown
 - relation_type [[WikiLink]] (optional context)
+- "multi word relation type" [[WikiLink]] (optional context)
+- 'multi word relation type' [[WikiLink]] (optional context)
 ```
+
+Unquoted relation types are single tokens. Use quotes when the relation type contains
+spaces. Bare wikilinks and prose with wikilinks are stored as `links_to` relations.
 
 Examples of relations:
 
@@ -295,6 +300,8 @@ Examples of relations:
 - contrasts_with [[Tea Brewing Methods]]
 - requires [[Burr Grinder]]
 - improves_with [[Fresh Beans]]
+- "pairs well with" [[Chocolate Desserts]]
+- 'documented in' [[Coffee Journal]]
 - relates_to [[Morning Routine]]
 - inspired_by [[Japanese Coffee Culture]]
 - documented_in [[Coffee Journal]]

--- a/docs/NOTE-FORMAT.md
+++ b/docs/NOTE-FORMAT.md
@@ -106,7 +106,7 @@ The parser excludes these list item patterns:
 |---------|---------|--------|
 | Checkboxes | `- [ ] Todo item`, `- [x] Done`, `- [-] Cancelled` | Task list syntax |
 | Markdown links | `- [text](url)` | URL link syntax |
-| Bare wiki links | `- [[Target]]` | Treated as a relation instead |
+| Bare wiki links | `- [[Target]]` | Treated as a `links_to` relation instead |
 
 A list item with `#tags` but no `[category]` is still parsed — the tags are extracted and the category defaults to `Note`.
 
@@ -116,47 +116,65 @@ Relations connect documents to form the knowledge graph. There are two kinds.
 
 ### Explicit Relations
 
-Written as list items with a relation type and a `[[wiki link]]` target.
+Written as list items with a relation type and a `[[wiki link]]` target. Unquoted
+relation types are single tokens. Quote relation types that contain spaces.
 
 **Syntax:**
 
 ```
 - relation_type [[Target Entity]] (context)
+- "multi word relation type" [[Target Entity]] (context)
+- 'multi word relation type' [[Target Entity]] (context)
 ```
 
 | Part | Required | Description |
 |------|----------|-------------|
-| `relation_type` | No | Text before `[[`. Defaults to `relates_to` if omitted. |
+| `relation_type` | Yes | Single unquoted token before `[[`, or quoted text for multi-word labels. |
 | `[[Target]]` | Yes | Wiki link to the target entity. Matched by title or permalink. |
 | `(context)` | No | Parenthesized text after `]]`. Supporting details. |
 
 ### Examples
 
+Explicit relations:
+
 ```markdown
 - implements [[Search Design]]
 - depends_on [[Database Schema]]
 - works_at [[Y Combinator]] (co-founder)
-- [[Some Entity]]
+- "based on" [[Customer Interview]]
+- 'in response to' [[Incident Review]]
 ```
 
-The last example — a bare `[[wiki link]]` in a list item — gets relation type `relates_to`.
+Bare wiki links and prose list items create implicit `links_to` relations:
+
+```markdown
+- [[Some Entity]]
+- some other thing [[Some Entity]]
+```
+
+Both examples above create `links_to [[Some Entity]]`. Use quotes when the words before
+`[[` are meant to be a multi-word relation type.
 
 Common relation types:
 - `implements`, `depends_on`, `relates_to`, `inspired_by`
 - `extends`, `part_of`, `contains`, `pairs_with`
 - `works_at`, `authored`, `collaborated_with`
 
-Any text works as a relation type. These are conventions, not a fixed set.
+Any single-token text or quoted text works as a relation type. These are conventions,
+not a fixed set.
 
 ### Inline References
 
-Wiki links appearing in regular prose (not as list items) create implicit `links_to` relations.
+Wiki links appearing in regular prose create implicit `links_to` relations. This includes
+list items that do not match the explicit relation grammar above.
 
 ```markdown
 This builds on [[Core Design]] and uses [[Utility Functions]].
+- We should revisit [[Search Design]] after the API changes.
 ```
 
-This creates two relations: `links_to [[Core Design]]` and `links_to [[Utility Functions]]`.
+This creates three relations: `links_to [[Core Design]]`, `links_to [[Utility Functions]]`,
+and `links_to [[Search Design]]`.
 
 ### Forward References
 

--- a/src/basic_memory/markdown/plugins.py
+++ b/src/basic_memory/markdown/plugins.py
@@ -85,6 +85,28 @@ def parse_observation(token: Token) -> Dict[str, Any]:
 
 
 # Relation handling functions
+def parse_relation_type(content: str) -> str | None:
+    """Return the explicit relation label before the first wikilink, if any."""
+    before_link = content.partition("[[")[0].strip()
+    if not before_link:
+        return None
+
+    # Trigger: relation labels that need spaces must be quoted.
+    # Why: unquoted multi-word prefixes are indistinguishable from prose
+    # containing a wikilink.
+    # Outcome: `some_type [[Target]]`, `"some type" [[Target]]`, and
+    # `'some type' [[Target]]` are explicit; `some other thing [[Target]]`
+    # falls back to inline `links_to` handling.
+    quote = before_link[0]
+    if quote in {"'", '"'} and before_link.endswith(quote):
+        quoted_label = before_link[1:-1].strip()
+        return quoted_label or None
+
+    if any(char.isspace() for char in before_link):
+        return None
+    return before_link
+
+
 def is_explicit_relation(token: Token) -> bool:
     """Check if token looks like our relation format."""
     if token.type != "inline":  # pragma: no cover
@@ -92,7 +114,7 @@ def is_explicit_relation(token: Token) -> bool:
 
     # Use token.tag which contains the actual content for test tokens, fallback to content
     content = (token.tag or token.content).strip()
-    return "[[" in content and "]]" in content
+    return "[[" in content and "]]" in content and parse_relation_type(content) is not None
 
 
 def parse_relation(token: Token) -> Dict[str, Any] | None:
@@ -101,20 +123,18 @@ def parse_relation(token: Token) -> Dict[str, Any] | None:
     # Use token.tag which contains the actual content for test tokens, fallback to content
     content = (token.tag or token.content).strip()
 
+    rel_type = parse_relation_type(content)
+    if rel_type is None:
+        return None
+
     # Extract [[target]]
     target = None
-    rel_type = "relates_to"  # default
     context = None
 
     start = content.find("[[")
-    end = content.find("]]")
+    end = content.find("]]", start + 2)
 
     if start != -1 and end != -1:
-        # Get text before link as relation type
-        before = content[:start].strip()
-        if before:
-            rel_type = before
-
         # Get target
         target = normalize_project_reference(content[start + 2 : end].strip())
 
@@ -217,6 +237,8 @@ def relation_plugin(md: MarkdownIt) -> None:
 
     Explicit relations:
     - relation_type [[target]] (context)
+    - "multi word relation type" [[target]] (context)
+    - 'multi word relation type' [[target]] (context)
 
     Implicit relations (links in content):
     Some text with [[target]] reference

--- a/src/basic_memory/mcp/tools/write_note.py
+++ b/src/basic_memory/mcp/tools/write_note.py
@@ -66,10 +66,14 @@ async def write_note(
 
     Relations format:
         - Explicit: `- relation_type [[Entity]] (optional context)`
-        - Inline: Any `[[Entity]]` reference creates a relation
+        - Quoted: `- "multi word relation type" [[Entity]] (optional context)`
+        - Quoted: `- 'multi word relation type' [[Entity]] (optional context)`
+        - Inline: Any other `[[Entity]]` reference creates a `links_to` relation
 
         Examples:
         `- depends_on [[Content Parser]] (Need for semantic extraction)`
+        `- "based on" [[Design Notes]]`
+        `- 'in response to' [[Incident Review]]`
         `- implements [[Search Spec]] (Initial implementation)`
         `- This feature extends [[Base Design]] and uses [[Core Utils]]`
 

--- a/test-int/mcp/test_long_relation_type_integration.py
+++ b/test-int/mcp/test_long_relation_type_integration.py
@@ -1,34 +1,30 @@
-"""
-Integration test for long relation_type values (regression guard for issue #721).
+"""Integration test for long prose before inline wikilinks.
 
-When a markdown bullet contains an inline `[[wikilink]]` preceded by long prose,
-`parse_relation()` extracts ALL of that prose as the `relation_type`. Previously
-the response model `RelationType` had a `MaxLen(200)` constraint that caused
-edit_note (which round-trips through the response model when re-indexing) to
-fail with:
+Issue #721 was originally triggered by markdown bullets that contained inline
+`[[wikilinks]]` preceded by long prose. The parser treated all prose before the
+wikilink as `relation_type`, and the response model's former `MaxLen(200)`
+constraint caused edit_note to fail with:
 
     1 validation error for EntityResponseV2
     relations.0.relation_type
       String should have at most 200 characters
 
-Commit 01cbad1d removed the cap from `RelationType`. This test locks in that
-fix so a future contributor reintroducing `MaxLen` will see the test fail
-before shipping it.
-
-Out of scope: improving `parse_relation()` to fall back to a default relation
-type when the prose-before-link looks like a sentence rather than a label.
-That's a knowledge-graph-quality improvement, not a correctness fix, and is
-not required to keep edit_note working.
+The relation grammar now fixes the root ambiguity too: unquoted multi-word
+prefixes are prose, so this shape should index as a generic `links_to`
+relation rather than preserving prose as a custom relation type.
 """
 
 import pytest
 from fastmcp import Client
 
+from basic_memory.repository.relation_repository import RelationRepository
+
 
 @pytest.mark.asyncio
-async def test_edit_note_handles_long_prose_around_wikilink(mcp_server, app, test_project):
-    """edit_note must succeed on notes whose inline wikilinks have >200 chars
-    of prose preceding them — that prose becomes the parsed relation_type."""
+async def test_edit_note_handles_long_prose_around_wikilink(
+    mcp_server, app, test_project, engine_factory
+):
+    """Long prose before an inline wikilink should not become a relation type."""
     long_prose = (
         "**Lorem ipsum dolor sit amet** — consectetur adipiscing elit, sed do eiusmod "
         "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, "
@@ -75,3 +71,11 @@ async def test_edit_note_handles_long_prose_around_wikilink(mcp_server, app, tes
         )
         assert len(edit_result.content) == 1
         assert "Edited note (append)" in edit_result.content[0].text
+
+    _, session_maker = engine_factory
+    relation_repository = RelationRepository(session_maker, project_id=test_project.id)
+    links_to_relations = await relation_repository.find_by_type("links_to")
+    prose_type_relations = await relation_repository.find_by_type(long_prose)
+
+    assert any(relation.to_name == "Some Note Title" for relation in links_to_relations)
+    assert not prose_type_relations

--- a/tests/api/v2/test_knowledge_router.py
+++ b/tests/api/v2/test_knowledge_router.py
@@ -302,7 +302,7 @@ async def test_create_entity_with_observations_and_relations(
 
 ## Observations
 - [note] This is a test observation #tag1 (context)
-- related to [[OtherEntity]]
+- "related to" [[OtherEntity]]
 """,
     }
 

--- a/tests/markdown/test_relation_edge_cases.py
+++ b/tests/markdown/test_relation_edge_cases.py
@@ -128,3 +128,51 @@ def test_unicode_targets():
     assert relation.type == "type"
     assert relation.target == "Target"
     assert relation.context == "测试"
+
+
+def test_quoted_multi_word_relation_type_parses_as_explicit_relation():
+    """Quoted relation labels allow explicit multi-word relation types."""
+    md = MarkdownIt().use(relation_plugin)
+
+    tokens = md.parse('- "some type" [[Target]] (context)')
+    token = next(t for t in tokens if t.type == "inline")
+
+    assert token.meta["relations"] == [
+        {"type": "some type", "target": "Target", "context": "context"}
+    ]
+    assert parse_relation(token) == {"type": "some type", "target": "Target", "context": "context"}
+
+
+def test_single_quoted_multi_word_relation_type_parses_as_explicit_relation():
+    """Single-quoted relation labels also allow explicit multi-word relation types."""
+    md = MarkdownIt().use(relation_plugin)
+
+    tokens = md.parse("- 'some type' [[Target]] (context)")
+    token = next(t for t in tokens if t.type == "inline")
+
+    assert token.meta["relations"] == [
+        {"type": "some type", "target": "Target", "context": "context"}
+    ]
+    assert parse_relation(token) == {"type": "some type", "target": "Target", "context": "context"}
+
+
+def test_unquoted_multi_word_prefix_is_inline_link_not_relation_type():
+    """Unquoted prose before a wikilink is an inline link, not a relation type."""
+    md = MarkdownIt().use(relation_plugin)
+
+    tokens = md.parse("- some other thing [[Target]]")
+    token = next(t for t in tokens if t.type == "inline")
+
+    assert token.meta["relations"] == [{"type": "links_to", "target": "Target", "context": None}]
+    assert parse_relation(token) is None
+
+
+def test_bare_list_wikilink_is_inline_link_not_default_explicit_relation():
+    """A list item containing only a wikilink is still a generic inline link."""
+    md = MarkdownIt().use(relation_plugin)
+
+    tokens = md.parse("- [[Target]]")
+    token = next(t for t in tokens if t.type == "inline")
+
+    assert token.meta["relations"] == [{"type": "links_to", "target": "Target", "context": None}]
+    assert parse_relation(token) is None

--- a/tests/mcp/test_tool_write_note.py
+++ b/tests/mcp/test_tool_write_note.py
@@ -7,6 +7,7 @@ import pytest
 
 from basic_memory import config as config_module
 from basic_memory.mcp.tools import write_note, read_note, delete_note
+from basic_memory.repository.relation_repository import RelationRepository
 from basic_memory.utils import normalize_newlines
 
 
@@ -309,7 +310,7 @@ async def test_write_note_with_tag_array_from_bug_report(app, test_project):
 
 
 @pytest.mark.asyncio
-async def test_write_note_verbose(app, test_project):
+async def test_write_note_verbose(app, test_project, engine_factory):
     """Test creating a new note.
 
     Should:
@@ -326,7 +327,7 @@ async def test_write_note_verbose(app, test_project):
 # Test\nThis is a test note
 
 - [note] First observation
-- relates to [[Knowledge]]
+- "relates to" [[Knowledge]]
 
 """,
         tags=["test", "documentation"],
@@ -342,6 +343,11 @@ async def test_write_note_verbose(app, test_project):
     assert "## Tags" in result
     assert "- test, documentation" in result
     assert f"[Session: Using project '{test_project.name}']" in result
+
+    _, session_maker = engine_factory
+    relation_repository = RelationRepository(session_maker, project_id=test_project.id)
+    relations = await relation_repository.find_by_type("relates to")
+    assert any(relation.to_name == "Knowledge" for relation in relations)
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_entity_service.py
+++ b/tests/services/test_entity_service.py
@@ -1006,7 +1006,7 @@ async def test_edit_entity_with_observations_and_relations(
         # Test Note
         
         - [note] This is an observation
-        - links to [[Other Entity]]
+        - "links to" [[Other Entity]]
         
         Original content
         """).strip()
@@ -1028,7 +1028,7 @@ async def test_edit_entity_with_observations_and_relations(
     updated = await entity_service.edit_entity(
         identifier=_permalink(entity),
         operation="append",
-        content="\n- [category] New observation\n- relates to [[New Entity]]",
+        content='\n- [category] New observation\n- "relates to" [[New Entity]]',
     )
 
     # Verify observations and relations were updated


### PR DESCRIPTION
## Summary
- Tighten explicit relation parsing so unquoted labels must be a single token, while quoted labels can contain spaces.
- Support both `"some type" [[Target]]` and `'some type' [[Target]]` as explicit multi-word relation types.
- Treat unquoted prose before a wikilink as a bare inline `links_to` relation instead of preserving the prose as `relation_type`.

## Credit
Credit to @picklesueat for opening #823 and surfacing the parser ambiguity. This PR carries the grammar variant we want to merge from that discussion.

## Tests
- `uv run ruff format src/basic_memory/markdown/plugins.py tests/markdown/test_relation_edge_cases.py tests/services/test_entity_service.py tests/api/v2/test_knowledge_router.py test-int/mcp/test_long_relation_type_integration.py`
- `uv run ruff check src/basic_memory/markdown/plugins.py tests/markdown/test_relation_edge_cases.py tests/services/test_entity_service.py tests/api/v2/test_knowledge_router.py test-int/mcp/test_long_relation_type_integration.py`
- `uv run pytest tests/markdown -q --no-cov`
- `uv run pytest tests/services/test_entity_service.py -q --no-cov`
- `uv run pytest tests/api/v2/test_knowledge_router.py tests/mcp/test_tool_write_note.py tests/mcp/test_tool_move_note.py -q --no-cov`
- `uv run pytest test-int/mcp/test_long_relation_type_integration.py -q --no-cov`
- `just typecheck`
- `just doctor`
