### PR TITLE
perf(cli): defer local ASGI app import

### DIFF
--- a/src/basic_memory/mcp/async_client.py
+++ b/src/basic_memory/mcp/async_client.py
@@ -6,7 +6,6 @@ from httpx import ASGITransport, AsyncClient, Timeout
 from loguru import logger
 
 import logfire
-from basic_memory.api.app import app as fastapi_app
 from basic_memory.config import ConfigManager, ProjectMode
 
 
@@ -37,6 +36,9 @@ def _build_timeout() -> Timeout:
 
 def _asgi_client(timeout: Timeout) -> AsyncClient:
     """Create a local ASGI client."""
+    # Import on first local-client use so CLI help/version paths can import
+    # routing helpers without constructing the full FastAPI router graph.
+    from basic_memory.api.app import app as fastapi_app
     from basic_memory.workspace_context import workspace_permalink_headers
 
     return AsyncClient(

--- a/tests/cli/test_cli_exit.py
+++ b/tests/cli/test_cli_exit.py
@@ -80,3 +80,26 @@ def test_bm_version_does_not_import_heavy_modules():
     assert "CLEAN" in result.stdout, (
         f"Heavy modules loaded during --version: {result.stdout.strip()}"
     )
+
+
+def test_bm_help_does_not_import_api_app():
+    """Regression test: 'bm --help' must not build the FastAPI app graph."""
+    check_script = (
+        "import sys; "
+        "sys.argv = ['bm', '--help']; "
+        "import basic_memory.cli.main; "
+        "heavy = [m for m in sys.modules "
+        "if m == 'basic_memory.api.app' or m.startswith('basic_memory.api.v2.routers')]; "
+        "print(','.join(heavy) if heavy else 'CLEAN')"
+    )
+    result = subprocess.run(
+        ["uv", "run", "python", "-c", check_script],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        cwd=Path(__file__).parent.parent.parent,
+    )
+    assert result.returncode == 0
+    assert "CLEAN" in result.stdout, (
+        f"API app modules loaded during --help: {result.stdout.strip()}"
+    )


### PR DESCRIPTION
## Summary

- Defer importing `basic_memory.api.app` until a local ASGI client is actually constructed.
- Keep CLI help from building the FastAPI router graph just to render command usage.
- Add a regression test that imports the `--help` path and asserts API app/router modules stay unloaded.

Fixes #740.

## Startup Measurements

Measured with `.venv/bin/basic-memory` on this worktree, 5 runs each:

- Before: `--help` median 3.027s; `import basic_memory.cli.main` median 3.015s; `--version` median 0.428s.
- After: `--help` median 1.711s; `import basic_memory.cli.main` median 1.771s; `--version` median 0.432s.

## Validation

- `uv run pytest -q tests/cli/test_cli_exit.py`
- `git diff --check`
- `just fast-check` completed ruff, format, and typecheck; the cold `pytest-testmon` run was intentionally left to CI after selecting the full suite in the fresh worktree.
