### PR TITLE
fix(mcp): preinitialize local ASGI database

### DIFF
--- a/src/basic_memory/mcp/async_client.py
+++ b/src/basic_memory/mcp/async_client.py
@@ -1,11 +1,11 @@
 import os
-from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from asyncio import Lock
+from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
-from inspect import isawaitable
 from threading import RLock
-from typing import TYPE_CHECKING, AsyncIterator, Callable, Optional, cast
+from typing import TYPE_CHECKING, Annotated, Any, AsyncIterator, Callable, Optional
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Request
 from httpx import ASGITransport, AsyncClient, Timeout
 from loguru import logger
 
@@ -24,9 +24,11 @@ class _PreparedLocalAsgiDatabase:
     active_count: int
     previous_engine: object
     previous_session_maker: object
+    dependency_context: AbstractAsyncContextManager[LocalDatabaseState]
 
 
 _prepared_local_asgi_database_lock = RLock()
+_prepared_local_asgi_database_prepare_locks: dict[FastAPI, Lock] = {}
 _prepared_local_asgi_databases: dict[FastAPI, _PreparedLocalAsgiDatabase] = {}
 
 
@@ -69,21 +71,60 @@ def _build_asgi_client(app: FastAPI, timeout: Timeout) -> AsyncClient:
     )
 
 
-async def _resolve_local_asgi_database(app: FastAPI) -> LocalDatabaseState:
+def _get_prepared_local_asgi_database_prepare_lock(app: FastAPI) -> Lock:
+    """Get the async lock that serializes first-time DB preparation for an app."""
+    with _prepared_local_asgi_database_lock:
+        prepare_lock = _prepared_local_asgi_database_prepare_locks.get(app)
+        if prepare_lock is None:
+            prepare_lock = Lock()
+            _prepared_local_asgi_database_prepare_locks[app] = prepare_lock
+        return prepare_lock
+
+
+@asynccontextmanager
+async def _resolve_local_asgi_database(app: FastAPI) -> AsyncIterator[LocalDatabaseState]:
     """Resolve database state for a local ASGI request."""
+    from fastapi.dependencies.utils import get_dependant, solve_dependencies
+
     from basic_memory.deps import get_engine_factory
 
-    override = app.dependency_overrides.get(get_engine_factory)
-    if override is not None:
-        result = override()
-        if isawaitable(result):
-            result = await result
-        return cast(LocalDatabaseState, result)
+    async def resolve_database_state(
+        database_state: Annotated[LocalDatabaseState, Depends(get_engine_factory)],
+    ) -> LocalDatabaseState:
+        return database_state
 
-    from basic_memory import db
+    scope: dict[str, Any] = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "root_path": "",
+        "query_string": b"",
+        "headers": [],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "app": app,
+        "path_params": {},
+    }
 
-    config = ConfigManager().config
-    return await db.get_or_create_db(config.database_path)
+    async with AsyncExitStack() as request_stack, AsyncExitStack() as function_stack:
+        scope["fastapi_inner_astack"] = request_stack
+        scope["fastapi_function_astack"] = function_stack
+        request = Request(scope)
+        dependant = get_dependant(path="/", call=resolve_database_state)
+        solved = await solve_dependencies(
+            request=request,
+            dependant=dependant,
+            dependency_overrides_provider=app,
+            async_exit_stack=request_stack,
+            embed_body_fields=False,
+        )
+        if solved.errors:
+            raise RuntimeError(f"Failed to resolve local ASGI database dependency: {solved.errors}")
+
+        yield await resolve_database_state(**solved.values)
 
 
 def _retain_prepared_local_asgi_database(app: FastAPI) -> bool:
@@ -100,13 +141,13 @@ def _retain_prepared_local_asgi_database(app: FastAPI) -> bool:
 def _install_prepared_local_asgi_database(
     app: FastAPI,
     database_state: LocalDatabaseState,
+    dependency_context: AbstractAsyncContextManager[LocalDatabaseState],
 ) -> None:
-    """Install local ASGI database state or retain an overlapping installation."""
+    """Install local ASGI database state after dependency resolution."""
     with _prepared_local_asgi_database_lock:
         active = _prepared_local_asgi_databases.get(app)
         if active is not None:
-            active.active_count += 1
-            return
+            raise RuntimeError("Local ASGI database state installed while another state is active")
 
         previous_engine = getattr(app.state, "engine", _MISSING_STATE_VALUE)
         previous_session_maker = getattr(app.state, "session_maker", _MISSING_STATE_VALUE)
@@ -118,6 +159,7 @@ def _install_prepared_local_asgi_database(
             active_count=1,
             previous_engine=previous_engine,
             previous_session_maker=previous_session_maker,
+            dependency_context=dependency_context,
         )
 
 
@@ -130,7 +172,9 @@ def _restore_local_asgi_state_attribute(app: FastAPI, name: str, previous_value:
         setattr(app.state, name, previous_value)
 
 
-def _release_prepared_local_asgi_database(app: FastAPI) -> None:
+def _release_prepared_local_asgi_database(
+    app: FastAPI,
+) -> AbstractAsyncContextManager[LocalDatabaseState] | None:
     """Release local ASGI database state after a client context exits."""
     with _prepared_local_asgi_database_lock:
         active = _prepared_local_asgi_databases.get(app)
@@ -139,7 +183,7 @@ def _release_prepared_local_asgi_database(app: FastAPI) -> None:
 
         active.active_count -= 1
         if active.active_count > 0:
-            return
+            return None
 
         del _prepared_local_asgi_databases[app]
         _restore_local_asgi_state_attribute(app, "engine", active.previous_engine)
@@ -148,19 +192,29 @@ def _release_prepared_local_asgi_database(app: FastAPI) -> None:
             "session_maker",
             active.previous_session_maker,
         )
+        return active.dependency_context
 
 
 @asynccontextmanager
 async def _prepared_local_asgi_database(app: FastAPI) -> AsyncIterator[None]:
     """Initialize local ASGI database state before the first request."""
-    if not _retain_prepared_local_asgi_database(app):
-        database_state = await _resolve_local_asgi_database(app)
-        _install_prepared_local_asgi_database(app, database_state)
+    prepare_lock = _get_prepared_local_asgi_database_prepare_lock(app)
+    async with prepare_lock:
+        if not _retain_prepared_local_asgi_database(app):
+            database_context = _resolve_local_asgi_database(app)
+            database_state = await database_context.__aenter__()
+            try:
+                _install_prepared_local_asgi_database(app, database_state, database_context)
+            except Exception:
+                await database_context.__aexit__(None, None, None)
+                raise
 
     try:
         yield
     finally:
-        _release_prepared_local_asgi_database(app)
+        database_context = _release_prepared_local_asgi_database(app)
+        if database_context is not None:
+            await database_context.__aexit__(None, None, None)
 
 
 @asynccontextmanager

--- a/src/basic_memory/mcp/async_client.py
+++ b/src/basic_memory/mcp/async_client.py
@@ -1,6 +1,8 @@
 import os
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from dataclasses import dataclass
 from inspect import isawaitable
+from threading import RLock
 from typing import TYPE_CHECKING, AsyncIterator, Callable, Optional, cast
 
 from fastapi import FastAPI
@@ -15,6 +17,17 @@ if TYPE_CHECKING:
 
 LocalDatabaseState = tuple["AsyncEngine", "async_sessionmaker[AsyncSession]"]
 _MISSING_STATE_VALUE = object()
+
+
+@dataclass
+class _PreparedLocalAsgiDatabase:
+    active_count: int
+    previous_engine: object
+    previous_session_maker: object
+
+
+_prepared_local_asgi_database_lock = RLock()
+_prepared_local_asgi_databases: dict[FastAPI, _PreparedLocalAsgiDatabase] = {}
 
 
 def _force_local_mode() -> bool:
@@ -73,30 +86,81 @@ async def _resolve_local_asgi_database(app: FastAPI) -> LocalDatabaseState:
     return await db.get_or_create_db(config.database_path)
 
 
+def _retain_prepared_local_asgi_database(app: FastAPI) -> bool:
+    """Retain an active local ASGI database preparation if one exists."""
+    with _prepared_local_asgi_database_lock:
+        active = _prepared_local_asgi_databases.get(app)
+        if active is None:
+            return False
+
+        active.active_count += 1
+        return True
+
+
+def _install_prepared_local_asgi_database(
+    app: FastAPI,
+    database_state: LocalDatabaseState,
+) -> None:
+    """Install local ASGI database state or retain an overlapping installation."""
+    with _prepared_local_asgi_database_lock:
+        active = _prepared_local_asgi_databases.get(app)
+        if active is not None:
+            active.active_count += 1
+            return
+
+        previous_engine = getattr(app.state, "engine", _MISSING_STATE_VALUE)
+        previous_session_maker = getattr(app.state, "session_maker", _MISSING_STATE_VALUE)
+        engine, session_maker = database_state
+
+        app.state.engine = engine
+        app.state.session_maker = session_maker
+        _prepared_local_asgi_databases[app] = _PreparedLocalAsgiDatabase(
+            active_count=1,
+            previous_engine=previous_engine,
+            previous_session_maker=previous_session_maker,
+        )
+
+
+def _restore_local_asgi_state_attribute(app: FastAPI, name: str, previous_value: object) -> None:
+    """Restore a FastAPI app.state attribute captured before local ASGI preparation."""
+    if previous_value is _MISSING_STATE_VALUE:
+        if hasattr(app.state, name):
+            delattr(app.state, name)
+    else:
+        setattr(app.state, name, previous_value)
+
+
+def _release_prepared_local_asgi_database(app: FastAPI) -> None:
+    """Release local ASGI database state after a client context exits."""
+    with _prepared_local_asgi_database_lock:
+        active = _prepared_local_asgi_databases.get(app)
+        if active is None:
+            raise RuntimeError("Local ASGI database state released without a matching retain")
+
+        active.active_count -= 1
+        if active.active_count > 0:
+            return
+
+        del _prepared_local_asgi_databases[app]
+        _restore_local_asgi_state_attribute(app, "engine", active.previous_engine)
+        _restore_local_asgi_state_attribute(
+            app,
+            "session_maker",
+            active.previous_session_maker,
+        )
+
+
 @asynccontextmanager
 async def _prepared_local_asgi_database(app: FastAPI) -> AsyncIterator[None]:
     """Initialize local ASGI database state before the first request."""
-    previous_engine = getattr(app.state, "engine", _MISSING_STATE_VALUE)
-    previous_session_maker = getattr(app.state, "session_maker", _MISSING_STATE_VALUE)
-
-    engine, session_maker = await _resolve_local_asgi_database(app)
-    app.state.engine = engine
-    app.state.session_maker = session_maker
+    if not _retain_prepared_local_asgi_database(app):
+        database_state = await _resolve_local_asgi_database(app)
+        _install_prepared_local_asgi_database(app, database_state)
 
     try:
         yield
     finally:
-        if previous_engine is _MISSING_STATE_VALUE:
-            if hasattr(app.state, "engine"):
-                delattr(app.state, "engine")
-        else:
-            app.state.engine = previous_engine
-
-        if previous_session_maker is _MISSING_STATE_VALUE:
-            if hasattr(app.state, "session_maker"):
-                delattr(app.state, "session_maker")
-        else:
-            app.state.session_maker = previous_session_maker
+        _release_prepared_local_asgi_database(app)
 
 
 @asynccontextmanager

--- a/src/basic_memory/mcp/async_client.py
+++ b/src/basic_memory/mcp/async_client.py
@@ -2,6 +2,7 @@ import os
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import AsyncIterator, Callable, Optional
 
+from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient, Timeout
 from loguru import logger
 
@@ -34,12 +35,12 @@ def _build_timeout() -> Timeout:
     )
 
 
-def _build_asgi_client(fastapi_app, timeout: Timeout) -> AsyncClient:
+def _build_asgi_client(app: FastAPI, timeout: Timeout) -> AsyncClient:
     """Create a local ASGI client for an already-prepared FastAPI app."""
     from basic_memory.workspace_context import workspace_permalink_headers
 
     return AsyncClient(
-        transport=ASGITransport(app=fastapi_app),
+        transport=ASGITransport(app=app),
         base_url="http://test",
         timeout=timeout,
         # Local ASGI calls still cross the HTTP boundary, so request handlers need
@@ -48,14 +49,14 @@ def _build_asgi_client(fastapi_app, timeout: Timeout) -> AsyncClient:
     )
 
 
-async def _prepare_local_asgi_database(fastapi_app) -> None:
+async def _prepare_local_asgi_database(app: FastAPI) -> None:
     """Initialize local ASGI database state before the first request."""
     from basic_memory import db
 
     config = ConfigManager().config
     engine, session_maker = await db.get_or_create_db(config.database_path)
-    fastapi_app.state.engine = engine
-    fastapi_app.state.session_maker = session_maker
+    app.state.engine = engine
+    app.state.session_maker = session_maker
 
 
 @asynccontextmanager

--- a/src/basic_memory/mcp/async_client.py
+++ b/src/basic_memory/mcp/async_client.py
@@ -1,6 +1,7 @@
 import os
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
-from typing import AsyncIterator, Callable, Optional
+from inspect import isawaitable
+from typing import TYPE_CHECKING, AsyncIterator, Callable, Optional, cast
 
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient, Timeout
@@ -8,6 +9,12 @@ from loguru import logger
 
 import logfire
 from basic_memory.config import ConfigManager, ProjectMode
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+LocalDatabaseState = tuple["AsyncEngine", "async_sessionmaker[AsyncSession]"]
+_MISSING_STATE_VALUE = object()
 
 
 def _force_local_mode() -> bool:
@@ -49,14 +56,47 @@ def _build_asgi_client(app: FastAPI, timeout: Timeout) -> AsyncClient:
     )
 
 
-async def _prepare_local_asgi_database(app: FastAPI) -> None:
-    """Initialize local ASGI database state before the first request."""
+async def _resolve_local_asgi_database(app: FastAPI) -> LocalDatabaseState:
+    """Resolve database state for a local ASGI request."""
+    from basic_memory.deps import get_engine_factory
+
+    override = app.dependency_overrides.get(get_engine_factory)
+    if override is not None:
+        result = override()
+        if isawaitable(result):
+            result = await result
+        return cast(LocalDatabaseState, result)
+
     from basic_memory import db
 
     config = ConfigManager().config
-    engine, session_maker = await db.get_or_create_db(config.database_path)
+    return await db.get_or_create_db(config.database_path)
+
+
+@asynccontextmanager
+async def _prepared_local_asgi_database(app: FastAPI) -> AsyncIterator[None]:
+    """Initialize local ASGI database state before the first request."""
+    previous_engine = getattr(app.state, "engine", _MISSING_STATE_VALUE)
+    previous_session_maker = getattr(app.state, "session_maker", _MISSING_STATE_VALUE)
+
+    engine, session_maker = await _resolve_local_asgi_database(app)
     app.state.engine = engine
     app.state.session_maker = session_maker
+
+    try:
+        yield
+    finally:
+        if previous_engine is _MISSING_STATE_VALUE:
+            if hasattr(app.state, "engine"):
+                delattr(app.state, "engine")
+        else:
+            app.state.engine = previous_engine
+
+        if previous_session_maker is _MISSING_STATE_VALUE:
+            if hasattr(app.state, "session_maker"):
+                delattr(app.state, "session_maker")
+        else:
+            app.state.session_maker = previous_session_maker
 
 
 @asynccontextmanager
@@ -71,9 +111,9 @@ async def _asgi_client(timeout: Timeout) -> AsyncIterator[AsyncClient]:
     # under Starlette's request loop and trigger CPython's empty-ready-queue race.
     # Outcome: request handling sees the same app.state database objects as API
     # lifespan startup would have provided.
-    await _prepare_local_asgi_database(fastapi_app)
-    async with _build_asgi_client(fastapi_app, timeout) as client:
-        yield client
+    async with _prepared_local_asgi_database(fastapi_app):
+        async with _build_asgi_client(fastapi_app, timeout) as client:
+            yield client
 
 
 async def _resolve_cloud_token(config) -> str:

--- a/src/basic_memory/mcp/async_client.py
+++ b/src/basic_memory/mcp/async_client.py
@@ -34,11 +34,8 @@ def _build_timeout() -> Timeout:
     )
 
 
-def _asgi_client(timeout: Timeout) -> AsyncClient:
-    """Create a local ASGI client."""
-    # Import on first local-client use so CLI help/version paths can import
-    # routing helpers without constructing the full FastAPI router graph.
-    from basic_memory.api.app import app as fastapi_app
+def _build_asgi_client(fastapi_app, timeout: Timeout) -> AsyncClient:
+    """Create a local ASGI client for an already-prepared FastAPI app."""
     from basic_memory.workspace_context import workspace_permalink_headers
 
     return AsyncClient(
@@ -49,6 +46,33 @@ def _asgi_client(timeout: Timeout) -> AsyncClient:
         # the same workspace permalink metadata that cloud proxy calls receive.
         headers=workspace_permalink_headers(),
     )
+
+
+async def _prepare_local_asgi_database(fastapi_app) -> None:
+    """Initialize local ASGI database state before the first request."""
+    from basic_memory import db
+
+    config = ConfigManager().config
+    engine, session_maker = await db.get_or_create_db(config.database_path)
+    fastapi_app.state.engine = engine
+    fastapi_app.state.session_maker = session_maker
+
+
+@asynccontextmanager
+async def _asgi_client(timeout: Timeout) -> AsyncIterator[AsyncClient]:
+    """Create a local ASGI client."""
+    # Import on first local-client use so CLI help/version paths can import
+    # routing helpers without constructing the full FastAPI router graph.
+    from basic_memory.api.app import app as fastapi_app
+
+    # Trigger: local ASGITransport does not execute FastAPI lifespan startup.
+    # Why: letting request dependencies initialize Postgres can run asyncpg DDL
+    # under Starlette's request loop and trigger CPython's empty-ready-queue race.
+    # Outcome: request handling sees the same app.state database objects as API
+    # lifespan startup would have provided.
+    await _prepare_local_asgi_database(fastapi_app)
+    async with _build_asgi_client(fastapi_app, timeout) as client:
+        yield client
 
 
 async def _resolve_cloud_token(config) -> str:
@@ -260,7 +284,12 @@ def create_client() -> AsyncClient:
 
     if _force_local_mode() or not _force_cloud_mode():
         logger.info("Creating ASGI client for local Basic Memory API")
-        return _asgi_client(timeout)
+        # Deprecated sync path: create_client() cannot await the local ASGI
+        # pre-initialization used by get_client(), so callers that need proper
+        # resource setup should use the async context manager instead.
+        from basic_memory.api.app import app as fastapi_app
+
+        return _build_asgi_client(fastapi_app, timeout)
 
     logger.info("Creating HTTP client for cloud proxy (legacy create_client path)")
     config = ConfigManager().config

--- a/tests/mcp/test_async_client_modes.py
+++ b/tests/mcp/test_async_client_modes.py
@@ -16,11 +16,13 @@ from basic_memory.mcp.async_client import (
 @pytest.fixture(autouse=True)
 def _reset_async_client_state(monkeypatch):
     async_client_module._client_factory = None
+    async_client_module._prepared_local_asgi_databases.clear()
     monkeypatch.delenv("BASIC_MEMORY_FORCE_LOCAL", raising=False)
     monkeypatch.delenv("BASIC_MEMORY_FORCE_CLOUD", raising=False)
     monkeypatch.delenv("BASIC_MEMORY_EXPLICIT_ROUTING", raising=False)
     yield
     async_client_module._client_factory = None
+    async_client_module._prepared_local_asgi_databases.clear()
 
 
 @pytest.mark.asyncio
@@ -141,6 +143,76 @@ async def test_get_client_uses_existing_local_asgi_database_override(
         assert not hasattr(fastapi_app.state, "session_maker")
     finally:
         fastapi_app.dependency_overrides = previous_overrides
+        if previous_engine is None:
+            fastapi_app.state._state.pop("engine", None)  # pyright: ignore[reportPrivateUsage]
+        else:
+            fastapi_app.state.engine = previous_engine
+        if previous_session_maker is None:
+            fastapi_app.state._state.pop("session_maker", None)  # pyright: ignore[reportPrivateUsage]
+        else:
+            fastapi_app.state.session_maker = previous_session_maker
+
+
+@pytest.mark.asyncio
+async def test_get_client_keeps_local_asgi_database_during_overlapping_contexts(
+    config_manager,
+    monkeypatch,
+):
+    """Local ASGI database state stays installed until the last overlapping client exits."""
+    from basic_memory import db
+    from basic_memory.api.app import app as fastapi_app
+
+    cfg = config_manager.load_config()
+    config_manager.save_config(cfg)
+
+    previous_engine = getattr(fastapi_app.state, "engine", None)
+    previous_session_maker = getattr(fastapi_app.state, "session_maker", None)
+    fastapi_app.state._state.pop("engine", None)  # pyright: ignore[reportPrivateUsage]
+    fastapi_app.state._state.pop("session_maker", None)  # pyright: ignore[reportPrivateUsage]
+
+    engine = object()
+    session_maker = object()
+    calls = []
+
+    async def fake_get_or_create_db(db_path):
+        calls.append(db_path)
+        return engine, session_maker
+
+    monkeypatch.setattr(db, "get_or_create_db", fake_get_or_create_db)
+
+    first_context = get_client()
+    second_context = get_client()
+    first_entered = False
+    second_entered = False
+    first_exited = False
+
+    try:
+        first_client = await first_context.__aenter__()
+        first_entered = True
+        second_client = await second_context.__aenter__()
+        second_entered = True
+
+        assert isinstance(first_client._transport, httpx.ASGITransport)  # pyright: ignore[reportPrivateUsage]
+        assert isinstance(second_client._transport, httpx.ASGITransport)  # pyright: ignore[reportPrivateUsage]
+        assert calls == [cfg.database_path]
+
+        await first_context.__aexit__(None, None, None)
+        first_exited = True
+
+        assert fastapi_app.state.engine is engine
+        assert fastapi_app.state.session_maker is session_maker
+
+        await second_context.__aexit__(None, None, None)
+        second_entered = False
+
+        assert not hasattr(fastapi_app.state, "engine")
+        assert not hasattr(fastapi_app.state, "session_maker")
+    finally:
+        if second_entered:
+            await second_context.__aexit__(None, None, None)
+        if first_entered and not first_exited:
+            await first_context.__aexit__(None, None, None)
+
         if previous_engine is None:
             fastapi_app.state._state.pop("engine", None)  # pyright: ignore[reportPrivateUsage]
         else:

--- a/tests/mcp/test_async_client_modes.py
+++ b/tests/mcp/test_async_client_modes.py
@@ -52,6 +52,47 @@ async def test_get_client_default_uses_local_asgi_transport(config_manager):
 
 
 @pytest.mark.asyncio
+async def test_get_client_preinitializes_local_asgi_database(config_manager, monkeypatch):
+    """Local ASGI routing initializes DB state before request handling."""
+    from basic_memory import db
+    from basic_memory.api.app import app as fastapi_app
+
+    cfg = config_manager.load_config()
+    config_manager.save_config(cfg)
+
+    previous_engine = getattr(fastapi_app.state, "engine", None)
+    previous_session_maker = getattr(fastapi_app.state, "session_maker", None)
+    fastapi_app.state._state.pop("engine", None)  # pyright: ignore[reportPrivateUsage]
+    fastapi_app.state._state.pop("session_maker", None)  # pyright: ignore[reportPrivateUsage]
+
+    engine = object()
+    session_maker = object()
+    calls = []
+
+    async def fake_get_or_create_db(db_path):
+        calls.append(db_path)
+        return engine, session_maker
+
+    monkeypatch.setattr(db, "get_or_create_db", fake_get_or_create_db)
+
+    try:
+        async with get_client() as client:
+            assert isinstance(client._transport, httpx.ASGITransport)  # pyright: ignore[reportPrivateUsage]
+            assert calls == [cfg.database_path]
+            assert fastapi_app.state.engine is engine
+            assert fastapi_app.state.session_maker is session_maker
+    finally:
+        if previous_engine is None:
+            fastapi_app.state._state.pop("engine", None)  # pyright: ignore[reportPrivateUsage]
+        else:
+            fastapi_app.state.engine = previous_engine
+        if previous_session_maker is None:
+            fastapi_app.state._state.pop("session_maker", None)  # pyright: ignore[reportPrivateUsage]
+        else:
+            fastapi_app.state.session_maker = previous_session_maker
+
+
+@pytest.mark.asyncio
 async def test_get_client_explicit_cloud_uses_api_key(config_manager, monkeypatch):
     cfg = config_manager.load_config()
     cfg.cloud_host = "https://cloud.example.test"

--- a/tests/mcp/test_async_client_modes.py
+++ b/tests/mcp/test_async_client_modes.py
@@ -94,8 +94,12 @@ async def test_get_client_preinitializes_local_asgi_database(config_manager, mon
             fastapi_app.state.session_maker = previous_session_maker
 
 
+@pytest.mark.parametrize("async_override", [False, True])
 @pytest.mark.asyncio
-async def test_get_client_uses_existing_local_asgi_database_override(config_manager):
+async def test_get_client_uses_existing_local_asgi_database_override(
+    config_manager,
+    async_override,
+):
     """Local ASGI routing honors FastAPI test dependency overrides."""
     from basic_memory.api.app import app as fastapi_app
     from basic_memory.deps import get_engine_factory
@@ -113,9 +117,17 @@ async def test_get_client_uses_existing_local_asgi_database_override(config_mana
     session_maker = object()
     calls = []
 
-    def override_engine_factory():
-        calls.append("override")
-        return engine, session_maker
+    if async_override:
+
+        async def override_engine_factory():
+            calls.append("override")
+            return engine, session_maker
+
+    else:
+
+        def override_engine_factory():
+            calls.append("override")
+            return engine, session_maker
 
     fastapi_app.dependency_overrides[get_engine_factory] = override_engine_factory
 

--- a/tests/mcp/test_async_client_modes.py
+++ b/tests/mcp/test_async_client_modes.py
@@ -81,7 +81,54 @@ async def test_get_client_preinitializes_local_asgi_database(config_manager, mon
             assert calls == [cfg.database_path]
             assert fastapi_app.state.engine is engine
             assert fastapi_app.state.session_maker is session_maker
+        assert not hasattr(fastapi_app.state, "engine")
+        assert not hasattr(fastapi_app.state, "session_maker")
     finally:
+        if previous_engine is None:
+            fastapi_app.state._state.pop("engine", None)  # pyright: ignore[reportPrivateUsage]
+        else:
+            fastapi_app.state.engine = previous_engine
+        if previous_session_maker is None:
+            fastapi_app.state._state.pop("session_maker", None)  # pyright: ignore[reportPrivateUsage]
+        else:
+            fastapi_app.state.session_maker = previous_session_maker
+
+
+@pytest.mark.asyncio
+async def test_get_client_uses_existing_local_asgi_database_override(config_manager):
+    """Local ASGI routing honors FastAPI test dependency overrides."""
+    from basic_memory.api.app import app as fastapi_app
+    from basic_memory.deps import get_engine_factory
+
+    cfg = config_manager.load_config()
+    config_manager.save_config(cfg)
+
+    previous_overrides = dict(fastapi_app.dependency_overrides)
+    previous_engine = getattr(fastapi_app.state, "engine", None)
+    previous_session_maker = getattr(fastapi_app.state, "session_maker", None)
+    fastapi_app.state._state.pop("engine", None)  # pyright: ignore[reportPrivateUsage]
+    fastapi_app.state._state.pop("session_maker", None)  # pyright: ignore[reportPrivateUsage]
+
+    engine = object()
+    session_maker = object()
+    calls = []
+
+    def override_engine_factory():
+        calls.append("override")
+        return engine, session_maker
+
+    fastapi_app.dependency_overrides[get_engine_factory] = override_engine_factory
+
+    try:
+        async with get_client() as client:
+            assert isinstance(client._transport, httpx.ASGITransport)  # pyright: ignore[reportPrivateUsage]
+            assert calls == ["override"]
+            assert fastapi_app.state.engine is engine
+            assert fastapi_app.state.session_maker is session_maker
+        assert not hasattr(fastapi_app.state, "engine")
+        assert not hasattr(fastapi_app.state, "session_maker")
+    finally:
+        fastapi_app.dependency_overrides = previous_overrides
         if previous_engine is None:
             fastapi_app.state._state.pop("engine", None)  # pyright: ignore[reportPrivateUsage]
         else:

--- a/tests/mcp/test_async_client_modes.py
+++ b/tests/mcp/test_async_client_modes.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+from typing import AsyncIterator
 
 import httpx
 import pytest
@@ -17,12 +18,14 @@ from basic_memory.mcp.async_client import (
 def _reset_async_client_state(monkeypatch):
     async_client_module._client_factory = None
     async_client_module._prepared_local_asgi_databases.clear()
+    async_client_module._prepared_local_asgi_database_prepare_locks.clear()
     monkeypatch.delenv("BASIC_MEMORY_FORCE_LOCAL", raising=False)
     monkeypatch.delenv("BASIC_MEMORY_FORCE_CLOUD", raising=False)
     monkeypatch.delenv("BASIC_MEMORY_EXPLICIT_ROUTING", raising=False)
     yield
     async_client_module._client_factory = None
     async_client_module._prepared_local_asgi_databases.clear()
+    async_client_module._prepared_local_asgi_database_prepare_locks.clear()
 
 
 @pytest.mark.asyncio
@@ -139,6 +142,63 @@ async def test_get_client_uses_existing_local_asgi_database_override(
             assert calls == ["override"]
             assert fastapi_app.state.engine is engine
             assert fastapi_app.state.session_maker is session_maker
+        assert not hasattr(fastapi_app.state, "engine")
+        assert not hasattr(fastapi_app.state, "session_maker")
+    finally:
+        fastapi_app.dependency_overrides = previous_overrides
+        if previous_engine is None:
+            fastapi_app.state._state.pop("engine", None)  # pyright: ignore[reportPrivateUsage]
+        else:
+            fastapi_app.state.engine = previous_engine
+        if previous_session_maker is None:
+            fastapi_app.state._state.pop("session_maker", None)  # pyright: ignore[reportPrivateUsage]
+        else:
+            fastapi_app.state.session_maker = previous_session_maker
+
+
+@pytest.mark.asyncio
+async def test_get_client_resolves_local_asgi_database_override_with_fastapi_di(
+    config_manager,
+):
+    """Local ASGI DB pre-init honors FastAPI dependency injection and cleanup."""
+    from fastapi import Request
+
+    from basic_memory.api.app import app as fastapi_app
+    from basic_memory.deps import get_engine_factory
+
+    cfg = config_manager.load_config()
+    config_manager.save_config(cfg)
+
+    previous_overrides = dict(fastapi_app.dependency_overrides)
+    previous_engine = getattr(fastapi_app.state, "engine", None)
+    previous_session_maker = getattr(fastapi_app.state, "session_maker", None)
+    fastapi_app.state._state.pop("engine", None)  # pyright: ignore[reportPrivateUsage]
+    fastapi_app.state._state.pop("session_maker", None)  # pyright: ignore[reportPrivateUsage]
+
+    engine = object()
+    session_maker = object()
+    calls = []
+    cleanup = []
+
+    async def override_engine_factory(
+        request: Request,
+    ) -> AsyncIterator[tuple[object, object]]:
+        calls.append(request.app)
+        try:
+            yield engine, session_maker
+        finally:
+            cleanup.append("closed")
+
+    fastapi_app.dependency_overrides[get_engine_factory] = override_engine_factory
+
+    try:
+        async with get_client() as client:
+            assert isinstance(client._transport, httpx.ASGITransport)  # pyright: ignore[reportPrivateUsage]
+            assert calls == [fastapi_app]
+            assert cleanup == []
+            assert fastapi_app.state.engine is engine
+            assert fastapi_app.state.session_maker is session_maker
+        assert cleanup == ["closed"]
         assert not hasattr(fastapi_app.state, "engine")
         assert not hasattr(fastapi_app.state, "session_maker")
     finally:


### PR DESCRIPTION
## Summary
- Fixes #831 by preparing the local ASGI app database state before yielding the in-process MCP/CLI client.
- Splits ASGI client construction from DB preparation so the deprecated sync `create_client()` path keeps its existing return contract.
- Adds a regression test that verifies local ASGI routing populates `app.state.engine` and `app.state.session_maker` before requests run.

## Root Cause
`httpx.ASGITransport(app=fastapi_app)` does not run FastAPI lifespan startup. For local CLI/MCP calls, that meant request dependencies could fall back to `db.get_or_create_db()` inside request handling. With Postgres + asyncpg, the first request can run vector extension/index initialization inside Starlette/anyio request machinery, which reproduced the reported `IndexError: pop from an empty deque` failure.

## Verification
- `UV_PYTHON=.venv/bin/python just lint`
- `UV_PYTHON=.venv/bin/python just typecheck`
- `.venv/bin/python -m pytest -p pytest_mock -v --no-cov tests/mcp/test_async_client_modes.py`
- Reproduced the original Postgres CLI path against `pgvector/pgvector:pg16` on Python 3.12.12, then confirmed `project list --local --json` completed 5 consecutive runs without `pop from an empty deque`.

