### PR TITLE
fix(cli): ignore CancelledError in background task done callback (#839)

### DIFF
--- a/src/basic_memory/deps/services.py
+++ b/src/basic_memory/deps/services.py
@@ -447,8 +447,12 @@ class TaskScheduler(Protocol):
 
 
 def _log_task_failure(completed: asyncio.Task) -> None:
+    if completed.cancelled():
+        return
     try:
         completed.result()
+    except asyncio.CancelledError:
+        return
     except Exception as exc:  # pragma: no cover
         logger.exception("Background task failed", error=str(exc))
 

--- a/tests/deps/test_task_failure_callback.py
+++ b/tests/deps/test_task_failure_callback.py
@@ -1,0 +1,38 @@
+"""Tests for background task done-callback error handling."""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from basic_memory.deps.services import _log_task_failure
+
+
+@pytest.mark.asyncio
+async def test_log_task_failure_ignores_cancelled_task():
+    async def slow():
+        await asyncio.sleep(10)
+
+    task = asyncio.create_task(slow())
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    with patch("basic_memory.deps.services.logger.exception") as mock_exc:
+        _log_task_failure(task)
+        mock_exc.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_log_task_failure_logs_real_exception():
+    async def boom():
+        raise ValueError("sync failed")
+
+    task = asyncio.create_task(boom())
+    with pytest.raises(ValueError):
+        await task
+
+    with patch("basic_memory.deps.services.logger.exception") as mock_exc:
+        _log_task_failure(task)
+        mock_exc.assert_called_once()
+        assert "sync failed" in str(mock_exc.call_args)


### PR DESCRIPTION
## Summary
After a successful `basic-memory tool write-note`, stderr could show an `asyncio.CancelledError` traceback even though exit code was 0 and stdout JSON was correct.

`LocalTaskScheduler` attaches `_log_task_failure` to background `sync_entity_vectors` tasks. On CLI teardown the task is cancelled; `completed.result()` raises `CancelledError`, which is a `BaseException` (not caught by `except Exception`).

## Fix
- Return early when `completed.cancelled()`
- Explicitly ignore `asyncio.CancelledError`
- Regression tests in `tests/deps/test_task_failure_callback.py`

## Test plan
- [x] `pytest tests/deps/test_task_failure_callback.py`

Fixes #839

Made with [Cursor](https://cursor.com)