### PR TITLE
test(core): isolate XDG_CONFIG_HOME so host env can't leak into tests

### DIFF
--- a/test-int/conftest.py
+++ b/test-int/conftest.py
@@ -149,6 +149,22 @@ def clean_routing_env(monkeypatch) -> None:
     monkeypatch.delenv("BASIC_MEMORY_EXPLICIT_ROUTING", raising=False)
 
 
+@pytest.fixture(autouse=True)
+def isolate_data_dir_env(monkeypatch) -> None:
+    """Keep host data-dir env vars from leaking into integration tests.
+
+    Why: GitHub Actions Ubuntu runners set ``XDG_CONFIG_HOME=/home/runner/.config``,
+    and ``resolve_data_dir()`` honors it ahead of ``Path.home() / ".basic-memory"``.
+    Without clearing it, the MCP tool process reads config.json from the host XDG
+    path instead of the tmp dir the ``config_manager`` fixture wrote to — so
+    ``test-project`` is missing from ``config.projects``, ``get_project_mode``
+    falls through to its CLOUD default (#837), and every tool call fails with
+    "Cloud routing requested but no credentials found."
+    """
+    monkeypatch.delenv("BASIC_MEMORY_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+
 POSTGRES_EPHEMERAL_TABLES = [
     "search_vector_embeddings",
     "search_vector_chunks",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -225,6 +225,19 @@ def isolate_routing_env(monkeypatch) -> None:
     monkeypatch.delenv("BASIC_MEMORY_EXPLICIT_ROUTING", raising=False)
 
 
+@pytest.fixture(autouse=True)
+def isolate_data_dir_env(monkeypatch) -> None:
+    """Keep host data-dir env vars from leaking into tests.
+
+    Why: GitHub Actions Ubuntu runners set ``XDG_CONFIG_HOME=/home/runner/.config``,
+    and ``resolve_data_dir()`` honors it ahead of ``Path.home() / ".basic-memory"``.
+    Without clearing it, tests that monkeypatch HOME still see the host XDG path
+    and assertions against the tmp home directory fail.
+    """
+    monkeypatch.delenv("BASIC_MEMORY_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+
 @pytest_asyncio.fixture(autouse=True)
 async def cleanup_global_db_after_test() -> AsyncGenerator[None, None]:
     """Close any module-level DB engine created outside fixture ownership."""


### PR DESCRIPTION
## Summary

Adds an autouse fixture to both `tests/conftest.py` and `test-int/conftest.py` that clears `XDG_CONFIG_HOME` and `BASIC_MEMORY_CONFIG_DIR` for every test, matching the existing routing-isolation pattern.

Fixes ~426 unit test failures and ~167 integration test failures on `main`, all introduced after #844 added XDG_CONFIG_HOME support and exposed by the way #837 routes unknown projects.

## Root cause

GitHub Actions Ubuntu runners set `XDG_CONFIG_HOME=/home/runner/.config` by default. After #844, `resolve_data_dir()` honors that env var ahead of `Path.home() / ".basic-memory"`. Tests monkeypatch `HOME` to a tmp dir but don't touch `XDG_CONFIG_HOME`, so on CI the resolver returned the host path.

This surfaced as three distinct failure modes:

1. **Unit tests asserting on tmp paths** (`tests/test_config.py`, `tests/repository/test_openai_provider.py`, etc.) — direct path mismatch.
2. **Python 3.14 `WindowsPath` failures in `tests/utils/test_setup_logging.py`** — those tests monkeypatch `os.name = "nt"`, and 3.14's pathlib then refuses to construct a fresh `Path()` from the leaked `XDG_CONFIG_HOME` value inside `resolve_data_dir()`.
3. **Integration tests with "Cloud routing requested but no credentials found"** (`test-int/mcp/*`, `test-int/cli/*`) — the integration `config_manager` fixture writes config.json to the tmp `.basic-memory/`, but the MCP tool process reads from `/home/runner/.config/basic-memory/` instead. `test-project` is missing from `config.projects`, so `get_project_mode` falls through to its CLOUD default (added in #837), and every tool call hits cloud routing with no credentials.

The two tests that actually exercise the resolver (`test_resolve_data_dir_uses_home_when_no_env_vars`, `test_resolve_data_dir_honors_xdg_config_home`) already manage these env vars explicitly via `monkeypatch.setenv` / `delenv`, so the new fixture is compatible with them.

## Test plan

- [x] Unit suite locally on Python 3.14: `2652 passed, 31 skipped`
- [x] Unit suite locally with simulated CI env (`XDG_CONFIG_HOME=/home/fakerunner/.config BASIC_MEMORY_CONFIG_DIR=/tmp/fake-bm`): `2652 passed, 31 skipped`
- [x] Integration suite locally with simulated CI env: `327 passed, 4 skipped` (14 docker-dependent semantic test errors unrelated — Docker not running locally)
- [x] CI Tests workflow goes green across the full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)