### PR TITLE
fix(cli): block team workspace rclone sync

### DIFF
--- a/src/basic_memory/cli/commands/cloud/project_sync.py
+++ b/src/basic_memory/cli/commands/cloud/project_sync.py
@@ -23,7 +23,7 @@ from basic_memory.cli.commands.cloud.rclone_commands import (
 )
 from basic_memory.cli.commands.command_utils import run_with_cleanup
 from basic_memory.cli.commands.routing import force_routing
-from basic_memory.config import ConfigManager, ProjectEntry
+from basic_memory.config import BasicMemoryConfig, ConfigManager, ProjectEntry
 from basic_memory.mcp.async_client import get_client
 from basic_memory.mcp.clients import ProjectClient
 from basic_memory.mcp.project_context import get_available_workspaces
@@ -44,14 +44,14 @@ TEAM_WORKSPACE_SYNC_UNSUPPORTED = (
 # --- Shared helpers ---
 
 
-def _has_cloud_credentials(config) -> bool:
+def _has_cloud_credentials(config: BasicMemoryConfig) -> bool:
     """Return whether cloud credentials are available (API key or OAuth token)."""
     from basic_memory.config import has_cloud_credentials
 
     return has_cloud_credentials(config)
 
 
-def _require_cloud_credentials(config) -> None:
+def _require_cloud_credentials(config: BasicMemoryConfig) -> None:
     """Exit with actionable guidance when cloud credentials are missing."""
     if _has_cloud_credentials(config):
         return
@@ -61,7 +61,7 @@ def _require_cloud_credentials(config) -> None:
     raise typer.Exit(1)
 
 
-async def _get_workspace_for_project(name: str, config) -> WorkspaceInfo:
+async def _get_workspace_for_project(name: str, config: BasicMemoryConfig) -> WorkspaceInfo:
     """Resolve the cloud workspace targeted by a project-scoped sync command."""
     workspaces = await get_available_workspaces()
     if not workspaces:
@@ -94,7 +94,7 @@ async def _get_workspace_for_project(name: str, config) -> WorkspaceInfo:
     )
 
 
-def _require_personal_workspace(name: str, config) -> WorkspaceInfo:
+def _require_personal_workspace(name: str, config: BasicMemoryConfig) -> WorkspaceInfo:
     """Exit before rclone work when the target workspace is not personal."""
     try:
         workspace = run_with_cleanup(_get_workspace_for_project(name, config))
@@ -120,7 +120,7 @@ async def _get_cloud_project(name: str) -> ProjectItem | None:
 
 
 def _get_sync_project(
-    name: str, config, project_data: ProjectItem
+    name: str, config: BasicMemoryConfig, project_data: ProjectItem
 ) -> tuple[SyncProject, str | None]:
     """Build a SyncProject and resolve local_sync_path from config.
 

--- a/src/basic_memory/cli/commands/cloud/project_sync.py
+++ b/src/basic_memory/cli/commands/cloud/project_sync.py
@@ -33,12 +33,9 @@ from basic_memory.utils import generate_permalink, normalize_project_path
 
 console = Console()
 
-TEAM_WORKSPACE_SYNC_UNSUPPORTED = (
-    "Mirror-style rclone sync/bisync is supported only for Personal workspaces.\n"
-    "Team workspaces should not use local mirror workflows because they can "
-    "overwrite or delete shared cloud files.\n"
-    "Use cloud API/MCP routing for Team workspace edits, or inspect projects with "
-    "`bm project list --workspace <workspace>`."
+TEAM_WORKSPACE_BISYNC_UNSUPPORTED = (
+    "The bisync operation is only supported on Personal workspaces.\n"
+    "Use `bm cloud sync --name {name}` instead."
 )
 
 
@@ -96,7 +93,7 @@ async def _get_workspace_for_project(name: str, config: BasicMemoryConfig) -> Wo
 
 
 def _require_personal_workspace(name: str, config: BasicMemoryConfig) -> WorkspaceInfo:
-    """Exit before rclone work when the target workspace is not personal."""
+    """Exit before bisync work when the target workspace is not personal."""
     try:
         workspace = run_with_cleanup(_get_workspace_for_project(name, config))
     except Exception as exc:
@@ -104,7 +101,7 @@ def _require_personal_workspace(name: str, config: BasicMemoryConfig) -> Workspa
         raise typer.Exit(1)
 
     if workspace.workspace_type != "personal":
-        console.print(f"[red]{TEAM_WORKSPACE_SYNC_UNSUPPORTED}[/red]")
+        console.print(f"[red]{TEAM_WORKSPACE_BISYNC_UNSUPPORTED.format(name=name)}[/red]")
         raise typer.Exit(1)
 
     return workspace
@@ -161,7 +158,6 @@ def sync_project_command(
     """
     config = ConfigManager().config
     _require_cloud_credentials(config)
-    _require_personal_workspace(name, config)
 
     try:
         # Get tenant info for bucket name
@@ -270,7 +266,6 @@ def check_project_command(
     """
     config = ConfigManager().config
     _require_cloud_credentials(config)
-    _require_personal_workspace(name, config)
 
     try:
         # Get tenant info for bucket name
@@ -353,7 +348,6 @@ def setup_project_sync(
     config_manager = ConfigManager()
     config = config_manager.config
     _require_cloud_credentials(config)
-    _require_personal_workspace(name, config)
 
     async def _verify_project_exists():
         """Verify the project exists on cloud by listing all projects."""
@@ -402,8 +396,8 @@ def setup_project_sync(
         console.print(f"[green]Sync configured for project '{name}'[/green]")
         console.print(f"\nLocal sync path: {resolved_path}")
         console.print("\nNext steps:")
-        console.print(f"  1. Preview: bm cloud bisync --name {name} --resync --dry-run")
-        console.print(f"  2. Sync: bm cloud bisync --name {name} --resync")
+        console.print(f"  1. Preview: bm cloud sync --name {name} --dry-run")
+        console.print(f"  2. Sync: bm cloud sync --name {name}")
     except Exception as e:
         console.print(f"[red]Error configuring sync: {str(e)}[/red]")
         raise typer.Exit(1)

--- a/src/basic_memory/cli/commands/cloud/project_sync.py
+++ b/src/basic_memory/cli/commands/cloud/project_sync.py
@@ -26,10 +26,19 @@ from basic_memory.cli.commands.routing import force_routing
 from basic_memory.config import ConfigManager, ProjectEntry
 from basic_memory.mcp.async_client import get_client
 from basic_memory.mcp.clients import ProjectClient
+from basic_memory.mcp.project_context import get_available_workspaces
+from basic_memory.schemas.cloud import WorkspaceInfo
 from basic_memory.schemas.project_info import ProjectItem
 from basic_memory.utils import generate_permalink, normalize_project_path
 
 console = Console()
+
+TEAM_WORKSPACE_SYNC_UNSUPPORTED = (
+    "Local rclone sync/bisync is supported only for Personal workspaces.\n"
+    "Team workspaces are accessed through the cloud API/MCP and do not support "
+    "local multi-user bisync.\n"
+    "Use `bm project list --workspace <workspace>` to inspect Team projects."
+)
 
 
 # --- Shared helpers ---
@@ -50,6 +59,54 @@ def _require_cloud_credentials(config) -> None:
     console.print("[red]Error: cloud credentials are required for this command[/red]")
     console.print("[dim]Run 'bm cloud login' or 'bm cloud api-key save <key>' first[/dim]")
     raise typer.Exit(1)
+
+
+async def _get_workspace_for_project(name: str, config) -> WorkspaceInfo:
+    """Resolve the cloud workspace targeted by a project-scoped sync command."""
+    workspaces = await get_available_workspaces()
+    if not workspaces:
+        raise ValueError("No accessible cloud workspaces found for this account")
+
+    entry = config.projects.get(name)
+    workspace_id = entry.workspace_id if entry and entry.workspace_id else config.default_workspace
+    if workspace_id:
+        workspace = next(
+            (item for item in workspaces if item.tenant_id == workspace_id),
+            None,
+        )
+        if workspace is None:
+            raise ValueError(
+                f"Configured workspace '{workspace_id}' for project '{name}' is not accessible"
+            )
+        return workspace
+
+    default_workspaces = [item for item in workspaces if item.is_default]
+    if len(default_workspaces) == 1:
+        return default_workspaces[0]
+
+    if len(workspaces) == 1:
+        return workspaces[0]
+
+    raise ValueError(
+        f"Project '{name}' does not have an unambiguous cloud workspace. "
+        "Set a default workspace with `bm cloud workspace set-default <workspace>` "
+        "or attach the project with `bm project set-cloud <name> --workspace <workspace>`."
+    )
+
+
+def _require_personal_workspace(name: str, config) -> WorkspaceInfo:
+    """Exit before rclone work when the target workspace is not personal."""
+    try:
+        workspace = run_with_cleanup(_get_workspace_for_project(name, config))
+    except Exception as exc:
+        console.print(f"[red]Error resolving workspace for project '{name}': {exc}[/red]")
+        raise typer.Exit(1)
+
+    if workspace.workspace_type != "personal":
+        console.print(f"[red]{TEAM_WORKSPACE_SYNC_UNSUPPORTED}[/red]")
+        raise typer.Exit(1)
+
+    return workspace
 
 
 async def _get_cloud_project(name: str) -> ProjectItem | None:
@@ -103,6 +160,7 @@ def sync_project_command(
     """
     config = ConfigManager().config
     _require_cloud_credentials(config)
+    _require_personal_workspace(name, config)
 
     try:
         # Get tenant info for bucket name
@@ -152,6 +210,7 @@ def bisync_project_command(
     """
     config = ConfigManager().config
     _require_cloud_credentials(config)
+    _require_personal_workspace(name, config)
 
     try:
         # Get tenant info for bucket name
@@ -210,6 +269,7 @@ def check_project_command(
     """
     config = ConfigManager().config
     _require_cloud_credentials(config)
+    _require_personal_workspace(name, config)
 
     try:
         # Get tenant info for bucket name
@@ -253,6 +313,10 @@ def bisync_reset(
     """
     import shutil
 
+    config = ConfigManager().config
+    if _has_cloud_credentials(config):
+        _require_personal_workspace(name, config)
+
     try:
         state_path = get_project_bisync_state(name)
 
@@ -288,6 +352,7 @@ def setup_project_sync(
     config_manager = ConfigManager()
     config = config_manager.config
     _require_cloud_credentials(config)
+    _require_personal_workspace(name, config)
 
     async def _verify_project_exists():
         """Verify the project exists on cloud by listing all projects."""

--- a/src/basic_memory/cli/commands/cloud/project_sync.py
+++ b/src/basic_memory/cli/commands/cloud/project_sync.py
@@ -34,10 +34,11 @@ from basic_memory.utils import generate_permalink, normalize_project_path
 console = Console()
 
 TEAM_WORKSPACE_SYNC_UNSUPPORTED = (
-    "Local rclone sync/bisync is supported only for Personal workspaces.\n"
-    "Team workspaces are accessed through the cloud API/MCP and do not support "
-    "local multi-user bisync.\n"
-    "Use `bm project list --workspace <workspace>` to inspect Team projects."
+    "Mirror-style rclone sync/bisync is supported only for Personal workspaces.\n"
+    "Team workspaces should not use local mirror workflows because they can "
+    "overwrite or delete shared cloud files.\n"
+    "Use cloud API/MCP routing for Team workspace edits, or inspect projects with "
+    "`bm project list --workspace <workspace>`."
 )
 
 

--- a/tests/cli/cloud/test_project_sync_command.py
+++ b/tests/cli/cloud/test_project_sync_command.py
@@ -134,8 +134,9 @@ def test_cloud_sync_commands_block_organization_workspace(monkeypatch, argv, con
     result = runner.invoke(app, argv)
 
     assert result.exit_code == 1, result.output
-    assert "Local rclone sync/bisync is supported only for Personal workspaces" in result.output
-    assert "Team workspaces are accessed through the cloud API/MCP" in result.output
+    output = " ".join(result.output.split())
+    assert "Mirror-style rclone sync/bisync is supported only for Personal workspaces" in output
+    assert "overwrite or delete shared cloud files" in output
 
 
 def test_require_personal_workspace_allows_personal_workspace(monkeypatch, config_manager):

--- a/tests/cli/cloud/test_project_sync_command.py
+++ b/tests/cli/cloud/test_project_sync_command.py
@@ -4,6 +4,7 @@ import importlib
 from types import SimpleNamespace
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from basic_memory.cli.app import app
@@ -161,6 +162,124 @@ def test_require_personal_workspace_allows_personal_workspace(monkeypatch, confi
     assert workspace.tenant_id == "personal-tenant"
 
 
+def test_require_personal_workspace_uses_default_workspace(monkeypatch, config_manager):
+    """When no project workspace is set, the single cloud default is used."""
+    project_sync_command = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
+
+    config = config_manager.load_config()
+    config.default_workspace = None
+    config.projects["research"] = ProjectEntry(path="/tmp/research", mode=ProjectMode.CLOUD)
+    config_manager.save_config(config)
+
+    monkeypatch.setattr(
+        project_sync_command,
+        "get_available_workspaces",
+        lambda: _async_value(
+            [
+                _workspace("team-tenant", "organization", "team"),
+                _workspace("personal-tenant", "personal", "personal", is_default=True),
+            ]
+        ),
+    )
+
+    workspace = project_sync_command._require_personal_workspace("research", config)
+
+    assert workspace.tenant_id == "personal-tenant"
+
+
+def test_require_personal_workspace_uses_single_workspace(monkeypatch, config_manager):
+    """A single accessible workspace is unambiguous even when none is marked default."""
+    project_sync_command = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
+
+    config = config_manager.load_config()
+    config.default_workspace = None
+    config.projects["research"] = ProjectEntry(path="/tmp/research", mode=ProjectMode.CLOUD)
+    config_manager.save_config(config)
+
+    monkeypatch.setattr(
+        project_sync_command,
+        "get_available_workspaces",
+        lambda: _async_value([_workspace("personal-tenant", "personal", "personal")]),
+    )
+
+    workspace = project_sync_command._require_personal_workspace("research", config)
+
+    assert workspace.tenant_id == "personal-tenant"
+
+
+def test_require_personal_workspace_reports_no_accessible_workspaces(monkeypatch, config_manager):
+    """Workspace resolution exits with a clear error when the account has no workspaces."""
+    project_sync_command = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
+
+    config = config_manager.load_config()
+    config.default_workspace = None
+    config.projects["research"] = ProjectEntry(path="/tmp/research", mode=ProjectMode.CLOUD)
+    config_manager.save_config(config)
+
+    monkeypatch.setattr(
+        project_sync_command,
+        "get_available_workspaces",
+        lambda: _async_value([]),
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        project_sync_command._require_personal_workspace("research", config)
+
+    assert exc_info.value.exit_code == 1
+
+
+def test_require_personal_workspace_reports_inaccessible_configured_workspace(
+    monkeypatch, config_manager
+):
+    """A configured workspace id must be present in the accessible workspace list."""
+    project_sync_command = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
+
+    config = config_manager.load_config()
+    config.projects["research"] = ProjectEntry(
+        path="/tmp/research",
+        mode=ProjectMode.CLOUD,
+        workspace_id="missing-tenant",
+    )
+    config_manager.save_config(config)
+
+    monkeypatch.setattr(
+        project_sync_command,
+        "get_available_workspaces",
+        lambda: _async_value([_workspace("personal-tenant", "personal", "personal")]),
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        project_sync_command._require_personal_workspace("research", config)
+
+    assert exc_info.value.exit_code == 1
+
+
+def test_require_personal_workspace_reports_ambiguous_workspace(monkeypatch, config_manager):
+    """Multiple accessible workspaces need an explicit project or account default."""
+    project_sync_command = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
+
+    config = config_manager.load_config()
+    config.default_workspace = None
+    config.projects["research"] = ProjectEntry(path="/tmp/research", mode=ProjectMode.CLOUD)
+    config_manager.save_config(config)
+
+    monkeypatch.setattr(
+        project_sync_command,
+        "get_available_workspaces",
+        lambda: _async_value(
+            [
+                _workspace("personal-tenant-a", "personal", "personal-a"),
+                _workspace("personal-tenant-b", "personal", "personal-b"),
+            ]
+        ),
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        project_sync_command._require_personal_workspace("research", config)
+
+    assert exc_info.value.exit_code == 1
+
+
 def test_bisync_reset_skips_workspace_check_without_credentials(monkeypatch, tmp_path):
     """Resetting local bisync state stays harmless when no cloud credentials exist."""
     project_sync_command = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
@@ -186,13 +305,15 @@ async def _async_value(value):
     return value
 
 
-def _workspace(tenant_id: str, workspace_type: str, slug: str) -> WorkspaceInfo:
+def _workspace(
+    tenant_id: str, workspace_type: str, slug: str, *, is_default: bool = False
+) -> WorkspaceInfo:
     return WorkspaceInfo(
         tenant_id=tenant_id,
         workspace_type=workspace_type,
         slug=slug,
         name=slug.title(),
         role="owner",
-        is_default=False,
+        is_default=is_default,
         has_active_subscription=True,
     )

--- a/tests/cli/cloud/test_project_sync_command.py
+++ b/tests/cli/cloud/test_project_sync_command.py
@@ -99,15 +99,12 @@ def test_cloud_bisync_fails_fast_when_sync_entry_disappears(monkeypatch, config_
 @pytest.mark.parametrize(
     "argv",
     [
-        ["cloud", "sync", "--name", "research"],
         ["cloud", "bisync", "--name", "research"],
-        ["cloud", "check", "--name", "research"],
         ["cloud", "bisync-reset", "research"],
-        ["cloud", "sync-setup", "research", "/tmp/research"],
     ],
 )
-def test_cloud_sync_commands_block_organization_workspace(monkeypatch, argv, config_manager):
-    """Rclone sync commands should fail before setup/execution for Team workspaces."""
+def test_cloud_bisync_commands_block_organization_workspace(monkeypatch, argv, config_manager):
+    """Bisync commands should fail before setup/execution for Team workspaces."""
     project_sync_command = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
 
     config = config_manager.load_config()
@@ -130,13 +127,62 @@ def test_cloud_sync_commands_block_organization_workspace(monkeypatch, argv, con
         "get_mount_info",
         lambda: pytest.fail("workspace guard should run before mount lookup"),
     )
+    monkeypatch.setattr(
+        project_sync_command,
+        "get_project_bisync_state",
+        lambda _name: pytest.fail("workspace guard should run before bisync state lookup"),
+    )
 
     result = runner.invoke(app, argv)
 
     assert result.exit_code == 1, result.output
     output = " ".join(result.output.split())
-    assert "Mirror-style rclone sync/bisync is supported only for Personal workspaces" in output
-    assert "overwrite or delete shared cloud files" in output
+    assert "The bisync operation is only supported on Personal workspaces" in output
+    assert "Use `bm cloud sync --name research` instead" in output
+
+
+def test_cloud_sync_allows_organization_workspace(monkeypatch, config_manager):
+    """Team workspaces can still use the one-way sync command."""
+    project_sync_command = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
+
+    config = config_manager.load_config()
+    config.cloud_api_key = "bmc_test"
+    config.projects["research"] = ProjectEntry(
+        path="/tmp/research",
+        mode=ProjectMode.CLOUD,
+        workspace_id="team-tenant",
+        local_sync_path="/tmp/research",
+    )
+    config_manager.save_config(config)
+
+    monkeypatch.setattr(
+        project_sync_command,
+        "get_available_workspaces",
+        lambda: pytest.fail("sync should not require a personal workspace"),
+    )
+    monkeypatch.setattr(
+        project_sync_command,
+        "get_mount_info",
+        lambda: _async_value(SimpleNamespace(bucket_name="tenant-bucket")),
+    )
+    monkeypatch.setattr(
+        project_sync_command,
+        "_get_cloud_project",
+        lambda _name: _async_value(
+            SimpleNamespace(name="research", external_id="external-project-id", path="research")
+        ),
+    )
+    monkeypatch.setattr(
+        project_sync_command,
+        "_get_sync_project",
+        lambda _name, _config, _project_data: (SimpleNamespace(name="research"), "/tmp/research"),
+    )
+    monkeypatch.setattr(project_sync_command, "project_sync", lambda *args, **kwargs: True)
+
+    result = runner.invoke(app, ["cloud", "sync", "--name", "research"])
+
+    assert result.exit_code == 0, result.output
+    assert "research synced successfully" in result.output
 
 
 def test_require_personal_workspace_allows_personal_workspace(monkeypatch, config_manager):

--- a/tests/cli/cloud/test_project_sync_command.py
+++ b/tests/cli/cloud/test_project_sync_command.py
@@ -7,7 +7,8 @@ import pytest
 from typer.testing import CliRunner
 
 from basic_memory.cli.app import app
-from basic_memory.config import ProjectMode
+from basic_memory.config import ProjectEntry, ProjectMode
+from basic_memory.schemas.cloud import WorkspaceInfo
 
 runner = CliRunner()
 
@@ -28,6 +29,9 @@ def test_cloud_sync_commands_skip_explicit_cloud_project_sync(monkeypatch, argv,
     config_manager.save_config(config)
 
     monkeypatch.setattr(project_sync_command, "_require_cloud_credentials", lambda _config: None)
+    monkeypatch.setattr(
+        project_sync_command, "_require_personal_workspace", lambda _name, _config: None
+    )
     monkeypatch.setattr(
         project_sync_command,
         "get_mount_info",
@@ -64,6 +68,9 @@ def test_cloud_bisync_fails_fast_when_sync_entry_disappears(monkeypatch, config_
 
     monkeypatch.setattr(project_sync_command, "_require_cloud_credentials", lambda _config: None)
     monkeypatch.setattr(
+        project_sync_command, "_require_personal_workspace", lambda _name, _config: None
+    )
+    monkeypatch.setattr(
         project_sync_command,
         "get_mount_info",
         lambda: _async_value(SimpleNamespace(bucket_name="tenant-bucket")),
@@ -88,5 +95,104 @@ def test_cloud_bisync_fails_fast_when_sync_entry_disappears(monkeypatch, config_
     assert "unexpectedly missing after validation" in result.output
 
 
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["cloud", "sync", "--name", "research"],
+        ["cloud", "bisync", "--name", "research"],
+        ["cloud", "check", "--name", "research"],
+        ["cloud", "bisync-reset", "research"],
+        ["cloud", "sync-setup", "research", "/tmp/research"],
+    ],
+)
+def test_cloud_sync_commands_block_organization_workspace(monkeypatch, argv, config_manager):
+    """Rclone sync commands should fail before setup/execution for Team workspaces."""
+    project_sync_command = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
+
+    config = config_manager.load_config()
+    config.cloud_api_key = "bmc_test"
+    config.projects["research"] = ProjectEntry(
+        path="/tmp/research",
+        mode=ProjectMode.CLOUD,
+        workspace_id="team-tenant",
+        local_sync_path="/tmp/research",
+    )
+    config_manager.save_config(config)
+
+    monkeypatch.setattr(
+        project_sync_command,
+        "get_available_workspaces",
+        lambda: _async_value([_workspace("team-tenant", "organization", "team")]),
+    )
+    monkeypatch.setattr(
+        project_sync_command,
+        "get_mount_info",
+        lambda: pytest.fail("workspace guard should run before mount lookup"),
+    )
+
+    result = runner.invoke(app, argv)
+
+    assert result.exit_code == 1, result.output
+    assert "Local rclone sync/bisync is supported only for Personal workspaces" in result.output
+    assert "Team workspaces are accessed through the cloud API/MCP" in result.output
+
+
+def test_require_personal_workspace_allows_personal_workspace(monkeypatch, config_manager):
+    """Personal workspaces keep the existing rclone sync path available."""
+    project_sync_command = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
+
+    config = config_manager.load_config()
+    config.projects["research"] = ProjectEntry(
+        path="/tmp/research",
+        mode=ProjectMode.CLOUD,
+        workspace_id="personal-tenant",
+        local_sync_path="/tmp/research",
+    )
+    config_manager.save_config(config)
+
+    monkeypatch.setattr(
+        project_sync_command,
+        "get_available_workspaces",
+        lambda: _async_value([_workspace("personal-tenant", "personal", "personal")]),
+    )
+
+    workspace = project_sync_command._require_personal_workspace("research", config)
+
+    assert workspace.tenant_id == "personal-tenant"
+
+
+def test_bisync_reset_skips_workspace_check_without_credentials(monkeypatch, tmp_path):
+    """Resetting local bisync state stays harmless when no cloud credentials exist."""
+    project_sync_command = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
+
+    monkeypatch.setattr(
+        project_sync_command,
+        "get_available_workspaces",
+        lambda: pytest.fail("workspace lookup requires cloud credentials"),
+    )
+    monkeypatch.setattr(
+        project_sync_command,
+        "get_project_bisync_state",
+        lambda _name: tmp_path / "missing-state",
+    )
+
+    result = runner.invoke(app, ["cloud", "bisync-reset", "research"])
+
+    assert result.exit_code == 0, result.output
+    assert "No bisync state found for project 'research'" in result.output
+
+
 async def _async_value(value):
     return value
+
+
+def _workspace(tenant_id: str, workspace_type: str, slug: str) -> WorkspaceInfo:
+    return WorkspaceInfo(
+        tenant_id=tenant_id,
+        workspace_type=workspace_type,
+        slug=slug,
+        name=slug.title(),
+        role="owner",
+        is_default=False,
+        has_active_subscription=True,
+    )


### PR DESCRIPTION
## Summary

- Resolve the target cloud workspace before rclone sync/bisync setup or execution.
- Block Team/organization workspaces with a clear Personal-workspace-only error.
- Keep Personal workspace sync behavior unchanged, and preserve credential-free local bisync reset behavior.

Fixes #849.

## Validation

- `uv run pytest tests/cli/cloud/test_project_sync_command.py`
- `uv run ruff check src/basic_memory/cli/commands/cloud/project_sync.py tests/cli/cloud/test_project_sync_command.py`
- `uv run ruff format --check src/basic_memory/cli/commands/cloud/project_sync.py tests/cli/cloud/test_project_sync_command.py`
- `just typecheck`
