### PR TITLE
feat(plugins): improve /basic-memory:setup — load-bearing focus, cloud-safe schema seeding, smoke test

### DIFF
--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -255,13 +255,27 @@ if shared_capped:
 # Trigger: a primaryProject is set (so capture is actually active — pre-compact and
 # proactive writes land somewhere intentional). Why: the output style tells Claude to
 # follow the project's placement conventions, but nothing else surfaces them.
-# Outcome: Claude sees the capture folder + any stored conventions, so writes land
-# where the user expects instead of being guesswork. Bounded — conventions are a
-# short string by design.
+# Outcome: Claude sees that session checkpoints go to captureFolder while decisions/
+# tasks/notes follow the stored conventions — so it doesn't dump everything into the
+# checkpoint folder. Bounded — conventions are a short string by design.
 if primary_project:
-    placement = ["", "## Where to write", f"- Auto-capture and checkpoints go to `{capture_folder}/`."]
+    # captureFolder is the PreCompact *checkpoint* folder only; proactive captures
+    # (decisions, tasks, notes) follow placementConventions, not this folder.
+    placement = [
+        "",
+        "## Where to write",
+        f"- Session checkpoints (the PreCompact auto-capture) go to `{capture_folder}/`.",
+    ]
     if placement_conventions:
-        placement.append(f"- Placement conventions: {placement_conventions}")
+        placement.append(
+            "- Decisions, tasks, and other notes follow these placement "
+            f"conventions: {placement_conventions}"
+        )
+    else:
+        placement.append(
+            "- Place decisions, tasks, and notes in folders that fit their topic, "
+            "not the checkpoint folder."
+        )
     lines += placement
 
 # --- First-run / config nudges ---

--- a/plugins/claude-code/hooks/session-start.sh
+++ b/plugins/claude-code/hooks/session-start.sh
@@ -109,6 +109,11 @@ default_prompt = (
     "Cite permalinks when referencing prior work."
 )
 recall_prompt = cfg.get("recallPrompt") or default_prompt
+# Placement guidance — surfaced in the brief below so the output style's "follow the
+# project's stored placement conventions" reflex has something concrete to follow.
+# Without this, setup writes them but they never reach Claude (dead config).
+placement_conventions = (cfg.get("placementConventions") or "").strip()
+capture_folder = (cfg.get("captureFolder") or "sessions").strip()
 
 # --- Resolve the shared/team read set ---
 # secondaryProjects (read-only recall sources) + teamProjects keys (share targets,
@@ -245,6 +250,19 @@ if shared_sections:
     ]
 if shared_capped:
     lines += ["", f"_(reading the first {MAX_SHARED} shared projects; more are configured.)_"]
+
+# --- Where to write (placement guidance) ---
+# Trigger: a primaryProject is set (so capture is actually active — pre-compact and
+# proactive writes land somewhere intentional). Why: the output style tells Claude to
+# follow the project's placement conventions, but nothing else surfaces them.
+# Outcome: Claude sees the capture folder + any stored conventions, so writes land
+# where the user expects instead of being guesswork. Bounded — conventions are a
+# short string by design.
+if primary_project:
+    placement = ["", "## Where to write", f"- Auto-capture and checkpoints go to `{capture_folder}/`."]
+    if placement_conventions:
+        placement.append(f"- Placement conventions: {placement_conventions}")
+    lines += placement
 
 # --- First-run / config nudges ---
 if not configured:

--- a/plugins/claude-code/skills/setup/SKILL.md
+++ b/plugins/claude-code/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: Set up the Basic Memory plugin for this project — a short guided interview that configures the project mapping, seeds note schemas, optionally learns the project's conventions, and enables capture reflexes. Use when the user runs /basic-memory:setup, says "set up basic memory", or asks to configure/bootstrap the plugin.
+description: Set up the Basic Memory plugin for this project — a short guided interview that configures the project mapping, seeds note schemas, learns or suggests placement conventions, and enables capture reflexes. Use when the user runs /basic-memory:setup, says "set up basic memory", or asks to configure/bootstrap the plugin.
 argument-hint: (no arguments — runs an interactive interview)
 ---
 
@@ -32,8 +32,13 @@ it succeeds.
 
 Ask only what you can't infer. Cover:
 
-1. **Focus.** "What's this project mostly about — code, writing, research, planning,
-   or a mix?" (Shapes folder suggestions later; one quick question.)
+1. **Focus / how you'll use it.** "What will this project mostly be — code/dev,
+   research, writing, knowledge capture, planning, or a mix?" This answer is
+   **load-bearing**, not small talk: it drives the folder structure you suggest
+   (step 4) and is stored so the SessionStart brief can surface it, keeping capture
+   matched to the use-case. Don't let it evaporate — if you infer it from context
+   instead of asking, still say the use-case you assumed and the structure it
+   implies, and let the user correct it in one word.
 
 2. **Project mapping.** "Do you already have a Basic Memory project for this, or
    should I create one?"
@@ -60,14 +65,23 @@ Ask only what you can't infer. Cover:
    Keep `primaryProject` a project the user owns for their *own* capture; team
    projects are for reading and deliberate sharing only.
 
-4. **Learn conventions** (optional). "Want me to look at your existing notes and
-   note your conventions so I place new notes consistently?" If yes, inspect the
-   project: `list_directory` for the folder layout, sample a few notes per folder
-   (and, where a folder holds recurring typed notes, you may run `schema_infer` to
-   see their shape). Summarize what you find — folder-by-topic conventions, naming
-   style, the observation categories they favor — into 3-6 short lines and store
-   that string as `placementConventions`. Infer from their *real* notes; don't
-   impose a structure.
+4. **Placement — learn or suggest** (depends on the project's state). The goal is a
+   short `placementConventions` string (3-6 lines) telling you where new notes go.
+   How you get it depends on whether the project already has notes:
+   - **Existing project with notes** → *learn*. Inspect it: `list_directory` for the
+     folder layout, sample a few notes per folder (and, where a folder holds
+     recurring typed notes, you may run `schema_infer` to see their shape).
+     Summarize the *real* conventions — folder-by-topic layout, naming style, the
+     observation categories they favor. Infer from their actual notes; don't impose.
+   - **New or empty project** → *suggest* (there's nothing to learn yet). Propose a
+     **light** structure that fits the focus from step 1 — 3-5 optional top-level
+     folders, no deep taxonomy — and be explicit that it's a starting point, not a
+     scaffold: notes work fine without it and structure can stay emergent. Don't
+     create empty folders; folders appear as notes land in them. Let the user edit
+     or decline in one word.
+   Either way, keep it short and store the result as `placementConventions`. The
+   SessionStart brief surfaces it (alongside `captureFolder`), so this is what makes
+   your captures land where the user expects — without it, placement is guesswork.
 
 5. **Schemas.** "I'll add schemas for session checkpoints, decisions, and tasks so
    I can find them precisely later — okay?" (See "Seed the schemas" below.)
@@ -99,12 +113,21 @@ For each one:
   (`search_notes` with `metadata_filters={"type": "schema"}`, or try
   `read_note("schemas/<name>")`). **If it exists, skip it** — never overwrite a
   schema the user may have customized.
-- Otherwise write it with `write_note`: `directory="schemas"`,
-  `title` = the schema's title (Session / Decision / Task), `content` = the file's
-  full contents (including its `---` frontmatter — Basic Memory merges that into the
-  note's frontmatter, so the `type: schema` + `entity` + `schema` definition land
-  intact and become resolvable by `schema_validate`), routed to `primaryProject`
-  (pass it as `project`, or as `project_id` if it's an `external_id` UUID).
+- Otherwise write it with `write_note`, routed to `primaryProject` (pass it as
+  `project`, or as `project_id` if it's an `external_id` UUID):
+  - `directory="schemas"`, `note_type="schema"`, `title` = the schema's title
+    (Session / Decision / Task).
+  - `content` = the markdown **body only** — everything *after* the `---`
+    frontmatter block (the `# Session` heading and the prose).
+  - `metadata` = the schema's structured frontmatter as a **nested dict**: `entity`,
+    `version`, the full `schema` map, and `settings` (keep its nested `frontmatter`,
+    and pass enum values as JSON arrays, e.g. `["open","resumed","closed"]`).
+  - **Do not** put the schema's `---` frontmatter inside `content`. On the cloud
+    write path that nested YAML is silently coerced to the string `'[object Object]'`
+    (basic-memory-cloud#1000), corrupting `schema`/`settings`. The `metadata` param
+    round-trips correctly on both local and cloud. After seeding, verify one note
+    with `read_note(..., output_format="json", include_frontmatter=true)` —
+    `schema`/`settings` must come back as nested objects, not strings.
 
 ### 2. Install the shared skills (if the user opted in)
 Run, from the project root:
@@ -130,7 +153,7 @@ Build the `basicMemory` block from the interview:
     "rememberFolder": "bm-remember",
     "recallTimeframe": "3d",
     "preCompactCapture": "extractive",
-    "placementConventions": "<inferred summary, or null>",
+    "placementConventions": "<learned or suggested summary, or null>",
     "teamProjects": {}
   },
   "outputStyle": "basic-memory"
@@ -145,10 +168,36 @@ valid JSON.
 Writing the `basicMemory` block is also what stops the SessionStart hook's first-run
 nudge — the config's presence is the signal that setup has run.
 
+### 4. Smoke-test the wiring
+Before you close, prove recall actually resolves — this catches a misnamed project,
+missing cloud credentials, or a ref that doesn't route, while the user is still here
+to fix it. Run the same structured query the SessionStart hook runs, via the CLI it
+uses (`basic-memory` / `bm` / `uvx basic-memory`):
+
+- **Primary:** `… tool search-notes --type schema --page-size 5` against
+  `primaryProject` — use `--project-id <uuid>` for a UUID, `--project <ref>`
+  otherwise. It should return the three schemas you just seeded.
+- **One shared project** (only if `secondaryProjects` is non-empty): a
+  `--type decision --status open` query against the first ref. It just needs to
+  return *cleanly* — `0 results` is fine; an **error** means the ref doesn't route.
+
+If a query errors, or the primary returns nothing, surface it and fix the project
+ref before closing — don't let the next session's brief come up empty.
+
 ## Close
 
 Confirm what you did in a few lines: the project mapping, which schemas were seeded
-vs. already present, whether conventions were learned, and whether the output style
-is on. End with: *"Done — I'll use this from the next message. Run
-`/basic-memory:status` anytime to see what I'm tracking."* Note that the output
-style (if enabled) takes effect on the next session, since it's fixed at startup.
+vs. already present, whether placement was learned or suggested, the smoke-test
+result, and whether the output style is on.
+
+Then handle activation based on the output style:
+- **Output style enabled** → it's fixed at session start, so the full capture
+  reflexes only take effect next session. Prompt the user to **restart the session**
+  (start a new Claude Code session) to activate them. Be precise so it doesn't read
+  as "nothing works yet": recall is already live this session (the SessionStart
+  hook's prompt ran), and the PreCompact checkpoint works now too — only the
+  proactive-capture reflexes wait for the restart.
+- **Output style off** → no restart needed; the hooks already run.
+
+End with: *"Done — I'll use this from the next message. Run `/basic-memory:status`
+anytime to see what I'm tracking."*

--- a/plugins/claude-code/skills/setup/SKILL.md
+++ b/plugins/claude-code/skills/setup/SKILL.md
@@ -150,7 +150,7 @@ copy with published versions. In that case **skip the install** and tell the use
 the skills are already present as source; don't run the command. Quick check:
 
 ```
-git ls-files skills/ | grep -q memory- && echo "source repo — skip install"
+git ls-files skills/ | grep -q memory- && echo "source repo - skip install"
 ```
 
 Otherwise, run from the project root:

--- a/plugins/claude-code/skills/setup/SKILL.md
+++ b/plugins/claude-code/skills/setup/SKILL.md
@@ -44,9 +44,18 @@ Ask only what you can't infer. Cover:
    should I create one?"
    - Existing → show `list_memory_projects()` and let them pick. That name becomes
      `primaryProject`.
-   - New → propose a name (default: this repo's directory name) and a path
-     (default: `~/basic-memory/<name>/`), then create it with
+   - New → propose a name (default: this repo's directory name) and create it with
      `create_memory_project`.
+     - *Local project* (default): path defaults to `~/basic-memory/<name>/`; any
+       connected Basic Memory server can create it.
+     - *Cloud project* (the user wants capture in a cloud workspace): pass the
+       `workspace` selector (a slug from `list_workspaces`) and a cloud-style path
+       like `/<name>`, and create it with a **cloud-connected** MCP server. A purely
+       local server (`uvx basic-memory mcp`) treats the path as a local directory and
+       fails to create it (e.g. read-only `/`). When both a local and a cloud server
+       are connected, route creation *and* the schema seeding through the cloud one,
+       and pin `primaryProject` to the new project's `external_id` UUID
+       (collision-proof across workspaces).
 
 3. **Cloud / teams** (skip if there are no extra workspaces). Run
    `list_workspaces`. If the user belongs to more than one workspace, they likely
@@ -57,6 +66,10 @@ Ask only what you can't infer. Cover:
    - **Read from the team** (recommended): ask which team projects to pull into the
      session brief for recall. Store their qualified names in `secondaryProjects`.
      These are **read-only** — recall reads across them; nothing is written to them.
+     **Cap:** the SessionStart brief reads only the first **6** shared projects per
+     session (a latency/output bound), in list order. If the user wants more than
+     six, order the most relevant first and tell them the rest are configured but
+     not read each session.
    - **Share target** (optional): if the user wants a place to *publish* notes to the
      team via `/basic-memory:share`, add it to `teamProjects` as
      `"<qualified-name>": { "promoteFolder": "shared" }`. Sharing is always a manual
@@ -130,7 +143,17 @@ For each one:
     `schema`/`settings` must come back as nested objects, not strings.
 
 ### 2. Install the shared skills (if the user opted in)
-Run, from the project root:
+**First, guard against clobbering a source checkout.** If `./skills` already exists,
+is tracked in git, and holds `memory-*` directories, you're inside the skills' own
+source repo (e.g. `basic-memory` itself) — the install would overwrite the working
+copy with published versions. In that case **skip the install** and tell the user
+the skills are already present as source; don't run the command. Quick check:
+
+```
+git ls-files skills/ | grep -q memory- && echo "source repo — skip install"
+```
+
+Otherwise, run from the project root:
 
 ```
 npx skills add basicmachines-co/basic-memory --path skills


### PR DESCRIPTION
Improvements to `/basic-memory:setup`, driven by the first real run of the skill against a **cloud** `primaryProject`. Three coherent changes plus three debrief fixes, in one PR.

## Core changes

- **Focus is now load-bearing.** The "what will this project be" question previously shaped nothing and was easy to infer away into the void. It now drives an adaptive, *light* folder-structure suggestion (3–5 optional folders, emergent-structure-respecting) and is stored. The placement step branches **learn** (existing project with notes) vs **suggest** (new/empty project) — the empty-project case had no guidance before.
- **Schema seeding uses the `write_note` `metadata` param** instead of content frontmatter. On the cloud write path, nested YAML in `content` is silently coerced to the string `'[object Object]'`, corrupting `schema`/`settings` (filed as basicmachines-co/basic-memory-cloud#1000). The `metadata` param round-trips correctly on both local and cloud; the instruction now includes a read-back verification.
- **`placementConventions` + `captureFolder` are surfaced in the SessionStart brief.** They were written by setup but never shown to the assistant — the output style said "follow stored placement conventions" with nothing to follow. `session-start.sh` now renders a "Where to write" section (gated on `primaryProject`).
- **Smoke-test + restart prompt.** Setup now runs the hook's recall query against primary + one shared project to prove routing resolves before closing, and prompts a session restart (gated on `outputStyle`, with a precise note that recall + checkpoint already work — only the proactive reflexes wait).

## Debrief fixes folded in

- **Cloud project creation guidance** — a cloud-workspace project needs a cloud-connected MCP server + workspace selector; a purely local server fails to `mkdir` the cloud-style path. Pin cloud `primaryProject` to the `external_id` UUID.
- **Skills-source guard** — if `./skills` is git-tracked and holds `memory-*` dirs (the skills' own source repo), skip the `npx skills add --path skills` install instead of overwriting the working copy with published versions.
- **Shared-read cap warning** — the brief reads only the first 6 shared projects per session; tell the user to order the most relevant first when more are configured.

## Testing

- `just package-check-claude-code` → `✔ Validation passed`.
- Ran `session-start.sh` against a live cloud-primary config: exit 0, brief renders, new "Where to write" section appears, `MAX_SHARED` cap fires correctly.
- Verified the `metadata`-param seeding round-trips (nested `schema`/`settings` come back as objects) and that the local Python server handles content-frontmatter correctly (confirming the corruption is cloud-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
