### PR TITLE
docs(ci): document auto bm dogfood install

### DIFF
--- a/src/basic_memory/ci/README.md
+++ b/src/basic_memory/ci/README.md
@@ -90,6 +90,9 @@ The generated workflow installs `basic-memory` from PyPI. When dogfooding an
 unreleased `bm ci` change, temporarily edit the workflow install step to install
 the branch or commit that contains the CI commands.
 
+This repository's live workflow may temporarily install from the checked-out
+repository while `bm ci` is being dogfooded ahead of the next package release.
+
 After the files and secrets are in place, verify the first run by merging a test
 PR or completing a configured production deploy workflow. The Auto BM workflow
 should create or update a `project_update` note under:


### PR DESCRIPTION
Documents the temporary checkout install used while dogfooding Auto BM before the next package release. This merged PR is also the live Auto BM publish-path smoke test.