### PR TITLE
fix(ci): require all codex synthesis schema fields

### DIFF
--- a/src/basic_memory/ci/project_updates.py
+++ b/src/basic_memory/ci/project_updates.py
@@ -430,22 +430,23 @@ def _extend_list_section(sections: list[str], title: str, values: list[str]) -> 
 
 def render_agent_synthesis_schema() -> str:
     """Render the optional Codex structured-output schema guardrail."""
+    properties = {
+        "summary": {"type": "string", "minLength": 1},
+        "why_it_matters": {"type": "string", "minLength": 1},
+        "user_facing_changes": {"type": "array", "items": {"type": "string"}},
+        "internal_changes": {"type": "array", "items": {"type": "string"}},
+        "verification": {"type": "array", "items": {"type": "string"}},
+        "follow_ups": {"type": "array", "items": {"type": "string"}},
+        "decision_candidates": {"type": "array", "items": {"type": "string"}},
+        "task_candidates": {"type": "array", "items": {"type": "string"}},
+    }
     schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AgentSynthesis",
         "type": "object",
         "additionalProperties": False,
-        "required": ["summary", "why_it_matters"],
-        "properties": {
-            "summary": {"type": "string", "minLength": 1},
-            "why_it_matters": {"type": "string", "minLength": 1},
-            "user_facing_changes": {"type": "array", "items": {"type": "string"}},
-            "internal_changes": {"type": "array", "items": {"type": "string"}},
-            "verification": {"type": "array", "items": {"type": "string"}},
-            "follow_ups": {"type": "array", "items": {"type": "string"}},
-            "decision_candidates": {"type": "array", "items": {"type": "string"}},
-            "task_candidates": {"type": "array", "items": {"type": "string"}},
-        },
+        "required": list(properties),
+        "properties": properties,
     }
     return json.dumps(schema, indent=2, sort_keys=True) + "\n"
 

--- a/tests/ci/test_project_updates.py
+++ b/tests/ci/test_project_updates.py
@@ -423,6 +423,7 @@ def test_render_agent_synthesis_schema_is_ci_guardrail_not_domain_schema() -> No
     assert schema["title"] == "AgentSynthesis"
     assert "summary" in schema["required"]
     assert "why_it_matters" in schema["required"]
+    assert set(schema["required"]) == set(schema["properties"])
     assert "project_update" not in json.dumps(schema)
 
 


### PR DESCRIPTION
Fixes the Auto BM live run failure from PR #890. Codex/OpenAI structured output schemas require every property to appear in required; the generated AgentSynthesis schema now derives required from properties and has a regression assertion.