### PR TITLE
fix(ci): allow ci PR title scope

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -38,6 +38,7 @@ jobs:
             mcp
             sync
             ui
+            ci
             deps
             installer
             plugins

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Before opening or updating a PR, run the checks that mirror the common required 
 - Run `just typecheck` in addition to targeted `ruff` and `pytest` commands when tests were added or changed.
 - Sign commits with `git commit -s` so DCO passes. If a PR branch already has unsigned commits, rewrite the branch with signed-off commits before asking for review.
 - Use a semantic PR title accepted by `.github/workflows/pr-title.yml`: `type(scope): summary`.
-- Use one of the allowed scopes: `core`, `cli`, `api`, `mcp`, `sync`, `ui`, `deps`, `installer`, `plugins`, `skills`, `integrations`.
+- Use one of the allowed scopes: `core`, `cli`, `api`, `mcp`, `sync`, `ui`, `ci`, `deps`, `installer`, `plugins`, `skills`, `integrations`.
 
 ### Test Structure
 
@@ -506,7 +506,7 @@ With GitHub integration, the development workflow includes:
 5. **Code Commits**: ALWAYS sign off commits with `git commit -s`
 6. **Pull Request Titles**: PR titles must follow the semantic format enforced by `.github/workflows/pr-title.yml`: `type(scope): summary`
    - Allowed types: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`
-   - Allowed scopes: `core`, `cli`, `api`, `mcp`, `sync`, `ui`, `deps`, `installer`, `plugins`, `skills`, `integrations`
+   - Allowed scopes: `core`, `cli`, `api`, `mcp`, `sync`, `ui`, `ci`, `deps`, `installer`, `plugins`, `skills`, `integrations`
    - Example: `fix(cli): propagate cloud workspace routing`
 
 This level of integration represents a new paradigm in AI-human collaboration, where the AI assistant becomes a full-fledged team member rather than just a tool for generating code snippets.

--- a/tests/test_pr_title_workflow.py
+++ b/tests/test_pr_title_workflow.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import yaml
+
+
+def _semantic_pr_action_inputs() -> dict:
+    workflow = yaml.safe_load(Path(".github/workflows/pr-title.yml").read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["main"]["steps"]
+    action_step = next(
+        step for step in steps if step.get("uses") == "amannn/action-semantic-pull-request@v6"
+    )
+    return action_step["with"]
+
+
+def test_pr_title_workflow_allows_ci_scope() -> None:
+    scopes = _semantic_pr_action_inputs()["scopes"].split()
+
+    assert "ci" in scopes


### PR DESCRIPTION
Allows ci as a semantic PR title scope, matching the CI workflow changes we are now making. Adds a small regression test that reads .github/workflows/pr-title.yml and asserts the scope is present.