### PR TITLE
feat(cli): improve workspace and cloud bisync command discoverability

### DIFF
--- a/src/basic_memory/cli/app.py
+++ b/src/basic_memory/cli/app.py
@@ -86,6 +86,7 @@ def app_callback(
         "reindex",
         "update",
         "watch",
+        "workspace",
     }
     if (
         not version

--- a/src/basic_memory/cli/commands/__init__.py
+++ b/src/basic_memory/cli/commands/__init__.py
@@ -9,6 +9,7 @@ from . import (
     format,
     schema,
     update,
+    workspace,
 )
 
 __all__ = [
@@ -27,4 +28,5 @@ __all__ = [
     "format",
     "schema",
     "update",
+    "workspace",
 ]

--- a/src/basic_memory/cli/commands/cloud/project_sync.py
+++ b/src/basic_memory/cli/commands/cloud/project_sync.py
@@ -146,7 +146,7 @@ def _get_sync_project(
 
 @cloud_app.command("sync")
 def sync_project_command(
-    name: str = typer.Option(..., "--name", help="Project name to sync"),
+    name: str = typer.Option(..., "--name", "--project", help="Project name to sync"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview changes without syncing"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output"),
 ) -> None:
@@ -193,7 +193,7 @@ def sync_project_command(
 
 @cloud_app.command("bisync")
 def bisync_project_command(
-    name: str = typer.Option(..., "--name", help="Project name to bisync"),
+    name: str = typer.Option(..., "--name", "--project", help="Project name to bisync"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview changes without syncing"),
     resync: bool = typer.Option(False, "--resync", help="Force new baseline"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output"),
@@ -256,7 +256,7 @@ def bisync_project_command(
 
 @cloud_app.command("check")
 def check_project_command(
-    name: str = typer.Option(..., "--name", help="Project name to check"),
+    name: str = typer.Option(..., "--name", "--project", help="Project name to check"),
     one_way: bool = typer.Option(False, "--one-way", help="Check one direction only (faster)"),
 ) -> None:
     """Verify file integrity between local and cloud.

--- a/src/basic_memory/cli/commands/workspace.py
+++ b/src/basic_memory/cli/commands/workspace.py
@@ -1,0 +1,23 @@
+"""Top-level `workspace` stub that redirects users to `bm cloud workspace`."""
+
+import typer
+
+from basic_memory.cli.app import app
+
+
+# Trigger: user runs `bm workspace`, `bm workspace list`, etc.
+# Why: workspace verbs live under `bm cloud workspace`; a bare top-level miss
+#   only emits Typer's terse "No such command 'workspace'." with exit 2.
+# Outcome: allow_extra_args + ignore_unknown_options absorb any trailing tokens
+#   (e.g. `list`, `set-default foo`) so every invocation reaches this body and
+#   prints actionable guidance instead of being rejected as bad usage.
+@app.command(
+    "workspace",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def workspace_stub(ctx: typer.Context) -> None:
+    """Point users to the real workspace verbs under `bm cloud workspace`."""
+    typer.echo("'bm workspace' is not a command. Workspace verbs live under 'bm cloud workspace':")
+    typer.echo("  bm cloud workspace list")
+    typer.echo("  bm cloud workspace set-default <name>")
+    raise typer.Exit(1)

--- a/src/basic_memory/cli/main.py
+++ b/src/basic_memory/cli/main.py
@@ -31,6 +31,7 @@ if not _version_only_invocation(sys.argv[1:]):
         status,
         tool,
         update,
+        workspace,
     )
 
 warnings.filterwarnings("ignore")  # pragma: no cover

--- a/tests/cli/cloud/test_project_sync_command.py
+++ b/tests/cli/cloud/test_project_sync_command.py
@@ -19,6 +19,9 @@ runner = CliRunner()
     [
         ["cloud", "sync", "--name", "research"],
         ["cloud", "bisync", "--name", "research"],
+        # --project is an alias for --name (issue #817)
+        ["cloud", "sync", "--project", "research"],
+        ["cloud", "bisync", "--project", "research"],
     ],
 )
 def test_cloud_sync_commands_skip_explicit_cloud_project_sync(monkeypatch, argv, config_manager):

--- a/tests/cli/test_workspace_stub.py
+++ b/tests/cli/test_workspace_stub.py
@@ -1,0 +1,31 @@
+"""Tests for the top-level `bm workspace` stub (issue #821).
+
+The stub redirects users to `bm cloud workspace` instead of letting Typer emit a
+bare "No such command 'workspace'." with exit code 2.
+"""
+
+import pytest
+from typer.testing import CliRunner
+
+from basic_memory.cli.app import app
+
+# Importing the module registers the workspace_stub command on the top-level app.
+import basic_memory.cli.commands.workspace  # noqa: F401
+
+runner = CliRunner()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["workspace"],
+        ["workspace", "list"],
+        ["workspace", "set-default", "foo"],
+    ],
+)
+def test_workspace_stub_redirects_to_cloud_workspace(argv):
+    """Every `bm workspace ...` form exits 1 and points to `bm cloud workspace`."""
+    result = runner.invoke(app, argv)
+
+    assert result.exit_code == 1, result.output
+    assert "bm cloud workspace" in result.output


### PR DESCRIPTION
## Summary
Two small, independent CLI UX wins that improve discoverability of cloud project sync and workspace commands.

## What changed
**Part A (#817) — `--project` alias for `--name`**
- `src/basic_memory/cli/commands/cloud/project_sync.py`: the `cloud sync`, `cloud bisync`, and `cloud check` commands now accept `--project` as an alias for `--name`. Typer binds both option strings to the same `name` argument, so there's zero downstream change and `--name` stays for back-compat. The `bisync-reset` / `sync-setup` commands take the project as a positional argument and are unchanged.

**Part B (#821) — `bm workspace` redirects to `bm cloud workspace`**
- New `src/basic_memory/cli/commands/workspace.py`: a top-level `workspace` stub command. Previously `bm workspace` / `bm workspace list` emitted a bare `No such command 'workspace'.` (exit 2). The stub prints actionable guidance pointing to `bm cloud workspace list` / `bm cloud workspace set-default <name>` and exits 1. `context_settings={"allow_extra_args": True, "ignore_unknown_options": True}` is load-bearing — it ensures `bm workspace`, `bm workspace list`, and `bm workspace set-default foo` all reach the body instead of being rejected as bad usage.
- Wiring: added `workspace` to `skip_init_commands` in `cli/app.py` (the stub doesn't need DB init), to the conditional import block in `cli/main.py`, and to `cli/commands/__init__.py` imports + `__all__`.
- The real `bm cloud workspace` sub-typer is unaffected — the stub registers on the top-level `app`, not under `cloud_app`.

## Testing (commands + results)
- `uv run ruff check .` — clean for all changed files (3 pre-existing errors in `integrations/hermes/tests/` are out of scope and untouched)
- `uv run ruff format .` — changed files formatted
- `uv run pytest tests/cli/test_workspace_stub.py tests/cli/cloud/test_project_sync_command.py -q` — **18 passed** (includes 2 new `--project` parametrized variants and the new workspace stub test asserting exit 1 + `bm cloud workspace` guidance for all three forms)
- `uv run ty check src tests test-int` — **All checks passed!**
- Manual sanity: `bm cloud workspace --help` still resolves (exit 0, `list` verb present); `bm cloud sync --help` shows `--project`.

Integration-style `CliRunner` tests against the real app; no mocks added (the existing project_sync test fixtures' monkeypatches are reused for the alias variants since those tests exercise the dispatch path, not cloud I/O).

## Risk
Low. `--project` is purely additive (Typer multi-name option). The `workspace` stub only intercepts a previously-failing invocation and registers on the top-level app without shadowing the real `bm cloud workspace` commands.

Closes #817
Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
