### PR TITLE
fix(core): make note_types search filter case-insensitive

### DIFF
--- a/src/basic_memory/repository/postgres_search_repository.py
+++ b/src/basic_memory/repository/postgres_search_repository.py
@@ -777,14 +777,22 @@ class PostgresSearchRepository(SearchRepositoryBase):
                 category_placeholders.append(f":{param_name}")
             conditions.append(f"search_index.category IN ({', '.join(category_placeholders)})")
 
-        # Handle note type filter using JSONB containment (parameterized)
+        # Handle note type filter (frontmatter type field, parameterized).
+        # Trigger: caller passed `note_types` to scope by the frontmatter `type` field.
+        # Why: the stored note_type preserves the frontmatter casing (e.g. `Chapter`),
+        #      but the filter is documented case-insensitive. JSONB `@>` containment is
+        #      exact-match, so capitalized types were unfindable.
+        # Outcome: compare LOWER(metadata->>'note_type') against lowercased filter
+        #          values so `note_types=["Chapter"]` matches a stored `Chapter`.
         if note_types:
-            type_conditions = []
+            type_placeholders = []
             for idx, note_type in enumerate(note_types):
                 param_name = f"note_type_{idx}"
-                params[param_name] = json.dumps({"note_type": note_type})
-                type_conditions.append(f"search_index.metadata @> CAST(:{param_name} AS jsonb)")
-            conditions.append(f"({' OR '.join(type_conditions)})")
+                params[param_name] = note_type.lower()
+                type_placeholders.append(f":{param_name}")
+            conditions.append(
+                f"LOWER(search_index.metadata->>'note_type') IN ({', '.join(type_placeholders)})"
+            )
 
         # Handle date filter
         if after_date:

--- a/src/basic_memory/repository/sqlite_search_repository.py
+++ b/src/basic_memory/repository/sqlite_search_repository.py
@@ -809,15 +809,22 @@ class SQLiteSearchRepository(SearchRepositoryBase):
                 category_placeholders.append(f":{param_name}")
             conditions.append(f"search_index.category IN ({', '.join(category_placeholders)})")
 
-        # Handle note type filter (frontmatter type field, parameterized)
+        # Handle note type filter (frontmatter type field, parameterized).
+        # Trigger: caller passed `note_types` to scope by the frontmatter `type` field.
+        # Why: the stored note_type preserves the frontmatter casing (e.g. `Chapter`),
+        #      but the filter is documented case-insensitive; comparing raw values
+        #      would miss capitalized types.
+        # Outcome: fold both sides to lowercase so `note_types=["Chapter"]` matches a
+        #          stored `Chapter`, `chapter`, etc.
         if note_types:
             type_placeholders = []
             for idx, t in enumerate(note_types):
                 param_name = f"note_type_{idx}"
-                params[param_name] = t
+                params[param_name] = t.lower()
                 type_placeholders.append(f":{param_name}")
             conditions.append(
-                f"json_extract(search_index.metadata, '$.note_type') IN ({', '.join(type_placeholders)})"
+                "LOWER(json_extract(search_index.metadata, '$.note_type')) "
+                f"IN ({', '.join(type_placeholders)})"
             )
 
         # Handle date filter using datetime() for proper comparison

--- a/test-int/mcp/test_search_note_types_case_insensitive.py
+++ b/test-int/mcp/test_search_note_types_case_insensitive.py
@@ -1,0 +1,98 @@
+"""Bughunt: search_notes note_types filter is documented case-insensitive but
+fails to match capitalized frontmatter `type` values.
+"""
+
+import json
+from typing import Any
+
+import pytest
+from fastmcp import Client
+
+
+def _json(tool_result) -> Any:
+    assert len(tool_result.content) == 1
+    assert tool_result.content[0].type == "text"
+    return json.loads(tool_result.content[0].text)
+
+
+@pytest.mark.asyncio
+async def test_note_types_filter_is_case_insensitive(mcp_server, app, test_project):
+    async with Client(mcp_server) as client:
+        content = (
+            "---\n"
+            "title: Capitalized Type Note\n"
+            "type: Chapter\n"
+            "---\n"
+            "# Capitalized Type Note\n\nuniqtoken99 body text\n"
+        )
+        await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Capitalized Type Note",
+                "directory": "types",
+                "content": content,
+            },
+        )
+        plain = await client.call_tool(
+            "search_notes",
+            {
+                "project": test_project.name,
+                "query": "uniqtoken99",
+                "search_type": "text",
+                "output_format": "json",
+            },
+        )
+        plain_data = _json(plain)
+        assert plain_data["results"], "note not indexed at all"
+        res = await client.call_tool(
+            "search_notes",
+            {
+                "project": test_project.name,
+                "query": "uniqtoken99",
+                "search_type": "text",
+                "note_types": ["Chapter"],
+                "output_format": "json",
+            },
+        )
+        data = _json(res)
+        titles = [r["title"] for r in data["results"]]
+        assert "Capitalized Type Note" in titles, (
+            "note_types filter is documented case-insensitive but did not match the "
+            f"capitalized frontmatter type 'Chapter'. results={data}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_note_types_lowercase_control(mcp_server, app, test_project):
+    """Control: a lowercase frontmatter type DOES match (proves the bug is casing)."""
+    async with Client(mcp_server) as client:
+        content = (
+            "---\n"
+            "title: Lowercase Type Note\n"
+            "type: chapter\n"
+            "---\n"
+            "# Lowercase Type Note\n\nuniqtoken88 body text\n"
+        )
+        await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Lowercase Type Note",
+                "directory": "types",
+                "content": content,
+            },
+        )
+        res = await client.call_tool(
+            "search_notes",
+            {
+                "project": test_project.name,
+                "query": "uniqtoken88",
+                "search_type": "text",
+                "note_types": ["Chapter"],
+                "output_format": "json",
+            },
+        )
+        data = _json(res)
+        titles = [r["title"] for r in data["results"]]
+        assert "Lowercase Type Note" in titles, data


### PR DESCRIPTION
## Summary

The `search_notes` `note_types` filter was case-sensitive on both the SQLite and Postgres backends, despite the MCP tool documenting it as case-insensitive. The tool lowercases the input (`"Chapter"` -> `"chapter"`), but the stored frontmatter `type` value preserves its original casing (`"Chapter"`), so the SQL comparison never matched capitalized types. A note with `type: Chapter` was findable by plain text search but invisible to `search_notes(note_types=["Chapter"])`.

This fix folds case on both ends of the comparison.

## Bugs fixed

- **Bug #14** — `note_types` filter is case-sensitive despite documented case-insensitivity (capitalized frontmatter `type` values were unfindable).
  - SQLite (`sqlite_search_repository.py`): wrap the column in `LOWER(json_extract(metadata, '$.note_type'))` and lowercase the parameter values.
  - Postgres (`postgres_search_repository.py`): replace the JSONB `@>` containment check (exact-match) with `LOWER(metadata->>'note_type') IN (...)` and lowercase the parameter values.
  - Values remain parameterized, so the existing SQL-injection protection is unchanged.

## Testing

Test came from the integration bug hunt; added under `test-int/mcp/test_search_note_types_case_insensitive.py` (real DB / ASGI / MCP client, no mocks).

- `uv run pytest test-int/mcp/test_search_note_types_case_insensitive.py -q --no-cov` -> 2 passed (SQLite)
- `BASIC_MEMORY_TEST_POSTGRES=1 uv run pytest test-int/mcp/test_search_note_types_case_insensitive.py -q --no-cov` -> 2 passed (Postgres)
- `uv run pytest tests/repository/test_search_repository.py test-int/mcp/test_search_integration.py -q --no-cov` -> 50 passed (SQLite)
- `BASIC_MEMORY_TEST_POSTGRES=1 uv run pytest tests/repository/test_postgres_search_repository.py tests/repository/test_search_repository.py -q --no-cov` -> 47 passed, 12 skipped (Postgres)
- `uv run ruff check` (scoped files) / `uv run ruff format .` / `uv run ty check src tests test-int` -> all pass

## Risk

Low. The change only affects the `note_types` filter clause. Lowercasing the stored value at comparison time broadens matching to be case-insensitive (the documented behavior); the SQL-injection regression tests for `note_types` still pass on both backends. No tool signature changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)