### PR TITLE
fix(mcp): point move mismatch guidance at landing path

### DIFF
--- a/src/basic_memory/mcp/tools/move_note.py
+++ b/src/basic_memory/mcp/tools/move_note.py
@@ -941,9 +941,9 @@ move_note("{identifier}", destination_folder="notes")
                     moved within the same project. To move content between projects:
 
                     ```
-                    read_note("{identifier}")
+                    read_note("{result.file_path}")
                     write_note("Title", "content", "folder", project="target-project")
-                    delete_note("{identifier}", project="{active_project.name}")
+                    delete_note("{result.file_path}", project="{active_project.name}")
                     ```
                     """).strip()
 

--- a/test-int/bughunt_fixes/test_move_note_edge_cases.py
+++ b/test-int/bughunt_fixes/test_move_note_edge_cases.py
@@ -166,3 +166,54 @@ async def test_move_into_nested_projects_folder_not_flagged(mcp_server, app, tes
             "Legit nested 'projects' folder wrongly flagged as cross-project move"
         )
         assert result["moved"] is True, result.get("error")
+
+
+@pytest.mark.asyncio
+async def test_move_outcome_mismatch_guidance_uses_actual_landing_path(
+    mcp_server, app, test_project, monkeypatch
+):
+    """The text guidance should point agents at the actual post-move path.
+
+    The real move service stores the requested destination verbatim today, so the
+    mismatch backstop is exercised by returning a divergent file_path after the real
+    move completes.
+    """
+    async with Client(mcp_server) as client:
+        await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Outcome Guidance Note",
+                "directory": "source",
+                "content": "# Outcome Guidance Note\n\nbody",
+                "output_format": "json",
+            },
+        )
+
+        from basic_memory.mcp.clients import KnowledgeClient
+
+        real_move_entity = KnowledgeClient.move_entity
+        actual_landing_path = "unexpected/outcome-guidance-note.md"
+
+        async def diverging_move_entity(self, entity_id, destination_path):
+            result = await real_move_entity(self, entity_id, destination_path)
+            return result.model_copy(update={"file_path": actual_landing_path})
+
+        monkeypatch.setattr(KnowledgeClient, "move_entity", diverging_move_entity)
+
+        move = await client.call_tool(
+            "move_note",
+            {
+                "project": test_project.name,
+                "identifier": "source/outcome-guidance-note",
+                "destination_path": "target/outcome-guidance-note.md",
+            },
+        )
+
+        guidance = move.content[0].text
+        stale_identifier = "source/outcome-guidance-note"
+        assert "Unexpected Result Location" in guidance
+        assert f'read_note("{actual_landing_path}")' in guidance
+        assert f'delete_note("{actual_landing_path}", project="{test_project.name}")' in guidance
+        assert f'read_note("{stale_identifier}")' not in guidance
+        assert f'delete_note("{stale_identifier}", project="{test_project.name}")' not in guidance


### PR DESCRIPTION
## Summary

- Update `MOVE_OUTCOME_MISMATCH` recovery guidance to read and delete the actual `result.file_path` after a divergent move result.
- Add a bughunt integration regression that exercises the text-mode MCP path and asserts the stale source identifier is not suggested.

The real move service currently stores the requested destination verbatim, so the regression lets the real move happen and then injects a divergent returned `file_path` at the MCP client boundary. That matches the defensive backstop this guidance belongs to.

## Testing

- Red: `uv run pytest test-int/bughunt_fixes/test_move_note_edge_cases.py::test_move_outcome_mismatch_guidance_uses_actual_landing_path -q --no-cov` failed before the fix on stale `read_note` guidance.
- Green: `uv run pytest test-int/bughunt_fixes/test_move_note_edge_cases.py::test_move_outcome_mismatch_guidance_uses_actual_landing_path -q --no-cov`
- `uv run pytest test-int/bughunt_fixes/test_move_note_edge_cases.py -q --no-cov`
- `uv run pytest tests/mcp/test_tool_move_note.py -q --no-cov`
- `just fast-check` — 3217 passed, 41 skipped, 117 warnings

Follow-up to #904.