### PR TITLE
fix: split comma-separated tags in search_notes tags parameter

### DIFF
--- a/src/basic_memory/mcp/tools/search.py
+++ b/src/basic_memory/mcp/tools/search.py
@@ -11,7 +11,7 @@ from fastmcp import Context
 from pydantic import AliasChoices, BeforeValidator, Field
 
 from basic_memory.config import ConfigManager, has_cloud_credentials
-from basic_memory.utils import build_canonical_permalink, coerce_dict, coerce_list
+from basic_memory.utils import build_canonical_permalink, coerce_dict, coerce_list, parse_tags
 from basic_memory.mcp.async_client import (
     _explicit_routing,
     _force_local_mode,
@@ -678,7 +678,10 @@ async def search_notes(
     ] = None,
     tags: Annotated[
         List[str] | None,
-        BeforeValidator(coerce_list),
+        # Use parse_tags (not coerce_list) so a bare comma string like "alpha,beta"
+        # splits into ["alpha", "beta"], matching the `tag:` query shorthand and
+        # write_note's tag convention. See #910.
+        BeforeValidator(parse_tags),
     ] = None,
     status: Optional[str] = None,
     min_similarity: Annotated[

--- a/test-int/mcp/test_search_integration.py
+++ b/test-int/mcp/test_search_integration.py
@@ -497,3 +497,55 @@ async def test_search_case_insensitive(mcp_server, app, test_project):
 
             result_text = search_result.content[0].text
             assert "Machine Learning Guide" in result_text, f"Failed for search term: {search_term}"
+
+
+@pytest.mark.asyncio
+async def test_tags_param_vs_tag_query_comma_consistency(mcp_server, app, test_project):
+    """The `tags=` parameter must split comma-separated strings like the `tag:` shorthand.
+
+    Regression test for #910: `search_notes(tags="alpha,beta")` previously coerced the
+    bare string into the single literal tag `["alpha,beta"]` (matching nothing), while
+    the `tag:alpha,beta` query shorthand splits on commas. Both paths must agree.
+    """
+
+    async with Client(mcp_server) as client:
+        # Note tagged alpha + beta
+        await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Tag Shorthand Note",
+                "directory": "tag-shorthand",
+                "content": "# Tag Shorthand Note\n\nTagShorthandToken body",
+                "tags": ["alpha", "beta"],
+            },
+        )
+
+        # Path A: tag: query shorthand with comma list -> splits, matches
+        via_query = await client.call_tool(
+            "search_notes",
+            {
+                "project": test_project.name,
+                "query": "tag:alpha,beta",
+                "search_type": "text",
+            },
+        )
+        query_hit = "Tag Shorthand Note" in via_query.content[0].text
+
+        # Path B: tags= parameter with the SAME comma string
+        via_param = await client.call_tool(
+            "search_notes",
+            {
+                "project": test_project.name,
+                "query": "TagShorthandToken",
+                "search_type": "text",
+                "tags": "alpha,beta",
+            },
+        )
+        param_hit = "Tag Shorthand Note" in via_param.content[0].text
+
+        assert query_hit, "tag: query shorthand should match (sanity)"
+        assert param_hit == query_hit, (
+            "tags='alpha,beta' param must behave like the tag: shorthand "
+            f"(both split commas). query_hit={query_hit} param_hit={param_hit}"
+        )


### PR DESCRIPTION
Fixes #910

---

`search_notes(tags="alpha,beta")` returned zero results because the `tags` parameter coerced the bare comma string into the single literal tag `["alpha,beta"]`, while the `tag:alpha,beta` query shorthand (and `write_note`'s tag convention) split on commas. Within one tool, comma-string tags behaved two different ways.

This swaps the `tags` `BeforeValidator` from `coerce_list` to the existing `parse_tags`, which already handles lists, JSON-array strings, and bare comma strings consistently (and is the same helper `write_note` and the entity parser use). This preserves the JSON-array-string handling `coerce_list` provided while adding comma-splitting, so the `tags=` parameter now matches the `tag:` shorthand.

Scope is kept to `tags`. The related `note_types` / `entity_types` / `categories` filters still use `coerce_list`; applying comma-splitting there is a separate decision (and `parse_tags`' `#`-stripping is tag-specific), so I left them untouched — happy to follow up if you'd like consistent splitting on those too.

Added an integration regression test asserting the `tags=` parameter and the `tag:` shorthand return the same results for the same comma string. A unit test at the `search_notes` level isn't included on purpose: the `BeforeValidator` doesn't run on direct Python calls (only through the validated MCP path), so the integration level is where this is meaningfully covered. `parse_tags` itself is already exhaustively unit-tested.

Verified locally: the full search unit + integration suites (64 passing), `ruff`, and `ty` all green.

🤖 AI-assisted (Claude Code), human-reviewed.

<!-- BM_BOSSBOT_SUMMARY:start -->
Reviewed SHA: `af64adadcdb1b5e0a422ff0355485a66869ee16d`
Verdict: `needs_human`
Status: `failure` - BM Bossbot review did not finish

Summary:
BM Bossbot intentionally did not run Codex because this PR was not opened by an owner, member, or collaborator.

Blocking findings:
- BM Bossbot does not run for outside contributors: This PR author association is NONE. BM Bossbot only runs for OWNER, MEMBER, and COLLABORATOR pull requests, so this PR requires a maintainer path outside the automatic merge gate.

Non-blocking findings:
- None
<!-- BM_BOSSBOT_SUMMARY:end -->
