### PR TITLE
feat(cli): per-workspace rclone remotes for Team push/pull

### DIFF
--- a/src/basic_memory/cli/commands/cloud/bisync_commands.py
+++ b/src/basic_memory/cli/commands/cloud/bisync_commands.py
@@ -32,14 +32,33 @@ def _rclone_exclude_filters(pattern: str) -> list[str]:
     return [f"- {path_pattern}", f"- {path_pattern}/**"]
 
 
-async def get_mount_info() -> TenantMountInfo:
-    """Get current tenant information from cloud API."""
+def _workspace_id_header(workspace_id: str | None) -> dict[str, str]:
+    """Header that routes a /tenant/mount/* request to a specific tenant.
+
+    The mount endpoints resolve the workspace from X-Workspace-ID (validating
+    membership + subscription) and fall back to the user's default tenant when
+    it is absent — so omitting it preserves the original default-tenant behavior.
+    """
+    return {"X-Workspace-ID": workspace_id} if workspace_id else {}
+
+
+async def get_mount_info(*, workspace_id: str | None = None) -> TenantMountInfo:
+    """Get tenant mount info (bucket name + tenant id) from the cloud API.
+
+    Args:
+        workspace_id: Tenant id of the target workspace. When omitted, the API
+            uses the authenticated user's default tenant.
+    """
     try:
         config_manager = ConfigManager()
         config = config_manager.config
         host_url = config.cloud_host.rstrip("/")
 
-        response = await make_api_request(method="GET", url=f"{host_url}/tenant/mount/info")
+        response = await make_api_request(
+            method="GET",
+            url=f"{host_url}/tenant/mount/info",
+            headers=_workspace_id_header(workspace_id),
+        )
 
         return TenantMountInfo.model_validate(response.json())
     except Exception as e:
@@ -47,13 +66,22 @@ async def get_mount_info() -> TenantMountInfo:
 
 
 async def generate_mount_credentials(tenant_id: str) -> MountCredentials:
-    """Generate scoped credentials for syncing."""
+    """Generate scoped S3 credentials for syncing a specific tenant's bucket.
+
+    Args:
+        tenant_id: Tenant id whose bucket-scoped credentials to mint. Routed via
+            X-Workspace-ID so team workspaces get their own bucket's credentials.
+    """
     try:
         config_manager = ConfigManager()
         config = config_manager.config
         host_url = config.cloud_host.rstrip("/")
 
-        response = await make_api_request(method="POST", url=f"{host_url}/tenant/mount/credentials")
+        response = await make_api_request(
+            method="POST",
+            url=f"{host_url}/tenant/mount/credentials",
+            headers=_workspace_id_header(tenant_id),
+        )
 
         return MountCredentials.model_validate(response.json())
     except Exception as e:

--- a/src/basic_memory/cli/commands/cloud/bisync_commands.py
+++ b/src/basic_memory/cli/commands/cloud/bisync_commands.py
@@ -77,6 +77,8 @@ async def generate_mount_credentials(tenant_id: str) -> MountCredentials:
         config = config_manager.config
         host_url = config.cloud_host.rstrip("/")
 
+        # The mount endpoints resolve X-Workspace-ID by matching the workspace's
+        # tenant_id, so passing a tenant_id here is the correct routing key.
         response = await make_api_request(
             method="POST",
             url=f"{host_url}/tenant/mount/credentials",

--- a/src/basic_memory/cli/commands/cloud/core_commands.py
+++ b/src/basic_memory/cli/commands/cloud/core_commands.py
@@ -26,13 +26,49 @@ from basic_memory.cli.commands.cloud.bisync_commands import (
     generate_mount_credentials,
     get_mount_info,
 )
-from basic_memory.cli.commands.cloud.rclone_config import configure_rclone_remote
+from basic_memory.cli.commands.cloud.rclone_config import (
+    configure_rclone_remote,
+    remote_name_for_workspace,
+)
 from basic_memory.cli.commands.cloud.rclone_installer import (
     RcloneInstallError,
     install_rclone,
 )
+from basic_memory.mcp.project_context import get_available_workspaces
+from basic_memory.schemas.cloud import (
+    WorkspaceInfo,
+    format_workspace_choices,
+    format_workspace_selection_choices,
+    workspace_matches_exact_identifier,
+)
 
 console = Console()
+
+
+def _resolve_setup_workspace(identifier: str) -> WorkspaceInfo:
+    """Resolve a workspace identifier (slug, name, or tenant_id) for setup.
+
+    Errors with copyable choices when the identifier matches zero or multiple
+    workspaces, so the user can disambiguate.
+    """
+    workspaces = run_with_cleanup(get_available_workspaces())
+    if not workspaces:
+        console.print("[red]No accessible cloud workspaces found for this account[/red]")
+        raise typer.Exit(1)
+
+    matches = [ws for ws in workspaces if workspace_matches_exact_identifier(ws, identifier)]
+    if len(matches) == 1:
+        return matches[0]
+
+    if not matches:
+        console.print(f"[red]No workspace matches '{identifier}'[/red]")
+        console.print("\nAvailable workspaces:")
+        console.print(format_workspace_choices(workspaces))
+    else:
+        console.print(f"[red]'{identifier}' matches multiple workspaces[/red]")
+        console.print("\nDisambiguate with the workspace slug or tenant_id:")
+        console.print(format_workspace_selection_choices(matches))
+    raise typer.Exit(1)
 
 
 @cloud_app.command()
@@ -164,13 +200,23 @@ def status() -> None:
 
 
 @cloud_app.command("setup")
-def setup() -> None:
+def setup(
+    workspace: str | None = typer.Option(
+        None,
+        "--workspace",
+        help="Set up sync for a specific workspace (slug, name, or tenant_id). "
+        "Omit for your default workspace.",
+    ),
+) -> None:
     """Set up cloud sync by installing rclone and configuring credentials.
 
-    After setup, use project commands for syncing:
-      bm project add <name> --cloud --local-path ~/projects/<name>
-      bm project bisync --name <name> --resync  # First time
-      bm project bisync --name <name>            # Subsequent syncs
+    Run once per workspace you sync. The default workspace uses the
+    'basic-memory-cloud' remote; other (e.g. Team) workspaces each get their own
+    tenant-scoped remote, since Tigris credentials are bucket-scoped.
+
+    After setup, use the cloud sync commands:
+      bm cloud pull --name <name>   # fetch cloud changes (Team-safe)
+      bm cloud push --name <name>   # upload local changes (Team-safe)
     """
     console.print("[bold blue]Basic Memory Cloud Setup[/bold blue]")
     console.print("Setting up cloud sync with rclone...\n")
@@ -180,35 +226,46 @@ def setup() -> None:
         console.print("[blue]Step 1: Installing rclone...[/blue]")
         install_rclone()
 
-        # Step 2: Get tenant info
+        # --- Resolve target workspace ---
+        # Trigger: --workspace given. Why: Tigris keys are tenant-scoped, so a
+        # non-default workspace needs its own bucket + remote. Outcome: scope the
+        # mount-info/credentials calls and name the remote after the workspace.
+        if workspace is not None:
+            target = _resolve_setup_workspace(workspace)
+            workspace_id: str | None = target.tenant_id
+            remote_name = remote_name_for_workspace(target.slug, is_default=target.is_default)
+            console.print(f"[dim]Workspace: {target.name} ({target.slug})[/dim]")
+        else:
+            workspace_id = None  # default tenant
+            remote_name = remote_name_for_workspace(None, is_default=True)
+
+        # Step 2: Get tenant info (scoped to the target workspace when given)
         console.print("\n[blue]Step 2: Getting tenant information...[/blue]")
-        tenant_info = run_with_cleanup(get_mount_info())
+        tenant_info = run_with_cleanup(get_mount_info(workspace_id=workspace_id))
         console.print(f"[green]Found tenant: {tenant_info.tenant_id}[/green]")
 
-        # Step 3: Generate credentials
+        # Step 3: Generate credentials for that tenant's bucket
         console.print("\n[blue]Step 3: Generating sync credentials...[/blue]")
         creds = run_with_cleanup(generate_mount_credentials(tenant_info.tenant_id))
         console.print("[green]Generated secure credentials[/green]")
 
-        # Step 4: Configure rclone remote
+        # Step 4: Configure the tenant's rclone remote
         console.print("\n[blue]Step 4: Configuring rclone remote...[/blue]")
         configure_rclone_remote(
             access_key=creds.access_key,
             secret_key=creds.secret_key,
+            remote_name=remote_name,
         )
 
         console.print("\n[bold green]Cloud setup completed successfully![/bold green]")
         console.print("\n[bold]Next steps:[/bold]")
-        console.print("1. Add a project with local sync path:")
-        console.print("   bm project add research --cloud --local-path ~/Documents/research")
-        console.print("\n   Or configure sync for an existing project:")
+        console.print("1. Configure sync for a project:")
         console.print("   bm cloud sync-setup research ~/Documents/research")
-        console.print("\n2. Preview the initial sync (recommended):")
-        console.print("   bm project bisync --name research --resync --dry-run")
-        console.print("\n3. If all looks good, run the actual sync:")
-        console.print("   bm project bisync --name research --resync")
-        console.print("\n4. Subsequent syncs (no --resync needed):")
-        console.print("   bm project bisync --name research")
+        console.print("\n2. Preview a pull (recommended):")
+        console.print("   bm cloud pull --name research --dry-run")
+        console.print("\n3. Fetch cloud changes / upload local changes:")
+        console.print("   bm cloud pull --name research")
+        console.print("   bm cloud push --name research")
         console.print(
             "\n[dim]Tip: Always use --dry-run first to preview changes before syncing[/dim]"
         )
@@ -216,6 +273,8 @@ def setup() -> None:
     except (RcloneInstallError, BisyncError, CloudAPIError) as e:
         console.print(f"\n[red]Setup failed: {e}[/red]")
         raise typer.Exit(1)
+    except typer.Exit:
+        raise
     except Exception as e:
         console.print(f"\n[red]Unexpected error during setup: {e}[/red]")
         raise typer.Exit(1)

--- a/src/basic_memory/cli/commands/cloud/project_sync.py
+++ b/src/basic_memory/cli/commands/cloud/project_sync.py
@@ -186,9 +186,15 @@ def _require_personal_workspace(
     return workspace
 
 
-async def _get_cloud_project(name: str) -> ProjectItem | None:
-    """Fetch a project by name from the cloud API."""
-    async with get_client(project_name=name) as client:
+async def _get_cloud_project(name: str, *, workspace_id: str | None = None) -> ProjectItem | None:
+    """Fetch a project by name from the cloud API.
+
+    ``workspace_id`` routes the lookup to a specific tenant so the project
+    metadata comes from the same workspace the transfer targets (otherwise
+    get_client would resolve the workspace from config/default and could read a
+    different tenant — see #920 review).
+    """
+    async with get_client(project_name=name, workspace=workspace_id) as client:
         projects_list = await ProjectClient(client).list_projects()
         for proj in projects_list.projects:
             if generate_permalink(proj.name) == generate_permalink(name):
@@ -252,7 +258,10 @@ def sync_project_command(
     _require_personal_workspace(name, config, unsupported_message=TEAM_WORKSPACE_SYNC_UNSUPPORTED)
 
     try:
-        # Get tenant info for bucket name
+        # Get tenant info for bucket name.
+        # TODO(#919): scope to the project's workspace like push/pull. Safe for now
+        # because these mirror commands are gated to the (default-tenant) Personal
+        # workspace, so the default mount info is correct.
         tenant_info = run_with_cleanup(get_mount_info())
         bucket_name = tenant_info.bucket_name
 
@@ -353,9 +362,12 @@ def _run_directional_transfer(
         tenant_info = run_with_cleanup(get_mount_info(workspace_id=target_workspace.tenant_id))
         bucket_name = tenant_info.bucket_name
 
-        # Get project info
+        # Get project info from the same workspace we resolved above, so the
+        # project path and the bucket/remote all refer to one tenant.
         with force_routing(cloud=True):
-            project_data = run_with_cleanup(_get_cloud_project(name))
+            project_data = run_with_cleanup(
+                _get_cloud_project(name, workspace_id=target_workspace.tenant_id)
+            )
         if not project_data:
             console.print(f"[red]Error: Project '{name}' not found[/red]")
             raise typer.Exit(1)
@@ -512,7 +524,10 @@ def bisync_project_command(
     _require_personal_workspace(name, config)
 
     try:
-        # Get tenant info for bucket name
+        # Get tenant info for bucket name.
+        # TODO(#919): scope to the project's workspace like push/pull. Safe for now
+        # because these mirror commands are gated to the (default-tenant) Personal
+        # workspace, so the default mount info is correct.
         tenant_info = run_with_cleanup(get_mount_info())
         bucket_name = tenant_info.bucket_name
 
@@ -570,7 +585,10 @@ def check_project_command(
     _require_cloud_credentials(config)
 
     try:
-        # Get tenant info for bucket name
+        # Get tenant info for bucket name.
+        # TODO(#919): scope to the project's workspace like push/pull. Safe for now
+        # because these mirror commands are gated to the (default-tenant) Personal
+        # workspace, so the default mount info is correct.
         tenant_info = run_with_cleanup(get_mount_info())
         bucket_name = tenant_info.bucket_name
 

--- a/src/basic_memory/cli/commands/cloud/project_sync.py
+++ b/src/basic_memory/cli/commands/cloud/project_sync.py
@@ -26,13 +26,23 @@ from basic_memory.cli.commands.cloud.rclone_commands import (
     project_sync,
     project_transfer,
 )
+from basic_memory.cli.commands.cloud.rclone_config import (
+    DEFAULT_RCLONE_REMOTE,
+    rclone_remote_exists,
+    remote_name_for_workspace,
+)
 from basic_memory.cli.commands.command_utils import run_with_cleanup
 from basic_memory.cli.commands.routing import force_routing
 from basic_memory.config import BasicMemoryConfig, ConfigManager, ProjectEntry
 from basic_memory.mcp.async_client import get_client
 from basic_memory.mcp.clients import ProjectClient
 from basic_memory.mcp.project_context import get_available_workspaces
-from basic_memory.schemas.cloud import WorkspaceInfo
+from basic_memory.schemas.cloud import (
+    WorkspaceInfo,
+    format_workspace_choices,
+    format_workspace_selection_choices,
+    workspace_matches_exact_identifier,
+)
 from basic_memory.schemas.project_info import ProjectItem
 from basic_memory.utils import generate_permalink, normalize_project_path
 
@@ -89,11 +99,40 @@ def _require_cloud_credentials(config: BasicMemoryConfig) -> None:
     raise typer.Exit(1)
 
 
-async def _get_workspace_for_project(name: str, config: BasicMemoryConfig) -> WorkspaceInfo:
-    """Resolve the cloud workspace targeted by a project-scoped sync command."""
+async def _get_workspace_for_project(
+    name: str,
+    config: BasicMemoryConfig,
+    *,
+    workspace_override: str | None = None,
+) -> WorkspaceInfo:
+    """Resolve the cloud workspace targeted by a project-scoped sync command.
+
+    ``workspace_override`` (a slug, name, or tenant_id, e.g. from ``--workspace``)
+    takes precedence over config, letting the user disambiguate a project name
+    that exists in more than one workspace.
+    """
     workspaces = await get_available_workspaces()
     if not workspaces:
         raise ValueError("No accessible cloud workspaces found for this account")
+
+    # An explicit override wins over config — this is how the user disambiguates.
+    if workspace_override is not None:
+        matches = [
+            item
+            for item in workspaces
+            if workspace_matches_exact_identifier(item, workspace_override)
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        if not matches:
+            raise ValueError(
+                f"No accessible workspace matches '{workspace_override}'.\n"
+                f"{format_workspace_choices(workspaces)}"
+            )
+        raise ValueError(
+            f"'{workspace_override}' matches multiple workspaces; use a slug or tenant_id:\n"
+            f"{format_workspace_selection_choices(matches)}"
+        )
 
     entry = config.projects.get(name)
     workspace_id = entry.workspace_id if entry and entry.workspace_id else config.default_workspace
@@ -158,9 +197,16 @@ async def _get_cloud_project(name: str) -> ProjectItem | None:
 
 
 def _get_sync_project(
-    name: str, config: BasicMemoryConfig, project_data: ProjectItem
+    name: str,
+    config: BasicMemoryConfig,
+    project_data: ProjectItem,
+    *,
+    remote_name: str = DEFAULT_RCLONE_REMOTE,
 ) -> tuple[SyncProject, str | None]:
     """Build a SyncProject and resolve local_sync_path from config.
+
+    ``remote_name`` selects which tenant-scoped rclone remote the project routes
+    through (default tenant vs a team workspace remote).
 
     Returns (sync_project, local_sync_path). Exits if no local_sync_path configured.
     """
@@ -177,6 +223,7 @@ def _get_sync_project(
         name=project_data.name,
         path=normalize_project_path(project_data.path),
         local_sync_path=local_sync_path,
+        remote_name=remote_name,
     )
     return sync_project, local_sync_path
 
@@ -259,19 +306,51 @@ def _run_directional_transfer(
     on_conflict: ConflictStrategy,
     dry_run: bool,
     verbose: bool,
+    workspace: str | None = None,
 ) -> None:
     """Shared orchestration for `bm cloud push` / `bm cloud pull`.
 
     Detects conflicts first, then aborts (the default) or applies the chosen
     resolution. Uses additive `rclone copy`, so it never deletes on the
     destination — safe for Team workspaces and therefore not gated.
+
+    Routes through the resolved workspace's own tenant-scoped rclone remote, so a
+    Team project reads/writes the right bucket (see #919).
     """
     config = ConfigManager().config
     _require_cloud_credentials(config)
 
     try:
-        # Get tenant info for bucket name
-        tenant_info = run_with_cleanup(get_mount_info())
+        # --- Resolve the target workspace and its tenant-scoped remote ---
+        # Tigris credentials are bucket/tenant-scoped, so each workspace has its
+        # own rclone remote. Resolve which workspace this project belongs to
+        # (config or --workspace override) before touching any bucket.
+        try:
+            target_workspace = run_with_cleanup(
+                _get_workspace_for_project(name, config, workspace_override=workspace)
+            )
+        except Exception as exc:
+            console.print(f"[red]Error resolving workspace for project '{name}': {exc}[/red]")
+            raise typer.Exit(1)
+
+        remote_name = remote_name_for_workspace(
+            target_workspace.slug, is_default=target_workspace.is_default
+        )
+
+        # Trigger: the workspace's remote has not been configured yet.
+        # Why: provisioning mints tenant-scoped credentials and must be explicit
+        # (no surprise key generation); push/pull only transfer.
+        # Outcome: stop with the exact setup command for this workspace.
+        if not rclone_remote_exists(remote_name):
+            setup_target = (
+                "" if target_workspace.is_default else f" --workspace {target_workspace.slug}"
+            )
+            console.print(f"[red]Workspace '{target_workspace.slug}' is not set up for sync.[/red]")
+            console.print(f"\nRun: bm cloud setup{setup_target}")
+            raise typer.Exit(1)
+
+        # Get tenant info for bucket name, scoped to the resolved workspace
+        tenant_info = run_with_cleanup(get_mount_info(workspace_id=target_workspace.tenant_id))
         bucket_name = tenant_info.bucket_name
 
         # Get project info
@@ -281,7 +360,7 @@ def _run_directional_transfer(
             console.print(f"[red]Error: Project '{name}' not found[/red]")
             raise typer.Exit(1)
 
-        sync_project, _ = _get_sync_project(name, config, project_data)
+        sync_project, _ = _get_sync_project(name, config, project_data, remote_name=remote_name)
 
         # --- Detect before transferring ---
         plan = project_diff(sync_project, bucket_name, direction)
@@ -355,6 +434,11 @@ def pull_project_command(
         "--on-conflict",
         help="Resolve files that differ on both sides (default: fail and list them)",
     ),
+    workspace: str | None = typer.Option(
+        None,
+        "--workspace",
+        help="Workspace (slug, name, or tenant_id) when the project name is ambiguous",
+    ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview changes without pulling"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output"),
 ) -> None:
@@ -368,9 +452,10 @@ def pull_project_command(
       bm cloud pull --name research
       bm cloud pull --name research --dry-run
       bm cloud pull --name research --on-conflict keep-cloud
+      bm cloud pull --name research --workspace acme
     """
     _run_directional_transfer(
-        name, "pull", on_conflict=on_conflict, dry_run=dry_run, verbose=verbose
+        name, "pull", on_conflict=on_conflict, dry_run=dry_run, verbose=verbose, workspace=workspace
     )
 
 
@@ -381,6 +466,11 @@ def push_project_command(
         ConflictStrategy.fail,
         "--on-conflict",
         help="Resolve files that differ on both sides (default: fail and list them)",
+    ),
+    workspace: str | None = typer.Option(
+        None,
+        "--workspace",
+        help="Workspace (slug, name, or tenant_id) when the project name is ambiguous",
     ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview changes without pushing"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output"),
@@ -396,9 +486,10 @@ def push_project_command(
       bm cloud push --name research
       bm cloud push --name research --dry-run
       bm cloud push --name research --on-conflict keep-local
+      bm cloud push --name research --workspace acme
     """
     _run_directional_transfer(
-        name, "push", on_conflict=on_conflict, dry_run=dry_run, verbose=verbose
+        name, "push", on_conflict=on_conflict, dry_run=dry_run, verbose=verbose, workspace=workspace
     )
 
 

--- a/src/basic_memory/cli/commands/cloud/rclone_commands.py
+++ b/src/basic_memory/cli/commands/cloud/rclone_commands.py
@@ -2,7 +2,8 @@
 
 This module provides simplified, project-scoped rclone operations:
 - Each project syncs independently
-- Uses single "basic-memory-cloud" remote (not tenant-specific)
+- Routes through the project's tenant-scoped remote (SyncProject.remote_name);
+  the default tenant keeps "basic-memory-cloud", others use their own (see #919)
 - Balanced defaults from SPEC-8 Phase 4 testing
 - Per-project bisync state tracking
 

--- a/src/basic_memory/cli/commands/cloud/rclone_commands.py
+++ b/src/basic_memory/cli/commands/cloud/rclone_commands.py
@@ -113,11 +113,15 @@ class SyncProject:
         name: Project name
         path: Cloud path (e.g., "app/data/research")
         local_sync_path: Local directory for syncing (optional)
+        remote_name: rclone remote serving this project's tenant bucket. Defaults
+            to the legacy single remote; team/non-default workspaces use their own
+            (see remote_name_for_workspace).
     """
 
     name: str
     path: str
     local_sync_path: Optional[str] = None
+    remote_name: str = "basic-memory-cloud"
 
 
 def get_bmignore_filter_path() -> Path:
@@ -179,10 +183,13 @@ def get_project_remote(project: SyncProject, bucket_name: str) -> str:
         The API returns paths like "/app/data/basic-memory-llc" because the S3 bucket
         is mounted at /app/data on the fly machine. We need to strip the /app/data/
         prefix to get the actual S3 path within the bucket.
+
+        The remote name comes from the project so non-default/team workspaces route
+        through their own tenant-scoped remote (see #919).
     """
     # Normalize path to strip /app/data/ mount point prefix
     cloud_path = normalize_project_path(project.path).lstrip("/")
-    return f"basic-memory-cloud:{bucket_name}/{cloud_path}"
+    return f"{project.remote_name}:{bucket_name}/{cloud_path}"
 
 
 # --- Directional transfer primitives (push / pull) ---

--- a/src/basic_memory/cli/commands/cloud/rclone_config.py
+++ b/src/basic_memory/cli/commands/cloud/rclone_config.py
@@ -61,25 +61,50 @@ def save_rclone_config(config: configparser.ConfigParser) -> None:
     console.print(f"[dim]Updated rclone config: {config_path}[/dim]")
 
 
+# The default remote serves the account's default tenant (back-compat with SPEC-20,
+# which used a single "basic-memory-cloud" remote). Non-default workspaces each get
+# their own remote, since Tigris credentials are bucket/tenant-scoped (see #919).
+DEFAULT_RCLONE_REMOTE = "basic-memory-cloud"
+
+
+def remote_name_for_workspace(slug: str | None, *, is_default: bool) -> str:
+    """Return the rclone remote name for a workspace.
+
+    The default workspace keeps the legacy ``basic-memory-cloud`` remote so
+    existing setups keep working; other workspaces get ``basic-memory-cloud-<slug>``.
+    """
+    if is_default or not slug:
+        return DEFAULT_RCLONE_REMOTE
+    return f"{DEFAULT_RCLONE_REMOTE}-{slug}"
+
+
+def rclone_remote_exists(remote_name: str) -> bool:
+    """Return whether an rclone remote section is already configured."""
+    return load_rclone_config().has_section(remote_name)
+
+
 def configure_rclone_remote(
     access_key: str,
     secret_key: str,
     endpoint: str = "https://fly.storage.tigris.dev",
     region: str = "auto",
+    remote_name: str = DEFAULT_RCLONE_REMOTE,
 ) -> str:
-    """Configure single rclone remote named 'basic-memory-cloud'.
+    """Configure an rclone remote for one tenant's bucket.
 
-    This is the simplified approach from SPEC-20 that uses one remote
-    for all Basic Memory cloud operations (not tenant-specific).
+    Each tenant (personal or team) has its own bucket-scoped credentials, so a
+    remote maps 1:1 to a tenant. The default tenant keeps ``basic-memory-cloud``;
+    other workspaces pass ``remote_name`` from :func:`remote_name_for_workspace`.
 
     Args:
         access_key: S3 access key ID
         secret_key: S3 secret access key
         endpoint: S3-compatible endpoint URL
         region: S3 region (default: auto)
+        remote_name: rclone remote section name to write
 
     Returns:
-        The remote name: "basic-memory-cloud"
+        The remote name that was configured
     """
     # Backup existing config
     backup_rclone_config()
@@ -87,24 +112,21 @@ def configure_rclone_remote(
     # Load existing config
     config = load_rclone_config()
 
-    # Single remote name (not tenant-specific)
-    REMOTE_NAME = "basic-memory-cloud"
-
     # Add/update the remote section
-    if not config.has_section(REMOTE_NAME):
-        config.add_section(REMOTE_NAME)
+    if not config.has_section(remote_name):
+        config.add_section(remote_name)
 
-    config.set(REMOTE_NAME, "type", "s3")
-    config.set(REMOTE_NAME, "provider", "Other")
-    config.set(REMOTE_NAME, "access_key_id", access_key)
-    config.set(REMOTE_NAME, "secret_access_key", secret_key)
-    config.set(REMOTE_NAME, "endpoint", endpoint)
-    config.set(REMOTE_NAME, "region", region)
+    config.set(remote_name, "type", "s3")
+    config.set(remote_name, "provider", "Other")
+    config.set(remote_name, "access_key_id", access_key)
+    config.set(remote_name, "secret_access_key", secret_key)
+    config.set(remote_name, "endpoint", endpoint)
+    config.set(remote_name, "region", region)
     # Prevent unnecessary encoding of filenames (only encode slashes and invalid UTF-8)
     # This prevents files with spaces like "Hello World.md" from being quoted
-    config.set(REMOTE_NAME, "encoding", "Slash,InvalidUtf8")
+    config.set(remote_name, "encoding", "Slash,InvalidUtf8")
     # Save updated config
     save_rclone_config(config)
 
-    console.print(f"[green]Configured rclone remote: {REMOTE_NAME}[/green]")
-    return REMOTE_NAME
+    console.print(f"[green]Configured rclone remote: {remote_name}[/green]")
+    return remote_name

--- a/src/basic_memory/cli/commands/cloud/rclone_config.py
+++ b/src/basic_memory/cli/commands/cloud/rclone_config.py
@@ -1,7 +1,9 @@
 """rclone configuration management for Basic Memory Cloud.
 
-This module provides simplified rclone configuration for SPEC-20.
-Uses a single "basic-memory-cloud" remote for all operations.
+This module owns rclone remote configuration and naming. The default tenant uses
+the "basic-memory-cloud" remote (from SPEC-20); non-default/team workspaces each
+get their own tenant-scoped remote via remote_name_for_workspace (see #919),
+since Tigris credentials are bucket-scoped.
 """
 
 import configparser

--- a/src/basic_memory/cli/commands/cloud/rclone_config.py
+++ b/src/basic_memory/cli/commands/cloud/rclone_config.py
@@ -6,6 +6,7 @@ Uses a single "basic-memory-cloud" remote for all operations.
 
 import configparser
 import os
+import re
 import shutil
 from pathlib import Path
 from typing import Optional
@@ -67,14 +68,29 @@ def save_rclone_config(config: configparser.ConfigParser) -> None:
 DEFAULT_RCLONE_REMOTE = "basic-memory-cloud"
 
 
+# rclone remote section names allow letters, digits, hyphens, and underscores.
+# The slug comes from the cloud API (a trust boundary), so validate it before
+# splicing it into a remote name to avoid a broken/unusable rclone.conf section.
+_SAFE_SLUG = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
 def remote_name_for_workspace(slug: str | None, *, is_default: bool) -> str:
     """Return the rclone remote name for a workspace.
 
     The default workspace keeps the legacy ``basic-memory-cloud`` remote so
     existing setups keep working; other workspaces get ``basic-memory-cloud-<slug>``.
+
+    Raises:
+        RcloneConfigError: If a non-default workspace slug contains characters
+            that are not valid in an rclone remote name.
     """
     if is_default or not slug:
         return DEFAULT_RCLONE_REMOTE
+    if not _SAFE_SLUG.match(slug):
+        raise RcloneConfigError(
+            f"Workspace slug '{slug}' cannot be used as an rclone remote name "
+            "(allowed: letters, digits, hyphens, underscores)."
+        )
     return f"{DEFAULT_RCLONE_REMOTE}-{slug}"
 
 

--- a/tests/cli/cloud/test_project_sync_command.py
+++ b/tests/cli/cloud/test_project_sync_command.py
@@ -387,13 +387,24 @@ def test_bisync_reset_skips_workspace_check_without_credentials(monkeypatch, tmp
     assert "No bisync state found for project 'research'" in result.output
 
 
-def _stub_transfer_env(monkeypatch, module, *, plan, transfer_result=True, recorder=None):
+def _stub_transfer_env(
+    monkeypatch, module, *, plan, transfer_result=True, recorder=None, workspace=None
+):
     """Stub the push/pull dependency chain so only diff/transfer logic is exercised."""
     monkeypatch.setattr(module, "_require_cloud_credentials", lambda _config: None)
+    ws = workspace or _workspace("personal-tenant", "personal", "personal", is_default=True)
+    monkeypatch.setattr(
+        module,
+        "_get_workspace_for_project",
+        lambda _name, _config, **_kwargs: _async_value(ws),
+    )
+    monkeypatch.setattr(module, "rclone_remote_exists", lambda _remote: True)
     monkeypatch.setattr(
         module,
         "get_mount_info",
-        lambda: _async_value(SimpleNamespace(bucket_name="tenant-bucket")),
+        lambda **_kwargs: _async_value(
+            SimpleNamespace(bucket_name="tenant-bucket", tenant_id=ws.tenant_id)
+        ),
     )
     monkeypatch.setattr(
         module,
@@ -403,7 +414,10 @@ def _stub_transfer_env(monkeypatch, module, *, plan, transfer_result=True, recor
     monkeypatch.setattr(
         module,
         "_get_sync_project",
-        lambda _name, _config, _project_data: (SimpleNamespace(name="research"), "/tmp/research"),
+        lambda _name, _config, _project_data, **kwargs: (
+            SimpleNamespace(name="research", remote_name=kwargs.get("remote_name")),
+            "/tmp/research",
+        ),
     )
     monkeypatch.setattr(module, "project_diff", lambda *args, **kwargs: plan)
 
@@ -510,31 +524,118 @@ def test_cloud_push_keep_local_resolves_conflict(monkeypatch, config_manager):
 
 
 def test_cloud_push_allows_organization_workspace(monkeypatch, config_manager):
-    """push is additive and Team-safe — it must not invoke the Personal-only guard."""
+    """push is additive and Team-safe — an organization workspace is allowed (no Personal gate)."""
     module = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
 
-    config = config_manager.load_config()
-    config.cloud_api_key = "bmc_test"
-    config.projects["research"] = ProjectEntry(
-        path="/tmp/research",
-        mode=ProjectMode.CLOUD,
-        workspace_id="team-tenant",
-        local_sync_path="/tmp/research",
-    )
-    config_manager.save_config(config)
-
+    org_ws = _workspace("team-tenant", "organization", "acme", is_default=False)
     plan = TransferPlan(new=["new.md"], conflicts=[], dest_only=[], errors=[])
-    _stub_transfer_env(monkeypatch, module, plan=plan)
-    monkeypatch.setattr(
-        module,
-        "get_available_workspaces",
-        lambda: pytest.fail("push/pull must not gate on workspace type"),
-    )
+    recorder: dict = {}
+    _stub_transfer_env(monkeypatch, module, plan=plan, recorder=recorder, workspace=org_ws)
 
     result = runner.invoke(app, ["cloud", "push", "--name", "research"])
 
     assert result.exit_code == 0, result.output
     assert "research push completed successfully" in result.output
+    # Routed through the team workspace's own remote, against its tenant's bucket.
+    assert recorder["args"][0].remote_name == "basic-memory-cloud-acme"
+
+
+def test_cloud_push_errors_when_workspace_remote_not_set_up(monkeypatch, config_manager):
+    """If the workspace's remote isn't configured, push stops with the setup command."""
+    module = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
+
+    org_ws = _workspace("team-tenant", "organization", "acme", is_default=False)
+    plan = TransferPlan(new=["new.md"], conflicts=[], dest_only=[], errors=[])
+    recorder: dict = {}
+    _stub_transfer_env(monkeypatch, module, plan=plan, recorder=recorder, workspace=org_ws)
+    # Override: this workspace has not been set up yet.
+    monkeypatch.setattr(module, "rclone_remote_exists", lambda _remote: False)
+
+    result = runner.invoke(app, ["cloud", "push", "--name", "research"])
+
+    assert result.exit_code == 1, result.output
+    output = " ".join(result.output.split())
+    assert "not set up for sync" in output
+    assert "bm cloud setup --workspace acme" in output
+    assert "args" not in recorder  # never transferred
+
+
+def test_get_workspace_for_project_override_resolves(monkeypatch, config_manager):
+    """An explicit --workspace override selects that workspace regardless of config."""
+    module = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
+    config = config_manager.load_config()
+    monkeypatch.setattr(
+        module,
+        "get_available_workspaces",
+        lambda: _async_value(
+            [
+                _workspace("personal-tenant", "personal", "personal", is_default=True),
+                _workspace("team-tenant", "organization", "acme"),
+            ]
+        ),
+    )
+
+    ws = module.run_with_cleanup(
+        module._get_workspace_for_project("research", config, workspace_override="acme")
+    )
+
+    assert ws.tenant_id == "team-tenant"
+
+
+def test_get_workspace_for_project_override_no_match_raises(monkeypatch, config_manager):
+    """An override that matches no accessible workspace is a clear error."""
+    module = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
+    config = config_manager.load_config()
+    monkeypatch.setattr(
+        module,
+        "get_available_workspaces",
+        lambda: _async_value(
+            [_workspace("personal-tenant", "personal", "personal", is_default=True)]
+        ),
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        module.run_with_cleanup(
+            module._get_workspace_for_project("research", config, workspace_override="acme")
+        )
+
+    assert "No accessible workspace matches 'acme'" in str(exc_info.value)
+
+
+def test_cloud_setup_workspace_configures_named_remote(monkeypatch):
+    """`bm cloud setup --workspace acme` provisions the acme tenant's own remote."""
+    core = importlib.import_module("basic_memory.cli.commands.cloud.core_commands")
+    recorder: dict = {}
+
+    monkeypatch.setattr(core, "install_rclone", lambda: None)
+    monkeypatch.setattr(
+        core,
+        "get_available_workspaces",
+        lambda: _async_value([_workspace("team-tenant", "organization", "acme")]),
+    )
+    monkeypatch.setattr(
+        core,
+        "get_mount_info",
+        lambda **_kwargs: _async_value(
+            SimpleNamespace(tenant_id="team-tenant", bucket_name="acme-bucket")
+        ),
+    )
+    monkeypatch.setattr(
+        core,
+        "generate_mount_credentials",
+        lambda _tenant_id: _async_value(SimpleNamespace(access_key="ak", secret_key="sk")),
+    )
+
+    def _fake_configure(**kwargs):
+        recorder.update(kwargs)
+        return kwargs.get("remote_name")
+
+    monkeypatch.setattr(core, "configure_rclone_remote", _fake_configure)
+
+    result = runner.invoke(app, ["cloud", "setup", "--workspace", "acme"])
+
+    assert result.exit_code == 0, result.output
+    assert recorder["remote_name"] == "basic-memory-cloud-acme"
 
 
 async def _async_value(value):

--- a/tests/cli/cloud/test_project_sync_command.py
+++ b/tests/cli/cloud/test_project_sync_command.py
@@ -409,7 +409,7 @@ def _stub_transfer_env(
     monkeypatch.setattr(
         module,
         "_get_cloud_project",
-        lambda _name: _async_value(SimpleNamespace(name="research", path="research")),
+        lambda _name, **_kwargs: _async_value(SimpleNamespace(name="research", path="research")),
     )
     monkeypatch.setattr(
         module,
@@ -538,6 +538,29 @@ def test_cloud_push_allows_organization_workspace(monkeypatch, config_manager):
     assert "research push completed successfully" in result.output
     # Routed through the team workspace's own remote, against its tenant's bucket.
     assert recorder["args"][0].remote_name == "basic-memory-cloud-acme"
+
+
+def test_cloud_pull_workspace_override_routes_through_workspace_remote(monkeypatch, config_manager):
+    """pull --workspace routes through the named workspace's own remote and bucket."""
+    module = importlib.import_module("basic_memory.cli.commands.cloud.project_sync")
+
+    org_ws = _workspace("team-tenant", "organization", "acme", is_default=False)
+    plan = TransferPlan(new=["new.md"], conflicts=[], dest_only=[], errors=[])
+    recorder: dict = {}
+
+    # _get_workspace_for_project must receive the override and return the org workspace.
+    def _resolve(_name, _config, *, workspace_override=None):
+        assert workspace_override == "acme"
+        return _async_value(org_ws)
+
+    _stub_transfer_env(monkeypatch, module, plan=plan, recorder=recorder, workspace=org_ws)
+    monkeypatch.setattr(module, "_get_workspace_for_project", _resolve)
+
+    result = runner.invoke(app, ["cloud", "pull", "--name", "research", "--workspace", "acme"])
+
+    assert result.exit_code == 0, result.output
+    assert recorder["args"][0].remote_name == "basic-memory-cloud-acme"
+    assert recorder["args"][2] == "pull"
 
 
 def test_cloud_push_errors_when_workspace_remote_not_set_up(monkeypatch, config_manager):

--- a/tests/cli/cloud/test_rclone_config_and_bmignore_filters.py
+++ b/tests/cli/cloud/test_rclone_config_and_bmignore_filters.py
@@ -4,6 +4,8 @@ from basic_memory.cli.commands.cloud.bisync_commands import convert_bmignore_to_
 from basic_memory.cli.commands.cloud.rclone_config import (
     configure_rclone_remote,
     get_rclone_config_path,
+    rclone_remote_exists,
+    remote_name_for_workspace,
 )
 from basic_memory.ignore_utils import get_bmignore_path
 
@@ -111,3 +113,28 @@ def test_configure_rclone_remote_writes_config_and_backs_up_existing(config_home
     # Backup exists
     backups = list(cfg_path.parent.glob("rclone.conf.backup-*"))
     assert backups, "expected a backup of rclone.conf to be created"
+
+
+def test_remote_name_for_workspace():
+    # Default workspace keeps the legacy remote name (back-compat)
+    assert remote_name_for_workspace("personal", is_default=True) == "basic-memory-cloud"
+    assert remote_name_for_workspace(None, is_default=False) == "basic-memory-cloud"
+    # Non-default workspaces get their own tenant-scoped remote
+    assert remote_name_for_workspace("acme", is_default=False) == "basic-memory-cloud-acme"
+
+
+def test_configure_rclone_remote_named_workspace_remote(config_home):
+    remote = configure_rclone_remote(
+        access_key="ak", secret_key="sk", remote_name="basic-memory-cloud-acme"
+    )
+    assert remote == "basic-memory-cloud-acme"
+
+    text = get_rclone_config_path().read_text(encoding="utf-8")
+    assert "[basic-memory-cloud-acme]" in text
+    assert "access_key_id = ak" in text
+
+
+def test_rclone_remote_exists(config_home):
+    assert rclone_remote_exists("basic-memory-cloud-acme") is False
+    configure_rclone_remote(access_key="ak", secret_key="sk", remote_name="basic-memory-cloud-acme")
+    assert rclone_remote_exists("basic-memory-cloud-acme") is True

--- a/tests/cli/cloud/test_rclone_config_and_bmignore_filters.py
+++ b/tests/cli/cloud/test_rclone_config_and_bmignore_filters.py
@@ -1,7 +1,10 @@
 import time
 
+import pytest
+
 from basic_memory.cli.commands.cloud.bisync_commands import convert_bmignore_to_rclone_filters
 from basic_memory.cli.commands.cloud.rclone_config import (
+    RcloneConfigError,
     configure_rclone_remote,
     get_rclone_config_path,
     rclone_remote_exists,
@@ -121,6 +124,14 @@ def test_remote_name_for_workspace():
     assert remote_name_for_workspace(None, is_default=False) == "basic-memory-cloud"
     # Non-default workspaces get their own tenant-scoped remote
     assert remote_name_for_workspace("acme", is_default=False) == "basic-memory-cloud-acme"
+
+
+def test_remote_name_for_workspace_rejects_unsafe_slug():
+    # A slug from the API with characters invalid in an rclone remote name must
+    # fail fast rather than write a broken rclone.conf section.
+    for bad in ["a/b", "has space", "dot.dot", "weird:name"]:
+        with pytest.raises(RcloneConfigError):
+            remote_name_for_workspace(bad, is_default=False)
 
 
 def test_configure_rclone_remote_named_workspace_remote(config_home):

--- a/tests/test_rclone_commands.py
+++ b/tests/test_rclone_commands.py
@@ -87,6 +87,19 @@ def test_get_project_remote():
     assert get_project_remote(project, "my-bucket") == "basic-memory-cloud:my-bucket/research"
 
 
+def test_get_project_remote_uses_workspace_remote():
+    # Non-default/team workspaces route through their own tenant-scoped remote.
+    project = SyncProject(name="research", path="/research", remote_name="basic-memory-cloud-acme")
+    assert (
+        get_project_remote(project, "acme-bucket") == "basic-memory-cloud-acme:acme-bucket/research"
+    )
+
+
+def test_sync_project_remote_name_defaults_to_legacy_remote():
+    project = SyncProject(name="research", path="/research")
+    assert project.remote_name == "basic-memory-cloud"
+
+
 def test_get_project_remote_strips_app_data_prefix():
     project = SyncProject(name="research", path="/app/data/research")
     assert get_project_remote(project, "my-bucket") == "basic-memory-cloud:my-bucket/research"


### PR DESCRIPTION
## Summary

Route `bm cloud push`/`pull` through the resolved workspace's **own tenant-scoped rclone remote**, so projects in non-default / Team workspaces read and write the correct Tigris bucket. Closes the Codex **P1** review note on #917. Design + research: #919.

Keys stay **tenant-scoped** (option A); each accessible tenant gets its own remote.

## Why

Tigris IAM keys are bucket/tenant-scoped (one tenant = one bucket — confirmed against the cloud DB model and the [Tigris IAM docs](https://www.tigrisdata.com/docs/iam/) / [Fly Tigris docs](https://fly.io/docs/tigris/)). The CLI used a single `basic-memory-cloud` remote configured with the **default tenant's** credentials, and `get_mount_info()` was called with no workspace context — so push/pull against a Team-workspace project would target the wrong bucket. The cloud mount endpoints already honor `X-Workspace-ID` (resolve workspace → validate membership + subscription → return that tenant's bucket-scoped creds), so the fix is client-side.

## What

- **`bisync_commands`** — `get_mount_info(workspace_id=...)` and `generate_mount_credentials(tenant_id)` send `X-Workspace-ID` (omitted → default tenant, unchanged).
- **`rclone_config`** — `remote_name_for_workspace` (default tenant keeps `basic-memory-cloud`; others get `basic-memory-cloud-<slug>`), `rclone_remote_exists`, and `configure_rclone_remote(remote_name=...)`.
- **`rclone_commands`** — `SyncProject.remote_name`; `get_project_remote` routes through it.
- **`core_commands`** — `bm cloud setup --workspace <slug|name|tenant_id>` provisions a per-workspace remote. Provisioning is **explicit and once** — avoids re-minting (and leaking) keys for legacy tenants whose `/tenant/mount/credentials` mints a fresh key each call.
- **`project_sync`** — push/pull resolve the project's workspace (config, or a new `--workspace` override with disambiguation by `tenant_id`/`slug`), select that workspace's remote, **error with the exact `bm cloud setup --workspace …` hint** if it isn't configured, and scope mount info to the workspace's tenant.

```
$ bm cloud pull --name team-notes
Workspace 'acme' is not set up for sync.
  Run: bm cloud setup --workspace acme

$ bm cloud setup --workspace acme
Configured rclone remote: basic-memory-cloud-acme
$ bm cloud pull --name team-notes   # routes through basic-memory-cloud-acme → acme bucket
```

## Scope / follow-ups

- `sync`/`bisync`/`check` still use the default remote (they're Personal-only); extending them to per-workspace remotes is a follow-up.
- Workspace resolution uses config + `--workspace` override (not a cross-workspace name search); `--workspace` covers same-name disambiguation.
- Backend hygiene (noted in #919): `tenant_mount_credentials.tenant_id` lacks a FK to `tenant(id)` — add it in basic-memory-cloud.

## Test plan

- [x] `rclone_config`: `remote_name_for_workspace`, named-remote write, `rclone_remote_exists`.
- [x] `rclone_commands`: `get_project_remote` honors `SyncProject.remote_name`; default remote unchanged.
- [x] `project_sync`: push/pull route a Team workspace through `basic-memory-cloud-<slug>`; error + setup hint when the remote is missing; `--workspace` override resolution (match / no-match).
- [x] `core_commands`: `bm cloud setup --workspace acme` configures `basic-memory-cloud-acme`.
- [x] 117 unit tests pass; `ty` + `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
