### PR TITLE
fix(cli): don't let bm cloud setup overwrite an existing rclone remote

### DIFF
--- a/src/basic_memory/cli/commands/cloud/core_commands.py
+++ b/src/basic_memory/cli/commands/cloud/core_commands.py
@@ -247,9 +247,9 @@ def setup(
 
         # Trigger: the target rclone remote already exists.
         # Why: re-running setup mints new credentials and overwrites the remote,
-        # silently repointing it (e.g. clobbering the shared basic-memory-cloud
-        # that served another tenant) — the #922 footgun. Checked BEFORE minting
-        # so an abort wastes no credentials.
+        # which would silently repoint it — e.g. clobbering the shared
+        # basic-memory-cloud remote that served another tenant. Checked BEFORE
+        # minting so an abort wastes no credentials.
         # Outcome: stop unless the user explicitly opts in with --force.
         if rclone_remote_exists(remote_name) and not force:
             console.print(f"[red]rclone remote '{remote_name}' is already configured.[/red]")

--- a/src/basic_memory/cli/commands/cloud/core_commands.py
+++ b/src/basic_memory/cli/commands/cloud/core_commands.py
@@ -28,6 +28,7 @@ from basic_memory.cli.commands.cloud.bisync_commands import (
 )
 from basic_memory.cli.commands.cloud.rclone_config import (
     configure_rclone_remote,
+    rclone_remote_exists,
     remote_name_for_workspace,
 )
 from basic_memory.cli.commands.cloud.rclone_installer import (
@@ -207,6 +208,11 @@ def setup(
         help="Set up sync for a specific workspace (slug, name, or tenant_id). "
         "Omit for your default workspace.",
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Reconfigure an rclone remote that already exists (mints new credentials).",
+    ),
 ) -> None:
     """Set up cloud sync by installing rclone and configuring credentials.
 
@@ -238,6 +244,20 @@ def setup(
         else:
             workspace_id = None  # default tenant
             remote_name = remote_name_for_workspace(None, is_default=True)
+
+        # Trigger: the target rclone remote already exists.
+        # Why: re-running setup mints new credentials and overwrites the remote,
+        # silently repointing it (e.g. clobbering the shared basic-memory-cloud
+        # that served another tenant) — the #922 footgun. Checked BEFORE minting
+        # so an abort wastes no credentials.
+        # Outcome: stop unless the user explicitly opts in with --force.
+        if rclone_remote_exists(remote_name) and not force:
+            console.print(f"[red]rclone remote '{remote_name}' is already configured.[/red]")
+            console.print(
+                "Re-running setup mints new credentials and overwrites it. "
+                "Pass --force to reconfigure."
+            )
+            raise typer.Exit(1)
 
         # Step 2: Get tenant info (scoped to the target workspace when given)
         console.print("\n[blue]Step 2: Getting tenant information...[/blue]")

--- a/tests/cli/cloud/test_project_sync_command.py
+++ b/tests/cli/cloud/test_project_sync_command.py
@@ -625,17 +625,21 @@ def test_get_workspace_for_project_override_no_match_raises(monkeypatch, config_
     assert "No accessible workspace matches 'acme'" in str(exc_info.value)
 
 
-def test_cloud_setup_workspace_configures_named_remote(monkeypatch):
-    """`bm cloud setup --workspace acme` provisions the acme tenant's own remote."""
-    core = importlib.import_module("basic_memory.cli.commands.cloud.core_commands")
-    recorder: dict = {}
-
+def _stub_setup_env(monkeypatch, core, *, remote_exists=False, recorder=None):
+    """Stub the `bm cloud setup` dependency chain for the acme workspace."""
     monkeypatch.setattr(core, "install_rclone", lambda: None)
     monkeypatch.setattr(
         core,
         "get_available_workspaces",
         lambda: _async_value([_workspace("team-tenant", "organization", "acme")]),
     )
+    monkeypatch.setattr(core, "rclone_remote_exists", lambda _remote: remote_exists)
+
+    def _mint(_tenant_id):
+        if recorder is not None:
+            recorder["minted"] = True
+        return _async_value(SimpleNamespace(access_key="ak", secret_key="sk"))
+
     monkeypatch.setattr(
         core,
         "get_mount_info",
@@ -643,22 +647,56 @@ def test_cloud_setup_workspace_configures_named_remote(monkeypatch):
             SimpleNamespace(tenant_id="team-tenant", bucket_name="acme-bucket")
         ),
     )
-    monkeypatch.setattr(
-        core,
-        "generate_mount_credentials",
-        lambda _tenant_id: _async_value(SimpleNamespace(access_key="ak", secret_key="sk")),
-    )
+    monkeypatch.setattr(core, "generate_mount_credentials", _mint)
 
     def _fake_configure(**kwargs):
-        recorder.update(kwargs)
+        if recorder is not None:
+            recorder.update(kwargs)
         return kwargs.get("remote_name")
 
     monkeypatch.setattr(core, "configure_rclone_remote", _fake_configure)
+
+
+def test_cloud_setup_workspace_configures_named_remote(monkeypatch):
+    """`bm cloud setup --workspace acme` provisions the acme tenant's own remote."""
+    core = importlib.import_module("basic_memory.cli.commands.cloud.core_commands")
+    recorder: dict = {}
+    _stub_setup_env(monkeypatch, core, remote_exists=False, recorder=recorder)
 
     result = runner.invoke(app, ["cloud", "setup", "--workspace", "acme"])
 
     assert result.exit_code == 0, result.output
     assert recorder["remote_name"] == "basic-memory-cloud-acme"
+
+
+def test_cloud_setup_aborts_when_remote_exists_without_force(monkeypatch):
+    """Setup refuses to overwrite an existing remote, and mints nothing (the #922 footgun)."""
+    core = importlib.import_module("basic_memory.cli.commands.cloud.core_commands")
+    recorder: dict = {}
+    _stub_setup_env(monkeypatch, core, remote_exists=True, recorder=recorder)
+
+    result = runner.invoke(app, ["cloud", "setup", "--workspace", "acme"])
+
+    assert result.exit_code == 1, result.output
+    output = " ".join(result.output.split())
+    assert "basic-memory-cloud-acme' is already configured" in output
+    assert "--force" in output
+    # Aborted before minting credentials or touching the remote.
+    assert "minted" not in recorder
+    assert "remote_name" not in recorder
+
+
+def test_cloud_setup_force_overwrites_existing_remote(monkeypatch):
+    """--force reconfigures an existing remote."""
+    core = importlib.import_module("basic_memory.cli.commands.cloud.core_commands")
+    recorder: dict = {}
+    _stub_setup_env(monkeypatch, core, remote_exists=True, recorder=recorder)
+
+    result = runner.invoke(app, ["cloud", "setup", "--workspace", "acme", "--force"])
+
+    assert result.exit_code == 0, result.output
+    assert recorder["remote_name"] == "basic-memory-cloud-acme"
+    assert recorder.get("minted") is True
 
 
 async def _async_value(value):

--- a/tests/cli/cloud/test_project_sync_command.py
+++ b/tests/cli/cloud/test_project_sync_command.py
@@ -699,6 +699,22 @@ def test_cloud_setup_force_overwrites_existing_remote(monkeypatch):
     assert recorder.get("minted") is True
 
 
+def test_cloud_setup_default_workspace_aborts_when_remote_exists(monkeypatch):
+    """The original footgun: `bm cloud setup` (no --workspace) must not clobber
+    the shared basic-memory-cloud remote without --force."""
+    core = importlib.import_module("basic_memory.cli.commands.cloud.core_commands")
+    recorder: dict = {}
+    _stub_setup_env(monkeypatch, core, remote_exists=True, recorder=recorder)
+
+    result = runner.invoke(app, ["cloud", "setup"])  # no --workspace → basic-memory-cloud
+
+    assert result.exit_code == 1, result.output
+    output = " ".join(result.output.split())
+    assert "'basic-memory-cloud' is already configured" in output
+    assert "minted" not in recorder  # nothing minted on abort
+    assert "remote_name" not in recorder
+
+
 async def _async_value(value):
     return value
 


### PR DESCRIPTION
## Summary

`bm cloud setup [--workspace X]` re-minted credentials and **silently overwrote** the target rclone remote. The dangerous case (surfaced while live-testing #920): a workspace with `is_default=True` maps to the shared `basic-memory-cloud` remote, so `bm cloud setup --workspace <default-org>` repointed `basic-memory-cloud` from one tenant's key to another with no warning — breaking any sync that relied on it.

Closes #922.

## Fix

`setup` now **aborts if the target rclone remote already exists**, unless `--force` is passed. The check runs **before** `get_mount_info` / `generate_mount_credentials`, so an aborted run mints no credentials (avoids adding to the key-leak).

```
$ bm cloud setup --workspace acme
rclone remote 'basic-memory-cloud-acme' is already configured.
Re-running setup mints new credentials and overwrites it. Pass --force to reconfigure.

$ bm cloud setup --workspace acme --force      # explicit reconfigure
  → Configured rclone remote: basic-memory-cloud-acme
```

## Out of scope (backend follow-up, tracked in #922)

The credential **leak** — re-minting via `POST /tenant/mount/credentials` leaves the prior key live on the tenant bucket (legacy tenants) — needs a backend change (revoke-on-remint or reuse) in `basic-memory-cloud`.

## Test plan

- [x] `setup --workspace acme` with no existing remote → configures `basic-memory-cloud-acme`.
- [x] `setup --workspace acme` with existing remote, no `--force` → aborts, exit 1, **mints nothing** and doesn't touch the remote.
- [x] `setup --workspace acme --force` with existing remote → reconfigures.
- [x] 116 cloud/rclone unit tests pass; `ty` + `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BM_BOSSBOT_SUMMARY:start -->
Reviewed SHA: `49d094054a3c2933723e435072de3b1167922336`
Verdict: `approve`
Status: `success` - BM Bossbot approved this head SHA

Summary:
Reviewed the full provided diff for head 49d094054a3c2933723e435072de3b1167922336 against the Basic Memory review priorities and engineering style. The setup guard resolves the target remote before credential minting, refuses existing rclone remotes unless --force is explicit, preserves forced reconfiguration, and adds focused regression coverage for named workspace and default shared-remote overwrite paths. No blocking correctness, security, packaging, workflow, test, or compatibility issues found.

Blocking findings:
- None

Non-blocking findings:
- None
<!-- BM_BOSSBOT_SUMMARY:end -->

<!-- pr-infographic:start -->
![BM Bossbot image for PR #923](https://raw.githubusercontent.com/basicmachines-co/basic-memory/pr-assets/fix-cloud-setup-remote-overwrite/docs/assets/infographics/pr-923.webp)
<!-- pr-infographic:end -->

<!-- BM_INFOGRAPHIC_PROVENANCE:start -->
<details>
<summary>BM Bossbot image choices</summary>

- Pull request: `#923`
- Generated asset: `/home/runner/work/basic-memory/basic-memory/docs/assets/infographics/pr-923.webp`
- Image model: `gpt-image-2`
- Size: `1536x1024`
- Quality: `high`
- Image mode: `editorial-image`
- Theme source: `auto`

Theme / visual direction:
<pre><code>French new wave movie poster: stark typography, city streets, jump-cut composition, and high-contrast editorial photography cues</code></pre>

</details>
<!-- BM_INFOGRAPHIC_PROVENANCE:end -->


