### PR TITLE
test(mcp): integration coverage for colliding observation permalinks (index + delete)

### DIFF
--- a/test-int/mcp/test_observation_permalink_collision_integration.py
+++ b/test-int/mcp/test_observation_permalink_collision_integration.py
@@ -1,0 +1,141 @@
+"""Regression tests for https://github.com/basicmachines-co/basic-memory/issues/909.
+
+Observation content is truncated to 200 chars when building the synthetic
+permalink (Postgres btree index limit), so distinct observations sharing a
+category and a 200-char content prefix used to collide and the second one was
+silently dropped from the search index, making it unfindable. #931 fixed this
+by appending a content digest to the truncated permalink.
+
+These tests pin the end-to-end behavior independent of the disambiguation
+mechanism: every observation stays searchable, and deleting the note removes
+every index row — including rows whose permalinks needed disambiguation.
+"""
+
+import json
+from typing import Any
+
+import pytest
+from fastmcp import Client
+
+
+def _json_content(tool_result) -> Any:
+    """Parse a FastMCP tool result content block into JSON."""
+    assert len(tool_result.content) == 1
+    assert tool_result.content[0].type == "text"
+    return json.loads(tool_result.content[0].text)  # pyright: ignore [reportAttributeAccessIssue]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_category_content_observations_both_searchable(
+    mcp_server, app, test_project
+):
+    """Both observations must be indexed even when their synthetic permalinks collide."""
+    async with Client(mcp_server) as client:
+        prefix = "x" * 210  # > 200 so the truncated permalink prefixes are identical
+        content = (
+            "# Dup Obs Note\n\n"
+            "## Observations\n"
+            f"- [note] {prefix} ALPHA_UNIQUE_MARKER\n"
+            f"- [note] {prefix} BETA_UNIQUE_MARKER\n"
+        )
+        await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Dup Obs Note",
+                "directory": "dup",
+                "content": content,
+            },
+        )
+
+        # Both observations should be independently findable by their unique suffix
+        for marker in ("ALPHA_UNIQUE_MARKER", "BETA_UNIQUE_MARKER"):
+            result = await client.call_tool(
+                "search_notes",
+                {
+                    "project": test_project.name,
+                    "query": marker,
+                    "search_type": "text",
+                    "entity_types": ["observation"],
+                    "output_format": "json",
+                },
+            )
+            data = _json_content(result)
+            snippets = [r.get("content") or "" for r in data["results"]]
+            assert any(marker in s for s in snippets), (
+                f"observation containing {marker} was dropped from the search index "
+                "due to a synthetic-permalink collision (content truncated to 200 chars). "
+                "results=" + json.dumps(data, default=str)[:800]
+            )
+
+
+@pytest.mark.asyncio
+async def test_delete_note_with_colliding_observations_leaves_no_ghost_rows(
+    mcp_server, app, test_project, search_service
+):
+    """Deleting a note must clean up disambiguated observation index rows.
+
+    search_index has no FK cascade from entity, so any index-time permalink
+    disambiguation must be matched by delete-time cleanup or the extra
+    observation survives in the search index as a ghost row pointing at the
+    deleted file.
+
+    The post-delete assertions inspect the index through ``search_service``
+    rather than the ``search_notes`` tool: the MCP search pipeline happens to
+    hide rows whose entity is gone, which would mask the orphan.
+    """
+    from basic_memory.schemas.search import SearchQuery
+
+    async with Client(mcp_server) as client:
+        prefix = "y" * 210  # > 200 so the truncated permalink prefixes are identical
+        content = (
+            "# Ghost Obs Note\n\n"
+            "## Observations\n"
+            f"- [note] {prefix} GHOST_ALPHA_MARKER\n"
+            f"- [note] {prefix} GHOST_BETA_MARKER\n"
+        )
+        await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Ghost Obs Note",
+                "directory": "ghost",
+                "content": content,
+            },
+        )
+
+        # Both observations are searchable before deletion
+        for marker in ("GHOST_ALPHA_MARKER", "GHOST_BETA_MARKER"):
+            result = await client.call_tool(
+                "search_notes",
+                {
+                    "project": test_project.name,
+                    "query": marker,
+                    "search_type": "text",
+                    "entity_types": ["observation"],
+                    "output_format": "json",
+                },
+            )
+            data = _json_content(result)
+            assert any(marker in (r.get("content") or "") for r in data["results"])
+
+        # Both rows exist in the search index itself under distinct permalinks
+        index_rows = await search_service.search(SearchQuery(text="GHOST_BETA_MARKER"))
+        assert any(r.type == "observation" for r in index_rows)
+
+        delete_result = await client.call_tool(
+            "delete_note",
+            {
+                "project": test_project.name,
+                "identifier": "Ghost Obs Note",
+            },
+        )
+        assert "true" in delete_result.content[0].text.lower()  # pyright: ignore [reportAttributeAccessIssue]
+
+        # No ghost rows remain in the index - including any disambiguated row
+        for marker in ("GHOST_ALPHA_MARKER", "GHOST_BETA_MARKER"):
+            index_rows = await search_service.search(SearchQuery(text=marker))
+            assert index_rows == [], (
+                f"search index row containing {marker} survived note deletion as a ghost: "
+                f"{[(r.type, r.permalink) for r in index_rows]}"
+            )


### PR DESCRIPTION
Refs #909

## Summary

Reworked per @phernandez's comment: #931 merged the fix for #909 first (digest-suffixed observation permalinks), so this PR now carries only the **additive integration coverage** — the source changes and unit tests that would double-handle the collision are dropped.

Two end-to-end MCP tests (`test-int/mcp/test_observation_permalink_collision_integration.py`) that pin the behavior independent of the disambiguation mechanism:

1. **Both colliding observations stay searchable** — two observations sharing a category and a 200-char content prefix are independently findable via `search_notes` (the original #909 repro, green since #931).
2. **`delete_note` leaves no ghost index rows** — `search_index` has no FK cascade from entity, so index-time permalink disambiguation must be matched by delete-time cleanup or the extra observation survives as a ghost row pointing at the deleted file. Post-delete assertions inspect the index via `search_service` directly, because the MCP search pipeline hides rows whose entity is gone — which would mask exactly the orphan this test guards against (that hiding behavior may deserve its own look).

The delete/ghost scenario is the one our earlier review round demonstrated empirically against an `-{obs.id}`-style fix; #931's recomputable digest permalinks handle it correctly, and this test keeps it that way.

## Test plan

- `uv run pytest test-int/mcp/test_observation_permalink_collision_integration.py` — 2 passed against current main
- `ruff check` / `ruff format --check` clean
- Branch rebuilt as a single signed-off commit on top of main (DCO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BM_BOSSBOT_SUMMARY:start -->
Reviewed SHA: `5cdc109ef0ddc64da9f013f1f3382cf5e7805ae9`
Verdict: `approve`
Status: `success` - BM Bossbot approved this head SHA

Summary:
Reviewed the full provided diff. The added integration coverage exercises the MCP write/search/delete flow and uses the direct search service only for the post-delete orphan-index assertion, which is an appropriate oracle for this regression. No blocking issues found.

Blocking findings:
- None

Non-blocking findings:
- None
<!-- BM_BOSSBOT_SUMMARY:end -->
