### PR TITLE
docs(skills): fix npx skill install docs and ignore docs assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ ENV/
 /docs/.obsidian/
 /examples/.obsidian/
 /examples/.basic-memory/
-
+/docs/assets
 
 # claude action
 claude-output

--- a/README.md
+++ b/README.md
@@ -216,14 +216,14 @@ Source: [`plugins/claude-code`](plugins/claude-code).
 ### Shared skills
 
 Framework-agnostic `SKILL.md` files live in [`skills/`](skills). If your
-Skills CLI supports subpath installs:
+Skills CLI supports repository subdirectory sources:
 
 ```bash
-npx skills add basicmachines-co/basic-memory --path skills
+npx skills add basicmachines-co/basic-memory/skills
 ```
 
-If it does not, copy the `memory-*` directories from `skills/` into your
-agent's skills directory as a temporary Phase 1 install path.
+If your installed Skills CLI cannot load that source, update the CLI or copy
+the `memory-*` directories from `skills/` into your agent's skills directory.
 
 ### Hermes
 

--- a/integrations/openclaw/MEMORY_TASK_FLOW.md
+++ b/integrations/openclaw/MEMORY_TASK_FLOW.md
@@ -150,7 +150,7 @@ This plugin ships with workflow-oriented skills that are automatically loaded wh
 No manual installation needed. To update skills or install new ones as they become available:
 
 ```bash
-npx skills add basicmachines-co/basic-memory --path skills --agent openclaw
+npx skills add basicmachines-co/basic-memory/skills --agent openclaw
 ```
 
 See the canonical source at [`basic-memory/skills`](../../skills).

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -24,7 +24,7 @@ Memory's durable graph**, rather than a memory layer of its own. See
   configures the project for the plugin: maps it to a Basic Memory project (picking
   an existing one or creating a new one), seeds the `session`/`decision`/`task`
   schemas into the project, installs the shared `memory-*` skills via
-  `npx skills add basicmachines-co/basic-memory --path skills` (the plugin doesn't
+  `npx skills add basicmachines-co/basic-memory/skills` (the plugin doesn't
   vendor its own copies — `skills/` is the single source of truth, shared with
   OpenClaw), optionally learns the project's placement conventions, and enables the
   capture reflexes. Writes the `basicMemory` block to

--- a/plugins/claude-code/skills/bm-setup/SKILL.md
+++ b/plugins/claude-code/skills/bm-setup/SKILL.md
@@ -156,7 +156,7 @@ git ls-files skills/ | grep -q memory- && echo "source repo - skip install"
 Otherwise, run from the project root:
 
 ```
-npx skills add basicmachines-co/basic-memory --path skills
+npx skills add basicmachines-co/basic-memory/skills
 ```
 
 This installs the canonical `memory-*` skills into the user's skills directory — the

--- a/skills/DEVELOPMENT.md
+++ b/skills/DEVELOPMENT.md
@@ -54,13 +54,13 @@ Users can install or update skills with the [Skills CLI](https://github.com/verc
 
 ```bash
 # Install all skills
-npx skills add basicmachines-co/basic-memory --path skills
+npx skills add basicmachines-co/basic-memory/skills
 
 # Install a specific skill
-npx skills add basicmachines-co/basic-memory --path skills --skill memory-tasks
+npx skills add basicmachines-co/basic-memory/skills --skill memory-tasks
 
 # Install for a specific agent
-npx skills add basicmachines-co/basic-memory --path skills --agent claude
+npx skills add basicmachines-co/basic-memory/skills --agent claude
 ```
 
 ## Adding a New Skill

--- a/skills/README.md
+++ b/skills/README.md
@@ -47,16 +47,16 @@ Install or update skills using the [Skills CLI](https://github.com/vercel-labs/s
 
 ```bash
 # Install all skills
-npx skills add basicmachines-co/basic-memory --path skills
+npx skills add basicmachines-co/basic-memory/skills
 
 # Install a specific skill
-npx skills add basicmachines-co/basic-memory --path skills --skill memory-tasks
+npx skills add basicmachines-co/basic-memory/skills --skill memory-tasks
 
 # Install all skills for a specific agent
-npx skills add basicmachines-co/basic-memory --path skills --agent claude
+npx skills add basicmachines-co/basic-memory/skills --agent claude
 
 # List available skills without installing
-npx skills add basicmachines-co/basic-memory --path skills --list
+npx skills add basicmachines-co/basic-memory/skills --list
 
 # Check for updates
 npx skills check

--- a/skills/README.md
+++ b/skills/README.md
@@ -67,7 +67,7 @@ npx skills update
 
 Skills are installed to your agent's skills directory (e.g., `~/.claude/skills/` for Claude Code global, or `.claude/skills/` for project-scoped).
 
-If your installed Skills CLI does not support `--path`, copy the `memory-*` directories manually for now. Phase 2 will add a first-class Codex/package install path.
+If your installed Skills CLI cannot load `basicmachines-co/basic-memory/skills`, update the CLI or copy the `memory-*` directories manually.
 
 ### Claude Desktop (claude.ai)
 


### PR DESCRIPTION
## Summary
- Fix the skill install instructions in `skills/README.md` to use the correct `npx` invocation
- Add `/docs/assets` to `.gitignore`

(Moved from two commits accidentally made directly on local main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BM_BOSSBOT_SUMMARY:start -->
Reviewed SHA: `26507148f0b7112adcf7c564803dc5b1fa12d0fa`
Verdict: `approve`
Status: `success` - BM Bossbot approved this head SHA

Summary:
Reviewed the full provided diff for head 26507148f0b7112adcf7c564803dc5b1fa12d0fa. The changes are limited to documentation command examples and a docs asset ignore pattern. The Skills CLI examples are updated consistently to the repository subdirectory source form, fallback wording is clearer, and /docs/assets aligns with the existing Bossbot infographic generation path. I found no concrete correctness, packaging, workflow, compatibility, or test blockers.

Blocking findings:
- None

Non-blocking findings:
- None
<!-- BM_BOSSBOT_SUMMARY:end -->

<!-- pr-infographic:start -->
![BM Bossbot image for PR #927](https://raw.githubusercontent.com/basicmachines-co/basic-memory/pr-assets/docs-skills-npx-and-gitignore/docs/assets/infographics/pr-927.webp)
<!-- pr-infographic:end -->

<!-- BM_INFOGRAPHIC_PROVENANCE:start -->
<details>
<summary>BM Bossbot image choices</summary>

- Pull request: `#927`
- Generated asset: `/home/runner/work/basic-memory/basic-memory/docs/assets/infographics/pr-927.webp`
- Image model: `gpt-image-2`
- Size: `1536x1024`
- Quality: `high`
- Image mode: `editorial-image`
- Theme source: `auto`

Theme / visual direction:
<pre><code>sword-and-sorcery: ruined temples, desert roads, battle standards, ancient maps, and heroic silhouettes with no named character likenesses</code></pre>

</details>
<!-- BM_INFOGRAPHIC_PROVENANCE:end -->


