### PR TITLE
fix(core): disambiguate truncated observation permalinks to prevent index collisions

### DIFF
--- a/src/basic_memory/models/knowledge.py
+++ b/src/basic_memory/models/knowledge.py
@@ -1,5 +1,6 @@
 """Knowledge graph models."""
 
+import hashlib
 import uuid
 from datetime import datetime
 from basic_memory.utils import ensure_timezone_aware
@@ -252,8 +253,18 @@ class Observation(Base):
         Content is truncated to 200 chars to stay under PostgreSQL's
         btree index limit of 2704 bytes.
         """
-        # Truncate content to avoid exceeding PostgreSQL's btree index limit
-        content_for_permalink = self.content[:200] if len(self.content) > 200 else self.content
+        if len(self.content) > 200:
+            # Trigger: content exceeds the 200-char budget imposed by PostgreSQL's
+            # 2704-byte btree index row limit, so the permalink can only carry a prefix.
+            # Why: two distinct observations with the same category and an identical
+            # 200-char prefix would collide on the same synthetic permalink, and the
+            # search index (permalink-keyed upsert) silently drops the second one.
+            # Outcome: a short stable digest of the FULL content disambiguates
+            # truncated permalinks while staying well under the index limit.
+            digest = hashlib.sha256(self.content.encode("utf-8")).hexdigest()[:12]
+            content_for_permalink = f"{self.content[:200]}-{digest}"
+        else:
+            content_for_permalink = self.content
         return generate_permalink(
             f"{self.entity.permalink}/observations/{self.category}/{content_for_permalink}"
         )

--- a/tests/repository/test_observation_repository.py
+++ b/tests/repository/test_observation_repository.py
@@ -466,3 +466,64 @@ async def test_observation_permalink_short_content_unchanged(
         # Short content should be fully included (after permalink normalization)
         # The generate_permalink function normalizes the content
         assert "short-observation-content" in permalink.lower()
+
+
+@pytest.mark.asyncio
+async def test_observation_permalink_disambiguates_truncated_content(
+    session_maker: async_sessionmaker, repo, test_project: Project
+):
+    """Regression test for issue #909: shared 200-char prefixes must not collide.
+
+    Truncating content to 200 chars (PostgreSQL btree limit) made two distinct
+    observations with the same category and an identical 200-char prefix produce
+    the same synthetic permalink, silently dropping the second from the search
+    index. A digest of the full content now disambiguates them.
+    """
+    async with db.scoped_session(session_maker) as session:
+        entity = Entity(
+            project_id=test_project.id,
+            title="test_entity",
+            note_type="test",
+            permalink="test/test-entity",
+            file_path="test/test_entity.md",
+            content_type="text/markdown",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        session.add(entity)
+        await session.flush()
+
+        shared_prefix = "x" * 210  # identical beyond the 200-char truncation point
+        obs_alpha = Observation(
+            project_id=test_project.id,
+            entity_id=entity.id,
+            content=f"{shared_prefix} ALPHA_UNIQUE_MARKER",
+            category="note",
+        )
+        obs_beta = Observation(
+            project_id=test_project.id,
+            entity_id=entity.id,
+            content=f"{shared_prefix} BETA_UNIQUE_MARKER",
+            category="note",
+        )
+        session.add_all([obs_alpha, obs_beta])
+        await session.flush()
+
+        # Distinct content must yield distinct permalinks despite the shared prefix
+        assert obs_alpha.permalink != obs_beta.permalink
+
+        # The digest suffix must keep permalinks under the PostgreSQL btree budget
+        assert len(obs_alpha.permalink) < 300
+        assert len(obs_beta.permalink) < 300
+
+        # Truly identical long content must still produce the same permalink so
+        # exact duplicates continue to dedupe in the search index
+        obs_beta_dup = Observation(
+            project_id=test_project.id,
+            entity_id=entity.id,
+            content=f"{shared_prefix} BETA_UNIQUE_MARKER",
+            category="note",
+        )
+        session.add(obs_beta_dup)
+        await session.flush()
+        assert obs_beta_dup.permalink == obs_beta.permalink

--- a/tests/services/test_search_service.py
+++ b/tests/services/test_search_service.py
@@ -1248,6 +1248,78 @@ async def test_index_entity_multiple_categories_same_content(
     assert len(results) >= 2
 
 
+@pytest.mark.asyncio
+async def test_index_entity_long_observations_shared_prefix_both_searchable(
+    search_service, session_maker, test_project
+):
+    """Regression test for issue #909: truncated permalink collisions drop observations.
+
+    Observation permalinks truncate content to 200 chars (PostgreSQL btree limit),
+    so two distinct observations of the same category sharing a 200-char prefix
+    collided on the same synthetic permalink and the second was silently skipped
+    during indexing. Both must be independently searchable.
+    """
+    from basic_memory.repository import EntityRepository, ObservationRepository
+    from datetime import datetime
+
+    entity_repo = EntityRepository(session_maker, project_id=test_project.id)
+    obs_repo = ObservationRepository(session_maker, project_id=test_project.id)
+
+    entity_data = {
+        "title": "Long Observation Collision Entity",
+        "note_type": "note",
+        "entity_metadata": {},
+        "content_type": "text/markdown",
+        "file_path": "test/long-obs-collision.md",
+        "permalink": "test/long-obs-collision",
+        "project_id": test_project.id,
+        "created_at": datetime.now(),
+        "updated_at": datetime.now(),
+    }
+    entity = await entity_repo.create(entity_data)
+
+    # Identical for the first 210 chars (beyond the 200-char truncation point),
+    # differing only in the trailing unique marker
+    shared_prefix = "x" * 210
+    await obs_repo.create(
+        {
+            "entity_id": entity.id,
+            "category": "note",
+            "content": f"{shared_prefix} ALPHA_UNIQUE_MARKER",
+        }
+    )
+    await obs_repo.create(
+        {
+            "entity_id": entity.id,
+            "category": "note",
+            "content": f"{shared_prefix} BETA_UNIQUE_MARKER",
+        }
+    )
+
+    # Reload entity with observations (get_by_permalink eagerly loads observations)
+    entity = await entity_repo.get_by_permalink("test/long-obs-collision")
+    assert entity is not None
+    assert len(entity.observations) == 2
+
+    # Distinct content must produce distinct permalinks despite the shared prefix
+    permalinks = {obs.permalink for obs in entity.observations}
+    assert len(permalinks) == 2
+
+    await search_service.index_entity(entity, content="")
+
+    # The second observation must be findable by its own unique marker
+    results = await search_service.search(
+        SearchQuery(text="BETA_UNIQUE_MARKER", entity_types=[SearchItemType.OBSERVATION])
+    )
+    assert any("BETA_UNIQUE_MARKER" in (r.content_snippet or "") for r in results)
+
+    # The first observation must remain findable as well
+    results = await search_service.search(
+        SearchQuery(text="ALPHA_UNIQUE_MARKER", entity_types=[SearchItemType.OBSERVATION])
+    )
+    assert any("ALPHA_UNIQUE_MARKER" in (r.content_snippet or "") for r in results)
+
+
 # Tests for NUL byte stripping
 
 


### PR DESCRIPTION
## Summary

`Observation.permalink` truncates content to 200 chars to stay under PostgreSQL's 2704-byte btree index row limit. Two distinct observations with the same category and an identical 200-char prefix collided on the same synthetic permalink, and `index_entity_markdown`'s permalink-keyed dedup silently dropped the second one from the search index, making it unfindable.

This change appends a short stable digest (first 12 hex chars of sha256 of the full content) to the truncated prefix, so distinct content always yields distinct permalinks while exact duplicates still dedupe and the permalink stays well under the btree limit. The permalink is a computed property, not a stored column, so no migration is needed.

**Upgrade note:** existing `search_index` rows for >200-char observations keep their old digest-less permalinks until the entity is re-synced or `bm reindex --search` runs; release notes should mention this.

## Test plan

- `uv run pytest tests/repository/test_observation_repository.py tests/services/test_search_service.py -x -q` — 73 passed

Closes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BM_BOSSBOT_SUMMARY:start -->
Reviewed SHA: `e1fe35560c58b4f0f825b55a243cb361796b726e`
Verdict: `approve`
Status: `success` - BM Bossbot approved this head SHA

Summary:
Reviewed the full provided diff against the Basic Memory engineering style and the affected observation permalink/search-indexing path. The change preserves short-content permalinks, keeps exact long duplicates dedupable, and disambiguates distinct long observations that share a truncated prefix. The added repository and search-service regression tests cover the reported failure mode. I found no blocking issues.

Blocking findings:
- None

Non-blocking findings:
- None
<!-- BM_BOSSBOT_SUMMARY:end -->

<!-- pr-infographic:start -->
![BM Bossbot infographic for PR #931](https://raw.githubusercontent.com/basicmachines-co/basic-memory/pr-assets/fix-909-observation-permalink-collision/docs/assets/infographics/pr-931.webp)
<!-- pr-infographic:end -->

<!-- BM_INFOGRAPHIC_PROVENANCE:start -->
<details>
<summary>BM Bossbot image provenance</summary>

- Pull request: `#931`
- Generated asset: `/home/runner/work/basic-memory/basic-memory/docs/assets/infographics/pr-931.webp`
- Image model: `gpt-image-2`
- Size: `1536x1024`
- Quality: `high`
- Visual format: `auto`
- Theme source: `none`

Theme / choice instruction:
_None supplied._

Image prompt sent to `gpt-image-2`:
<pre><code>Create a polished landscape WebP visual for Basic Memory PR #931.

This is a non-gating visual summary. The authoritative merge gate is the
GitHub commit status named BM Bossbot Approval, not this image.

Use the BM Bossbot review summary below as source material. Preserve the
concrete before/after value story without inventing facts or turning
implementation details into clutter.

Choose the most appropriate visual form: infographic, map, scene, poster,
painting, tableau, cover image, illustrated artifact, or another image form that
best communicates the PR intent. Choose exactly one visual mode and follow only
that mode's rules. Do not blend the modes.

Mode A - infographic/map:
- Use a readable map backbone with structured information design: sections,
  route lines, checkpoints, nodes, annotations, status badges, compact evidence
  bullets, and a legend.
- Use this mode when the PR needs several facts, gates, checks, or before/after
  points to be read explicitly.

Mode B - editorial scene/poster/painting:
- Use image-first composition: an actual scene, movie poster, painting, tableau,
  cover image, or symbolic illustrated artifact.
- Use this mode when the PR intent can be shown through one staged visual moment
  with minimal text.
- Avoid dashboard layouts, data panels, timeline strips, flowcharts, legends,
  before/after boxes, bullet lists, and checklist columns in this mode.

The visual theme should drive the composition through original style cues while
the engineering meaning stays easy to scan.

Use high contrast, smooth anti-aliased text when text is present, clean edges,
and non-tiny labels. Text is optional for scene-first images, but any text that
appears must be readable.

Avoid fake screenshots, code blocks, invented claims, copyrighted characters,
logos, named fictional universes, direct band logos, album art, celebrity
likenesses, or decorations that obscure content.

BM Bossbot summary:
Reviewed SHA: `e1fe35560c58b4f0f825b55a243cb361796b726e`
Verdict: `approve`
Status: `success` - BM Bossbot approved this head SHA

Summary:
Reviewed the full provided diff against the Basic Memory engineering style and the affected observation permalink/search-indexing path. The change preserves short-content permalinks, keeps exact long duplicates dedupable, and disambiguates distinct long observations that share a truncated prefix. The added repository and search-service regression tests cover the reported failure mode. I found no blocking issues.

Blocking findings:
- None

Non-blocking findings:
- None</code></pre>

Images API revised prompt:
_Not provided by the Images API._

</details>
<!-- BM_INFOGRAPHIC_PROVENANCE:end -->
