### PR TITLE
fix(ci): make BM Bossbot asset cleanup idempotent

### DIFF
--- a/.github/workflows/bm-bossbot.yml
+++ b/.github/workflows/bm-bossbot.yml
@@ -282,7 +282,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch --orphan "${asset_branch}"
-          git rm -rf .
+          git rm -rf --ignore-unmatch .
           mkdir -p "$(dirname "${asset_path}")"
           cp "${tmp_asset}" "${asset_path}"
           git add "${asset_path}"

--- a/tests/ci/test_bm_bossbot_workflow.py
+++ b/tests/ci/test_bm_bossbot_workflow.py
@@ -91,6 +91,10 @@ def test_bm_bossbot_assets_are_non_gating_and_separate_from_review_job() -> None
         encoding="utf-8"
     )
     assert "--provenance-output" in WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "git rm -rf --ignore-unmatch ." in WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "<!-- pr-infographic:start -->" in WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "gh pr edit" in WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "--body-file" in WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "BM_INFOGRAPHIC_PROVENANCE:start" in WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "BM_INFOGRAPHIC_PROVENANCE:end" in WORKFLOW_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Make the BM Bossbot asset orphan-branch cleanup tolerate an empty index with `git rm --ignore-unmatch`.
- Add a workflow regression assertion for the idempotent cleanup command.

## Verification
- `uv run pytest tests/ci/test_bm_bossbot_workflow.py -q`
- `uv run ruff check tests/ci/test_bm_bossbot_workflow.py`
- `git diff --check`

## Context
Fixes the non-gating asset publishing annotation seen in BM Bossbot Assets for PR #928, where `git rm -rf .` failed after `git switch --orphan` because no paths matched.

<!-- BM_BOSSBOT_SUMMARY:start -->
Reviewed SHA: `ec94feb6a411d44e941e63daf95c56175659772c`
Verdict: `approve`
Status: `success` - BM Bossbot approved this head SHA

Summary:
No blocking issues found. The workflow cleanup now tolerates an empty orphan-branch index with `git rm -rf --ignore-unmatch .`, which matches the reported failure mode, and the CI test adds a direct regression assertion for the idempotent cleanup command.

Blocking findings:
- None

Non-blocking findings:
- None
<!-- BM_BOSSBOT_SUMMARY:end -->

<!-- pr-infographic:start -->
![BM Bossbot infographic for PR #935](https://raw.githubusercontent.com/basicmachines-co/basic-memory/pr-assets/codex-fix-bossbot-assets-publish/docs/assets/infographics/pr-935.webp)
<!-- pr-infographic:end -->

<!-- BM_INFOGRAPHIC_PROVENANCE:start -->
<details>
<summary>BM Bossbot image provenance</summary>

- Pull request: `#935`
- Generated asset: `/home/runner/work/basic-memory/basic-memory/docs/assets/infographics/pr-935.webp`
- Image model: `gpt-image-2`
- Size: `1536x1024`
- Quality: `high`
- Visual format: `auto`
- Theme source: `none`

Theme / choice instruction:
_None supplied._

Image prompt sent to `gpt-image-2`:
<pre><code>Create a polished landscape WebP visual for Basic Memory PR #935.

This is a non-gating visual summary. The authoritative merge gate is the
GitHub commit status named BM Bossbot Approval, not this image.

Use the BM Bossbot review summary below as source material. Preserve the
concrete before/after value story without inventing facts or turning
implementation details into clutter.

Choose the most appropriate visual form: infographic, map, scene, poster,
painting, tableau, cover image, illustrated artifact, or another image form that
best communicates the PR intent. Choose exactly one visual mode and follow only
that mode's rules. Do not blend the modes.

Mode A - infographic/map:
- Use a readable map backbone with structured information design: sections,
  route lines, checkpoints, nodes, annotations, status badges, compact evidence
  bullets, and a legend.
- Use this mode when the PR needs several facts, gates, checks, or before/after
  points to be read explicitly.

Mode B - editorial scene/poster/painting:
- Use image-first composition: an actual scene, movie poster, painting, tableau,
  cover image, or symbolic illustrated artifact.
- Use this mode when the PR intent can be shown through one staged visual moment
  with minimal text.
- Avoid dashboard layouts, data panels, timeline strips, flowcharts, legends,
  before/after boxes, bullet lists, and checklist columns in this mode.

The visual theme should drive the composition through original style cues while
the engineering meaning stays easy to scan.

Use high contrast, smooth anti-aliased text when text is present, clean edges,
and non-tiny labels. Text is optional for scene-first images, but any text that
appears must be readable.

Avoid fake screenshots, code blocks, invented claims, copyrighted characters,
logos, named fictional universes, direct band logos, album art, celebrity
likenesses, or decorations that obscure content.

BM Bossbot summary:
Reviewed SHA: `ec94feb6a411d44e941e63daf95c56175659772c`
Verdict: `approve`
Status: `success` - BM Bossbot approved this head SHA

Summary:
No blocking issues found. The workflow cleanup now tolerates an empty orphan-branch index with `git rm -rf --ignore-unmatch .`, which matches the reported failure mode, and the CI test adds a direct regression assertion for the idempotent cleanup command.

Blocking findings:
- None

Non-blocking findings:
- None</code></pre>

Images API revised prompt:
_Not provided by the Images API._

</details>
<!-- BM_INFOGRAPHIC_PROVENANCE:end -->
