### PR TITLE
ci(ci): gate bossbot on passing tests

### DIFF
--- a/.agents/skills/infographics/SKILL.md
+++ b/.agents/skills/infographics/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: infographics
-description: Use when generating Basic Memory PR, changelog, release, or weekly infographics from Codex.
+description: Use when generating Basic Memory PR, changelog, release, or weekly images from Codex.
 ---
 
-# Basic Memory Infographics
+# Basic Memory Images
 
 Generate repository visuals with evidence-grounded content and canonical output
-paths. The file names still say "infographic", but the image may be an
-infographic, map, poster, scene, tableau, cover, or other visual form when that
-better describes the intent of the PR. PR images are non-gating BM Bossbot
-artifacts; changelog and release-summary images are manual evidence-pack
-workflows.
+paths. The file and marker names still say "infographic" for compatibility, but
+PR generation is image-first: scene, poster, painting, photograph, cover,
+tableau, staged artifact, or another editorial visual moment that describes the
+intent of the PR. PR images are non-gating BM Bossbot artifacts; changelog and
+release-summary images are manual evidence-pack workflows.
 
 ## Output Contract
 
 - Base output directory: `docs/assets/infographics/`
-- PR infographic: `docs/assets/infographics/pr-<number>.webp`
-- Changelog infographic: `docs/assets/infographics/changelog.webp`
-- Weekly infographic:
+- PR image: `docs/assets/infographics/pr-<number>.webp`
+- Changelog image: `docs/assets/infographics/changelog.webp`
+- Weekly image:
   - This is always a 2-Week Retro window: previous ISO week through current ISO
     week (`start-week = current-week - 1`, `end-week = current-week`).
   - Same year window: `docs/assets/infographics/<year>-w<start-week>-w<end-week>.webp`
@@ -42,12 +42,11 @@ uv run --script scripts/generate_pr_infographic.py \
   --pr-number <number> \
   --pr-body-file /tmp/bm-pr-body.md \
   --theme "<optional visual theme>" \
-  --visual-format auto \
   --provenance-output /tmp/bm-infographic-provenance.md \
   --output docs/assets/infographics/pr-<number>.webp
 ```
 
-If the PR body contains a managed infographic theme block, the script reads it
+If the PR body contains a managed image theme block, the script reads it
 automatically:
 
 ```markdown
@@ -63,7 +62,6 @@ uv run --script scripts/generate_pr_infographic.py \
   --pr-number <number> \
   --pr-body-file /tmp/bm-pr-body.md \
   --theme "<optional visual theme>" \
-  --visual-format auto \
   --output docs/assets/infographics/pr-<number>.webp \
   --print-prompt
 ```
@@ -71,11 +69,9 @@ uv run --script scripts/generate_pr_infographic.py \
 `--dry-run` is an alias for `--print-prompt`; both print the final prompt and
 exit without calling OpenAI.
 
-Use `--visual-format auto` by default so the model can choose the strongest
-form. Use `--visual-format infographic` when the user wants a structured,
-text-forward map/infographic. Use `--visual-format image` when the user wants an
-actual editorial scene, movie poster, painting, photograph, tableau, cover, or
-symbolic visual moment with minimal text.
+When no theme is supplied, the script selects a deterministic BM visual
+direction from the style pool below based on the PR number and Bossbot summary.
+This keeps repeated PR images from collapsing into the same generic visual.
 
 When the image is generated, also write provenance with
 `--provenance-output <path>`. BM Bossbot publishes that managed block into the
@@ -88,12 +84,11 @@ PR body with these markers:
 ```
 
 The provenance block records the generated asset path, image model, size,
-quality, visual format, theme source, theme or category-choice instruction, and
-the exact "Image prompt sent to" the image model. When the Images API provides
-a revised prompt, the block records that model interpretation too. Treat this
-block as debugging and creative provenance only; it is not a merge gate.
+quality, image mode, theme source, and selected visual direction. It
+intentionally does not dump the full generated prompt into the PR body. Treat
+this block as debugging and creative provenance only; it is not a merge gate.
 
-The PR infographic is visual support only. The authoritative merge gate is the
+The PR image is visual support only. The authoritative merge gate is the
 GitHub commit status named `BM Bossbot Approval`.
 
 ## Changelog Mode
@@ -104,8 +99,8 @@ Build an evidence pack before writing a prompt:
 - changed-file orientation: `git diff --stat` plus key file reads
 - impact ledger: before/after outcomes tied to actual changes
 - discard list: misleading titles, reverted work, rename-only churn, speculative TODOs
-- chosen visual format: infographic, map, poster, scene, tableau, cover, or let
-  the model choose
+- chosen image form: poster, scene, tableau, cover, painting, photograph,
+  staged artifact, or another editorial visual moment
 - chosen BM style category: exactly one category from the selection pool below
 
 Read these references before drafting the prompt:
@@ -118,15 +113,14 @@ changes.
 
 ## Style And Category Selection
 
-Select exactly one BM style category per infographic based on semantic fit. The
+Select exactly one BM style category per image based on semantic fit. The
 visual language should be recognizable and tasteful, while staying
 business-readable.
 
-Also choose the visual form that best communicates the change. Use an
-infographic or map when the work has several discrete facts, gates, checks, or
-before/after points. Use a poster, scene, tableau, cover image, illustrated
-moment, or other image when the PR has a clear intent that is better described
-as a visual story. If neither is obvious, let the model choose.
+Create an image-first visual form that communicates the change: poster, scene,
+tableau, cover image, painting, photograph, staged artifact, or another
+editorial visual moment. Maps, diagrams, dossiers, charts, and labels can appear
+as props inside the scene, but do not make a text-heavy infographic.
 
 BM category pool:
 
@@ -183,17 +177,15 @@ BM category pool:
 Selection rules:
 
 - Pick one category only; do not create mixed mashups.
-- Pick the most appropriate visual form; do not force a text-heavy infographic
-  when an actual scene, poster, painting, photograph, tableau, or cover would
-  communicate the intent better.
+- Pick the most appropriate image form. Prefer an actual scene, poster,
+  painting, photograph, tableau, or cover over a text-heavy infographic.
 - Match metaphor to content, but do not overthink it. The category is a creative
   catalyst, not a semantic constraint.
-- Use a polished upscaled editorial rendering direction: smooth anti-aliased
+- Use a polished editorial rendering direction: smooth anti-aliased
   text, high contrast, clean edges, readable labels.
-- Go bold with a map backbone when using an infographic or map. For scene-first
-  images, make the category drive the composition through a readable staged
-  moment, editorial composition, symbolic environment, route, artifact, or
-  visual metaphor.
+- Make the category drive the composition through a readable staged moment,
+  editorial composition, symbolic environment, route, artifact, or visual
+  metaphor.
 - Keep the structure literal enough to aid understanding, but not so heavy that
   it obscures engineering meaning.
 - Give the image generator creative latitude on layout, structure, color palette,
@@ -205,17 +197,16 @@ Selection rules:
 ## Content-First Aesthetic Contract
 
 The meaning must be readable and clearly hierarchical. Everything else is
-creative territory: visual format, layout, visual metaphors, decorative
-elements, color choices, and category-specific visual language.
+creative territory: image form, layout, visual metaphors, decorative elements,
+color choices, and category-specific visual language.
 
 Hierarchy:
 
 1. Meaning: what shipped, what changed, and why it matters must be clear.
 2. If the image uses text, labels, sections, or evidence bullets, they must be
    legible.
-3. The selected category's visual DNA should drive the composition, whether that
-   is a readable map structure, a poster, a scene, a tableau, or a symbolic
-   object arrangement.
+3. The selected category's visual DNA should drive the composition as a poster,
+   scene, painting, photograph, tableau, cover, or symbolic object arrangement.
 4. Do not play it safe. A visually striking image that someone wants to look at
    beats a correct but boring one.
 
@@ -224,9 +215,9 @@ Hard rules:
 - Content sections and labels must be readable when present. Text cannot be
   obscured by decorations.
 - Do not use lore-heavy copy that competes with engineering or business meaning.
-- Every prompt must include a clear composition cue: map regions, route lines,
-  checkpoints, node graphs, a staged scene, a poster composition, a symbolic
-  tableau, or a hero object.
+- Every prompt must include a clear image-first composition cue: a staged scene,
+  poster composition, painting, photograph, symbolic tableau, hero object,
+  mission room, dossier, artifact, route, or visual metaphor.
 - Do not over-prescribe exact coordinates or panel geometry; give a composition
   backbone and let the model compose around it.
 
@@ -248,8 +239,8 @@ uv run --script scripts/generate_infographic.py \
 - Tell a concrete before/after value story, not vague improvement claims.
 - Stay understandable for both engineers and non-technical stakeholders.
 - Use plain-language section titles and labels when text is present.
-- Include clear visual hierarchy: title, sections, evidence bullets, staged
-  focal point, or symbolic scene.
+- Include clear visual hierarchy: title, staged focal point, symbolic scene,
+  evidence props, or hero object.
 - Avoid invented facts; only use provided source material.
 - Favor shipped outcomes over intermediate or reverted work.
 - Preserve readability with high contrast, non-tiny labels, and uncluttered

--- a/.agents/skills/infographics/references/prompt-blueprint.md
+++ b/.agents/skills/infographics/references/prompt-blueprint.md
@@ -9,29 +9,29 @@ content and loose about visual execution.
 - Changed-file orientation summary
 - Impact ledger with before/after outcomes
 - Discard list for excluded noise
-- Chosen visual format, or explicit instruction to let the model choose
+- Chosen image form
 - Chosen BM style category
 
 ## Prompt Shape
 
 ```text
-Create a polished Basic Memory visual inspired by <BM_STYLE_CATEGORY>. Choose
-the most appropriate visual format: infographic, map, poster, scene, tableau,
-painting, photograph, cover image, illustrated artifact, or another image form
-that best communicates the intent. Use HD editorial rendering with smooth
-anti-aliased text when text is present. Go bold and let the selected category
-drive the visual language through original, non-infringing cues.
+Create a polished Basic Memory editorial image inspired by
+<BM_STYLE_CATEGORY>. Use a poster, scene, tableau, painting, photograph, cover
+image, staged artifact, or another image-first form that best communicates the
+intent. Use HD editorial rendering with smooth anti-aliased text when text is
+present. Go bold and let the selected category drive the visual language through
+original, non-infringing cues.
 
 TITLE:
 - "<clear title>"
 - "<scope subtitle>"
 
 COMPOSITION:
-- If the visual is an infographic or map, use a readable map backbone: regions,
-  route lines, checkpoints, nodes, and a legend.
-- If the visual is a scene, poster, painting, photograph, tableau, cover, or
-  illustrated artifact, recreate a clear staged moment or symbolic image that
-  describes the PR intent.
+- Recreate a clear staged moment or symbolic image that describes the PR
+  intent.
+- Maps, diagrams, dossiers, route lines, labels, and artifacts can appear as
+  props inside the scene, but the output should read as an image rather than a
+  dense infographic.
 - Take creative liberty with layout and styling.
 - The hard rule: the meaning must be readable and clearly hierarchical.
 - Keep labels plain-language and technical when labels are used.
@@ -57,8 +57,8 @@ STYLE DIRECTION:
 
 DO NOT:
 - Make text unreadable or let decoration obscure content.
-- Force a text-heavy infographic when a scene, poster, painting, photograph, or
-  tableau would communicate the PR intent better.
+- Render a text-heavy infographic, dashboard, flowchart, timeline strip,
+  checklist, bullet-list panel, or dense explanatory diagram.
 - Use crunchy low-resolution pixel art.
 - Invent facts not present in the evidence pack.
 ```

--- a/.agents/skills/infographics/references/style-balance.md
+++ b/.agents/skills/infographics/references/style-balance.md
@@ -3,9 +3,9 @@
 ## Core Principle
 
 Be bold, not confusing. The selected BM style category should structure the
-visual through a readable composition, not decorate a generic grid. Use an
-infographic or map when structure matters; use an editorial scene, poster,
-painting, photograph, or tableau when intent is better shown as an image.
+visual through a readable image-first composition, not decorate a generic grid.
+Use an editorial scene, poster, painting, photograph, cover, staged artifact, or
+tableau that turns the PR intent into a visual moment.
 
 ## Required Traits
 
@@ -13,9 +13,9 @@ painting, photograph, or tableau when intent is better shown as an image.
 - Smooth edges
 - High contrast between text and background
 - Plain-language section labels
-- Clear composition backbone: map regions, routes, nodes, checkpoints, legend,
-  staged scene, editorial poster, painting, photograph, symbolic tableau, or
-  hero artifact
+- Clear composition backbone: staged scene, editorial poster, painting,
+  photograph, symbolic tableau, hero artifact, dossier, mission room, or route
+  embodied as part of the scene
 - A single coherent BM style category, expressed through original visual cues
 
 ## Reject Or Rewrite If
@@ -33,9 +33,10 @@ painting, photograph, or tableau when intent is better shown as an image.
 - Use category-native map details to organize content: textbook diagrams,
   literary journeys, quest maps, tour posters, mission-control routes, stage
   blocking, mythic constellations, star charts, mission trajectories, case
-  boards, or civic plans.
+  boards, or civic plans as props inside the image.
 - Recreate a scene, editorial poster, painting, photograph, cover, artifact, or
-  tableau when that better describes the PR intent than sectioned bullets.
-- Map engineering metrics to visual counters, route progress, or status boards.
+  tableau instead of sectioned bullets.
+- Map engineering metrics to visual counters, route progress, or status boards
+  only when they naturally belong in the scene.
 - Let headers and accents borrow from the selected style.
 - Keep atmospheric details behind or around content, never over it.

--- a/.agents/skills/pr-create/SKILL.md
+++ b/.agents/skills/pr-create/SKILL.md
@@ -11,7 +11,7 @@ Bossbot to approve the latest head SHA. This skill never merges a PR.
 ## Inputs
 
 - Optional `<theme>`: free-form visual direction for the non-gating PR
-  infographic. Example: `$pr-create "Italian movie poster"`.
+  image. Example: `$pr-create "Italian movie poster"`.
 - Treat `<theme>` as style guidance only. It must not affect PR readiness,
   BM Bossbot review, status checks, or merge behavior.
 
@@ -48,9 +48,8 @@ model choose from BM categories").
    <!-- BM_INFOGRAPHIC_PROVENANCE:end -->
    ```
 
-   The provenance records the visual format, theme source, image settings, the
-   exact image prompt, and the Images API revised prompt when available. It is
-   for review/debugging context only.
+   The provenance records the image mode, theme source, selected visual
+   direction, and image settings. It is for review/debugging context only.
 5. Codex reports the PR URL, head SHA, checks watched, verification run, and BM
    Bossbot verdict.
 
@@ -94,8 +93,8 @@ provenance block as a gate. The only required merge signal is the
 <!-- BM_INFOGRAPHIC_THEME:end -->
 ```
 
-Keep the rest of the PR body intact. The theme is non-gating infographic
-guidance only.
+Keep the rest of the PR body intact. The theme is non-gating image guidance
+only.
 
 5. Do not merge. Do not enable auto-merge.
 
@@ -111,5 +110,5 @@ guidance only.
 ## Report
 
 Return the PR URL, current head SHA, checks watched, verification run, and the
-BM Bossbot verdict. Include the infographic `<theme>` if one was supplied. Be
+BM Bossbot verdict. Include the image `<theme>` if one was supplied. Be
 explicit when any check is still pending.

--- a/.github/workflows/bm-bossbot.yml
+++ b/.github/workflows/bm-bossbot.yml
@@ -1,12 +1,11 @@
 name: BM Bossbot
 
 "on":
-  pull_request_target:
+  workflow_run:
+    workflows:
+      - Tests
     types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+      - completed
   workflow_dispatch:
     inputs:
       pr_number:
@@ -20,7 +19,7 @@ permissions:
   issues: read
 
 concurrency:
-  group: bm-bossbot-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: bm-bossbot-${{ github.event.workflow_run.pull_requests[0].number || inputs.pr_number }}
   cancel-in-progress: true
 
 env:
@@ -30,17 +29,23 @@ env:
 jobs:
   review:
     name: BM Bossbot Review
-    if: github.event.pull_request.draft != true
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.pull_requests[0].number != ''
+      )
     runs-on: ubuntu-latest
     outputs:
       pr_number: ${{ steps.pr.outputs.pr_number }}
       head_ref: ${{ steps.pr.outputs.head_ref }}
+      should_review: ${{ steps.pr.outputs.should_review }}
 
     steps:
       - name: Checkout trusted base ref
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
 
       - name: Set up uv
@@ -53,22 +58,59 @@ jobs:
         run: |
           set -euo pipefail
           event_file="${RUNNER_TEMP}/bm-bossbot-event.json"
+          should_review=true
+
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            gh api "repos/${GITHUB_REPOSITORY}/pulls/${{ inputs.pr_number }}" > "${RUNNER_TEMP}/pull.json"
-            jq --arg repo "${GITHUB_REPOSITORY}" \
-              '{repository:{full_name:$repo}, pull_request:{number:.number,title:.title,body:(.body // ""),html_url:.html_url,head:{sha:.head.sha,ref:.head.ref},base:{ref:.base.ref,sha:.base.sha},author_association:.author_association,draft:.draft}}' \
-              "${RUNNER_TEMP}/pull.json" > "${event_file}"
+            pr_number="${{ inputs.pr_number }}"
+            tested_sha=""
           else
-            cp "${GITHUB_EVENT_PATH}" "${event_file}"
+            pr_number="$(jq -r '.workflow_run.pull_requests[0].number // ""' "${GITHUB_EVENT_PATH}")"
+            tested_sha="$(jq -r '.workflow_run.head_sha // ""' "${GITHUB_EVENT_PATH}")"
           fi
+
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" > "${RUNNER_TEMP}/pull.json"
+          current_head_sha="$(jq -r '.head.sha' "${RUNNER_TEMP}/pull.json")"
+          draft="$(jq -r '.draft' "${RUNNER_TEMP}/pull.json")"
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            tests_run_id="$(
+              gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/test.yml/runs" \
+                -f event=pull_request \
+                -f head_sha="${current_head_sha}" \
+                -f status=completed \
+                --jq '[.workflow_runs[] | select(.conclusion == "success")][0].id // ""'
+            )"
+            if [ -z "${tests_run_id}" ]; then
+              should_review=false
+              echo "BM Bossbot skipped PR ${pr_number}: no successful Tests workflow for ${current_head_sha}."
+            fi
+          fi
+
+          if [ "${draft}" = "true" ]; then
+            should_review=false
+            echo "BM Bossbot skipped PR ${pr_number}: draft pull request."
+          fi
+
+          if [ -n "${tested_sha}" ] && [ "${tested_sha}" != "${current_head_sha}" ]; then
+            should_review=false
+            echo "BM Bossbot skipped PR ${pr_number}: Tests passed for ${tested_sha}, but current head is ${current_head_sha}."
+          fi
+
+          jq --arg repo "${GITHUB_REPOSITORY}" \
+            '{repository:{full_name:$repo}, pull_request:{number:.number,title:.title,body:(.body // ""),html_url:.html_url,head:{sha:.head.sha,ref:.head.ref},base:{ref:.base.ref,sha:.base.sha},author_association:.author_association,draft:.draft}}' \
+            "${RUNNER_TEMP}/pull.json" > "${event_file}"
+
           echo "event_file=${event_file}" >> "${GITHUB_OUTPUT}"
           echo "pr_number=$(jq -r '.pull_request.number' "${event_file}")" >> "${GITHUB_OUTPUT}"
           echo "head_sha=$(jq -r '.pull_request.head.sha' "${event_file}")" >> "${GITHUB_OUTPUT}"
           echo "head_ref=$(jq -r '.pull_request.head.ref' "${event_file}")" >> "${GITHUB_OUTPUT}"
           echo "author_association=$(jq -r '.pull_request.author_association // ""' "${event_file}")" >> "${GITHUB_OUTPUT}"
+          echo "tested_sha=${tested_sha}" >> "${GITHUB_OUTPUT}"
+          echo "should_review=${should_review}" >> "${GITHUB_OUTPUT}"
 
       - name: Classify PR author
         id: trust
+        if: steps.pr.outputs.should_review == 'true'
         env:
           AUTHOR_ASSOCIATION: ${{ steps.pr.outputs.author_association }}
         run: |
@@ -85,6 +127,7 @@ jobs:
           echo "author_association=${AUTHOR_ASSOCIATION}" >> "${GITHUB_OUTPUT}"
 
       - name: Mark BM Bossbot approval pending
+        if: steps.pr.outputs.should_review == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -95,7 +138,7 @@ jobs:
 
       - name: Decline outside contributor PRs
         id: outside
-        if: steps.trust.outputs.trusted_author != 'true'
+        if: steps.pr.outputs.should_review == 'true' && steps.trust.outputs.trusted_author != 'true'
         env:
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           AUTHOR_ASSOCIATION: ${{ steps.trust.outputs.author_association }}
@@ -122,7 +165,7 @@ jobs:
 
       - name: Collect sanitized PR context
         id: context
-        if: steps.trust.outputs.trusted_author == 'true'
+        if: steps.pr.outputs.should_review == 'true' && steps.trust.outputs.trusted_author == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
@@ -195,7 +238,7 @@ jobs:
 
       - name: Run BM Bossbot review with Codex
         id: codex
-        if: steps.trust.outputs.trusted_author == 'true' && steps.context.outputs.diff_truncated != 'true'
+        if: steps.pr.outputs.should_review == 'true' && steps.trust.outputs.trusted_author == 'true' && steps.context.outputs.diff_truncated != 'true'
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -207,7 +250,7 @@ jobs:
 
       - name: Select BM Bossbot review output
         id: review_output
-        if: always()
+        if: always() && steps.pr.outputs.should_review == 'true'
         env:
           OUTSIDE_REVIEW_FILE: ${{ steps.outside.outputs.review_file }}
           CONTEXT_REVIEW_FILE: ${{ steps.context.outputs.review_file }}
@@ -217,7 +260,7 @@ jobs:
           echo "review_file=${review_file}" >> "${GITHUB_OUTPUT}"
 
       - name: Finalize BM Bossbot approval
-        if: always()
+        if: always() && steps.pr.outputs.should_review == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -230,7 +273,7 @@ jobs:
   assets:
     name: BM Bossbot Assets
     needs: review
-    if: needs.review.result == 'success'
+    if: needs.review.result == 'success' && needs.review.outputs.should_review == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -240,13 +283,13 @@ jobs:
       - name: Checkout trusted base ref
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.ref || github.ref }}
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v3
 
-      - name: Generate non-gating PR infographic
+      - name: Generate non-gating PR image
         continue-on-error: true
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -258,10 +301,10 @@ jobs:
           uv run --script scripts/generate_pr_infographic.py \
             --pr-number "${PR_NUMBER}" \
             --pr-body-file "${RUNNER_TEMP}/bm-bossbot-pr-body.md" \
-            --provenance-output "${RUNNER_TEMP}/bm-bossbot-infographic-provenance.md" \
+            --provenance-output "${RUNNER_TEMP}/bm-bossbot-image-provenance.md" \
             --output "docs/assets/infographics/pr-${PR_NUMBER}.webp"
 
-      - name: Publish non-gating PR infographic
+      - name: Publish non-gating PR image
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -270,7 +313,7 @@ jobs:
         run: |
           set -euo pipefail
           asset_path="docs/assets/infographics/pr-${PR_NUMBER}.webp"
-          provenance_file="${RUNNER_TEMP}/bm-bossbot-infographic-provenance.md"
+          provenance_file="${RUNNER_TEMP}/bm-bossbot-image-provenance.md"
           test -f "${asset_path}"
           test -f "${provenance_file}"
 
@@ -286,7 +329,7 @@ jobs:
           mkdir -p "$(dirname "${asset_path}")"
           cp "${tmp_asset}" "${asset_path}"
           git add "${asset_path}"
-          git commit -m "chore: publish PR ${PR_NUMBER} infographic"
+          git commit -m "chore: publish PR ${PR_NUMBER} image"
           git push --force origin "HEAD:${asset_branch}"
 
           asset_url="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${asset_branch}/${asset_path}"
@@ -312,7 +355,7 @@ jobs:
           image_block = "\n".join(
               [
                   "<!-- pr-infographic:start -->",
-                  f"![BM Bossbot infographic for PR #{pr_number}]({asset_url})",
+                  f"![BM Bossbot image for PR #{pr_number}]({asset_url})",
                   "<!-- pr-infographic:end -->",
               ]
           )

--- a/.github/workflows/bm-bossbot.yml
+++ b/.github/workflows/bm-bossbot.yml
@@ -75,7 +75,7 @@ jobs:
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             tests_run_id="$(
               gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/test.yml/runs" \
-                -f event=pull_request \
+                -f event=push \
                 -f head_sha="${current_head_sha}" \
                 -f status=completed \
                 --jq '[.workflow_runs[] | select(.conclusion == "success")][0].id // ""'

--- a/scripts/generate_pr_infographic.py
+++ b/scripts/generate_pr_infographic.py
@@ -7,10 +7,11 @@
 #   "typer>=0.9.0",
 # ]
 # ///
-"""Build and generate a non-gating BM Bossbot PR infographic."""
+"""Build and generate a non-gating BM Bossbot PR image."""
 
 from __future__ import annotations
 
+import hashlib
 import html
 import re
 from dataclasses import dataclass
@@ -44,27 +45,63 @@ PROVENANCE_START = "<!-- BM_INFOGRAPHIC_PROVENANCE:start -->"
 PROVENANCE_END = "<!-- BM_INFOGRAPHIC_PROVENANCE:end -->"
 app = typer.Typer(
     add_completion=False,
-    help="Generate a non-gating BM Bossbot PR infographic.",
+    help="Generate a non-gating BM Bossbot PR image.",
     no_args_is_help=True,
 )
 
 
-class VisualFormat(StrEnum):
-    AUTO = "auto"
-    INFOGRAPHIC = "infographic"
-    IMAGE = "image"
-
-
 class ThemeSource(StrEnum):
+    AUTO = "auto"
     CLI = "cli"
     PR_BODY = "pr-body"
-    NONE = "none"
 
 
 @dataclass(frozen=True)
 class ThemeSelection:
-    theme: str | None
+    theme: str
     source: ThemeSource
+
+
+BM_IMAGE_THEME_POOL = (
+    "computer science college textbook: SICP-style diagrams, automata, compiler "
+    "pipelines, type theory, and annotated chalkboard rigor",
+    "classic literature: sea voyages, gothic manors, Dickensian streets, library "
+    "marginalia, and travel-journal artifacts",
+    "fantasy quest ledger: original guild maps, spellbooks, dungeon keys, tavern "
+    "notices, and artifact inventories with no copyrighted settings",
+    "heavy music editorial: metal, hard rock, punk, techno, soul, or reggae "
+    "tour-poster energy with no direct band logos or likenesses",
+    "knockoff space opera: fleet routes, mission consoles, contraband manifests, "
+    "and practical starship drama with no named fictional universes",
+    "sword-and-sorcery: ruined temples, desert roads, battle standards, ancient "
+    "maps, and heroic silhouettes with no named character likenesses",
+    "comic book cover: original splash-page composition, caption boxes, clean "
+    "halftone texture, and bold issue-cover drama",
+    "French new wave movie poster: stark typography, city streets, jump-cut "
+    "composition, and high-contrast editorial photography cues",
+    "WWII public-information poster: home-front logistics, mobilization arrows, "
+    "bold simplified figures, and no real-world party symbols or hate imagery",
+    "Italian movie poster: hand-painted drama, expressive color, credit-block "
+    "energy, and 1960s or 1970s cinema composition with no actor likenesses",
+    "Shakespearean stage: acts and scenes, court intrigue, stage blocking, "
+    "dramatis personae, backstage cue sheets, and theatrical light",
+    "Greek mythology: temple steps, oracle tablets, constellations, labyrinths, "
+    "ship routes, and original heroic allegory",
+    "noir detective photography: case files, typed evidence labels, civic "
+    "infrastructure, streetlight shadows, and newsroom archive grit",
+    "space exploration and astronomy: celestial atlases, observatory charts, "
+    "orbital mechanics, planetary survey routes, and deep-space mission drama",
+    "editorial painting: abstract, classical landscape, western action, "
+    "chiaroscuro, historical mural, stormy seascape, or allegorical canvas",
+    "classic black-and-white photography: documentary field report, contact "
+    "sheet, street photography, civic infrastructure, and darkroom contrast",
+    "80's action movie poster: smoky backlit warehouses, neon streets, practical "
+    "explosions, mission dossiers, countdowns, and no actor likenesses",
+    "alchemy manuscript: transformation diagrams, annotated symbols, recipe-like "
+    "process artifacts, and illuminated margins",
+    "brutalist civic planning: concrete signage, zoning blocks, transit diagrams, "
+    "infrastructure maps, and stern public-service clarity",
+)
 
 
 def extract_bossbot_summary(pr_body: str) -> str:
@@ -90,66 +127,23 @@ def extract_infographic_theme(pr_body: str) -> str | None:
     return theme or None
 
 
-def select_infographic_theme(*, pr_body: str, theme_override: str | None) -> ThemeSelection:
+def select_image_theme(
+    *,
+    pr_number: int,
+    summary: str,
+    pr_body: str,
+    theme_override: str | None,
+) -> ThemeSelection:
     if theme_override:
         return ThemeSelection(theme=theme_override, source=ThemeSource.CLI)
     body_theme = extract_infographic_theme(pr_body)
     if body_theme:
         return ThemeSelection(theme=body_theme, source=ThemeSource.PR_BODY)
-    return ThemeSelection(theme=None, source=ThemeSource.NONE)
-
-
-def _visual_format_guidance(visual_format: VisualFormat) -> str:
-    if visual_format == VisualFormat.INFOGRAPHIC:
-        return """
-Visual mode: infographic/map.
-
-Use an infographic or map format. Use structured information design:
-- data panels, route maps, timeline bands, status badges, legends, checkpoints,
-  before/after boxes, and compact bullet list sections are appropriate.
-- Organize the source facts into scannable sections with plain-language labels.
-- Show the before/after value story through layout, hierarchy, and evidence.
-- Do not render this as a primarily scenic image, movie poster, or painting.
-""".strip()
-    if visual_format == VisualFormat.IMAGE:
-        return """
-Visual mode: regular image/scene.
-
-Use a regular image format: actual scene, movie poster, editorial painting,
-tableau, cover image, or illustrated artifact.
-
-Use image-first composition:
-- Create a single staged visual moment with one strong focal point.
-- Communicate intent through cinematic staging, editorial metaphor, atmosphere,
-  characters, objects, architecture, landscape, lighting, and motion.
-- Use at most a short title plus zero to three short labels when text is needed.
-- Convert process details into visual symbols instead of explanatory boxes.
-- Do not use data panels, dashboard layouts, timeline strips, flowcharts,
-  legends, before/after boxes, bullet lists, checklist columns, or small
-  explanatory labels.
-- Do not render an infographic or dense text-heavy infographic.
-""".strip()
-    return """
-Choose the most appropriate visual form: infographic, map, scene, poster,
-painting, tableau, cover image, illustrated artifact, or another image form that
-best communicates the PR intent. Choose exactly one visual mode and follow only
-that mode's rules. Do not blend the modes.
-
-Mode A - infographic/map:
-- Use a readable map backbone with structured information design: sections,
-  route lines, checkpoints, nodes, annotations, status badges, compact evidence
-  bullets, and a legend.
-- Use this mode when the PR needs several facts, gates, checks, or before/after
-  points to be read explicitly.
-
-Mode B - editorial scene/poster/painting:
-- Use image-first composition: an actual scene, movie poster, painting, tableau,
-  cover image, or symbolic illustrated artifact.
-- Use this mode when the PR intent can be shown through one staged visual moment
-  with minimal text.
-- Avoid dashboard layouts, data panels, timeline strips, flowcharts, legends,
-  before/after boxes, bullet lists, and checklist columns in this mode.
-""".strip()
+    seed = f"{pr_number}\n{summary}".encode("utf-8")
+    index = int.from_bytes(hashlib.sha256(seed).digest()[:2], byteorder="big") % len(
+        BM_IMAGE_THEME_POOL
+    )
+    return ThemeSelection(theme=BM_IMAGE_THEME_POOL[index], source=ThemeSource.AUTO)
 
 
 def _preformatted(value: str) -> str:
@@ -163,39 +157,24 @@ def build_infographic_provenance_block(
     model: str,
     size: str,
     quality: str,
-    visual_format: VisualFormat,
-    theme: str | None,
+    theme: str,
     theme_source: ThemeSource,
-    prompt: str,
-    revised_prompt: str | None = None,
 ) -> str:
-    theme_section = "_None supplied._" if theme is None else _preformatted(theme)
-    revised_prompt_section = (
-        "_Not provided by the Images API._"
-        if revised_prompt is None
-        else _preformatted(revised_prompt)
-    )
     return f"""
 {PROVENANCE_START}
 <details>
-<summary>BM Bossbot image provenance</summary>
+<summary>BM Bossbot image choices</summary>
 
 - Pull request: `#{pr_number}`
 - Generated asset: `{output_path.as_posix()}`
 - Image model: `{model}`
 - Size: `{size}`
 - Quality: `{quality}`
-- Visual format: `{visual_format.value}`
+- Image mode: `editorial-image`
 - Theme source: `{theme_source.value}`
 
-Theme / choice instruction:
-{theme_section}
-
-Image prompt sent to `{model}`:
-{_preformatted(prompt)}
-
-Images API revised prompt:
-{revised_prompt_section}
+Theme / visual direction:
+{_preformatted(theme)}
 
 </details>
 {PROVENANCE_END}
@@ -215,38 +194,44 @@ def build_infographic_prompt(
     *,
     pr_number: int,
     summary: str,
-    theme: str | None = None,
-    visual_format: VisualFormat = VisualFormat.AUTO,
+    theme: str,
+    theme_source: ThemeSource,
 ) -> str:
-    theme_section = ""
-    if theme:
-        theme_section = f"""
-
-Optional user-supplied visual theme preference:
-{theme}
-
-Treat the theme as style inspiration only. Do not let it override facts,
-readability, source material, or the non-gating status of this image.
-""".rstrip()
+    theme_label = (
+        "Selected BM visual direction"
+        if theme_source == ThemeSource.AUTO
+        else "User-supplied visual direction"
+    )
 
     return f"""
-Create a polished landscape WebP visual for Basic Memory PR #{pr_number}.
+Create a polished landscape WebP editorial image for Basic Memory PR #{pr_number}.
 
-This is a non-gating visual summary. The authoritative merge gate is the
+This is a non-gating visual asset. The authoritative merge gate is the
 GitHub commit status named BM Bossbot Approval, not this image.
 
 Use the BM Bossbot review summary below as source material. Preserve the
 concrete before/after value story without inventing facts or turning
 implementation details into clutter.
 
-{_visual_format_guidance(visual_format)}
+{theme_label}:
+{theme}
 
-The visual theme should drive the composition through original style cues while
-the engineering meaning stays easy to scan.
+Treat the visual direction as style inspiration only. Do not let it override
+facts, readability, source material, or the non-gating status of this image.
 
-Use high contrast, smooth anti-aliased text when text is present, clean edges,
-and non-tiny labels. Text is optional for scene-first images, but any text that
-appears must be readable.
+Use image-first composition: create a scene, movie poster, editorial painting,
+classic photograph, cover image, symbolic tableau, staged artifact, or another
+visual moment that expresses the PR intent.
+
+Make the selected direction shape the subject, lighting, composition, props,
+environment, and mood. Use one strong focal point. Prefer visual metaphor over
+explanatory UI.
+
+Use at most a short title and zero to three short labels if text helps. Any text
+that appears must be high-contrast, smooth, anti-aliased, and readable.
+
+Do not render an infographic, dashboard, flowchart, timeline strip, checklist,
+bullet-list panel, data panel, or dense explanatory diagram.
 
 Avoid fake screenshots, code blocks, invented claims, copyrighted characters,
 logos, named fictional universes, direct band logos, album art, celebrity
@@ -254,7 +239,6 @@ likenesses, or decorations that obscure content.
 
 BM Bossbot summary:
 {summary}
-{theme_section}
 """.strip()
 
 
@@ -291,14 +275,6 @@ def generate(
             help="Optional file to write the managed PR-body provenance block.",
         ),
     ] = None,
-    visual_format: Annotated[
-        VisualFormat,
-        typer.Option(
-            "--visual-format",
-            case_sensitive=False,
-            help="Visual format to request: auto, infographic, or image.",
-        ),
-    ] = VisualFormat.AUTO,
     print_prompt: Annotated[
         bool,
         typer.Option(
@@ -308,15 +284,20 @@ def generate(
         ),
     ] = False,
 ) -> None:
-    """Generate the canonical PR infographic from a BM Bossbot summary block."""
+    """Generate the canonical PR image from a BM Bossbot summary block."""
     pr_body = pr_body_file.read_text(encoding="utf-8")
     summary = extract_bossbot_summary(pr_body)
-    theme_selection = select_infographic_theme(pr_body=pr_body, theme_override=theme)
+    theme_selection = select_image_theme(
+        pr_number=pr_number,
+        summary=summary,
+        pr_body=pr_body,
+        theme_override=theme,
+    )
     prompt = build_infographic_prompt(
         pr_number=pr_number,
         summary=summary,
         theme=theme_selection.theme,
-        visual_format=visual_format,
+        theme_source=theme_selection.source,
     )
     if print_prompt:
         typer.echo(prompt)
@@ -340,11 +321,8 @@ def generate(
                 model=model,
                 size=size,
                 quality=quality,
-                visual_format=visual_format,
                 theme=theme_selection.theme,
                 theme_source=theme_selection.source,
-                prompt=prompt,
-                revised_prompt=image_result.revised_prompt,
             ),
             encoding="utf-8",
         )

--- a/tests/ci/test_bm_bossbot_workflow.py
+++ b/tests/ci/test_bm_bossbot_workflow.py
@@ -11,18 +11,18 @@ def _workflow() -> dict:
     return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
 
 
-def test_bm_bossbot_uses_safe_pull_request_target_gate() -> None:
+def test_bm_bossbot_runs_after_successful_tests_workflow() -> None:
     workflow = _workflow()
+    review_job = workflow["jobs"]["review"]
 
     assert workflow["name"] == "BM Bossbot"
-    assert "pull_request_target" in workflow["on"]
-    assert workflow["on"]["pull_request_target"]["types"] == [
-        "opened",
-        "synchronize",
-        "reopened",
-        "ready_for_review",
-    ]
+    assert "pull_request_target" not in workflow["on"]
+    assert workflow["on"]["workflow_run"]["workflows"] == ["Tests"]
+    assert workflow["on"]["workflow_run"]["types"] == ["completed"]
     assert "workflow_dispatch" in workflow["on"]
+    assert "github.event.workflow_run.conclusion == 'success'" in review_job["if"]
+    assert "github.event.workflow_run.pull_requests[0].number != ''" in review_job["if"]
+    assert review_job["outputs"]["should_review"] == "${{ steps.pr.outputs.should_review }}"
 
     permissions = workflow["permissions"]
     assert permissions["contents"] == "read"
@@ -36,12 +36,18 @@ def test_bm_bossbot_uses_safe_pull_request_target_gate() -> None:
 
 def test_bm_bossbot_workflow_never_checks_out_untrusted_head() -> None:
     workflow = _workflow()
-    review_job = workflow["jobs"]["review"]
-    steps = review_job["steps"]
-    checkout_step = next(step for step in steps if step.get("uses") == "actions/checkout@v6")
+    checkout_steps = [
+        step
+        for job in workflow["jobs"].values()
+        for step in job["steps"]
+        if step.get("uses") == "actions/checkout@v6"
+    ]
 
-    assert checkout_step["with"]["ref"] == "${{ github.event.pull_request.base.ref || github.ref }}"
-    assert "${{ github.event.pull_request.head.sha }}" not in str(checkout_step)
+    assert checkout_steps
+    for checkout_step in checkout_steps:
+        assert checkout_step["with"]["ref"] == "${{ github.event.repository.default_branch }}"
+        assert "${{ github.event.pull_request.head.sha }}" not in str(checkout_step)
+    assert "github.event.pull_request" not in WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "cancel-in-progress: true" in WORKFLOW_PATH.read_text(encoding="utf-8")
 
 
@@ -59,9 +65,12 @@ def test_bm_bossbot_workflow_has_deterministic_status_steps() -> None:
     assert run_codex["uses"] == "openai/codex-action@v1"
     assert run_codex["with"]["openai-api-key"] == "${{ secrets.OPENAI_API_KEY }}"
     assert "--output-schema" in run_codex["with"]["codex-args"]
+    assert "steps.pr.outputs.should_review == 'true'" in run_codex["if"]
 
+    pending = next(step for step in steps if step["name"] == "Mark BM Bossbot approval pending")
+    assert pending["if"] == "steps.pr.outputs.should_review == 'true'"
     finalize = next(step for step in steps if step["name"] == "Finalize BM Bossbot approval")
-    assert finalize["if"] == "always()"
+    assert finalize["if"] == "always() && steps.pr.outputs.should_review == 'true'"
     assert "BM Bossbot Approval" in WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "uv run --script scripts/bm_bossbot_status.py pending" in WORKFLOW_PATH.read_text(
         encoding="utf-8"
@@ -71,6 +80,26 @@ def test_bm_bossbot_workflow_has_deterministic_status_steps() -> None:
     )
 
 
+def test_bm_bossbot_rejects_stale_successful_test_runs_before_codex() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    workflow = _workflow()
+    steps = workflow["jobs"]["review"]["steps"]
+    normalize = next(step for step in steps if step["name"] == "Normalize PR event")
+    classify = next(step for step in steps if step["name"] == "Classify PR author")
+
+    assert "tested_sha" in normalize["run"]
+    assert "current_head_sha" in normalize["run"]
+    assert "actions/workflows/test.yml/runs" in normalize["run"]
+    assert "-f head_sha=\"${current_head_sha}\"" in normalize["run"]
+    assert 'select(.conclusion == "success")' in normalize["run"]
+    assert "no successful Tests workflow for ${current_head_sha}" in workflow_text
+    stale_sha_guard = '[ -n "${tested_sha}" ] && [ "${tested_sha}" != "${current_head_sha}" ]'
+    assert stale_sha_guard in normalize["run"]
+    assert "should_review=false" in normalize["run"]
+    assert "Tests passed for ${tested_sha}, but current head is ${current_head_sha}" in workflow_text
+    assert classify["if"] == "steps.pr.outputs.should_review == 'true'"
+
+
 def test_bm_bossbot_assets_are_non_gating_and_separate_from_review_job() -> None:
     workflow = _workflow()
     review_steps = workflow["jobs"]["review"]["steps"]
@@ -78,12 +107,14 @@ def test_bm_bossbot_assets_are_non_gating_and_separate_from_review_job() -> None
     asset_steps = asset_job["steps"]
 
     assert asset_job["needs"] == "review"
-    assert asset_job["if"] == "needs.review.result == 'success'"
-    assert not any(step["name"] == "Generate non-gating PR infographic" for step in review_steps)
-    assert not any(step["name"] == "Publish non-gating PR infographic" for step in review_steps)
+    assert asset_job["if"] == (
+        "needs.review.result == 'success' && needs.review.outputs.should_review == 'true'"
+    )
+    assert not any(step["name"] == "Generate non-gating PR image" for step in review_steps)
+    assert not any(step["name"] == "Publish non-gating PR image" for step in review_steps)
 
-    generate = next(step for step in asset_steps if step["name"] == "Generate non-gating PR infographic")
-    publish = next(step for step in asset_steps if step["name"] == "Publish non-gating PR infographic")
+    generate = next(step for step in asset_steps if step["name"] == "Generate non-gating PR image")
+    publish = next(step for step in asset_steps if step["name"] == "Publish non-gating PR image")
 
     assert generate["continue-on-error"] is True
     assert publish["continue-on-error"] is True
@@ -93,6 +124,7 @@ def test_bm_bossbot_assets_are_non_gating_and_separate_from_review_job() -> None
     assert "--provenance-output" in WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "git rm -rf --ignore-unmatch ." in WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "<!-- pr-infographic:start -->" in WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "BM Bossbot image for PR" in WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "gh pr edit" in WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "--body-file" in WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "BM_INFOGRAPHIC_PROVENANCE:start" in WORKFLOW_PATH.read_text(encoding="utf-8")
@@ -112,7 +144,9 @@ def test_bm_bossbot_rejects_oversized_diffs_without_partial_approval() -> None:
     assert "Diff exceeds BM Bossbot review limit" in workflow_text
     assert (
         run_codex["if"]
-        == "steps.trust.outputs.trusted_author == 'true' && steps.context.outputs.diff_truncated != 'true'"
+        == "steps.pr.outputs.should_review == 'true' && "
+        "steps.trust.outputs.trusted_author == 'true' && "
+        "steps.context.outputs.diff_truncated != 'true'"
     )
     assert "head -c 120000" not in workflow_text
 
@@ -130,13 +164,22 @@ def test_bm_bossbot_does_not_run_codex_for_outside_contributors() -> None:
     finalize = next(step for step in steps if step["name"] == "Finalize BM Bossbot approval")
 
     assert "OWNER|MEMBER|COLLABORATOR" in classify["run"]
-    assert outside["if"] == "steps.trust.outputs.trusted_author != 'true'"
-    assert collect["if"] == "steps.trust.outputs.trusted_author == 'true'"
+    assert (
+        outside["if"]
+        == "steps.pr.outputs.should_review == 'true' && steps.trust.outputs.trusted_author != 'true'"
+    )
+    assert (
+        collect["if"]
+        == "steps.pr.outputs.should_review == 'true' && steps.trust.outputs.trusted_author == 'true'"
+    )
     assert (
         run_codex["if"]
-        == "steps.trust.outputs.trusted_author == 'true' && steps.context.outputs.diff_truncated != 'true'"
+        == "steps.pr.outputs.should_review == 'true' && "
+        "steps.trust.outputs.trusted_author == 'true' && "
+        "steps.context.outputs.diff_truncated != 'true'"
     )
-    assert select_review["if"] == "always()"
+    assert select_review["if"] == "always() && steps.pr.outputs.should_review == 'true'"
+    assert finalize["if"] == "always() && steps.pr.outputs.should_review == 'true'"
     assert "BM Bossbot does not run for outside contributors" in workflow_text
     assert "missing-bm-bossbot-review.json" in workflow_text
     assert '--review "${{ steps.review_output.outputs.review_file }}"' in finalize["run"]

--- a/tests/ci/test_bm_bossbot_workflow.py
+++ b/tests/ci/test_bm_bossbot_workflow.py
@@ -90,6 +90,8 @@ def test_bm_bossbot_rejects_stale_successful_test_runs_before_codex() -> None:
     assert "tested_sha" in normalize["run"]
     assert "current_head_sha" in normalize["run"]
     assert "actions/workflows/test.yml/runs" in normalize["run"]
+    assert "-f event=push" in normalize["run"]
+    assert "-f event=pull_request" not in normalize["run"]
     assert "-f head_sha=\"${current_head_sha}\"" in normalize["run"]
     assert 'select(.conclusion == "success")' in normalize["run"]
     assert "no successful Tests workflow for ${current_head_sha}" in workflow_text

--- a/tests/scripts/test_generate_pr_infographic.py
+++ b/tests/scripts/test_generate_pr_infographic.py
@@ -28,7 +28,6 @@ def test_generate_pr_infographic_cli_help_exposes_useful_options() -> None:
     assert "--pr-body-file" in help_text
     assert "--output" in help_text
     assert "--theme" in help_text
-    assert "--visual-format" in help_text
     assert "--provenance-output" in help_text
     assert "--print-prompt" in help_text
     assert "--dry-run" in help_text
@@ -76,7 +75,7 @@ def test_extract_infographic_theme_is_optional() -> None:
     assert generate_pr_infographic.extract_infographic_theme("No theme") is None
 
 
-def test_select_infographic_theme_reports_source() -> None:
+def test_select_image_theme_reports_source() -> None:
     body = "\n".join(
         [
             "<!-- BM_INFOGRAPHIC_THEME:start -->",
@@ -85,15 +84,21 @@ def test_select_infographic_theme_reports_source() -> None:
         ]
     )
 
-    from_body = generate_pr_infographic.select_infographic_theme(
+    from_body = generate_pr_infographic.select_image_theme(
+        pr_number=42,
+        summary="Summary: Adds a merge gate.",
         pr_body=body,
         theme_override=None,
     )
-    from_cli = generate_pr_infographic.select_infographic_theme(
+    from_cli = generate_pr_infographic.select_image_theme(
+        pr_number=42,
+        summary="Summary: Adds a merge gate.",
         pr_body=body,
         theme_override="80's action movies",
     )
-    from_none = generate_pr_infographic.select_infographic_theme(
+    from_auto = generate_pr_infographic.select_image_theme(
+        pr_number=42,
+        summary="Summary: Adds a merge gate.",
         pr_body="No theme",
         theme_override=None,
     )
@@ -102,8 +107,8 @@ def test_select_infographic_theme_reports_source() -> None:
     assert from_body.source == generate_pr_infographic.ThemeSource.PR_BODY
     assert from_cli.theme == "80's action movies"
     assert from_cli.source == generate_pr_infographic.ThemeSource.CLI
-    assert from_none.theme is None
-    assert from_none.source == generate_pr_infographic.ThemeSource.NONE
+    assert from_auto.theme in generate_pr_infographic.BM_IMAGE_THEME_POOL
+    assert from_auto.source == generate_pr_infographic.ThemeSource.AUTO
 
 
 def test_build_infographic_prompt_uses_summary_without_making_gate_claims() -> None:
@@ -111,56 +116,54 @@ def test_build_infographic_prompt_uses_summary_without_making_gate_claims() -> N
         pr_number=42,
         summary="Verdict: approve\nSummary: Adds a merge gate.",
         theme="WWII propaganda posters with home-front logistics routes",
-        visual_format=generate_pr_infographic.VisualFormat.AUTO,
+        theme_source=generate_pr_infographic.ThemeSource.CLI,
     )
 
     assert "PR #42" in prompt
     assert "Adds a merge gate" in prompt
     assert "WWII propaganda posters" in prompt
+    assert "User-supplied visual direction" in prompt
     assert "style inspiration only" in prompt
-    assert "choose the most appropriate visual form" in prompt.lower()
-    assert "Choose exactly one visual mode" in prompt
-    assert "Do not blend the modes" in prompt
+    assert "polished landscape WebP editorial image" in prompt
+    assert "image-first composition" in prompt
     assert "scene" in prompt
     assert "poster" in prompt
-    assert "tableau" in prompt
-    assert "map backbone" in prompt
+    assert "painting" in prompt
+    assert "classic photograph" in prompt
+    assert "symbolic tableau" in prompt
     assert "before/after value story" in prompt
+    assert "Do not render an infographic" in prompt
+    assert "dashboard" in prompt
+    assert "flowchart" in prompt
     assert "copyrighted characters" in prompt
     assert "restrained" not in prompt
     assert "non-gating" in prompt
     assert "BM Bossbot Approval" in prompt
 
 
-def test_build_infographic_provenance_block_includes_choices_and_prompt() -> None:
-    prompt = "Create <gate> & keep `sha` exact."
+def test_build_infographic_provenance_block_includes_image_choices_without_prompt() -> None:
     block = generate_pr_infographic.build_infographic_provenance_block(
         pr_number=42,
         output_path=Path("docs/assets/infographics/pr-42.webp"),
         model="gpt-image-2",
         size="1536x1024",
         quality="high",
-        visual_format=generate_pr_infographic.VisualFormat.IMAGE,
         theme="classic black-and-white photography",
         theme_source=generate_pr_infographic.ThemeSource.CLI,
-        prompt=prompt,
-        revised_prompt="A black-and-white editorial photo of a guarded merge gate.",
     )
 
     assert generate_pr_infographic.PROVENANCE_START in block
     assert generate_pr_infographic.PROVENANCE_END in block
-    assert "BM Bossbot image provenance" in block
+    assert "BM Bossbot image choices" in block
     assert "Generated asset: `docs/assets/infographics/pr-42.webp`" in block
     assert "Image model: `gpt-image-2`" in block
     assert "Size: `1536x1024`" in block
     assert "Quality: `high`" in block
-    assert "Visual format: `image`" in block
+    assert "Image mode: `editorial-image`" in block
     assert "Theme source: `cli`" in block
     assert "classic black-and-white photography" in block
-    assert "Image prompt sent to `gpt-image-2`" in block
-    assert "Create &lt;gate&gt; &amp; keep `sha` exact." in block
-    assert "Images API revised prompt" in block
-    assert "black-and-white editorial photo" in block
+    assert "Image prompt sent to" not in block
+    assert "Images API revised prompt" not in block
 
 
 def test_upsert_managed_block_appends_and_replaces() -> None:
@@ -198,47 +201,35 @@ def test_upsert_managed_block_appends_and_replaces() -> None:
     assert replaced.count(generate_pr_infographic.PROVENANCE_START) == 1
 
 
-def test_build_infographic_prompt_can_force_infographic_format() -> None:
+def test_build_infographic_prompt_uses_auto_theme_as_visual_direction() -> None:
+    theme = generate_pr_infographic.select_image_theme(
+        pr_number=42,
+        summary="Verdict: approve\nSummary: Adds a merge gate.",
+        pr_body="No theme",
+        theme_override=None,
+    )
     prompt = generate_pr_infographic.build_infographic_prompt(
         pr_number=42,
         summary="Verdict: approve\nSummary: Adds a merge gate.",
-        visual_format=generate_pr_infographic.VisualFormat.INFOGRAPHIC,
+        theme=theme.theme,
+        theme_source=theme.source,
     )
 
-    assert "Use an infographic or map format." in prompt
-    assert "Use structured information design" in prompt
-    assert "data panels" in prompt
-    assert "timeline" in prompt
-    assert "bullet list" in prompt
-    assert "primarily scenic image" in prompt
-
-
-def test_build_infographic_prompt_can_force_regular_image_format() -> None:
-    prompt = generate_pr_infographic.build_infographic_prompt(
-        pr_number=42,
-        summary="Verdict: approve\nSummary: Adds a merge gate.",
-        visual_format=generate_pr_infographic.VisualFormat.IMAGE,
-    )
-
-    assert "Use a regular image format" in prompt
+    assert "Selected BM visual direction" in prompt
+    assert theme.theme in prompt
     assert "Use image-first composition" in prompt
-    assert "actual scene" in prompt
     assert "movie poster" in prompt
     assert "painting" in prompt
-    assert "editorial" in prompt
-    assert "single staged visual moment" in prompt
+    assert "classic photograph" in prompt
     assert "scene" in prompt
     assert "poster" in prompt
-    assert "tableau" in prompt
     assert "cover image" in prompt
-    assert "illustrated" in prompt
-    assert "at most a short title" in prompt
-    assert "Do not use data panels" in prompt
-    assert "dashboard" in prompt
-    assert "timeline strips" in prompt
-    assert "bullet lists" in prompt
+    assert "symbolic tableau" in prompt
+    assert "Use at most a short title" in prompt
     assert "Do not render an infographic" in prompt
-    assert "dense text-heavy infographic" in prompt
+    assert "dashboard" in prompt
+    assert "flowchart" in prompt
+    assert "bullet-list panel" in prompt
 
 
 @pytest.mark.parametrize("flag", ["--print-prompt", "--dry-run"])
@@ -280,17 +271,19 @@ def test_generate_pr_infographic_can_print_prompt_without_image_call(
             str(body_file),
             "--output",
             str(output),
-            "--visual-format",
-            "image",
             flag,
         ],
     )
 
     assert result.exit_code == 0, result.output
-    assert "Create a polished landscape WebP visual for Basic Memory PR #42" in result.output
+    assert (
+        "Create a polished landscape WebP editorial image for Basic Memory PR #42"
+        in result.output
+    )
     assert "Adds a merge gate" in result.output
     assert "space exploration and astronomy" in result.output
-    assert "Use a regular image format" in result.output
+    assert "image-first composition" in result.output
+    assert "Do not render an infographic" in result.output
     assert "BM Bossbot Approval" in result.output
     assert not output.exists()
 
@@ -340,8 +333,6 @@ def test_generate_pr_infographic_writes_provenance_after_image_generation(
             str(body_file),
             "--output",
             str(output),
-            "--visual-format",
-            "image",
             "--provenance-output",
             str(provenance),
         ],
@@ -351,13 +342,13 @@ def test_generate_pr_infographic_writes_provenance_after_image_generation(
     assert output.exists()
     text = provenance.read_text(encoding="utf-8")
     assert "Generated asset:" in text
-    assert "Visual format: `image`" in text
+    assert "Image mode: `editorial-image`" in text
     assert "Theme source: `pr-body`" in text
     assert "paintings: Rembrandt-inspired merge gate" in text
-    assert "Image prompt sent to `gpt-image-2`" in text
-    assert "Images API revised prompt" in text
-    assert "robot guarding a merge gate" in text
-    assert "Adds a merge gate" in text
+    assert "Image prompt sent to" not in text
+    assert "Images API revised prompt" not in text
+    assert "robot guarding a merge gate" not in text
+    assert "Adds a merge gate" not in text
 
 
 def test_validate_output_path_must_stay_under_docs_assets_infographics(tmp_path: Path) -> None:

--- a/tests/test_codex_plugin_package.py
+++ b/tests/test_codex_plugin_package.py
@@ -66,8 +66,9 @@ def test_infographics_skill_keeps_weekly_contract_and_bm_style_pool() -> None:
     prompt_blueprint = (
         repo_root / ".agents/skills/infographics/references/prompt-blueprint.md"
     ).read_text(encoding="utf-8")
+    skill_flat = " ".join(skill.split())
 
-    assert "Weekly infographic" in skill
+    assert "Weekly image" in skill
     assert "2-Week Retro window" in skill
     assert "docs/assets/infographics/<year>-w<start-week>-w<end-week>.webp" in skill
     assert (
@@ -91,30 +92,29 @@ def test_infographics_skill_keeps_weekly_contract_and_bm_style_pool() -> None:
     assert "80's action movies" in skill
     assert "practical explosions" in skill
     assert "no direct actor likenesses" in skill
-    assert "infographic, map, poster, scene, tableau" in skill
-    assert "let the model choose" in skill
+    assert "poster, scene, tableau, cover image" in skill_flat
+    assert "image-first" in skill
     assert "--print-prompt" in skill
     assert "--dry-run" in skill
-    assert "--visual-format auto" in skill
-    assert "--visual-format infographic" in skill
-    assert "--visual-format image" in skill
+    assert "--visual-format" not in skill
     assert "--provenance-output" in skill
     assert "BM_INFOGRAPHIC_PROVENANCE:start" in skill
-    assert "Image prompt sent to" in skill
-    assert "revised prompt" in skill
+    assert "Image prompt sent to" not in skill
+    assert "revised prompt" not in skill
     assert "star charts" in style_balance
     assert "editorial scene" in style_balance
     assert "painting, photograph" in style_balance
     assert "copyrighted characters, logos, or named fictional universes" in skill
     assert "retro game or classic app aesthetic" not in skill
     assert "BM style category" in style_balance
-    assert "Chosen visual format" in prompt_blueprint
+    assert "Chosen image form" in prompt_blueprint
     assert "Chosen BM style category" in prompt_blueprint
 
 
 def test_pr_create_skill_documents_optional_infographic_theme_arg() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     skill = (repo_root / ".agents/skills/pr-create/SKILL.md").read_text(encoding="utf-8")
+    skill_flat = " ".join(skill.split())
 
     assert "## How To Use" in skill
     assert "$pr-create" in skill
@@ -125,6 +125,6 @@ def test_pr_create_skill_documents_optional_infographic_theme_arg() -> None:
     assert "<!-- BM_INFOGRAPHIC_THEME:end -->" in skill
     assert "<!-- BM_INFOGRAPHIC_PROVENANCE:start -->" in skill
     assert "BM Bossbot Approval" in skill
-    assert "Images API revised prompt" in skill
+    assert "selected visual direction" in skill_flat
     assert "never merges" in skill
     assert "non-gating" in skill


### PR DESCRIPTION
## Summary
- Move BM Bossbot automatic reviews behind successful `Tests` workflow runs instead of direct PR events.
- Add stale-head and manual-dispatch guards so Bossbot skips Codex/status/image work unless the current PR head has green tests.
- Make PR visuals image-first with deterministic BM visual directions and compact provenance focused on theme/settings instead of dumping the full prompt.

## Verification
- `uv run pytest tests/ci/test_bm_bossbot_workflow.py tests/scripts/test_generate_pr_infographic.py tests/test_codex_plugin_package.py -q`
- `uv run ruff check scripts/generate_pr_infographic.py tests/ci/test_bm_bossbot_workflow.py tests/scripts/test_generate_pr_infographic.py tests/test_codex_plugin_package.py`
- `just typecheck`
- `just package-check`

<!-- BM_BOSSBOT_SUMMARY:start -->
Reviewed SHA: `1da2ec08ba2ea5f80ebf308b6d2853efdd487981`
Verdict: `approve`
Status: `success` - BM Bossbot approved this head SHA

Summary:
Reviewed the full provided diff against the Basic Memory engineering style and Bossbot merge-gate priorities. The prior manual-dispatch blocker is addressed by matching the push-only Tests workflow, and I found no remaining concrete merge blockers.

Blocking findings:
- None

Non-blocking findings:
- None
<!-- BM_BOSSBOT_SUMMARY:end -->

<!-- pr-infographic:start -->
![BM Bossbot infographic for PR #937](https://raw.githubusercontent.com/basicmachines-co/basic-memory/pr-assets/codex-gate-bossbot-after-tests/docs/assets/infographics/pr-937.webp)
<!-- pr-infographic:end -->

<!-- BM_INFOGRAPHIC_PROVENANCE:start -->
<details>
<summary>BM Bossbot image provenance</summary>

- Pull request: `#937`
- Generated asset: `/home/runner/work/basic-memory/basic-memory/docs/assets/infographics/pr-937.webp`
- Image model: `gpt-image-2`
- Size: `1536x1024`
- Quality: `high`
- Visual format: `auto`
- Theme source: `none`

Theme / choice instruction:
_None supplied._

Image prompt sent to `gpt-image-2`:
<pre><code>Create a polished landscape WebP visual for Basic Memory PR #937.

This is a non-gating visual summary. The authoritative merge gate is the
GitHub commit status named BM Bossbot Approval, not this image.

Use the BM Bossbot review summary below as source material. Preserve the
concrete before/after value story without inventing facts or turning
implementation details into clutter.

Choose the most appropriate visual form: infographic, map, scene, poster,
painting, tableau, cover image, illustrated artifact, or another image form that
best communicates the PR intent. Choose exactly one visual mode and follow only
that mode's rules. Do not blend the modes.

Mode A - infographic/map:
- Use a readable map backbone with structured information design: sections,
  route lines, checkpoints, nodes, annotations, status badges, compact evidence
  bullets, and a legend.
- Use this mode when the PR needs several facts, gates, checks, or before/after
  points to be read explicitly.

Mode B - editorial scene/poster/painting:
- Use image-first composition: an actual scene, movie poster, painting, tableau,
  cover image, or symbolic illustrated artifact.
- Use this mode when the PR intent can be shown through one staged visual moment
  with minimal text.
- Avoid dashboard layouts, data panels, timeline strips, flowcharts, legends,
  before/after boxes, bullet lists, and checklist columns in this mode.

The visual theme should drive the composition through original style cues while
the engineering meaning stays easy to scan.

Use high contrast, smooth anti-aliased text when text is present, clean edges,
and non-tiny labels. Text is optional for scene-first images, but any text that
appears must be readable.

Avoid fake screenshots, code blocks, invented claims, copyrighted characters,
logos, named fictional universes, direct band logos, album art, celebrity
likenesses, or decorations that obscure content.

BM Bossbot summary:
Reviewed SHA: `1da2ec08ba2ea5f80ebf308b6d2853efdd487981`
Verdict: `approve`
Status: `success` - BM Bossbot approved this head SHA

Summary:
Reviewed the full provided diff against the Basic Memory engineering style and Bossbot merge-gate priorities. The prior manual-dispatch blocker is addressed by matching the push-only Tests workflow, and I found no remaining concrete merge blockers.

Blocking findings:
- None

Non-blocking findings:
- None</code></pre>

Images API revised prompt:
_Not provided by the Images API._

</details>
<!-- BM_INFOGRAPHIC_PROVENANCE:end -->
