### PR TITLE
test(mcp): assert tags param and tag: shorthand comma equivalence

### DIFF
--- a/test-int/mcp/test_search_integration.py
+++ b/test-int/mcp/test_search_integration.py
@@ -497,3 +497,55 @@ async def test_search_case_insensitive(mcp_server, app, test_project):
 
             result_text = search_result.content[0].text
             assert "Machine Learning Guide" in result_text, f"Failed for search term: {search_term}"
+
+
+@pytest.mark.asyncio
+async def test_tags_param_vs_tag_query_comma_consistency(mcp_server, app, test_project):
+    """The `tags=` parameter must split comma-separated strings like the `tag:` shorthand.
+
+    Regression test for #910: `search_notes(tags="alpha,beta")` previously coerced the
+    bare string into the single literal tag `["alpha,beta"]` (matching nothing), while
+    the `tag:alpha,beta` query shorthand splits on commas. Both paths must agree.
+    """
+
+    async with Client(mcp_server) as client:
+        # Note tagged alpha + beta
+        await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Tag Shorthand Note",
+                "directory": "tag-shorthand",
+                "content": "# Tag Shorthand Note\n\nTagShorthandToken body",
+                "tags": ["alpha", "beta"],
+            },
+        )
+
+        # Path A: tag: query shorthand with comma list -> splits, matches
+        via_query = await client.call_tool(
+            "search_notes",
+            {
+                "project": test_project.name,
+                "query": "tag:alpha,beta",
+                "search_type": "text",
+            },
+        )
+        query_hit = "Tag Shorthand Note" in via_query.content[0].text
+
+        # Path B: tags= parameter with the SAME comma string
+        via_param = await client.call_tool(
+            "search_notes",
+            {
+                "project": test_project.name,
+                "query": "TagShorthandToken",
+                "search_type": "text",
+                "tags": "alpha,beta",
+            },
+        )
+        param_hit = "Tag Shorthand Note" in via_param.content[0].text
+
+        assert query_hit, "tag: query shorthand should match (sanity)"
+        assert param_hit == query_hit, (
+            "tags='alpha,beta' param must behave like the tag: shorthand "
+            f"(both split commas). query_hit={query_hit} param_hit={param_hit}"
+        )


### PR DESCRIPTION
## Summary

Carries the remaining piece of #918 by @jagadeeswara-ks, with original commit authorship preserved — please **rebase-merge** this PR (not squash) so the commit lands on main credited to its author.

@jagadeeswara-ks had the correct fix for #910 in review before our duplicate (#932) merged and auto-closed the issue. The validator swap (`coerce_list` → `parse_tags`) is therefore already on main, but his integration regression test is additive: nothing else asserts end-to-end that `search_notes(tags="alpha,beta")` and the `tag:alpha,beta` query shorthand return the **same results** for the same comma string — and that equivalence is the heart of #910.

The cherry-pick keeps his test verbatim and drops only the already-landed `search.py` hunk; his DCO sign-off is intact.

## Test plan

- `uv run pytest "test-int/mcp/test_search_integration.py::test_tags_param_vs_tag_query_comma_consistency" -q` — passes on current main

Refs #910, #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- BM_BOSSBOT_SUMMARY:start -->
Reviewed SHA: `61ea09968889a3628c4952e9d80b436878d26147`
Verdict: `approve`
Status: `success` - BM Bossbot approved this head SHA

Summary:
Reviewed the full provided diff for head SHA 61ea09968889a3628c4952e9d80b436878d26147. The added integration regression test exercises the MCP client/server path and introduces no blocking correctness, packaging, workflow, or compatibility risk.

Blocking findings:
- None

Non-blocking findings:
- Targeted test not run in sandbox: The filesystem is read-only in this review environment, so I did not run the pytest target. The provided diff is test-only, scoped to the MCP search integration suite, and the assertion would catch the original regression where tags='alpha,beta' was treated as one literal tag while tag:alpha,beta split correctly.
<!-- BM_BOSSBOT_SUMMARY:end -->

<!-- pr-infographic:start -->
![BM Bossbot image for PR #943](https://raw.githubusercontent.com/basicmachines-co/basic-memory/pr-assets/test-910-tags-shorthand-equivalence/docs/assets/infographics/pr-943.webp)
<!-- pr-infographic:end -->

<!-- BM_INFOGRAPHIC_PROVENANCE:start -->
<details>
<summary>BM Bossbot image choices</summary>

- Pull request: `#943`
- Generated asset: `/home/runner/work/basic-memory/basic-memory/docs/assets/infographics/pr-943.webp`
- Image model: `gpt-image-2`
- Size: `1536x1024`
- Quality: `high`
- Image mode: `editorial-image`
- Theme source: `auto`

Theme / visual direction:
<pre><code>Italian movie poster: hand-painted drama, expressive color, credit-block energy, and 1960s or 1970s cinema composition with no actor likenesses</code></pre>

</details>
<!-- BM_INFOGRAPHIC_PROVENANCE:end -->

