### PR TITLE
docs(cli): document personal-vs-team cloud sync semantics

### DIFF
--- a/docs/cloud-cli.md
+++ b/docs/cloud-cli.md
@@ -318,7 +318,7 @@ For MCP stdio, routing is always local.
 | `bm cloud push` | local → cloud | Personal + Team | Upload local changes, additively (git-style) |
 | `bm cloud sync` | local → cloud | Personal only | One-way mirror (cloud becomes identical to local) |
 | `bm cloud bisync` | local ↔ cloud | Personal only | Two-way mirror (recommended for solo use) |
-| `bm cloud check` | — | Personal + Team | Verify files match (no changes) |
+| `bm cloud check` | — | Personal only | Verify mirror integrity (no changes) |
 
 If you collaborate on a shared Team workspace, use **`push`/`pull`** (see [Team Workspaces](#team-workspaces-push--pull-additive-git-style)). If you are the only writer (a Personal workspace), the mirror commands `sync`/`bisync` give you a single source of truth.
 
@@ -459,9 +459,11 @@ bm cloud bisync --name research
 - You edit in multiple places
 - You want automatic conflict resolution
 
-### Verify Sync Integrity
+### Verify Sync Integrity (Personal only)
 
 **Use case:** Check if local and cloud match without making changes.
+
+> **Personal workspaces only.** `check` compares against the Personal workspace mirror remote, like `sync`/`bisync`. On Team workspaces use `bm cloud pull --dry-run` / `bm cloud push --dry-run` to preview differences instead.
 
 ```bash
 bm cloud check --name research
@@ -999,7 +1001,7 @@ bm cloud bisync --name <project> --resync # First time / force baseline
 bm cloud bisync --name <project> --dry-run
 bm cloud bisync --name <project> --verbose
 
-# Integrity check
+# Integrity check - Personal workspaces only
 bm cloud check --name <project>
 bm cloud check --name <project> --one-way
 

--- a/src/basic_memory/cli/commands/cloud/project_sync.py
+++ b/src/basic_memory/cli/commands/cloud/project_sync.py
@@ -512,7 +512,11 @@ def bisync_project_command(
     resync: bool = typer.Option(False, "--resync", help="Force new baseline"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed output"),
 ) -> None:
-    """Two-way sync: local <-> cloud (bidirectional sync).
+    """Two-way mirror: local <-> cloud (bidirectional sync).
+
+    Personal workspaces only. This mirror can delete and overwrite files on both
+    sides, so on Team workspaces use `bm cloud pull` (fetch) / `bm cloud push`
+    (additive upload) instead.
 
     Examples:
       bm cloud bisync --name research --resync  # First time
@@ -576,7 +580,11 @@ def check_project_command(
     name: str = typer.Option(..., "--name", "--project", help="Project name to check"),
     one_way: bool = typer.Option(False, "--one-way", help="Check one direction only (faster)"),
 ) -> None:
-    """Verify file integrity between local and cloud.
+    """Verify file integrity between local and cloud (no changes made).
+
+    Personal workspaces only: check compares against the Personal workspace
+    mirror remote. On Team workspaces use `bm cloud pull --dry-run` /
+    `bm cloud push --dry-run` to preview differences instead.
 
     Example:
       bm cloud check --name research
@@ -623,6 +631,9 @@ def bisync_reset(
     name: str = typer.Argument(..., help="Project name to reset bisync state for"),
 ) -> None:
     """Clear bisync state for a project.
+
+    Personal workspaces only (bisync is a Personal-workspace mirror; on Team
+    workspaces use `bm cloud pull` / `bm cloud push` instead).
 
     This removes the bisync metadata files, forcing a fresh --resync on next bisync.
     Useful when bisync gets into an inconsistent state or when remote path changes.

--- a/tests/cli/cloud/test_project_sync_command.py
+++ b/tests/cli/cloud/test_project_sync_command.py
@@ -16,6 +16,21 @@ runner = CliRunner()
 
 
 @pytest.mark.parametrize(
+    "command",
+    ["sync", "bisync", "check", "bisync-reset"],
+)
+def test_cloud_mirror_command_help_marks_personal_workspaces_only(command):
+    """Mirror-family help must say Personal-only and point Team users at push/pull (#851)."""
+    result = runner.invoke(app, ["cloud", command, "--help"])
+
+    assert result.exit_code == 0, result.output
+    output = " ".join(result.output.split())
+    assert "Personal workspaces only" in output
+    assert "bm cloud pull" in output
+    assert "bm cloud push" in output
+
+
+@pytest.mark.parametrize(
     "argv",
     [
         ["cloud", "sync", "--name", "research"],


### PR DESCRIPTION
Folds the intent of #857 (by @groksrc — thank you!) into documentation that matches the post-#920 reality, where `bm cloud push` / `bm cloud pull` are the Team-safe additive transfer commands and the rclone mirror family is gated to Personal workspaces.

Closes #851
Supersedes #857

## What changed

**CLI help text** (`src/basic_memory/cli/commands/cloud/project_sync.py`):
- `bm cloud bisync`, `bm cloud check`, and `bm cloud bisync-reset` now state they are Personal-workspace local mirror operations, not supported for Team workspaces, and point Team users at `bm cloud push` / `bm cloud pull` (`bm cloud sync` already said so after #920)
- `bisync` help also reads "Two-way mirror" to match the docs and the `sync` mirror framing
- `sync-setup` is deliberately *not* marked Personal-only (as #857 had it): the local path it configures also serves Team-safe push/pull

**docs/cloud-cli.md**:
- `bm cloud check` corrected from "Personal + Team" to Personal-only in the sync-command table, the Verify Sync Integrity section, and the command reference — it compares against the Personal workspace mirror remote like `sync`/`bisync`; Team users preview diffs with `push`/`pull --dry-run`
- Most of #857's doc intent (command renames, Personal-vs-Team framing, push/pull `--on-conflict` modes) already landed on main via #920, so this reconciles rather than rewrites

**Tests** (`tests/cli/cloud/test_project_sync_command.py`):
- Ported #857's help-text assertions: the mirror-family commands (`sync`, `bisync`, `check`, `bisync-reset`) must advertise "Personal workspaces only" and the `push`/`pull` alternatives

## Test plan

- `uv run pytest tests/cli/cloud/test_project_sync_command.py -x -q` — 35 passed (4 new help-text tests + 31 existing)
- `uv run ruff format` / `ruff check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)