### PR TITLE
Add glama.json to claim the Glama MCP directory listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "phernandez",
+    "groksrc"
+  ]
+}


### PR DESCRIPTION
Adds the `glama.json` manifest Glama requires to claim an org-owned server listing (see "How to claim a server that belongs to an organization" on [the listing](https://glama.ai/mcp/servers/@basicmachines-co/basic-memory)). Maintainers: phernandez, groksrc.

Why: the listing is currently unclaimed, and Glama explicitly limits discoverability of unclaimed servers. Claiming also enables description control and review notifications. After this merges, a maintainer clicks "Login with GitHub to claim" on the listing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)