### PR TITLE
fix(cli): preload deferred rich/typer modules before in-place upgrade

### DIFF
--- a/src/basic_memory/cli/auto_update.py
+++ b/src/basic_memory/cli/auto_update.py
@@ -168,6 +168,20 @@ def _manual_update_hint(source: InstallSource) -> str:
     )
 
 
+def _preload_lazy_console_modules() -> None:
+    """Import modules the post-upgrade output path defers until print time.
+
+    Trigger: an in-place upgrade is about to replace this installation on disk.
+    Why: rich and typer defer some imports until print/excepthook time; once
+    `brew upgrade` / `uv tool upgrade` removes the running version's files,
+    those imports raise ModuleNotFoundError and the final status message
+    crashes the exiting process.
+    Outcome: import the deferred modules now, while the files still exist.
+    """
+    import rich._emoji_codes  # noqa: F401
+    import typer.rich_utils  # noqa: F401
+
+
 def _save_last_checked_timestamp(config_manager: ConfigManager, checked_at: datetime) -> None:
     """Persist the timestamp for the most recent attempted update check."""
     config = config_manager.load_config()
@@ -288,6 +302,7 @@ def run_auto_update(
             else BREW_UPGRADE_TIMEOUT_SECONDS
         )
 
+        _preload_lazy_console_modules()
         install_result = _run_subprocess(
             command,
             timeout_seconds=timeout,

--- a/tests/cli/test_auto_update.py
+++ b/tests/cli/test_auto_update.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from datetime import datetime, timedelta, timezone
 from io import StringIO
 from typing import Any, cast
@@ -15,6 +16,7 @@ from basic_memory.cli.auto_update import (
     InstallSource,
     _check_homebrew_update_available,
     _is_interactive_session,
+    _preload_lazy_console_modules,
     detect_install_source,
     maybe_run_periodic_auto_update,
     run_auto_update,
@@ -157,6 +159,19 @@ def test_check_homebrew_update_available_exit_code_0_means_up_to_date(monkeypatc
     monkeypatch.setattr("basic_memory.cli.auto_update._run_subprocess", _fake_run)
     is_outdated, _ = _check_homebrew_update_available(silent=False)
     assert is_outdated is False
+
+
+def test_preload_lazy_console_modules_imports_deferred_modules(monkeypatch):
+    # Regression: the in-place upgrade deletes the running install's files, so
+    # any module rich/typer defers until print time must already be loaded or
+    # the final status message crashes with ModuleNotFoundError.
+    monkeypatch.delitem(sys.modules, "rich._emoji_codes", raising=False)
+    monkeypatch.delitem(sys.modules, "typer.rich_utils", raising=False)
+
+    _preload_lazy_console_modules()
+
+    assert "rich._emoji_codes" in sys.modules
+    assert "typer.rich_utils" in sys.modules
 
 
 def test_homebrew_outdated_triggers_upgrade(monkeypatch, tmp_path):


### PR DESCRIPTION
## Problem

Every successful `bm update` (Homebrew or uv tool install) ends with a crash from the *old* process:

```
ImportError: cannot import name 'rich_utils' from 'typer' ...
ModuleNotFoundError: No module named 'rich._emoji_codes'
```

`brew upgrade basic-memory` removes the old keg (e.g. `Cellar/basic-memory/0.21.6/`) while the 0.21.6 Python process that launched it is still running. When `run_auto_update` returns and the CLI prints the final status via rich, rich lazily imports `rich._emoji_codes` from files that no longer exist — and typer's excepthook then fails the same way trying to lazily import `typer.rich_utils` to render the traceback. The upgrade itself succeeds; it's the dying process crashing on its last words.

## Fix

Import both deferred modules in `run_auto_update` immediately before launching the upgrade subprocess, while this install's files still exist. Covers both `bm update` and the periodic auto-update path.

## Verification

- New regression test pops the modules from `sys.modules`, calls the preload, asserts they're back.
- `uv run pytest tests/cli/test_auto_update.py tests/cli/test_update_command.py` — 24 passed.
- `just lint` + `just typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)