### PR TITLE
feat(cli): add Rich human-readable output to bm tool commands

### DIFF
--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -59,15 +59,23 @@ def _print_json(result: Any) -> None:
 # --- Rich formatters ---
 
 
-def _display_search_results(result: dict[str, Any]) -> None:
-    """Render search-notes results as a Rich table."""
+def _display_search_results(result: dict[str, Any], query: str = "") -> None:
+    """Render search-notes results as a Rich table.
+
+    Real SearchResponse.model_dump() shape:
+      results: list of SearchResult dicts (title, type, permalink, score, matched_chunk, content)
+      current_page: int   (NOT "page")
+      page_size: int
+      total: int
+      has_more: bool
+    """
     results = result.get("results", [])
     total = result.get("total", len(results))
-    query = result.get("query") or ""
-    page = result.get("page", 1)
-    page_size = result.get("page_size", len(results))
+    # Real key is "current_page"; fall back to "page" for forward-compat.
+    page = result.get("current_page") or result.get("page", 1)
+    page_size = result.get("page_size", len(results)) or 1
 
-    title = f"Search results for [bold cyan]{query}[/bold cyan]" if query else "Search results"
+    title = f"Search: [bold cyan]{query}[/bold cyan]" if query else "Search results"
     subtitle = f"{total} result(s)  •  page {page} of {max(1, -(-total // page_size))}"
 
     if not results:
@@ -77,13 +85,21 @@ def _display_search_results(result: dict[str, Any]) -> None:
     table = Table(show_header=True, header_style="bold", expand=False)
     table.add_column("Type", style="dim", width=12)
     table.add_column("Title", style="bold cyan")
+    table.add_column("Score", style="yellow", width=7)
     table.add_column("Permalink", style="green")
+    table.add_column("Snippet", style="dim", max_width=60)
 
     for item in results:
         item_type = item.get("type", "")
         item_title = item.get("title") or item.get("permalink", "")
         permalink = item.get("permalink", "")
-        table.add_row(item_type, item_title, permalink)
+        score = item.get("score")
+        score_str = f"{score:.2f}" if score is not None else ""
+        # Prefer matched_chunk as the most relevant snippet; fall back to content.
+        raw_snippet = item.get("matched_chunk") or item.get("content") or ""
+        # Truncate to ~200 chars so the table stays readable.
+        snippet = raw_snippet[:200].replace("\n", " ") if raw_snippet else ""
+        table.add_row(item_type, item_title, score_str, permalink, snippet)
 
     console.print(Panel(table, title=title, subtitle=subtitle, expand=False))
 
@@ -108,33 +124,59 @@ def _display_read_note(result: dict[str, Any]) -> None:
 
 
 def _display_build_context(result: dict[str, Any]) -> None:
-    """Render build-context result as a Rich tree."""
+    """Render build-context result as a Rich tree.
+
+    Real GraphContext.model_dump() shape:
+      results: list of ContextResult dicts, each with:
+        primary_result: EntitySummary | RelationSummary | ObservationSummary
+        observations:   list of ObservationSummary
+        related_results: list of EntitySummary | RelationSummary | ObservationSummary
+      metadata: {"uri": ..., ...}
+      page/page_size/has_more
+
+    Each summary has: type, title (EntitySummary/RelationSummary), permalink,
+    and relation_type (RelationSummary only).
+    """
     metadata = result.get("metadata", {})
     uri = metadata.get("uri", "")
-    results = result.get("results", [])
-    total = len(results)
+    context_items: list[dict[str, Any]] = list(result.get("results", []))
 
     label = f"[bold cyan]{uri}[/bold cyan]" if uri else "Context"
     tree = Tree(f"[bold]Context:[/bold] {label}")
 
-    if not results:
+    if not context_items:
         tree.add("[dim]No related content found.[/dim]")
     else:
-        for item in results:
-            item_title = item.get("title") or item.get("permalink", "")
-            relation = item.get("relation_type", "")
-            item_type = item.get("type", "")
+        for context_result in context_items:
+            # --- Primary result node ---
+            primary = context_result.get("primary_result", {})
+            p_title = primary.get("title") or primary.get("permalink", "")
+            p_type = primary.get("type", "")
+            primary_label = f"[cyan]{p_title}[/cyan]"
+            if p_type:
+                primary_label = f"[dim]{p_type}[/dim]  {primary_label}"
+            primary_node = tree.add(primary_label)
 
-            parts = []
-            if relation:
-                parts.append(f"[yellow]{relation}[/yellow]")
-            if item_type:
-                parts.append(f"[dim]{item_type}[/dim]")
-            parts.append(f"[cyan]{item_title}[/cyan]")
+            # --- Related items as children ---
+            related: list[dict[str, Any]] = list(context_result.get("related_results", []))
+            for rel_item in related:
+                rel_title = rel_item.get("title") or rel_item.get("permalink", "")
+                rel_type = rel_item.get("type", "")
+                relation = rel_item.get("relation_type", "")
 
-            tree.add(" ".join(parts))
+                parts = []
+                if relation:
+                    parts.append(f"[yellow]{relation}[/yellow]")
+                if rel_type:
+                    parts.append(f"[dim]{rel_type}[/dim]")
+                parts.append(f"[cyan]{rel_title}[/cyan]")
+                primary_node.add(" ".join(parts))
 
-    subtitle = f"{total} related item(s)"
+    # Count total related items across all primary results.
+    total_related = sum(
+        len(cr.get("related_results", [])) for cr in context_items
+    )
+    subtitle = f"{len(context_items)} primary  •  {total_related} related"
     console.print(Panel(tree, subtitle=subtitle, expand=False))
 
 
@@ -858,7 +900,7 @@ def search_notes(
         if json_output or not _use_rich():
             _print_json(result)
         else:
-            _display_search_results(result)
+            _display_search_results(result, query=query or "")
     except ValueError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -36,6 +36,7 @@ from rich.tree import Tree
 from basic_memory.cli.app import app
 from basic_memory.cli.commands.command_utils import run_with_cleanup
 from basic_memory.config import ConfigManager
+from basic_memory.file_utils import has_frontmatter, remove_frontmatter
 from basic_memory.cli.commands.routing import force_routing, validate_routing_flags
 
 # MCP tool functions are imported inside each command: importing
@@ -206,8 +207,16 @@ def _display_read_note(result: dict[str, Any], *, include_frontmatter: bool = Fa
             fm_table.add_row(markup_escape(str(key)), markup_escape(str(value)))
         console.print(Panel(fm_table, title="[dim]frontmatter[/dim]", expand=False))
 
-    if content:
-        console.print(Markdown(content))
+    # Trigger: --include-frontmatter makes the API return the literal file, so
+    # content starts with the frontmatter block the panel above already shows.
+    # Why: rendering it again through Markdown duplicates the frontmatter (and
+    #      Markdown mangles the --- fences into rules/headings).
+    # Outcome: strip the block from the body; the panel is the frontmatter view.
+    body = content
+    if include_frontmatter and content and has_frontmatter(content):
+        body = remove_frontmatter(content)
+    if body and body.strip():
+        console.print(Markdown(body))
     else:
         console.print(Text("(no content)", style="dim"))
 
@@ -377,24 +386,17 @@ def _plain_read_note(result: dict[str, Any], *, include_frontmatter: bool = Fals
     title = result.get("title", "")
     permalink = result.get("permalink", "")
     content = result.get("content", "")
-    frontmatter: dict[str, Any] = result.get("frontmatter") or {}
 
     header = f"{title}  [{permalink}]" if permalink else title
     print(header)
 
-    # Trigger: --include-frontmatter was passed and the payload carries frontmatter.
-    # Why: the JSON payload always includes a "frontmatter" key, so the flag (not
-    #      mere presence) gates whether the key/value block is printed -- matching
-    #      the Rich path's gating behavior.
-    # Outcome: a blank line then "key: value" lines above the body.
-    if include_frontmatter and frontmatter:
-        print()
-        for key, value in frontmatter.items():
-            print(f"{key}: {value}")
-
     print()
-    # The API's content field keeps the blank line left by frontmatter
-    # stripping; trim newlines so the header gap stays a single blank line.
+    # Trigger: --include-frontmatter makes the API return the literal file
+    # (frontmatter block included) as content.
+    # Why: plain mode should show that file verbatim -- synthesizing a separate
+    #      key/value block would print the frontmatter twice.
+    # Outcome: with the flag, the body IS the frontmatter view; either way trim
+    #      surrounding newlines so the header gap stays a single blank line.
     body = content.strip("\n") if content else ""
     if body:
         print(body)

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -2,14 +2,26 @@
 
 Every command calls its MCP tool with output_format="json" and prints the result.
 Commands that benefit from human-readable output (search-notes, read-note,
-build-context, recent-activity) default to Rich formatting when stdout is a TTY
-and fall back to raw JSON when piped or when --json is supplied.  This follows
-the same bm status / bm project list precedent.
+build-context, recent-activity) support three output modes:
+
+- **JSON** — raw machine-readable JSON.  Used when ``--json`` is passed, or
+  automatically when stdout is not a TTY (piped/redirected), so scripts stay
+  parseable.  This follows the same bm status / bm project list precedent.
+- **Rich** — colored Panel/Table/Tree/Markdown output.  The default interactive
+  experience when stdout is a TTY.
+- **Plain** — undecorated, greppable text (no ANSI colors, no box-drawing, no
+  markup).  Forced with ``--plain`` even when piped.
+
+Precedence, highest first: ``--json`` > ``--plain`` > non-TTY (JSON) > TTY
+(config ``cli_output_style``, ``rich`` by default).  Passing both ``--json`` and
+``--plain`` is an error.  The interactive default for a TTY is controlled by the
+``cli_output_style`` config option (``rich``/``plain``; env
+``BASIC_MEMORY_CLI_OUTPUT_STYLE``).
 """
 
 import json
 import sys
-from typing import Annotated, Any, Dict, List, Optional
+from typing import Annotated, Any, Dict, List, Literal, Optional
 
 import typer
 from loguru import logger
@@ -23,6 +35,7 @@ from rich.tree import Tree
 
 from basic_memory.cli.app import app
 from basic_memory.cli.commands.command_utils import run_with_cleanup
+from basic_memory.config import ConfigManager
 from basic_memory.cli.commands.routing import force_routing, validate_routing_flags
 
 # MCP tool functions are imported inside each command: importing
@@ -40,16 +53,57 @@ console = Console()
 
 # --- Shared helpers ---
 
+OutputMode = Literal["json", "rich", "plain"]
+
 
 def _use_rich() -> bool:
-    """Return True when stdout is an interactive TTY and Rich output is appropriate.
+    """Return True when stdout is an interactive TTY.
 
-    Trigger: caller did not pass --json and stdout is a TTY.
-    Why: piped output (scripts, jq, etc.) must stay machine-parseable;
-         human-readable formatting is only useful in an interactive terminal.
-    Outcome: Rich output in a terminal; raw JSON when piped or redirected.
+    Why: piped output (scripts, jq, etc.) must stay machine-parseable; the
+         interactive (Rich/plain) renderers are only the default in a terminal.
+    Outcome: a formatted renderer in a terminal; raw JSON when piped or redirected.
+
+    Note: tests patch this to simulate a TTY, so the precedence logic in
+    ``_resolve_output_mode`` routes its terminal check through here.
     """
     return sys.stdout.isatty()
+
+
+def _validate_output_flags(json_output: bool, plain: bool) -> None:
+    """Reject the contradictory --json/--plain combination.
+
+    Trigger: both --json and --plain were passed.
+    Why: they request mutually exclusive output modes (raw JSON vs undecorated
+         human text); silently picking one would hide a user mistake.
+    Outcome: a clear typer error with a non-zero exit.
+    """
+    if json_output and plain:
+        typer.echo("Error: --json and --plain are mutually exclusive.", err=True)
+        raise typer.Exit(1)
+
+
+def _resolve_output_mode(json_output: bool, plain: bool) -> OutputMode:
+    """Resolve the effective output mode from flags, TTY state, and config.
+
+    Precedence, highest first:
+      1. --json            → raw JSON (wins over everything else)
+      2. --plain           → undecorated plain text (even when piped)
+      3. non-TTY stdout    → raw JSON (script compatibility, unchanged)
+      4. TTY               → config ``cli_output_style`` (rich by default)
+
+    Callers must invoke ``_validate_output_flags`` first; this helper assumes the
+    --json/--plain combination has already been rejected.
+    """
+    if json_output:
+        return "json"
+    if plain:
+        return "plain"
+    if not _use_rich():
+        return "json"
+    # Trigger: interactive TTY with no explicit mode flag.
+    # Why: let users choose their default terminal experience without a flag.
+    # Outcome: honor cli_output_style (rich out of the box, plain if configured).
+    return ConfigManager().config.cli_output_style
 
 
 def _print_json(result: Any) -> None:
@@ -278,6 +332,128 @@ def _display_recent_activity(result: list[dict[str, Any]]) -> None:
     console.print(Panel(table, title="Recent Activity", expand=False))
 
 
+# --- Plain formatters ---
+#
+# Plain output is NOT Rich markup: it is undecorated, greppable text printed via
+# the builtin print().  Literal brackets ([draft], [fact]) must survive verbatim,
+# so we deliberately do NOT call rich.markup.escape here -- escaping is only for
+# the Rich path and would corrupt literal brackets in plain text.
+
+
+def _plain_search_results(result: dict[str, Any], query: str = "") -> None:
+    """Render search-notes results as numbered plain-text entries.
+
+    Mirrors the Rich table content: a header line, then one numbered block per
+    result (title / score / permalink) with an indented snippet line.
+    """
+    results = result.get("results", [])
+    # Mirror the Rich path's total fix: the API can return total=0 with a
+    # populated results list, so fall back to len(results) when total is falsy.
+    raw_total = result.get("total", len(results))
+    total = raw_total if raw_total else len(results)
+
+    header = f"Search: {query}" if query else "Search results"
+    print(header)
+    print(f"{total} result(s)")
+
+    if not results:
+        print("No results found.")
+        return
+
+    for index, item in enumerate(results, start=1):
+        item_title = item.get("title") or item.get("permalink", "")
+        permalink = item.get("permalink", "")
+        score = item.get("score")
+        score_str = f"{score:.2f}" if score is not None else ""
+        print(f"{index}. {item_title}  (score: {score_str})  {permalink}")
+        raw_snippet = item.get("matched_chunk") or item.get("content") or ""
+        if raw_snippet:
+            snippet = raw_snippet[:200].replace("\n", " ")
+            print(f"    {snippet}")
+
+
+def _plain_read_note(result: dict[str, Any], *, include_frontmatter: bool = False) -> None:
+    """Render read-note as a plain title/permalink header, optional frontmatter, then body."""
+    title = result.get("title", "")
+    permalink = result.get("permalink", "")
+    content = result.get("content", "")
+    frontmatter: dict[str, Any] = result.get("frontmatter") or {}
+
+    header = f"{title}  [{permalink}]" if permalink else title
+    print(header)
+
+    # Trigger: --include-frontmatter was passed and the payload carries frontmatter.
+    # Why: the JSON payload always includes a "frontmatter" key, so the flag (not
+    #      mere presence) gates whether the key/value block is printed -- matching
+    #      the Rich path's gating behavior.
+    # Outcome: a blank line then "key: value" lines above the body.
+    if include_frontmatter and frontmatter:
+        print()
+        for key, value in frontmatter.items():
+            print(f"{key}: {value}")
+
+    print()
+    if content:
+        print(content)
+    else:
+        print("(no content)")
+
+
+def _plain_build_context(result: dict[str, Any]) -> None:
+    """Render build-context as an ASCII-indented outline.
+
+    Each primary result is a top-level line; its observations and related items
+    are two-space indented beneath it, mirroring the Rich tree content.
+    """
+    metadata = result.get("metadata", {})
+    uri = metadata.get("uri", "")
+    context_items: list[dict[str, Any]] = list(result.get("results", []))
+
+    print(f"Context: {uri}" if uri else "Context")
+
+    if not context_items:
+        print("No related content found.")
+        return
+
+    for context_result in context_items:
+        primary = context_result.get("primary_result", {})
+        p_title = primary.get("title") or primary.get("permalink", "")
+        p_type = primary.get("type", "")
+        primary_line = f"{p_type}  {p_title}" if p_type else p_title
+        print(primary_line)
+
+        observations: list[dict[str, Any]] = list(context_result.get("observations", []))
+        for obs in observations:
+            category = obs.get("category", "")
+            obs_content = obs.get("content", "")
+            if len(obs_content) > 120:
+                obs_content = obs_content[:117] + "..."
+            print(f"  [{category}] {obs_content}")
+
+        related: list[dict[str, Any]] = list(context_result.get("related_results", []))
+        for rel_item in related:
+            rel_title = rel_item.get("title") or rel_item.get("permalink", "")
+            rel_type = rel_item.get("type", "")
+            relation = rel_item.get("relation_type", "")
+            parts = [part for part in (relation, rel_type, rel_title) if part]
+            print(f"  {'  '.join(parts)}")
+
+
+def _plain_recent_activity(result: list[dict[str, Any]]) -> None:
+    """Render recent-activity as plain "- title (type) permalink updated" lines."""
+    if not result:
+        print("No recent activity.")
+        return
+
+    print("Recent Activity")
+    for item in result:
+        item_type = item.get("type", "")
+        item_title = item.get("title") or item.get("permalink", "")
+        permalink = item.get("permalink", "")
+        updated = str(item.get("updated_at") or item.get("created_at") or "")
+        print(f"- {item_title} ({item_type}) {permalink} {updated}".rstrip())
+
+
 def _delete_note_failure_message(result: dict[str, Any]) -> str | None:
     """Return the CLI failure message for delete-note JSON results, if any."""
     error = result.get("error")
@@ -426,6 +602,9 @@ def read_note(
     json_output: bool = typer.Option(
         False, "--json", help="Output raw JSON instead of formatted display"
     ),
+    plain: bool = typer.Option(
+        False, "--plain", help="Output undecorated plain text (no colors/markup), even when piped"
+    ),
     project: Annotated[
         Optional[str],
         typer.Option(help="The project to use. If not provided, the default project will be used."),
@@ -444,13 +623,16 @@ def read_note(
 ):
     """Read a markdown note from the knowledge base.
 
-    Displays formatted Markdown output by default when run in a terminal.
-    Use --json for raw machine-readable output.
+    Three output modes: Rich formatted Markdown (default in a terminal), plain
+    undecorated text (--plain), and raw JSON (--json, or automatically when
+    piped). The interactive default is set by the cli_output_style config option
+    (rich/plain). --json and --plain are mutually exclusive.
 
     Examples:
 
     bm tool read-note my-note
     bm tool read-note my-note --include-frontmatter
+    bm tool read-note my-note --plain
     bm tool read-note my-note --json
     """
     # Deferred: loading the MCP tool stack at module import slows CLI startup (#886).
@@ -458,6 +640,7 @@ def read_note(
 
     try:
         validate_routing_flags(local, cloud)
+        _validate_output_flags(json_output, plain)
 
         with force_routing(local=local, cloud=cloud):
             result = run_with_cleanup(
@@ -482,12 +665,13 @@ def read_note(
             _print_json(result)
             raise typer.Exit(1)
 
-        # Trigger: --json flag or non-TTY stdout (piped output).
-        # Why: scripts and downstream tools need parseable JSON; Rich markup
-        #      would corrupt those pipelines.
-        # Outcome: raw JSON for machine consumers; formatted display for humans.
-        if json_output or not _use_rich() or isinstance(result, str):
+        # A string result (e.g. a not-found message) has no structured shape to
+        # format, so always fall back to JSON regardless of the resolved mode.
+        mode = _resolve_output_mode(json_output, plain)
+        if mode == "json" or isinstance(result, str):
             _print_json(result)
+        elif mode == "plain":
+            _plain_read_note(result, include_frontmatter=include_frontmatter)
         else:
             _display_read_note(result, include_frontmatter=include_frontmatter)
     except ValueError as e:
@@ -656,6 +840,9 @@ def build_context(
     json_output: bool = typer.Option(
         False, "--json", help="Output raw JSON instead of formatted display"
     ),
+    plain: bool = typer.Option(
+        False, "--plain", help="Output undecorated plain text (no colors/markup), even when piped"
+    ),
     project: Annotated[
         Optional[str],
         typer.Option(help="The project to use. If not provided, the default project will be used."),
@@ -674,13 +861,16 @@ def build_context(
 ):
     """Get context needed to continue a discussion.
 
-    Displays a Rich tree view by default when run in a terminal.
-    Use --json for raw machine-readable output.
+    Three output modes: a Rich tree view (default in a terminal), a plain
+    ASCII-indented outline (--plain), and raw JSON (--json, or automatically when
+    piped). The interactive default is set by the cli_output_style config option
+    (rich/plain). --json and --plain are mutually exclusive.
 
     Examples:
 
     bm tool build-context memory://specs/search
     bm tool build-context specs/search --depth 2 --timeframe 30d
+    bm tool build-context memory://specs/search --plain
     bm tool build-context memory://specs/search --json
     """
     # Deferred: loading the MCP tool stack at module import slows CLI startup (#886).
@@ -688,6 +878,7 @@ def build_context(
 
     try:
         validate_routing_flags(local, cloud)
+        _validate_output_flags(json_output, plain)
 
         with force_routing(local=local, cloud=cloud):
             result = run_with_cleanup(
@@ -704,12 +895,12 @@ def build_context(
                 )
             )
 
-        # Trigger: --json flag or non-TTY stdout (piped output).
-        # Why: scripts and downstream tools need parseable JSON; Rich markup
-        #      would corrupt those pipelines.
-        # Outcome: raw JSON for machine consumers; formatted display for humans.
-        if json_output or not _use_rich() or isinstance(result, str):
+        # A string result has no structured shape to format, so fall back to JSON.
+        mode = _resolve_output_mode(json_output, plain)
+        if mode == "json" or isinstance(result, str):
             _print_json(result)
+        elif mode == "plain":
+            _plain_build_context(result)
         else:
             _display_build_context(result)
     except ValueError as e:
@@ -736,6 +927,9 @@ def recent_activity(
     json_output: bool = typer.Option(
         False, "--json", help="Output raw JSON instead of formatted display"
     ),
+    plain: bool = typer.Option(
+        False, "--plain", help="Output undecorated plain text (no colors/markup), even when piped"
+    ),
     project: Annotated[
         Optional[str],
         typer.Option(help="The project to use. If not provided, the default project will be used."),
@@ -754,14 +948,17 @@ def recent_activity(
 ):
     """Get recent activity across the knowledge base.
 
-    Displays a formatted table by default when run in a terminal.
-    Use --json for raw machine-readable output.
+    Three output modes: a formatted Rich table (default in a terminal), plain
+    undecorated lines (--plain), and raw JSON (--json, or automatically when
+    piped). The interactive default is set by the cli_output_style config option
+    (rich/plain). --json and --plain are mutually exclusive.
 
     Examples:
 
     bm tool recent-activity
     bm tool recent-activity --timeframe 30d --page-size 20
     bm tool recent-activity --type entity --type observation
+    bm tool recent-activity --plain
     bm tool recent-activity --json
     """
     # Deferred: loading the MCP tool stack at module import slows CLI startup (#886).
@@ -769,6 +966,7 @@ def recent_activity(
 
     try:
         validate_routing_flags(local, cloud)
+        _validate_output_flags(json_output, plain)
 
         with force_routing(local=local, cloud=cloud):
             result = run_with_cleanup(
@@ -784,12 +982,12 @@ def recent_activity(
                 )
             )
 
-        # Trigger: --json flag or non-TTY stdout (piped output).
-        # Why: scripts and downstream tools need parseable JSON; Rich markup
-        #      would corrupt those pipelines.
-        # Outcome: raw JSON for machine consumers; formatted display for humans.
-        if json_output or not _use_rich() or isinstance(result, str):
+        # A string result has no structured shape to format, so fall back to JSON.
+        mode = _resolve_output_mode(json_output, plain)
+        if mode == "json" or isinstance(result, str):
             _print_json(result)
+        elif mode == "plain":
+            _plain_recent_activity(result)
         else:
             _display_recent_activity(result)
     except ValueError as e:
@@ -858,6 +1056,9 @@ def search_notes(
     json_output: bool = typer.Option(
         False, "--json", help="Output raw JSON instead of formatted display"
     ),
+    plain: bool = typer.Option(
+        False, "--plain", help="Output undecorated plain text (no colors/markup), even when piped"
+    ),
     project: Annotated[
         Optional[str],
         typer.Option(help="The project to use. If not provided, the default project will be used."),
@@ -876,8 +1077,10 @@ def search_notes(
 ):
     """Search across all content in the knowledge base.
 
-    Displays a formatted table by default when run in a terminal.
-    Use --json for raw machine-readable output.
+    Three output modes: a formatted Rich table (default in a terminal), plain
+    numbered text results (--plain), and raw JSON (--json, or automatically when
+    piped). The interactive default is set by the cli_output_style config option
+    (rich/plain). --json and --plain are mutually exclusive.
 
     Examples:
 
@@ -886,6 +1089,7 @@ def search_notes(
     bm tool search-notes --tag python --tag async
     bm tool search-notes --meta status=draft
     bm tool search-notes "auth" --entity-type observation --category requirement
+    bm tool search-notes "my query" --plain
     bm tool search-notes "my query" --json
     """
     # Deferred: loading the MCP tool stack at module import slows CLI startup (#886).
@@ -893,6 +1097,7 @@ def search_notes(
 
     try:
         validate_routing_flags(local, cloud)
+        _validate_output_flags(json_output, plain)
 
         mode_flags = [permalink, title, vector, hybrid]
         if sum(1 for enabled in mode_flags if enabled) > 1:  # pragma: no cover
@@ -967,12 +1172,11 @@ def search_notes(
             typer.echo(result, err=True)
             raise typer.Exit(1)
 
-        # Trigger: --json flag or non-TTY stdout (piped output).
-        # Why: scripts and downstream tools need parseable JSON; Rich markup
-        #      would corrupt those pipelines.
-        # Outcome: raw JSON for machine consumers; formatted display for humans.
-        if json_output or not _use_rich():
+        mode = _resolve_output_mode(json_output, plain)
+        if mode == "json":
             _print_json(result)
+        elif mode == "plain":
+            _plain_search_results(result, query=query or "")
         else:
             _display_search_results(result, query=query or "")
     except ValueError as e:

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -381,17 +381,20 @@ def _plain_search_results(result: dict[str, Any], query: str = "") -> None:
             print(f"    {snippet}")
 
 
-def _plain_read_note(result: dict[str, Any]) -> None:
-    """Render read-note content faithfully: the note body, or the literal file.
+def _plain_read_note(result: dict[str, Any], *, include_frontmatter: bool = False) -> None:
+    """Render the note body for humans or the literal file for round-tripping.
 
     Plain mode adds NO decoration: no header line, no synthesized frontmatter
-    block, no placeholder for empty notes. Without --frontmatter the
-    API returns the note body; with it, the literal file (frontmatter block
-    included). Either is printed verbatim, trimmed only of the surrounding
-    newline artifacts the API keeps from frontmatter stripping, so the output
-    round-trips (e.g. ``read-note X --plain --frontmatter > note.md``).
+    block, no placeholder for empty notes. Without --frontmatter, trim the
+    surrounding newline artifacts left by the API's frontmatter removal. With
+    --frontmatter, write the literal file exactly so redirection round-trips
+    every boundary newline (e.g. ``read-note X --plain --frontmatter > note.md``).
     """
     content = result.get("content", "")
+    if include_frontmatter:
+        sys.stdout.write(content)
+        return
+
     body = content.strip("\n") if content else ""
     if body:
         print(body)
@@ -672,7 +675,7 @@ def read_note(
         if mode == "json" or isinstance(result, str):
             _print_json(result)
         elif mode == "plain":
-            _plain_read_note(result)
+            _plain_read_note(result, include_frontmatter=include_frontmatter)
         else:
             _display_read_note(result, include_frontmatter=include_frontmatter)
     except ValueError as e:

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -393,8 +393,11 @@ def _plain_read_note(result: dict[str, Any], *, include_frontmatter: bool = Fals
             print(f"{key}: {value}")
 
     print()
-    if content:
-        print(content)
+    # The API's content field keeps the blank line left by frontmatter
+    # stripping; trim newlines so the header gap stays a single blank line.
+    body = content.strip("\n") if content else ""
+    if body:
+        print(body)
     else:
         print("(no content)")
 

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -15,6 +15,7 @@ import typer
 from loguru import logger
 from rich.console import Console
 from rich.markdown import Markdown
+from rich.markup import escape as markup_escape
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
@@ -70,12 +71,23 @@ def _display_search_results(result: dict[str, Any], query: str = "") -> None:
       has_more: bool
     """
     results = result.get("results", [])
-    total = result.get("total", len(results))
+    # Trigger: API returns total=0 even when results is non-empty (upstream quirk).
+    # Why: the key exists with value 0, so result.get("total", len(results)) never
+    #      applies its default, leaving the subtitle as "0 result(s)" under a
+    #      populated table.
+    # Outcome: fall back to len(results) when total is falsy but results is non-empty.
+    raw_total = result.get("total", len(results))
+    total = raw_total if raw_total else len(results)
     # Real key is "current_page"; fall back to "page" for forward-compat.
     page = result.get("current_page") or result.get("page", 1)
     page_size = result.get("page_size", len(results)) or 1
 
-    title = f"Search: [bold cyan]{query}[/bold cyan]" if query else "Search results"
+    # Trigger: query is user-supplied text that may contain Rich markup characters.
+    # Why: interpolating it directly into a markup string causes brackets to be
+    #      parsed as style tags, swallowing or restyling bracketed content.
+    # Outcome: escape the query so its literal characters are always displayed.
+    escaped_query = markup_escape(query) if query else query
+    title = f"Search: [bold cyan]{escaped_query}[/bold cyan]" if query else "Search results"
     subtitle = f"{total} result(s)  •  page {page} of {max(1, -(-total // page_size))}"
 
     if not results:
@@ -91,26 +103,31 @@ def _display_search_results(result: dict[str, Any], query: str = "") -> None:
 
     for item in results:
         item_type = item.get("type", "")
-        item_title = item.get("title") or item.get("permalink", "")
-        permalink = item.get("permalink", "")
+        # Trigger: user-sourced title/permalink may contain bracketed text.
+        # Why: Rich table cells with a style column interpret markup in cell values,
+        #      swallowing brackets (e.g. "Spec [draft] v2" → "Spec  v2").
+        # Outcome: escape every user-sourced cell value before adding to the table.
+        item_title = markup_escape(item.get("title") or item.get("permalink", ""))
+        permalink = markup_escape(item.get("permalink", ""))
         score = item.get("score")
         score_str = f"{score:.2f}" if score is not None else ""
         # Prefer matched_chunk as the most relevant snippet; fall back to content.
         raw_snippet = item.get("matched_chunk") or item.get("content") or ""
         # Truncate to ~200 chars so the table stays readable.
-        snippet = raw_snippet[:200].replace("\n", " ") if raw_snippet else ""
+        snippet = markup_escape(raw_snippet[:200].replace("\n", " ")) if raw_snippet else ""
         table.add_row(item_type, item_title, score_str, permalink, snippet)
 
     console.print(Panel(table, title=title, subtitle=subtitle, expand=False))
 
 
-def _display_read_note(result: dict[str, Any]) -> None:
+def _display_read_note(result: dict[str, Any], *, include_frontmatter: bool = False) -> None:
     """Render read-note result: header panel + optional frontmatter + rendered Markdown content."""
     title = result.get("title", "")
     permalink = result.get("permalink", "")
     content = result.get("content", "")
     frontmatter: dict[str, Any] = result.get("frontmatter") or {}
 
+    # The header already uses Text.append so title is never markup-interpreted.
     header = Text()
     header.append(title, style="bold cyan")
     if permalink:
@@ -119,15 +136,20 @@ def _display_read_note(result: dict[str, Any]) -> None:
     console.print(Panel(header, expand=False))
 
     # Trigger: --include-frontmatter was passed; the MCP tool populates "frontmatter".
-    # Why: without rendering it here, the explicitly requested metadata is silently
-    #      dropped in the Rich path — users must also know to add --json to see it.
-    # Outcome: print a dim key/value block above the content when frontmatter is present.
-    if frontmatter:
+    # Why: the JSON payload always carries a "frontmatter" key regardless of the flag,
+    #      so checking non-empty alone would render it even without the flag.  The flag
+    #      must be threaded in to gate the panel.
+    # Outcome: print a dim key/value block above the content only when the flag is set.
+    if include_frontmatter and frontmatter:
         fm_table = Table(show_header=False, box=None, padding=(0, 1), expand=False)
         fm_table.add_column("key", style="dim")
         fm_table.add_column("value", style="dim")
         for key, value in frontmatter.items():
-            fm_table.add_row(str(key), str(value))
+            # Trigger: frontmatter keys/values are user-sourced and may contain markup.
+            # Why: Rich table cells with a style column parse markup, so bracketed
+            #      keys or values would be silently consumed or restyled.
+            # Outcome: escape both key and value before adding them to the table.
+            fm_table.add_row(markup_escape(str(key)), markup_escape(str(value)))
         console.print(Panel(fm_table, title="[dim]frontmatter[/dim]", expand=False))
 
     if content:
@@ -154,7 +176,11 @@ def _display_build_context(result: dict[str, Any]) -> None:
     uri = metadata.get("uri", "")
     context_items: list[dict[str, Any]] = list(result.get("results", []))
 
-    label = f"[bold cyan]{uri}[/bold cyan]" if uri else "Context"
+    # Trigger: uri is user-sourced and may contain Rich markup characters.
+    # Why: interpolating it directly into a markup string causes brackets to be
+    #      parsed as style tags, swallowing or restyling bracketed content.
+    # Outcome: escape the uri so its literal characters are always displayed.
+    label = f"[bold cyan]{markup_escape(uri)}[/bold cyan]" if uri else "Context"
     tree = Tree(f"[bold]Context:[/bold] {label}")
 
     if not context_items:
@@ -163,8 +189,13 @@ def _display_build_context(result: dict[str, Any]) -> None:
         for context_result in context_items:
             # --- Primary result node ---
             primary = context_result.get("primary_result", {})
-            p_title = primary.get("title") or primary.get("permalink", "")
-            p_type = primary.get("type", "")
+            # Trigger: p_title and p_type are user-sourced values from the knowledge graph.
+            # Why: embedding them in markup strings without escaping would cause any
+            #      bracketed text (e.g. an entity titled "Spec [draft]") to be consumed
+            #      by the Rich markup parser and silently dropped from output.
+            # Outcome: escape all user values before interpolating into markup strings.
+            p_title = markup_escape(primary.get("title") or primary.get("permalink", ""))
+            p_type = markup_escape(primary.get("type", ""))
             primary_label = f"[cyan]{p_title}[/cyan]"
             if p_type:
                 primary_label = f"[dim]{p_type}[/dim]  {primary_label}"
@@ -185,15 +216,23 @@ def _display_build_context(result: dict[str, Any]) -> None:
                 # Truncate long observations so the tree stays readable.
                 if len(obs_content) > 120:
                     obs_content = obs_content[:117] + "..."
-                obs_label = f"[dim][{category}] {obs_content}[/dim]"
+                # Trigger: category and obs_content are user-sourced strings that may
+                #          contain Rich markup characters.  The category is also wrapped
+                #          in literal "[" "]" brackets in the label, which must be
+                #          escaped too so Rich does not treat "[fact]" as a style tag.
+                # Why: embedding "[fact]" in a markup string causes Rich to parse it as
+                #      an unknown tag and silently drop the text.
+                # Outcome: escape the full "[category] content" fragment including the
+                #          surrounding brackets before embedding it in a styled label.
+                obs_label = f"[dim]{markup_escape(f'[{category}] {obs_content}')}[/dim]"
                 primary_node.add(obs_label)
 
             # --- Related items as children ---
             related: list[dict[str, Any]] = list(context_result.get("related_results", []))
             for rel_item in related:
-                rel_title = rel_item.get("title") or rel_item.get("permalink", "")
-                rel_type = rel_item.get("type", "")
-                relation = rel_item.get("relation_type", "")
+                rel_title = markup_escape(rel_item.get("title") or rel_item.get("permalink", ""))
+                rel_type = markup_escape(rel_item.get("type", ""))
+                relation = markup_escape(rel_item.get("relation_type", ""))
 
                 parts = []
                 if relation:
@@ -226,8 +265,13 @@ def _display_recent_activity(result: list[dict[str, Any]]) -> None:
 
     for item in result:
         item_type = item.get("type", "")
-        item_title = item.get("title") or item.get("permalink", "")
-        permalink = item.get("permalink", "")
+        # Trigger: title, permalink, and timestamps are user-sourced strings from the
+        #          knowledge graph and may contain Rich markup characters.
+        # Why: Rich table cells with a style column parse markup in cell values, so
+        #      bracketed content would be silently consumed or restyled.
+        # Outcome: escape all user-sourced cell values before adding to the table.
+        item_title = markup_escape(item.get("title") or item.get("permalink", ""))
+        permalink = markup_escape(item.get("permalink", ""))
         updated = str(item.get("updated_at") or item.get("created_at") or "")
         table.add_row(item_type, item_title, permalink, updated)
 
@@ -445,7 +489,7 @@ def read_note(
         if json_output or not _use_rich() or isinstance(result, str):
             _print_json(result)
         else:
-            _display_read_note(result)
+            _display_read_note(result, include_frontmatter=include_frontmatter)
     except ValueError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -1,7 +1,10 @@
 """CLI tool commands for Basic Memory.
 
 Every command calls its MCP tool with output_format="json" and prints the result.
-No text formatting, no separate code paths, no duplicate data fetching.
+Commands that benefit from human-readable output (search-notes, read-note,
+build-context, recent-activity) default to Rich formatting when stdout is a TTY
+and fall back to raw JSON when piped or when --json is supplied.  This follows
+the same bm status / bm project list precedent.
 """
 
 import json
@@ -10,6 +13,12 @@ from typing import Annotated, Any, Dict, List, Optional
 
 import typer
 from loguru import logger
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+from rich.tree import Tree
 
 from basic_memory.cli.app import app
 from basic_memory.cli.commands.command_utils import run_with_cleanup
@@ -24,13 +33,133 @@ app.add_typer(tool_app, name="tool", help="Access to MCP tools via CLI")
 
 VALID_EDIT_OPERATIONS = ["append", "prepend", "find_replace", "replace_section"]
 
+# Shared Rich console (stderr=False so output goes to stdout, matching _print_json).
+console = Console()
+
 
 # --- Shared helpers ---
+
+
+def _use_rich() -> bool:
+    """Return True when stdout is an interactive TTY and Rich output is appropriate.
+
+    Trigger: caller did not pass --json and stdout is a TTY.
+    Why: piped output (scripts, jq, etc.) must stay machine-parseable;
+         human-readable formatting is only useful in an interactive terminal.
+    Outcome: Rich output in a terminal; raw JSON when piped or redirected.
+    """
+    return sys.stdout.isatty()
 
 
 def _print_json(result: Any) -> None:
     """Print a result as formatted JSON."""
     print(json.dumps(result, indent=2, ensure_ascii=True, default=str))
+
+
+# --- Rich formatters ---
+
+
+def _display_search_results(result: dict[str, Any]) -> None:
+    """Render search-notes results as a Rich table."""
+    results = result.get("results", [])
+    total = result.get("total", len(results))
+    query = result.get("query") or ""
+    page = result.get("page", 1)
+    page_size = result.get("page_size", len(results))
+
+    title = f"Search results for [bold cyan]{query}[/bold cyan]" if query else "Search results"
+    subtitle = f"{total} result(s)  •  page {page} of {max(1, -(-total // page_size))}"
+
+    if not results:
+        console.print(Panel(Text("No results found.", style="dim"), title=title, expand=False))
+        return
+
+    table = Table(show_header=True, header_style="bold", expand=False)
+    table.add_column("Type", style="dim", width=12)
+    table.add_column("Title", style="bold cyan")
+    table.add_column("Permalink", style="green")
+
+    for item in results:
+        item_type = item.get("type", "")
+        item_title = item.get("title") or item.get("permalink", "")
+        permalink = item.get("permalink", "")
+        table.add_row(item_type, item_title, permalink)
+
+    console.print(Panel(table, title=title, subtitle=subtitle, expand=False))
+
+
+def _display_read_note(result: dict[str, Any]) -> None:
+    """Render read-note result: header panel + rendered Markdown content."""
+    title = result.get("title", "")
+    permalink = result.get("permalink", "")
+    content = result.get("content", "")
+
+    header = Text()
+    header.append(title, style="bold cyan")
+    if permalink:
+        header.append(f"  [{permalink}]", style="dim green")
+
+    console.print(Panel(header, expand=False))
+
+    if content:
+        console.print(Markdown(content))
+    else:
+        console.print(Text("(no content)", style="dim"))
+
+
+def _display_build_context(result: dict[str, Any]) -> None:
+    """Render build-context result as a Rich tree."""
+    metadata = result.get("metadata", {})
+    uri = metadata.get("uri", "")
+    results = result.get("results", [])
+    total = len(results)
+
+    label = f"[bold cyan]{uri}[/bold cyan]" if uri else "Context"
+    tree = Tree(f"[bold]Context:[/bold] {label}")
+
+    if not results:
+        tree.add("[dim]No related content found.[/dim]")
+    else:
+        for item in results:
+            item_title = item.get("title") or item.get("permalink", "")
+            relation = item.get("relation_type", "")
+            item_type = item.get("type", "")
+
+            parts = []
+            if relation:
+                parts.append(f"[yellow]{relation}[/yellow]")
+            if item_type:
+                parts.append(f"[dim]{item_type}[/dim]")
+            parts.append(f"[cyan]{item_title}[/cyan]")
+
+            tree.add(" ".join(parts))
+
+    subtitle = f"{total} related item(s)"
+    console.print(Panel(tree, subtitle=subtitle, expand=False))
+
+
+def _display_recent_activity(result: list[dict[str, Any]]) -> None:
+    """Render recent-activity results as a Rich table."""
+    if not result:
+        console.print(
+            Panel(Text("No recent activity.", style="dim"), title="Recent Activity", expand=False)
+        )
+        return
+
+    table = Table(show_header=True, header_style="bold", expand=False)
+    table.add_column("Type", style="dim", width=12)
+    table.add_column("Title", style="bold cyan")
+    table.add_column("Permalink", style="green")
+    table.add_column("Updated", style="dim")
+
+    for item in result:
+        item_type = item.get("type", "")
+        item_title = item.get("title") or item.get("permalink", "")
+        permalink = item.get("permalink", "")
+        updated = str(item.get("updated_at") or item.get("created_at") or "")
+        table.add_row(item_type, item_title, permalink, updated)
+
+    console.print(Panel(table, title="Recent Activity", expand=False))
 
 
 def _delete_note_failure_message(result: dict[str, Any]) -> str | None:
@@ -178,6 +307,9 @@ def read_note(
     include_frontmatter: bool = typer.Option(
         False, "--include-frontmatter", help="Include YAML frontmatter in output"
     ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Output raw JSON instead of formatted display"
+    ),
     project: Annotated[
         Optional[str],
         typer.Option(help="The project to use. If not provided, the default project will be used."),
@@ -196,10 +328,14 @@ def read_note(
 ):
     """Read a markdown note from the knowledge base.
 
+    Displays formatted Markdown output by default when run in a terminal.
+    Use --json for raw machine-readable output.
+
     Examples:
 
     bm tool read-note my-note
     bm tool read-note my-note --include-frontmatter
+    bm tool read-note my-note --json
     """
     # Deferred: loading the MCP tool stack at module import slows CLI startup (#886).
     from basic_memory.mcp.tools import read_note as mcp_read_note
@@ -230,7 +366,14 @@ def read_note(
             _print_json(result)
             raise typer.Exit(1)
 
-        _print_json(result)
+        # Trigger: --json flag or non-TTY stdout (piped output).
+        # Why: scripts and downstream tools need parseable JSON; Rich markup
+        #      would corrupt those pipelines.
+        # Outcome: raw JSON for machine consumers; formatted display for humans.
+        if json_output or not _use_rich():
+            _print_json(result)
+        else:
+            _display_read_note(result)
     except ValueError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
@@ -394,6 +537,9 @@ def build_context(
     page: int = typer.Option(1, "--page", help="Page number for pagination"),
     page_size: int = typer.Option(10, "--page-size", help="Number of results per page"),
     max_related: int = typer.Option(10, "--max-related", help="Maximum related items to return"),
+    json_output: bool = typer.Option(
+        False, "--json", help="Output raw JSON instead of formatted display"
+    ),
     project: Annotated[
         Optional[str],
         typer.Option(help="The project to use. If not provided, the default project will be used."),
@@ -412,10 +558,14 @@ def build_context(
 ):
     """Get context needed to continue a discussion.
 
+    Displays a Rich tree view by default when run in a terminal.
+    Use --json for raw machine-readable output.
+
     Examples:
 
     bm tool build-context memory://specs/search
     bm tool build-context specs/search --depth 2 --timeframe 30d
+    bm tool build-context memory://specs/search --json
     """
     # Deferred: loading the MCP tool stack at module import slows CLI startup (#886).
     from basic_memory.mcp.tools import build_context as mcp_build_context
@@ -437,7 +587,15 @@ def build_context(
                     output_format="json",
                 )
             )
-        _print_json(result)
+
+        # Trigger: --json flag or non-TTY stdout (piped output).
+        # Why: scripts and downstream tools need parseable JSON; Rich markup
+        #      would corrupt those pipelines.
+        # Outcome: raw JSON for machine consumers; formatted display for humans.
+        if json_output or not _use_rich():
+            _print_json(result)
+        else:
+            _display_build_context(result)
     except ValueError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
@@ -459,6 +617,9 @@ def recent_activity(
     # Match the MCP recent_activity default (page_size=10) so identical default
     # invocations return the same number of rows from CLI and MCP.
     page_size: int = typer.Option(10, "--page-size", help="Number of results per page"),
+    json_output: bool = typer.Option(
+        False, "--json", help="Output raw JSON instead of formatted display"
+    ),
     project: Annotated[
         Optional[str],
         typer.Option(help="The project to use. If not provided, the default project will be used."),
@@ -477,11 +638,15 @@ def recent_activity(
 ):
     """Get recent activity across the knowledge base.
 
+    Displays a formatted table by default when run in a terminal.
+    Use --json for raw machine-readable output.
+
     Examples:
 
     bm tool recent-activity
     bm tool recent-activity --timeframe 30d --page-size 20
     bm tool recent-activity --type entity --type observation
+    bm tool recent-activity --json
     """
     # Deferred: loading the MCP tool stack at module import slows CLI startup (#886).
     from basic_memory.mcp.tools import recent_activity as mcp_recent_activity
@@ -502,7 +667,15 @@ def recent_activity(
                     output_format="json",
                 )
             )
-        _print_json(result)
+
+        # Trigger: --json flag or non-TTY stdout (piped output).
+        # Why: scripts and downstream tools need parseable JSON; Rich markup
+        #      would corrupt those pipelines.
+        # Outcome: raw JSON for machine consumers; formatted display for humans.
+        if json_output or not _use_rich():
+            _print_json(result)
+        else:
+            _display_recent_activity(result)
     except ValueError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
@@ -566,6 +739,9 @@ def search_notes(
     ] = None,
     page: int = typer.Option(1, "--page", help="Page number for pagination"),
     page_size: int = typer.Option(10, "--page-size", help="Number of results per page"),
+    json_output: bool = typer.Option(
+        False, "--json", help="Output raw JSON instead of formatted display"
+    ),
     project: Annotated[
         Optional[str],
         typer.Option(help="The project to use. If not provided, the default project will be used."),
@@ -584,6 +760,9 @@ def search_notes(
 ):
     """Search across all content in the knowledge base.
 
+    Displays a formatted table by default when run in a terminal.
+    Use --json for raw machine-readable output.
+
     Examples:
 
     bm tool search-notes "my query"
@@ -591,6 +770,7 @@ def search_notes(
     bm tool search-notes --tag python --tag async
     bm tool search-notes --meta status=draft
     bm tool search-notes "auth" --entity-type observation --category requirement
+    bm tool search-notes "my query" --json
     """
     # Deferred: loading the MCP tool stack at module import slows CLI startup (#886).
     from basic_memory.mcp.tools import search_notes as mcp_search
@@ -671,7 +851,14 @@ def search_notes(
             typer.echo(result, err=True)
             raise typer.Exit(1)
 
-        _print_json(result)
+        # Trigger: --json flag or non-TTY stdout (piped output).
+        # Why: scripts and downstream tools need parseable JSON; Rich markup
+        #      would corrupt those pipelines.
+        # Outcome: raw JSON for machine consumers; formatted display for humans.
+        if json_output or not _use_rich():
+            _print_json(result)
+        else:
+            _display_search_results(result)
     except ValueError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -190,7 +190,7 @@ def _display_read_note(result: dict[str, Any], *, include_frontmatter: bool = Fa
 
     console.print(Panel(header, expand=False))
 
-    # Trigger: --include-frontmatter was passed; the MCP tool populates "frontmatter".
+    # Trigger: --frontmatter was passed; the MCP tool populates "frontmatter".
     # Why: the JSON payload always carries a "frontmatter" key regardless of the flag,
     #      so checking non-empty alone would render it even without the flag.  The flag
     #      must be threaded in to gate the panel.
@@ -207,7 +207,7 @@ def _display_read_note(result: dict[str, Any], *, include_frontmatter: bool = Fa
             fm_table.add_row(markup_escape(str(key)), markup_escape(str(value)))
         console.print(Panel(fm_table, title="[dim]frontmatter[/dim]", expand=False))
 
-    # Trigger: --include-frontmatter makes the API return the literal file, so
+    # Trigger: --frontmatter makes the API return the literal file, so
     # content starts with the frontmatter block the panel above already shows.
     # Why: rendering it again through Markdown duplicates the frontmatter (and
     #      Markdown mangles the --- fences into rules/headings).
@@ -385,11 +385,11 @@ def _plain_read_note(result: dict[str, Any]) -> None:
     """Render read-note content faithfully: the note body, or the literal file.
 
     Plain mode adds NO decoration: no header line, no synthesized frontmatter
-    block, no placeholder for empty notes. Without --include-frontmatter the
+    block, no placeholder for empty notes. Without --frontmatter the
     API returns the note body; with it, the literal file (frontmatter block
     included). Either is printed verbatim, trimmed only of the surrounding
     newline artifacts the API keeps from frontmatter stripping, so the output
-    round-trips (e.g. ``read-note X --plain --include-frontmatter > note.md``).
+    round-trips (e.g. ``read-note X --plain --frontmatter > note.md``).
     """
     content = result.get("content", "")
     body = content.strip("\n") if content else ""
@@ -595,7 +595,10 @@ def write_note(
 def read_note(
     identifier: str,
     include_frontmatter: bool = typer.Option(
-        False, "--include-frontmatter", help="Include YAML frontmatter in output"
+        False,
+        "--frontmatter",
+        "--include-frontmatter",
+        help="Include YAML frontmatter in output (--include-frontmatter is a deprecated alias)",
     ),
     json_output: bool = typer.Option(
         False, "--json", help="Output raw JSON instead of formatted display"
@@ -629,7 +632,7 @@ def read_note(
     Examples:
 
     bm tool read-note my-note
-    bm tool read-note my-note --include-frontmatter
+    bm tool read-note my-note --frontmatter
     bm tool read-note my-note --plain
     bm tool read-note my-note --json
     """

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -112,6 +112,23 @@ def _print_json(result: Any) -> None:
     print(json.dumps(result, indent=2, ensure_ascii=True, default=str))
 
 
+def _search_result_summary(result: dict[str, Any]) -> str:
+    """Describe search count and pagination without inventing a final page."""
+    results = result.get("results", [])
+    raw_total = result.get("total")
+    total_is_known = isinstance(raw_total, int) and raw_total > 0
+    total = raw_total if total_is_known else len(results)
+    page = result.get("current_page") or result.get("page", 1)
+    page_size = result.get("page_size", len(results)) or 1
+
+    summary = f"{total} result(s)  •  page {page}"
+    if total_is_known:
+        summary += f" of {max(1, -(-total // page_size))}"
+    if result.get("has_more") is True:
+        summary += "  •  more results available"
+    return summary
+
+
 # --- Rich formatters ---
 
 
@@ -126,24 +143,13 @@ def _display_search_results(result: dict[str, Any], query: str = "") -> None:
       has_more: bool
     """
     results = result.get("results", [])
-    # Trigger: API returns total=0 even when results is non-empty (upstream quirk).
-    # Why: the key exists with value 0, so result.get("total", len(results)) never
-    #      applies its default, leaving the subtitle as "0 result(s)" under a
-    #      populated table.
-    # Outcome: fall back to len(results) when total is falsy but results is non-empty.
-    raw_total = result.get("total", len(results))
-    total = raw_total if raw_total else len(results)
-    # Real key is "current_page"; fall back to "page" for forward-compat.
-    page = result.get("current_page") or result.get("page", 1)
-    page_size = result.get("page_size", len(results)) or 1
-
     # Trigger: query is user-supplied text that may contain Rich markup characters.
     # Why: interpolating it directly into a markup string causes brackets to be
     #      parsed as style tags, swallowing or restyling bracketed content.
     # Outcome: escape the query so its literal characters are always displayed.
     escaped_query = markup_escape(query) if query else query
     title = f"Search: [bold cyan]{escaped_query}[/bold cyan]" if query else "Search results"
-    subtitle = f"{total} result(s)  •  page {page} of {max(1, -(-total // page_size))}"
+    subtitle = _search_result_summary(result)
 
     if not results:
         console.print(Panel(Text("No results found.", style="dim"), title=title, expand=False))
@@ -301,6 +307,18 @@ def _display_build_context(result: dict[str, Any]) -> None:
                 primary_label = f"[dim]{p_type}[/dim]  {primary_label}"
             primary_node = tree.add(primary_label)
 
+            # Entity summaries can carry the note body independently of observations.
+            # Preserve it so human-readable output contains the same primary context
+            # as JSON, even for prose-heavy notes with no structured observations.
+            raw_primary_content = primary.get("content")
+            primary_content = (
+                raw_primary_content.strip()
+                if isinstance(raw_primary_content, str) and raw_primary_content.strip()
+                else ""
+            )
+            if primary_content:
+                primary_node.add(Text(primary_content, style="dim"))
+
             # --- Observations as children (category + truncated content) ---
             # Trigger: ContextResult.observations exists in the JSON output but was
             #          never rendered in the Rich path.
@@ -360,6 +378,9 @@ def _display_recent_activity(result: list[dict[str, Any]]) -> None:
     table = Table(show_header=True, header_style="bold", expand=False)
     table.add_column("Type", style="dim", width=12)
     table.add_column("Title", style="bold cyan")
+    show_project = any(item.get("project") for item in result)
+    if show_project:
+        table.add_column("Project", style="magenta")
     table.add_column("Permalink", style="green")
     table.add_column("Updated", style="dim")
 
@@ -371,9 +392,14 @@ def _display_recent_activity(result: list[dict[str, Any]]) -> None:
         #      bracketed content would be silently consumed or restyled.
         # Outcome: escape all user-sourced cell values before adding to the table.
         item_title = markup_escape(item.get("title") or item.get("permalink", ""))
+        project = markup_escape(str(item.get("project") or ""))
         permalink = markup_escape(item.get("permalink", ""))
         updated = str(item.get("updated_at") or item.get("created_at") or "")
-        table.add_row(item_type, item_title, permalink, updated)
+        row = [item_type, item_title]
+        if show_project:
+            row.append(project)
+        row.extend((permalink, updated))
+        table.add_row(*row)
 
     console.print(Panel(table, title="Recent Activity", expand=False))
 
@@ -393,14 +419,9 @@ def _plain_search_results(result: dict[str, Any], query: str = "") -> None:
     result (title / score / permalink) with an indented snippet line.
     """
     results = result.get("results", [])
-    # Mirror the Rich path's total fix: the API can return total=0 with a
-    # populated results list, so fall back to len(results) when total is falsy.
-    raw_total = result.get("total", len(results))
-    total = raw_total if raw_total else len(results)
-
     header = f"Search: {query}" if query else "Search results"
     print(header)
-    print(f"{total} result(s)")
+    print(_search_result_summary(result).replace("  •  ", " | "))
 
     if not results:
         print("No results found.")
@@ -484,6 +505,16 @@ def _plain_build_context(result: dict[str, Any]) -> None:
         primary_line = f"{p_type}  {p_title}" if p_type else p_title
         print(primary_line)
 
+        raw_primary_content = primary.get("content")
+        primary_content = (
+            raw_primary_content.strip()
+            if isinstance(raw_primary_content, str) and raw_primary_content.strip()
+            else ""
+        )
+        if primary_content:
+            for line in primary_content.splitlines():
+                print(f"  {line}")
+
         observations: list[dict[str, Any]] = list(context_result.get("observations", []))
         for obs in observations:
             category = obs.get("category", "")
@@ -508,12 +539,15 @@ def _plain_recent_activity(result: list[dict[str, Any]]) -> None:
         return
 
     print("Recent Activity")
+    show_project = any(item.get("project") for item in result)
     for item in result:
         item_type = item.get("type", "")
         item_title = item.get("title") or item.get("permalink", "")
+        project = str(item.get("project") or "")
         permalink = item.get("permalink", "")
         updated = str(item.get("updated_at") or item.get("created_at") or "")
-        print(f"- {item_title} ({item_type}) {permalink} {updated}".rstrip())
+        project_label = f" [project: {project}]" if show_project and project else ""
+        print(f"- {item_title} ({item_type}){project_label} {permalink} {updated}".rstrip())
 
 
 def _delete_note_failure_message(result: dict[str, Any]) -> str | None:

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -105,10 +105,11 @@ def _display_search_results(result: dict[str, Any], query: str = "") -> None:
 
 
 def _display_read_note(result: dict[str, Any]) -> None:
-    """Render read-note result: header panel + rendered Markdown content."""
+    """Render read-note result: header panel + optional frontmatter + rendered Markdown content."""
     title = result.get("title", "")
     permalink = result.get("permalink", "")
     content = result.get("content", "")
+    frontmatter: dict[str, Any] = result.get("frontmatter") or {}
 
     header = Text()
     header.append(title, style="bold cyan")
@@ -116,6 +117,18 @@ def _display_read_note(result: dict[str, Any]) -> None:
         header.append(f"  [{permalink}]", style="dim green")
 
     console.print(Panel(header, expand=False))
+
+    # Trigger: --include-frontmatter was passed; the MCP tool populates "frontmatter".
+    # Why: without rendering it here, the explicitly requested metadata is silently
+    #      dropped in the Rich path — users must also know to add --json to see it.
+    # Outcome: print a dim key/value block above the content when frontmatter is present.
+    if frontmatter:
+        fm_table = Table(show_header=False, box=None, padding=(0, 1), expand=False)
+        fm_table.add_column("key", style="dim")
+        fm_table.add_column("value", style="dim")
+        for key, value in frontmatter.items():
+            fm_table.add_row(str(key), str(value))
+        console.print(Panel(fm_table, title="[dim]frontmatter[/dim]", expand=False))
 
     if content:
         console.print(Markdown(content))
@@ -157,6 +170,24 @@ def _display_build_context(result: dict[str, Any]) -> None:
                 primary_label = f"[dim]{p_type}[/dim]  {primary_label}"
             primary_node = tree.add(primary_label)
 
+            # --- Observations as children (category + truncated content) ---
+            # Trigger: ContextResult.observations exists in the JSON output but was
+            #          never rendered in the Rich path.
+            # Why: users running interactively lost core entity facts (observations)
+            #      that the --json path exposes; the TTY view must be at least as
+            #      informative as the JSON view for the primary entity.
+            # Outcome: each observation appears as a dim "[category] content" leaf
+            #          under its primary node, truncated at 120 chars.
+            observations: list[dict[str, Any]] = list(context_result.get("observations", []))
+            for obs in observations:
+                category = obs.get("category", "")
+                obs_content = obs.get("content", "")
+                # Truncate long observations so the tree stays readable.
+                if len(obs_content) > 120:
+                    obs_content = obs_content[:117] + "..."
+                obs_label = f"[dim][{category}] {obs_content}[/dim]"
+                primary_node.add(obs_label)
+
             # --- Related items as children ---
             related: list[dict[str, Any]] = list(context_result.get("related_results", []))
             for rel_item in related:
@@ -174,7 +205,8 @@ def _display_build_context(result: dict[str, Any]) -> None:
 
     # Count total related items across all primary results.
     total_related = sum(len(cr.get("related_results", [])) for cr in context_items)
-    subtitle = f"{len(context_items)} primary  •  {total_related} related"
+    total_observations = sum(len(cr.get("observations", [])) for cr in context_items)
+    subtitle = f"{len(context_items)} primary  •  {total_observations} observations  •  {total_related} related"
     console.print(Panel(tree, subtitle=subtitle, expand=False))
 
 

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -381,28 +381,20 @@ def _plain_search_results(result: dict[str, Any], query: str = "") -> None:
             print(f"    {snippet}")
 
 
-def _plain_read_note(result: dict[str, Any], *, include_frontmatter: bool = False) -> None:
-    """Render read-note as a plain title/permalink header, optional frontmatter, then body."""
-    title = result.get("title", "")
-    permalink = result.get("permalink", "")
-    content = result.get("content", "")
+def _plain_read_note(result: dict[str, Any]) -> None:
+    """Render read-note content faithfully: the note body, or the literal file.
 
-    # Trigger: --include-frontmatter makes the API return the literal file
-    # (frontmatter block included) as content.
-    # Why: plain mode should show that file verbatim -- the file's own
-    #      frontmatter already carries title/permalink, so a header line and a
-    #      synthesized key/value block would both duplicate it.
-    # Outcome: with the flag, emit ONLY the file; without it, a title/permalink
-    #      header then the body, trimmed to keep the gap a single blank line.
-    if not include_frontmatter:
-        header = f"{title}  [{permalink}]" if permalink else title
-        print(header)
-        print()
+    Plain mode adds NO decoration: no header line, no synthesized frontmatter
+    block, no placeholder for empty notes. Without --include-frontmatter the
+    API returns the note body; with it, the literal file (frontmatter block
+    included). Either is printed verbatim, trimmed only of the surrounding
+    newline artifacts the API keeps from frontmatter stripping, so the output
+    round-trips (e.g. ``read-note X --plain --include-frontmatter > note.md``).
+    """
+    content = result.get("content", "")
     body = content.strip("\n") if content else ""
     if body:
         print(body)
-    else:
-        print("(no content)")
 
 
 def _plain_build_context(result: dict[str, Any]) -> None:
@@ -677,7 +669,7 @@ def read_note(
         if mode == "json" or isinstance(result, str):
             _print_json(result)
         elif mode == "plain":
-            _plain_read_note(result, include_frontmatter=include_frontmatter)
+            _plain_read_note(result)
         else:
             _display_read_note(result, include_frontmatter=include_frontmatter)
     except ValueError as e:

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -387,16 +387,17 @@ def _plain_read_note(result: dict[str, Any], *, include_frontmatter: bool = Fals
     permalink = result.get("permalink", "")
     content = result.get("content", "")
 
-    header = f"{title}  [{permalink}]" if permalink else title
-    print(header)
-
-    print()
     # Trigger: --include-frontmatter makes the API return the literal file
     # (frontmatter block included) as content.
-    # Why: plain mode should show that file verbatim -- synthesizing a separate
-    #      key/value block would print the frontmatter twice.
-    # Outcome: with the flag, the body IS the frontmatter view; either way trim
-    #      surrounding newlines so the header gap stays a single blank line.
+    # Why: plain mode should show that file verbatim -- the file's own
+    #      frontmatter already carries title/permalink, so a header line and a
+    #      synthesized key/value block would both duplicate it.
+    # Outcome: with the flag, emit ONLY the file; without it, a title/permalink
+    #      header then the body, trimmed to keep the gap a single blank line.
+    if not include_frontmatter:
+        header = f"{title}  [{permalink}]" if permalink else title
+        print(header)
+        print()
     body = content.strip("\n") if content else ""
     if body:
         print(body)

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -422,15 +422,38 @@ def _plain_read_note(result: dict[str, Any], *, include_frontmatter: bool = Fals
     """Render the note body for humans or the literal file for round-tripping.
 
     Plain mode adds NO decoration: no header line, no synthesized frontmatter
-    block, no placeholder for empty notes. Without --frontmatter, trim the
-    surrounding newline artifacts left by the API's frontmatter removal. With
-    --frontmatter, write the literal file exactly so redirection round-trips
-    every boundary newline (e.g. ``read-note X --plain --frontmatter > note.md``).
+    block, no placeholder for empty notes. A missing note still reports the miss
+    and any related results so it cannot be confused with an empty note. Without
+    --frontmatter, trim the surrounding newline artifacts left by the API's
+    frontmatter removal. With --frontmatter, write the literal file exactly so
+    redirection round-trips every boundary newline (e.g.
+    ``read-note X --plain --frontmatter > note.md``).
     """
     raw_content = result.get("content")
     content = raw_content if isinstance(raw_content, str) else ""
     if include_frontmatter:
         sys.stdout.write(content)
+        return
+
+    # Trigger: the MCP fallback returns null note fields when no note resolves.
+    # Why: silence makes a miss indistinguishable from a real empty note in plain mode.
+    # Outcome: report the miss and preserve any related-note suggestions.
+    if raw_content is None and not result.get("title") and not result.get("permalink"):
+        print("Note not found.")
+        raw_related = result.get("related_results")
+        related_results = (
+            [item for item in raw_related if isinstance(item, dict)]
+            if isinstance(raw_related, list)
+            else []
+        )
+        if related_results:
+            print("Related results:")
+            for item in related_results:
+                title = str(item.get("title") or item.get("permalink") or "")
+                permalink = str(item.get("permalink") or "")
+                print(f"- {title}  {permalink}".rstrip())
+        else:
+            print("No note or related content found.")
         return
 
     body = content.strip("\n") if content else ""

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -177,10 +177,47 @@ def _display_search_results(result: dict[str, Any], query: str = "") -> None:
 
 def _display_read_note(result: dict[str, Any], *, include_frontmatter: bool = False) -> None:
     """Render read-note result: header panel + optional frontmatter + rendered Markdown content."""
-    title = result.get("title", "")
-    permalink = result.get("permalink", "")
-    content = result.get("content", "")
-    frontmatter: dict[str, Any] = result.get("frontmatter") or {}
+    title = str(result.get("title") or "")
+    permalink = str(result.get("permalink") or "")
+    raw_content = result.get("content")
+    content = raw_content if isinstance(raw_content, str) else ""
+    raw_frontmatter = result.get("frontmatter")
+    frontmatter: dict[str, Any] = raw_frontmatter if isinstance(raw_frontmatter, dict) else {}
+
+    # Trigger: read_note returns an explicit all-None payload when no note resolves.
+    # Why: treating those values as strings crashes Rich and hides any related-note
+    #      suggestions that the MCP fallback already found.
+    # Outcome: render a stable not-found panel, including safe, copyable suggestions.
+    if raw_content is None and not title and not permalink:
+        raw_related = result.get("related_results")
+        related_results: list[dict[str, Any]] = (
+            [item for item in raw_related if isinstance(item, dict)]
+            if isinstance(raw_related, list)
+            else []
+        )
+        if related_results:
+            table = Table(show_header=True, header_style="bold", expand=False)
+            table.add_column("Title", style="bold cyan")
+            table.add_column("Permalink", style="green")
+            table.add_column("File", style="dim")
+            for item in related_results:
+                table.add_row(
+                    markup_escape(str(item.get("title") or "")),
+                    markup_escape(str(item.get("permalink") or "")),
+                    markup_escape(str(item.get("file_path") or "")),
+                )
+            console.print(
+                Panel(
+                    table,
+                    title="Note not found",
+                    subtitle=f"{len(related_results)} related result(s)",
+                    expand=False,
+                )
+            )
+        else:
+            message = str(result.get("error") or "No note or related content found.")
+            console.print(Panel(Text(message, style="dim"), title="Note not found", expand=False))
+        return
 
     # The header already uses Text.append so title is never markup-interpreted.
     header = Text()
@@ -390,7 +427,8 @@ def _plain_read_note(result: dict[str, Any], *, include_frontmatter: bool = Fals
     --frontmatter, write the literal file exactly so redirection round-trips
     every boundary newline (e.g. ``read-note X --plain --frontmatter > note.md``).
     """
-    content = result.get("content", "")
+    raw_content = result.get("content")
+    content = raw_content if isinstance(raw_content, str) else ""
     if include_frontmatter:
         sys.stdout.write(content)
         return

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -173,9 +173,7 @@ def _display_build_context(result: dict[str, Any]) -> None:
                 primary_node.add(" ".join(parts))
 
     # Count total related items across all primary results.
-    total_related = sum(
-        len(cr.get("related_results", [])) for cr in context_items
-    )
+    total_related = sum(len(cr.get("related_results", [])) for cr in context_items)
     subtitle = f"{len(context_items)} primary  •  {total_related} related"
     console.print(Panel(tree, subtitle=subtitle, expand=False))
 
@@ -412,7 +410,7 @@ def read_note(
         # Why: scripts and downstream tools need parseable JSON; Rich markup
         #      would corrupt those pipelines.
         # Outcome: raw JSON for machine consumers; formatted display for humans.
-        if json_output or not _use_rich():
+        if json_output or not _use_rich() or isinstance(result, str):
             _print_json(result)
         else:
             _display_read_note(result)
@@ -634,7 +632,7 @@ def build_context(
         # Why: scripts and downstream tools need parseable JSON; Rich markup
         #      would corrupt those pipelines.
         # Outcome: raw JSON for machine consumers; formatted display for humans.
-        if json_output or not _use_rich():
+        if json_output or not _use_rich() or isinstance(result, str):
             _print_json(result)
         else:
             _display_build_context(result)
@@ -714,7 +712,7 @@ def recent_activity(
         # Why: scripts and downstream tools need parseable JSON; Rich markup
         #      would corrupt those pipelines.
         # Outcome: raw JSON for machine consumers; formatted display for humans.
-        if json_output or not _use_rich():
+        if json_output or not _use_rich() or isinstance(result, str):
             _print_json(result)
         else:
             _display_recent_activity(result)

--- a/src/basic_memory/config.py
+++ b/src/basic_memory/config.py
@@ -476,6 +476,18 @@ class BasicMemoryConfig(BaseSettings):
         ),
     )
 
+    cli_output_style: Literal["rich", "plain"] = Field(
+        default="rich",
+        description=(
+            "Default human-readable output style for interactive `bm tool` commands "
+            "(search-notes, read-note, build-context, recent-activity) when stdout is a TTY. "
+            "'rich' (default) renders colored Panel/Table/Tree/Markdown output; "
+            "'plain' renders undecorated greppable text with no ANSI colors or box-drawing. "
+            "Overridden per-invocation by --json (raw JSON) or --plain (forces plain). "
+            "Env: BASIC_MEMORY_CLI_OUTPUT_STYLE"
+        ),
+    )
+
     ensure_frontmatter_on_sync: bool = Field(
         default=True,
         description="Ensure markdown files have frontmatter during sync by adding derived title/type/permalink when missing. When combined with disable_permalinks=True, this setting takes precedence for missing-frontmatter files and still writes permalinks.",

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -848,6 +848,40 @@ def test_read_note_plain_include_frontmatter_not_found_is_empty(mock_mcp):
 @patch(
     "basic_memory.mcp.tools.read_note",
     new_callable=AsyncMock,
+    return_value=READ_NOTE_NOT_FOUND_RESULT,
+)
+def test_read_note_plain_not_found_renders_related_results(mock_mcp):
+    """A plain-mode miss stays distinct from an empty note and preserves suggestions."""
+    result = _tty_runner(["tool", "read-note", "missing-note", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "Note not found." in result.output
+    assert "Related [draft] Note" in result.output
+    assert "notes/related-note" in result.output
+
+
+@patch(
+    "basic_memory.mcp.tools.read_note",
+    new_callable=AsyncMock,
+    return_value={
+        "title": None,
+        "permalink": None,
+        "file_path": None,
+        "content": None,
+        "frontmatter": None,
+    },
+)
+def test_read_note_plain_not_found_without_suggestions(mock_mcp):
+    """A plain-mode miss without suggestions still reports a clear empty fallback."""
+    result = _tty_runner(["tool", "read-note", "missing-note", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert result.output == "Note not found.\nNo note or related content found.\n"
+
+
+@patch(
+    "basic_memory.mcp.tools.read_note",
+    new_callable=AsyncMock,
     return_value=READ_NOTE_RESULT_WITH_FRONTMATTER,
 )
 def test_read_note_include_frontmatter_alias(mock_mcp):

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -5,6 +5,7 @@ when stdout is piped or --json is supplied.  These tests verify both modes.
 """
 
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -139,8 +140,22 @@ RECENT_ACTIVITY_RESULT = [
 
 
 def _tty_runner(args, **kwargs):
-    """Invoke CLI as if stdout is a TTY (Rich output enabled)."""
+    """Invoke CLI as if stdout is a TTY (interactive output enabled)."""
     with patch("basic_memory.cli.commands.tool._use_rich", return_value=True):
+        return runner.invoke(cli_app, args, **kwargs)
+
+
+def _tty_runner_with_style(args, style, **kwargs):
+    """Invoke CLI as if stdout is a TTY with a given cli_output_style config value.
+
+    Patches both _use_rich (simulate TTY) and tool.ConfigManager so that
+    _resolve_output_mode reads the configured interactive style.
+    """
+    fake_cm = patch(
+        "basic_memory.cli.commands.tool.ConfigManager",
+        return_value=SimpleNamespace(config=SimpleNamespace(cli_output_style=style)),
+    )
+    with patch("basic_memory.cli.commands.tool._use_rich", return_value=True), fake_cm:
         return runner.invoke(cli_app, args, **kwargs)
 
 
@@ -642,3 +657,299 @@ def test_search_notes_rich_zero_total_falls_back_to_result_count(mock_mcp):
     # The subtitle must show the real count (2), not 0
     assert "2 result(s)" in result.output
     assert "0 result(s)" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# --plain output mode (issue #678 follow-up)
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT,
+)
+def test_search_notes_plain_output(mock_mcp):
+    """search-notes --plain emits undecorated numbered text, not JSON or Rich boxes."""
+    result = _tty_runner(["tool", "search-notes", "test", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    # Not JSON
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        json.loads(result.output)
+    # Numbered, greppable entries with titles, scores, and permalinks
+    assert "1. Test Note" in result.output
+    assert "2. Another Note" in result.output
+    assert "notes/test-note" in result.output
+    assert "0.95" in result.output
+    # Snippet line present
+    assert "A snippet about test notes" in result.output
+    # No Rich box-drawing characters
+    assert "─" not in result.output
+    assert "│" not in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT_BRACKETED_TITLE,
+)
+def test_search_notes_plain_brackets_survive(mock_mcp):
+    """Literal brackets must survive verbatim in plain output (no markup escaping)."""
+    result = _tty_runner(["tool", "search-notes", "spec", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    # The literal title and snippet brackets must be present unmangled
+    assert "Spec [draft] v2" in result.output
+    assert "[red]" in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT_ZERO_TOTAL,
+)
+def test_search_notes_plain_zero_total_fallback(mock_mcp):
+    """Plain search output shows the corrected count when the API returns total=0."""
+    result = _tty_runner(["tool", "search-notes", "found", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "2 result(s)" in result.output
+    assert "0 result(s)" not in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT_EMPTY,
+)
+def test_search_notes_plain_empty(mock_mcp):
+    """Plain search output handles empty results."""
+    result = _tty_runner(["tool", "search-notes", "nothing", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "No results found." in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_read_note",
+    new_callable=AsyncMock,
+    return_value=READ_NOTE_RESULT,
+)
+def test_read_note_plain_output(mock_mcp):
+    """read-note --plain emits a header line and the raw markdown body."""
+    result = _tty_runner(["tool", "read-note", "test-note", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "Test Note  [notes/test-note]" in result.output
+    # Raw markdown body, not Rich-rendered
+    assert "# Test Note" in result.output
+    assert "hello world" in result.output
+    # No frontmatter without the flag
+    assert "tags:" not in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_read_note",
+    new_callable=AsyncMock,
+    return_value=READ_NOTE_RESULT,
+)
+def test_read_note_plain_include_frontmatter(mock_mcp):
+    """read-note --plain --include-frontmatter renders key: value lines."""
+    result = _tty_runner(["tool", "read-note", "test-note", "--plain", "--include-frontmatter"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "title: Test Note" in result.output
+    assert "tags:" in result.output
+    assert "hello world" in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_read_note",
+    new_callable=AsyncMock,
+    return_value={"title": "", "permalink": "", "content": "", "frontmatter": {}},
+)
+def test_read_note_plain_empty_content(mock_mcp):
+    """read-note --plain handles empty content."""
+    result = _tty_runner(["tool", "read-note", "empty-note", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "(no content)" in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_build_context",
+    new_callable=AsyncMock,
+    return_value=BUILD_CONTEXT_RESULT,
+)
+def test_build_context_plain_output(mock_mcp):
+    """build-context --plain emits an ASCII-indented outline with observations."""
+    result = _tty_runner(["tool", "build-context", "memory://notes/test-note", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "Context: notes/test-note" in result.output
+    assert "Test Note" in result.output
+    # Observation rendered with literal bracketed category, indented
+    assert "  [fact] This is a key fact about the test note" in result.output
+    # Related item with relation type, indented
+    assert "Related Note" in result.output
+    assert "references" in result.output
+    # Not JSON
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        json.loads(result.output)
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_build_context",
+    new_callable=AsyncMock,
+    return_value=BUILD_CONTEXT_BRACKETED_OBS,
+)
+def test_build_context_plain_bracket_survives(mock_mcp):
+    """Observation category [fact] must appear literally in plain build-context output."""
+    result = _tty_runner(["tool", "build-context", "memory://people/joanna", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "[fact]" in result.output
+    assert "Joanna lives in Austin" in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_build_context",
+    new_callable=AsyncMock,
+    return_value=BUILD_CONTEXT_EMPTY,
+)
+def test_build_context_plain_empty(mock_mcp):
+    """build-context --plain handles empty results."""
+    result = _tty_runner(["tool", "build-context", "memory://notes/test-note", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "No related content found." in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_recent_activity",
+    new_callable=AsyncMock,
+    return_value=RECENT_ACTIVITY_RESULT,
+)
+def test_recent_activity_plain_output(mock_mcp):
+    """recent-activity --plain emits "- title (type) permalink updated" lines."""
+    result = _tty_runner(["tool", "recent-activity", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "- Note A (entity) notes/note-a" in result.output
+    assert "- Note B (entity) notes/note-b" in result.output
+    # Not JSON
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        json.loads(result.output)
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_recent_activity",
+    new_callable=AsyncMock,
+    return_value=[],
+)
+def test_recent_activity_plain_empty(mock_mcp):
+    """recent-activity --plain handles empty results."""
+    result = _tty_runner(["tool", "recent-activity", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "No recent activity." in result.output
+
+
+# ---------------------------------------------------------------------------
+# Precedence matrix: --json > --plain > non-TTY (JSON) > TTY (config style)
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT,
+)
+def test_json_beats_plain(mock_mcp):
+    """--json wins over --plain... when they are not used together, --json alone is JSON.
+
+    The contradictory combination is tested separately (must error); here we
+    confirm --json on its own produces JSON even in a TTY.
+    """
+    result = _tty_runner(["tool", "search-notes", "test", "--json"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    data = json.loads(result.output)
+    assert data["total"] == 2
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT,
+)
+def test_json_and_plain_together_errors(mock_mcp):
+    """Passing both --json and --plain is a clear, non-zero error."""
+    result = _tty_runner(["tool", "search-notes", "test", "--json", "--plain"])
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_read_note",
+    new_callable=AsyncMock,
+    return_value=READ_NOTE_RESULT,
+)
+def test_read_note_json_and_plain_together_errors(mock_mcp):
+    """read-note also rejects --json --plain together."""
+    result = _tty_runner(["tool", "read-note", "test-note", "--json", "--plain"])
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT,
+)
+def test_plain_forces_plain_when_piped(mock_mcp):
+    """--plain forces plain output even when stdout is NOT a TTY (piped)."""
+    # No _use_rich patch: the default CliRunner stdout is not a TTY, so absent
+    # --plain this would be JSON.  --plain must override that into plain text.
+    result = runner.invoke(cli_app, ["tool", "search-notes", "test", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        json.loads(result.output)
+    assert "1. Test Note" in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT,
+)
+def test_tty_config_rich_renders_rich(mock_mcp):
+    """TTY + cli_output_style=rich → Rich output (box-drawing present)."""
+    result = _tty_runner_with_style(["tool", "search-notes", "test"], style="rich")
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        json.loads(result.output)
+    # Rich draws a Panel border
+    assert "─" in result.output or "│" in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT,
+)
+def test_tty_config_plain_renders_plain(mock_mcp):
+    """TTY + cli_output_style=plain → plain output (no box-drawing)."""
+    result = _tty_runner_with_style(["tool", "search-notes", "test"], style="plain")
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        json.loads(result.output)
+    assert "1. Test Note" in result.output
+    assert "─" not in result.output
+    assert "│" not in result.output

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -27,46 +27,72 @@ READ_NOTE_RESULT = {
 }
 
 SEARCH_RESULT = {
-    "query": "test",
+    # Real SearchResponse.model_dump() uses "current_page", not "page".
+    # No "query" key in the response -- the query comes from the CLI argument.
     "total": 2,
-    "page": 1,
+    "current_page": 1,
     "page_size": 10,
+    "has_more": False,
     "results": [
         {
             "type": "entity",
             "title": "Test Note",
             "permalink": "notes/test-note",
             "file_path": "notes/Test Note.md",
+            "score": 0.95,
+            "matched_chunk": "A snippet about test notes",
+            "content": None,
         },
         {
             "type": "observation",
             "title": "Another Note",
             "permalink": "notes/another-note",
             "file_path": "notes/Another Note.md",
+            "score": 0.72,
+            "matched_chunk": None,
+            "content": "Full content here",
         },
     ],
 }
 
 SEARCH_RESULT_EMPTY = {
-    "query": "nothing",
     "total": 0,
-    "page": 1,
+    "current_page": 1,
     "page_size": 10,
+    "has_more": False,
     "results": [],
 }
 
 BUILD_CONTEXT_RESULT = {
+    # Real GraphContext.model_dump() shape: results is a list of ContextResult dicts.
+    # Each ContextResult has primary_result + observations + related_results.
     "results": [
         {
-            "type": "entity",
-            "title": "Related Note",
-            "permalink": "notes/related",
-            "relation_type": "references",
+            "primary_result": {
+                "type": "entity",
+                "external_id": "abc123",
+                "title": "Test Note",
+                "permalink": "notes/test-note",
+                "file_path": "notes/Test Note.md",
+                "created_at": "2025-01-01T00:00:00",
+            },
+            "observations": [],
+            "related_results": [
+                {
+                    "type": "relation",
+                    "title": "Related Note",
+                    "permalink": "notes/related",
+                    "file_path": "notes/Related Note.md",
+                    "relation_type": "references",
+                    "created_at": "2025-01-01T00:00:00",
+                }
+            ],
         }
     ],
     "metadata": {"uri": "notes/test-note", "depth": 1},
     "page": 1,
     "page_size": 10,
+    "has_more": False,
 }
 
 BUILD_CONTEXT_EMPTY = {
@@ -74,16 +100,18 @@ BUILD_CONTEXT_EMPTY = {
     "metadata": {"uri": "notes/test-note", "depth": 1},
     "page": 1,
     "page_size": 10,
+    "has_more": False,
 }
 
 RECENT_ACTIVITY_RESULT = [
+    # Real _extract_recent_rows output keys: type/title/permalink/file_path/created_at
+    # (optional: project).  No "updated_at" key in the real output.
     {
         "type": "entity",
         "title": "Note A",
         "permalink": "notes/note-a",
         "file_path": "notes/Note A.md",
         "created_at": "2025-01-01 00:00:00",
-        "updated_at": "2025-01-01 12:00:00",
     },
     {
         "type": "entity",
@@ -91,7 +119,6 @@ RECENT_ACTIVITY_RESULT = [
         "permalink": "notes/note-b",
         "file_path": "notes/Note B.md",
         "created_at": "2025-01-02 00:00:00",
-        "updated_at": None,
     },
 ]
 
@@ -125,10 +152,11 @@ def test_search_notes_rich_output_default(mock_mcp):
     # Rich output should NOT be valid JSON
     with pytest.raises((json.JSONDecodeError, ValueError)):
         json.loads(result.output)
-    # But it should contain the result titles
+    # But it should contain the result titles and partial permalink
     assert "Test Note" in result.output
     assert "Another Note" in result.output
-    assert "notes/test-note" in result.output
+    # Rich may truncate long permalinks with ellipsis; check the prefix.
+    assert "notes/test-no" in result.output
 
 
 @patch(
@@ -287,7 +315,9 @@ def test_build_context_json_flag_overrides_tty(mock_mcp):
     assert result.exit_code == 0, f"CLI failed: {result.output}"
     data = json.loads(result.output)
     assert "results" in data
-    assert data["results"][0]["title"] == "Related Note"
+    # Real shape: results[i] is a ContextResult with primary_result nested inside.
+    assert data["results"][0]["primary_result"]["title"] == "Test Note"
+    assert data["results"][0]["related_results"][0]["title"] == "Related Note"
 
 
 @patch(

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -23,7 +23,8 @@ READ_NOTE_RESULT = {
     "title": "Test Note",
     "permalink": "notes/test-note",
     "file_path": "notes/Test Note.md",
-    "content": "# Test Note\n\nhello world",
+    # Real payloads keep the leading newline left by frontmatter stripping.
+    "content": "\n# Test Note\n\nhello world",
     "frontmatter": {"title": "Test Note", "tags": ["test"]},
 }
 
@@ -263,7 +264,9 @@ def test_read_note_json_flag_overrides_tty(mock_mcp):
     assert result.exit_code == 0, f"CLI failed: {result.output}"
     data = json.loads(result.output)
     assert data["title"] == "Test Note"
-    assert data["content"] == "# Test Note\n\nhello world"
+    # JSON mode is byte-faithful: the payload's leading newline (frontmatter-strip
+    # artifact) is preserved here even though display modes trim it.
+    assert data["content"] == "\n# Test Note\n\nhello world"
 
 
 @patch(
@@ -747,6 +750,9 @@ def test_read_note_plain_output(mock_mcp):
     assert "hello world" in result.output
     # No frontmatter without the flag
     assert "tags:" not in result.output
+    # Exactly one blank line between header and body: the payload's leading
+    # newline (frontmatter-strip artifact) must not stack with the renderer's.
+    assert "Test Note  [notes/test-note]\n\n# Test Note" in result.output
 
 
 @patch(

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -456,7 +456,7 @@ def test_read_note_rich_include_frontmatter(mock_mcp):
     frontmatter block must be stripped from the Markdown body or it renders
     again under the panel.
     """
-    result = _tty_runner(["tool", "read-note", "test-note", "--include-frontmatter"])
+    result = _tty_runner(["tool", "read-note", "test-note", "--frontmatter"])
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"
     # Frontmatter panel appears with key/value data
@@ -776,7 +776,7 @@ def test_read_note_plain_include_frontmatter(mock_mcp):
     With the flag, content IS the file (frontmatter block included); plain mode
     prints it verbatim and must not prepend a synthesized key/value block.
     """
-    result = _tty_runner(["tool", "read-note", "test-note", "--plain", "--include-frontmatter"])
+    result = _tty_runner(["tool", "read-note", "test-note", "--plain", "--frontmatter"])
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"
     # ONLY the literal file: no header line, output starts at the fence
@@ -785,6 +785,19 @@ def test_read_note_plain_include_frontmatter(mock_mcp):
     assert "hello world" in result.output
     # No duplicated frontmatter from a synthesized block or header
     assert result.output.count("title: Test Note") == 1
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_read_note",
+    new_callable=AsyncMock,
+    return_value=READ_NOTE_RESULT_WITH_FRONTMATTER,
+)
+def test_read_note_include_frontmatter_alias(mock_mcp):
+    """--include-frontmatter still works as a deprecated alias for --frontmatter."""
+    result = _tty_runner(["tool", "read-note", "test-note", "--plain", "--include-frontmatter"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert result.output.startswith("---\ntitle: Test Note")
 
 
 @patch(

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -28,13 +28,13 @@ READ_NOTE_RESULT = {
     "frontmatter": {"title": "Test Note", "tags": ["test"]},
 }
 
-# With --include-frontmatter the API returns the LITERAL FILE as content
+# With --frontmatter the API returns the LITERAL FILE as content
 # (frontmatter block included) alongside the parsed frontmatter dict.
 READ_NOTE_RESULT_WITH_FRONTMATTER = {
     "title": "Test Note",
     "permalink": "notes/test-note",
     "file_path": "notes/Test Note.md",
-    "content": "---\ntitle: Test Note\ntags:\n- test\n---\n\n# Test Note\n\nhello world",
+    "content": "---\ntitle: Test Note\ntags:\n- test\n---\n\n# Test Note\n\nhello world\n\n",
     "frontmatter": {"title": "Test Note", "tags": ["test"]},
 }
 
@@ -176,7 +176,7 @@ def _tty_runner_with_style(args, style, **kwargs):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT,
 )
@@ -196,7 +196,7 @@ def test_search_notes_rich_output_default(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT_EMPTY,
 )
@@ -209,7 +209,7 @@ def test_search_notes_rich_empty(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT,
 )
@@ -224,7 +224,7 @@ def test_search_notes_json_flag_overrides_tty(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT,
 )
@@ -244,7 +244,7 @@ def test_search_notes_non_tty_gives_json(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_read_note",
+    "basic_memory.mcp.tools.read_note",
     new_callable=AsyncMock,
     return_value=READ_NOTE_RESULT,
 )
@@ -263,7 +263,7 @@ def test_read_note_rich_output_default(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_read_note",
+    "basic_memory.mcp.tools.read_note",
     new_callable=AsyncMock,
     return_value=READ_NOTE_RESULT,
 )
@@ -280,7 +280,7 @@ def test_read_note_json_flag_overrides_tty(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_read_note",
+    "basic_memory.mcp.tools.read_note",
     new_callable=AsyncMock,
     return_value={"title": "", "permalink": "", "content": "", "frontmatter": {}},
 )
@@ -293,7 +293,7 @@ def test_read_note_rich_empty_content(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_read_note",
+    "basic_memory.mcp.tools.read_note",
     new_callable=AsyncMock,
     return_value=READ_NOTE_RESULT,
 )
@@ -312,7 +312,7 @@ def test_read_note_non_tty_gives_json(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_build_context",
+    "basic_memory.mcp.tools.build_context",
     new_callable=AsyncMock,
     return_value=BUILD_CONTEXT_RESULT,
 )
@@ -329,7 +329,7 @@ def test_build_context_rich_output_default(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_build_context",
+    "basic_memory.mcp.tools.build_context",
     new_callable=AsyncMock,
     return_value=BUILD_CONTEXT_EMPTY,
 )
@@ -342,7 +342,7 @@ def test_build_context_rich_empty(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_build_context",
+    "basic_memory.mcp.tools.build_context",
     new_callable=AsyncMock,
     return_value=BUILD_CONTEXT_RESULT,
 )
@@ -359,7 +359,7 @@ def test_build_context_json_flag_overrides_tty(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_build_context",
+    "basic_memory.mcp.tools.build_context",
     new_callable=AsyncMock,
     return_value=BUILD_CONTEXT_RESULT,
 )
@@ -378,7 +378,7 @@ def test_build_context_non_tty_gives_json(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_recent_activity",
+    "basic_memory.mcp.tools.recent_activity",
     new_callable=AsyncMock,
     return_value=RECENT_ACTIVITY_RESULT,
 )
@@ -396,7 +396,7 @@ def test_recent_activity_rich_output_default(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_recent_activity",
+    "basic_memory.mcp.tools.recent_activity",
     new_callable=AsyncMock,
     return_value=[],
 )
@@ -409,7 +409,7 @@ def test_recent_activity_rich_empty(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_recent_activity",
+    "basic_memory.mcp.tools.recent_activity",
     new_callable=AsyncMock,
     return_value=RECENT_ACTIVITY_RESULT,
 )
@@ -424,7 +424,7 @@ def test_recent_activity_json_flag_overrides_tty(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_recent_activity",
+    "basic_memory.mcp.tools.recent_activity",
     new_callable=AsyncMock,
     return_value=RECENT_ACTIVITY_RESULT,
 )
@@ -444,12 +444,12 @@ def test_recent_activity_non_tty_gives_json(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_read_note",
+    "basic_memory.mcp.tools.read_note",
     new_callable=AsyncMock,
     return_value=READ_NOTE_RESULT_WITH_FRONTMATTER,
 )
 def test_read_note_rich_include_frontmatter(mock_mcp):
-    """read-note --include-frontmatter renders the panel once, not twice.
+    """read-note --frontmatter renders the panel once, not twice.
 
     Regression 1: the Rich renderer silently dropped frontmatter even with the
     flag. Regression 2: with the flag, content is the LITERAL FILE, so the
@@ -472,12 +472,12 @@ def test_read_note_rich_include_frontmatter(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_read_note",
+    "basic_memory.mcp.tools.read_note",
     new_callable=AsyncMock,
     return_value=READ_NOTE_RESULT,
 )
 def test_read_note_rich_no_frontmatter_without_flag(mock_mcp):
-    """read-note WITHOUT --include-frontmatter must not render the frontmatter panel.
+    """read-note without --frontmatter must not render the frontmatter panel.
 
     Regression (Bug 2): the JSON payload always contains a non-empty "frontmatter"
     key, so the previous `if frontmatter:` guard rendered it even without the flag.
@@ -499,7 +499,7 @@ def test_read_note_rich_no_frontmatter_without_flag(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_build_context",
+    "basic_memory.mcp.tools.build_context",
     new_callable=AsyncMock,
     return_value=BUILD_CONTEXT_RESULT,
 )
@@ -578,7 +578,7 @@ BUILD_CONTEXT_BRACKETED_OBS = {
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT_BRACKETED_TITLE,
 )
@@ -599,7 +599,7 @@ def test_search_notes_rich_title_with_brackets_survives(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_build_context",
+    "basic_memory.mcp.tools.build_context",
     new_callable=AsyncMock,
     return_value=BUILD_CONTEXT_BRACKETED_OBS,
 )
@@ -654,7 +654,7 @@ SEARCH_RESULT_ZERO_TOTAL = {
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT_ZERO_TOTAL,
 )
@@ -683,7 +683,7 @@ def test_search_notes_rich_zero_total_falls_back_to_result_count(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT,
 )
@@ -708,7 +708,7 @@ def test_search_notes_plain_output(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT_BRACKETED_TITLE,
 )
@@ -723,7 +723,7 @@ def test_search_notes_plain_brackets_survive(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT_ZERO_TOTAL,
 )
@@ -737,7 +737,7 @@ def test_search_notes_plain_zero_total_fallback(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT_EMPTY,
 )
@@ -750,7 +750,7 @@ def test_search_notes_plain_empty(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_read_note",
+    "basic_memory.mcp.tools.read_note",
     new_callable=AsyncMock,
     return_value=READ_NOTE_RESULT,
 )
@@ -766,29 +766,24 @@ def test_read_note_plain_output(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_read_note",
+    "basic_memory.mcp.tools.read_note",
     new_callable=AsyncMock,
     return_value=READ_NOTE_RESULT_WITH_FRONTMATTER,
 )
 def test_read_note_plain_include_frontmatter(mock_mcp):
-    """read-note --plain --include-frontmatter shows the literal file, once.
+    """read-note --plain --frontmatter writes the literal file byte-for-byte.
 
     With the flag, content IS the file (frontmatter block included); plain mode
-    prints it verbatim and must not prepend a synthesized key/value block.
+    must not add decoration or alter leading/trailing newlines.
     """
     result = _tty_runner(["tool", "read-note", "test-note", "--plain", "--frontmatter"])
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"
-    # ONLY the literal file: no header line, output starts at the fence
-    assert "Test Note  [notes/test-note]" not in result.output
-    assert result.output.startswith("---\ntitle: Test Note\ntags:\n- test\n---")
-    assert "hello world" in result.output
-    # No duplicated frontmatter from a synthesized block or header
-    assert result.output.count("title: Test Note") == 1
+    assert result.output == READ_NOTE_RESULT_WITH_FRONTMATTER["content"]
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_read_note",
+    "basic_memory.mcp.tools.read_note",
     new_callable=AsyncMock,
     return_value=READ_NOTE_RESULT_WITH_FRONTMATTER,
 )
@@ -801,7 +796,7 @@ def test_read_note_include_frontmatter_alias(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_read_note",
+    "basic_memory.mcp.tools.read_note",
     new_callable=AsyncMock,
     return_value={"title": "", "permalink": "", "content": "", "frontmatter": {}},
 )
@@ -814,7 +809,7 @@ def test_read_note_plain_empty_content(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_build_context",
+    "basic_memory.mcp.tools.build_context",
     new_callable=AsyncMock,
     return_value=BUILD_CONTEXT_RESULT,
 )
@@ -836,7 +831,7 @@ def test_build_context_plain_output(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_build_context",
+    "basic_memory.mcp.tools.build_context",
     new_callable=AsyncMock,
     return_value=BUILD_CONTEXT_BRACKETED_OBS,
 )
@@ -850,7 +845,7 @@ def test_build_context_plain_bracket_survives(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_build_context",
+    "basic_memory.mcp.tools.build_context",
     new_callable=AsyncMock,
     return_value=BUILD_CONTEXT_EMPTY,
 )
@@ -863,7 +858,7 @@ def test_build_context_plain_empty(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_recent_activity",
+    "basic_memory.mcp.tools.recent_activity",
     new_callable=AsyncMock,
     return_value=RECENT_ACTIVITY_RESULT,
 )
@@ -880,7 +875,7 @@ def test_recent_activity_plain_output(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_recent_activity",
+    "basic_memory.mcp.tools.recent_activity",
     new_callable=AsyncMock,
     return_value=[],
 )
@@ -898,7 +893,7 @@ def test_recent_activity_plain_empty(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT,
 )
@@ -916,7 +911,7 @@ def test_json_beats_plain(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT,
 )
@@ -929,7 +924,7 @@ def test_json_and_plain_together_errors(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_read_note",
+    "basic_memory.mcp.tools.read_note",
     new_callable=AsyncMock,
     return_value=READ_NOTE_RESULT,
 )
@@ -942,7 +937,7 @@ def test_read_note_json_and_plain_together_errors(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT,
 )
@@ -959,7 +954,7 @@ def test_plain_forces_plain_when_piped(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT,
 )
@@ -975,7 +970,7 @@ def test_tty_config_rich_renders_rich(mock_mcp):
 
 
 @patch(
-    "basic_memory.cli.commands.tool.mcp_search",
+    "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
     return_value=SEARCH_RESULT,
 )

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -28,6 +28,16 @@ READ_NOTE_RESULT = {
     "frontmatter": {"title": "Test Note", "tags": ["test"]},
 }
 
+# With --include-frontmatter the API returns the LITERAL FILE as content
+# (frontmatter block included) alongside the parsed frontmatter dict.
+READ_NOTE_RESULT_WITH_FRONTMATTER = {
+    "title": "Test Note",
+    "permalink": "notes/test-note",
+    "file_path": "notes/Test Note.md",
+    "content": "---\ntitle: Test Note\ntags:\n- test\n---\n\n# Test Note\n\nhello world",
+    "frontmatter": {"title": "Test Note", "tags": ["test"]},
+}
+
 SEARCH_RESULT = {
     # Real SearchResponse.model_dump() uses "current_page", not "page".
     # No "query" key in the response -- the query comes from the CLI argument.
@@ -436,24 +446,29 @@ def test_recent_activity_non_tty_gives_json(mock_mcp):
 @patch(
     "basic_memory.cli.commands.tool.mcp_read_note",
     new_callable=AsyncMock,
-    return_value=READ_NOTE_RESULT,
+    return_value=READ_NOTE_RESULT_WITH_FRONTMATTER,
 )
 def test_read_note_rich_include_frontmatter(mock_mcp):
-    """read-note --include-frontmatter renders frontmatter keys in Rich path.
+    """read-note --include-frontmatter renders the panel once, not twice.
 
-    Regression: previously the Rich renderer silently dropped frontmatter even
-    when --include-frontmatter was passed, requiring --json to see the data.
+    Regression 1: the Rich renderer silently dropped frontmatter even with the
+    flag. Regression 2: with the flag, content is the LITERAL FILE, so the
+    frontmatter block must be stripped from the Markdown body or it renders
+    again under the panel.
     """
     result = _tty_runner(["tool", "read-note", "test-note", "--include-frontmatter"])
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"
-    # Frontmatter section header should appear
+    # Frontmatter panel appears with key/value data
     assert "frontmatter" in result.output
-    # The frontmatter key and value from READ_NOTE_RESULT should be visible
     assert "tags" in result.output
     assert "test" in result.output
-    # The note content should still appear
+    # The note content still appears
     assert "hello world" in result.output
+    # The frontmatter block is NOT rendered a second time through Markdown:
+    # the raw fence is stripped, and the title key appears only in the panel.
+    assert "---" not in result.output
+    assert result.output.count("title") == 1
 
 
 @patch(
@@ -758,16 +773,22 @@ def test_read_note_plain_output(mock_mcp):
 @patch(
     "basic_memory.cli.commands.tool.mcp_read_note",
     new_callable=AsyncMock,
-    return_value=READ_NOTE_RESULT,
+    return_value=READ_NOTE_RESULT_WITH_FRONTMATTER,
 )
 def test_read_note_plain_include_frontmatter(mock_mcp):
-    """read-note --plain --include-frontmatter renders key: value lines."""
+    """read-note --plain --include-frontmatter shows the literal file, once.
+
+    With the flag, content IS the file (frontmatter block included); plain mode
+    prints it verbatim and must not prepend a synthesized key/value block.
+    """
     result = _tty_runner(["tool", "read-note", "test-note", "--plain", "--include-frontmatter"])
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"
-    assert "title: Test Note" in result.output
-    assert "tags:" in result.output
+    # The literal file: fences and YAML lines exactly as stored
+    assert "---\ntitle: Test Note\ntags:\n- test\n---" in result.output
     assert "hello world" in result.output
+    # No duplicated frontmatter from a synthesized block
+    assert result.output.count("title: Test Note") == 1
 
 
 @patch(

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -784,10 +784,11 @@ def test_read_note_plain_include_frontmatter(mock_mcp):
     result = _tty_runner(["tool", "read-note", "test-note", "--plain", "--include-frontmatter"])
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"
-    # The literal file: fences and YAML lines exactly as stored
-    assert "---\ntitle: Test Note\ntags:\n- test\n---" in result.output
+    # ONLY the literal file: no header line, output starts at the fence
+    assert "Test Note  [notes/test-note]" not in result.output
+    assert result.output.startswith("---\ntitle: Test Note\ntags:\n- test\n---")
     assert "hello world" in result.output
-    # No duplicated frontmatter from a synthesized block
+    # No duplicated frontmatter from a synthesized block or header
     assert result.output.count("title: Test Note") == 1
 
 

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -438,6 +438,28 @@ def test_read_note_rich_include_frontmatter(mock_mcp):
     assert "hello world" in result.output
 
 
+@patch(
+    "basic_memory.cli.commands.tool.mcp_read_note",
+    new_callable=AsyncMock,
+    return_value=READ_NOTE_RESULT,
+)
+def test_read_note_rich_no_frontmatter_without_flag(mock_mcp):
+    """read-note WITHOUT --include-frontmatter must not render the frontmatter panel.
+
+    Regression (Bug 2): the JSON payload always contains a non-empty "frontmatter"
+    key, so the previous `if frontmatter:` guard rendered it even without the flag.
+    The flag must be threaded into _display_read_note to gate the panel.
+    """
+    result = _tty_runner(["tool", "read-note", "test-note"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    # The note title and content must still appear
+    assert "Test Note" in result.output
+    assert "hello world" in result.output
+    # The frontmatter panel must NOT appear
+    assert "frontmatter" not in result.output
+
+
 # ---------------------------------------------------------------------------
 # build-context – observations rendering (issue #678)
 # ---------------------------------------------------------------------------
@@ -463,3 +485,160 @@ def test_build_context_rich_renders_observations(mock_mcp):
     assert "key fact" in result.output
     # The subtitle should include an observations count
     assert "observations" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Rich markup injection – bracketed user text must survive (Bug 1, issue #678)
+# ---------------------------------------------------------------------------
+
+# Search result whose title contains a bracket expression like "[draft]".
+SEARCH_RESULT_BRACKETED_TITLE = {
+    "total": 1,
+    "current_page": 1,
+    "page_size": 10,
+    "has_more": False,
+    "results": [
+        {
+            "type": "entity",
+            "title": "Spec [draft] v2",
+            "permalink": "specs/spec-draft-v2",
+            "file_path": "specs/Spec [draft] v2.md",
+            "score": 0.90,
+            "matched_chunk": "An important [red] section",
+            "content": None,
+        },
+    ],
+}
+
+# build-context payload where the observation category is "fact" — previously
+# `[fact]` in the obs_label markup was interpreted as an unknown Rich tag and
+# the text was swallowed.
+BUILD_CONTEXT_BRACKETED_OBS = {
+    "results": [
+        {
+            "primary_result": {
+                "type": "entity",
+                "external_id": "xyz",
+                "title": "Joanna",
+                "permalink": "people/joanna",
+                "file_path": "people/Joanna.md",
+                "created_at": "2025-01-01T00:00:00",
+            },
+            "observations": [
+                {
+                    "type": "observation",
+                    "category": "fact",
+                    "content": "Joanna lives in Austin",
+                    "permalink": "people/joanna",
+                    "file_path": "people/Joanna.md",
+                    "created_at": "2025-01-01T00:00:00",
+                }
+            ],
+            "related_results": [],
+        }
+    ],
+    "metadata": {"uri": "people/joanna", "depth": 1},
+    "page": 1,
+    "page_size": 10,
+    "has_more": False,
+}
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT_BRACKETED_TITLE,
+)
+def test_search_notes_rich_title_with_brackets_survives(mock_mcp):
+    """Bracketed text in a search result title must appear literally in Rich output.
+
+    Regression (Bug 1): user-sourced titles were interpolated directly into Rich
+    markup strings, so "[draft]" was treated as an unknown style tag and stripped.
+    After escaping, the literal text "[draft]" must be present in the output.
+    """
+    result = _tty_runner(["tool", "search-notes", "spec"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    # The full title including the bracket expression must survive
+    assert "[draft]" in result.output
+    # The snippet "[red]" should also survive (not restyle the output)
+    assert "[red]" in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_build_context",
+    new_callable=AsyncMock,
+    return_value=BUILD_CONTEXT_BRACKETED_OBS,
+)
+def test_build_context_rich_observation_category_bracket_survives(mock_mcp):
+    """Observation category "[fact]" must appear literally in build-context Rich tree.
+
+    Regression (Bug 1): the obs_label was built as f"[dim][{category}] content[/dim]",
+    which caused the inner "[fact]" to be parsed as an unknown Rich tag and dropped,
+    rendering "Joanna lives in Austin" without the category prefix.
+    After escaping the category, "[fact]" must be present in the tree output.
+    """
+    result = _tty_runner(["tool", "build-context", "memory://people/joanna"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    # The observation category prefix must appear literally
+    assert "[fact]" in result.output
+    # The observation content must also appear
+    assert "Joanna lives in Austin" in result.output
+
+
+# ---------------------------------------------------------------------------
+# search-notes – total=0 with non-empty results subtitle (Bug 3, issue #678)
+# ---------------------------------------------------------------------------
+
+# Fixture that mirrors the upstream quirk: total=0 but results is non-empty.
+SEARCH_RESULT_ZERO_TOTAL = {
+    "total": 0,
+    "current_page": 1,
+    "page_size": 10,
+    "has_more": False,
+    "results": [
+        {
+            "type": "entity",
+            "title": "Found Note",
+            "permalink": "notes/found-note",
+            "file_path": "notes/Found Note.md",
+            "score": 0.80,
+            "matched_chunk": "some content",
+            "content": None,
+        },
+        {
+            "type": "entity",
+            "title": "Another Found",
+            "permalink": "notes/another-found",
+            "file_path": "notes/Another Found.md",
+            "score": 0.70,
+            "matched_chunk": "more content",
+            "content": None,
+        },
+    ],
+}
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT_ZERO_TOTAL,
+)
+def test_search_notes_rich_zero_total_falls_back_to_result_count(mock_mcp):
+    """When the API returns total=0 but results is non-empty, subtitle shows real count.
+
+    Regression (Bug 3): result.get("total", len(results)) never triggered its
+    default because the "total" key exists (with value 0), so the subtitle read
+    "0 result(s)" under a table showing rows.  The fix detects a falsy total with
+    non-empty results and falls back to len(results).
+    """
+    result = _tty_runner(["tool", "search-notes", "found"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    # Both result rows must appear
+    assert "Found Note" in result.output
+    assert "Another Found" in result.output
+    # The subtitle must show the real count (2), not 0
+    assert "2 result(s)" in result.output
+    assert "0 result(s)" not in result.output

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -1,0 +1,370 @@
+"""Tests for Rich (human-readable) output mode for bm tool commands.
+
+Commands default to Rich output when stdout is a TTY and fall back to raw JSON
+when stdout is piped or --json is supplied.  These tests verify both modes.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from basic_memory.cli.main import app as cli_app
+
+runner = CliRunner()
+
+# ---------------------------------------------------------------------------
+# Shared mock payloads (mirrors test_cli_tool_json_output.py for symmetry)
+# ---------------------------------------------------------------------------
+
+READ_NOTE_RESULT = {
+    "title": "Test Note",
+    "permalink": "notes/test-note",
+    "file_path": "notes/Test Note.md",
+    "content": "# Test Note\n\nhello world",
+    "frontmatter": {"title": "Test Note", "tags": ["test"]},
+}
+
+SEARCH_RESULT = {
+    "query": "test",
+    "total": 2,
+    "page": 1,
+    "page_size": 10,
+    "results": [
+        {
+            "type": "entity",
+            "title": "Test Note",
+            "permalink": "notes/test-note",
+            "file_path": "notes/Test Note.md",
+        },
+        {
+            "type": "observation",
+            "title": "Another Note",
+            "permalink": "notes/another-note",
+            "file_path": "notes/Another Note.md",
+        },
+    ],
+}
+
+SEARCH_RESULT_EMPTY = {
+    "query": "nothing",
+    "total": 0,
+    "page": 1,
+    "page_size": 10,
+    "results": [],
+}
+
+BUILD_CONTEXT_RESULT = {
+    "results": [
+        {
+            "type": "entity",
+            "title": "Related Note",
+            "permalink": "notes/related",
+            "relation_type": "references",
+        }
+    ],
+    "metadata": {"uri": "notes/test-note", "depth": 1},
+    "page": 1,
+    "page_size": 10,
+}
+
+BUILD_CONTEXT_EMPTY = {
+    "results": [],
+    "metadata": {"uri": "notes/test-note", "depth": 1},
+    "page": 1,
+    "page_size": 10,
+}
+
+RECENT_ACTIVITY_RESULT = [
+    {
+        "type": "entity",
+        "title": "Note A",
+        "permalink": "notes/note-a",
+        "file_path": "notes/Note A.md",
+        "created_at": "2025-01-01 00:00:00",
+        "updated_at": "2025-01-01 12:00:00",
+    },
+    {
+        "type": "entity",
+        "title": "Note B",
+        "permalink": "notes/note-b",
+        "file_path": "notes/Note B.md",
+        "created_at": "2025-01-02 00:00:00",
+        "updated_at": None,
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Helper: simulate a TTY by patching _use_rich to return True
+# ---------------------------------------------------------------------------
+
+
+def _tty_runner(args, **kwargs):
+    """Invoke CLI as if stdout is a TTY (Rich output enabled)."""
+    with patch("basic_memory.cli.commands.tool._use_rich", return_value=True):
+        return runner.invoke(cli_app, args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# search-notes – Rich output
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT,
+)
+def test_search_notes_rich_output_default(mock_mcp):
+    """search-notes produces Rich table output when stdout is a TTY."""
+    result = _tty_runner(["tool", "search-notes", "test"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    # Rich output should NOT be valid JSON
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        json.loads(result.output)
+    # But it should contain the result titles
+    assert "Test Note" in result.output
+    assert "Another Note" in result.output
+    assert "notes/test-note" in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT_EMPTY,
+)
+def test_search_notes_rich_empty(mock_mcp):
+    """search-notes Rich output handles empty results gracefully."""
+    result = _tty_runner(["tool", "search-notes", "nothing"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "No results found" in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT,
+)
+def test_search_notes_json_flag_overrides_tty(mock_mcp):
+    """search-notes --json outputs raw JSON even when stdout is a TTY."""
+    result = _tty_runner(["tool", "search-notes", "test", "--json"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    data = json.loads(result.output)
+    assert data["total"] == 2
+    assert data["results"][0]["title"] == "Test Note"
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_search",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT,
+)
+def test_search_notes_non_tty_gives_json(mock_mcp):
+    """search-notes outputs JSON when stdout is not a TTY (default runner behaviour)."""
+    # CliRunner does not set isatty(); _use_rich() returns False → JSON path.
+    result = runner.invoke(cli_app, ["tool", "search-notes", "test"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    data = json.loads(result.output)
+    assert data["total"] == 2
+
+
+# ---------------------------------------------------------------------------
+# read-note – Rich output
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_read_note",
+    new_callable=AsyncMock,
+    return_value=READ_NOTE_RESULT,
+)
+def test_read_note_rich_output_default(mock_mcp):
+    """read-note produces Rich formatted output when stdout is a TTY."""
+    result = _tty_runner(["tool", "read-note", "test-note"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    # Rich output contains the note title
+    assert "Test Note" in result.output
+    # And the rendered markdown content
+    assert "hello world" in result.output
+    # Not raw JSON
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        json.loads(result.output)
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_read_note",
+    new_callable=AsyncMock,
+    return_value=READ_NOTE_RESULT,
+)
+def test_read_note_json_flag_overrides_tty(mock_mcp):
+    """read-note --json outputs raw JSON even when stdout is a TTY."""
+    result = _tty_runner(["tool", "read-note", "test-note", "--json"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    data = json.loads(result.output)
+    assert data["title"] == "Test Note"
+    assert data["content"] == "# Test Note\n\nhello world"
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_read_note",
+    new_callable=AsyncMock,
+    return_value={"title": "", "permalink": "", "content": "", "frontmatter": {}},
+)
+def test_read_note_rich_empty_content(mock_mcp):
+    """read-note Rich output handles empty content without crashing."""
+    result = _tty_runner(["tool", "read-note", "empty-note"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "no content" in result.output.lower()
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_read_note",
+    new_callable=AsyncMock,
+    return_value=READ_NOTE_RESULT,
+)
+def test_read_note_non_tty_gives_json(mock_mcp):
+    """read-note outputs JSON when stdout is not a TTY."""
+    result = runner.invoke(cli_app, ["tool", "read-note", "test-note"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    data = json.loads(result.output)
+    assert data["title"] == "Test Note"
+
+
+# ---------------------------------------------------------------------------
+# build-context – Rich output
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_build_context",
+    new_callable=AsyncMock,
+    return_value=BUILD_CONTEXT_RESULT,
+)
+def test_build_context_rich_output_default(mock_mcp):
+    """build-context produces Rich tree output when stdout is a TTY."""
+    result = _tty_runner(["tool", "build-context", "memory://notes/test-note"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "notes/test-note" in result.output
+    assert "Related Note" in result.output
+    # Not raw JSON
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        json.loads(result.output)
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_build_context",
+    new_callable=AsyncMock,
+    return_value=BUILD_CONTEXT_EMPTY,
+)
+def test_build_context_rich_empty(mock_mcp):
+    """build-context Rich output handles empty results gracefully."""
+    result = _tty_runner(["tool", "build-context", "memory://notes/test-note"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "No related content found" in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_build_context",
+    new_callable=AsyncMock,
+    return_value=BUILD_CONTEXT_RESULT,
+)
+def test_build_context_json_flag_overrides_tty(mock_mcp):
+    """build-context --json outputs raw JSON even when stdout is a TTY."""
+    result = _tty_runner(["tool", "build-context", "memory://notes/test-note", "--json"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    data = json.loads(result.output)
+    assert "results" in data
+    assert data["results"][0]["title"] == "Related Note"
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_build_context",
+    new_callable=AsyncMock,
+    return_value=BUILD_CONTEXT_RESULT,
+)
+def test_build_context_non_tty_gives_json(mock_mcp):
+    """build-context outputs JSON when stdout is not a TTY."""
+    result = runner.invoke(cli_app, ["tool", "build-context", "memory://notes/test-note"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    data = json.loads(result.output)
+    assert "results" in data
+
+
+# ---------------------------------------------------------------------------
+# recent-activity – Rich output
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_recent_activity",
+    new_callable=AsyncMock,
+    return_value=RECENT_ACTIVITY_RESULT,
+)
+def test_recent_activity_rich_output_default(mock_mcp):
+    """recent-activity produces Rich table output when stdout is a TTY."""
+    result = _tty_runner(["tool", "recent-activity"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "Note A" in result.output
+    assert "Note B" in result.output
+    assert "notes/note-a" in result.output
+    # Not raw JSON
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        json.loads(result.output)
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_recent_activity",
+    new_callable=AsyncMock,
+    return_value=[],
+)
+def test_recent_activity_rich_empty(mock_mcp):
+    """recent-activity Rich output handles empty results gracefully."""
+    result = _tty_runner(["tool", "recent-activity"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "No recent activity" in result.output
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_recent_activity",
+    new_callable=AsyncMock,
+    return_value=RECENT_ACTIVITY_RESULT,
+)
+def test_recent_activity_json_flag_overrides_tty(mock_mcp):
+    """recent-activity --json outputs raw JSON even when stdout is a TTY."""
+    result = _tty_runner(["tool", "recent-activity", "--json"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert data[0]["title"] == "Note A"
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_recent_activity",
+    new_callable=AsyncMock,
+    return_value=RECENT_ACTIVITY_RESULT,
+)
+def test_recent_activity_non_tty_gives_json(mock_mcp):
+    """recent-activity outputs JSON when stdout is not a TTY."""
+    result = runner.invoke(cli_app, ["tool", "recent-activity"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert len(data) == 2

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -38,6 +38,21 @@ READ_NOTE_RESULT_WITH_FRONTMATTER = {
     "frontmatter": {"title": "Test Note", "tags": ["test"]},
 }
 
+READ_NOTE_NOT_FOUND_RESULT = {
+    "title": None,
+    "permalink": None,
+    "file_path": None,
+    "content": None,
+    "frontmatter": None,
+    "related_results": [
+        {
+            "title": "Related [draft] Note",
+            "permalink": "notes/related-note",
+            "file_path": "notes/Related Note.md",
+        }
+    ],
+}
+
 SEARCH_RESULT = {
     # Real SearchResponse.model_dump() uses "current_page", not "page".
     # No "query" key in the response -- the query comes from the CLI argument.
@@ -290,6 +305,41 @@ def test_read_note_rich_empty_content(mock_mcp):
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"
     assert "no content" in result.output.lower()
+
+
+@patch(
+    "basic_memory.mcp.tools.read_note",
+    new_callable=AsyncMock,
+    return_value=READ_NOTE_NOT_FOUND_RESULT,
+)
+def test_read_note_rich_not_found_renders_related_results(mock_mcp):
+    """A normal miss renders suggestions instead of failing on nullable fields."""
+    result = _tty_runner(["tool", "read-note", "missing-note"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "Note not found" in result.output
+    assert "Related [draft] Note" in result.output
+    assert "notes/related-note" in result.output
+
+
+@patch(
+    "basic_memory.mcp.tools.read_note",
+    new_callable=AsyncMock,
+    return_value={
+        "title": None,
+        "permalink": None,
+        "file_path": None,
+        "content": None,
+        "frontmatter": None,
+    },
+)
+def test_read_note_rich_not_found_without_suggestions(mock_mcp):
+    """A miss without fallback matches still returns a clear, successful result."""
+    result = _tty_runner(["tool", "read-note", "missing-note"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "Note not found" in result.output
+    assert "No note or related content found" in result.output
 
 
 @patch(
@@ -780,6 +830,19 @@ def test_read_note_plain_include_frontmatter(mock_mcp):
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"
     assert result.output == READ_NOTE_RESULT_WITH_FRONTMATTER["content"]
+
+
+@patch(
+    "basic_memory.mcp.tools.read_note",
+    new_callable=AsyncMock,
+    return_value=READ_NOTE_NOT_FOUND_RESULT,
+)
+def test_read_note_plain_include_frontmatter_not_found_is_empty(mock_mcp):
+    """Byte-faithful frontmatter mode emits no bytes when no note exists."""
+    result = _tty_runner(["tool", "read-note", "missing-note", "--plain", "--frontmatter"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert result.output == ""
 
 
 @patch(

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -755,19 +755,14 @@ def test_search_notes_plain_empty(mock_mcp):
     return_value=READ_NOTE_RESULT,
 )
 def test_read_note_plain_output(mock_mcp):
-    """read-note --plain emits a header line and the raw markdown body."""
+    """read-note --plain emits the note body faithfully, with no decoration."""
     result = _tty_runner(["tool", "read-note", "test-note", "--plain"])
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"
-    assert "Test Note  [notes/test-note]" in result.output
-    # Raw markdown body, not Rich-rendered
-    assert "# Test Note" in result.output
-    assert "hello world" in result.output
-    # No frontmatter without the flag
-    assert "tags:" not in result.output
-    # Exactly one blank line between header and body: the payload's leading
-    # newline (frontmatter-strip artifact) must not stack with the renderer's.
-    assert "Test Note  [notes/test-note]\n\n# Test Note" in result.output
+    # No synthesized header line -- plain mode is the payload, faithfully.
+    assert "[notes/test-note]" not in result.output
+    # The body verbatim, trimmed of the API's frontmatter-strip newline artifact.
+    assert result.output == "# Test Note\n\nhello world\n"
 
 
 @patch(
@@ -798,11 +793,11 @@ def test_read_note_plain_include_frontmatter(mock_mcp):
     return_value={"title": "", "permalink": "", "content": "", "frontmatter": {}},
 )
 def test_read_note_plain_empty_content(mock_mcp):
-    """read-note --plain handles empty content."""
+    """read-note --plain prints nothing for an empty note (no placeholder)."""
     result = _tty_runner(["tool", "read-note", "empty-note", "--plain"])
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"
-    assert "(no content)" in result.output
+    assert result.output == ""
 
 
 @patch(

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -102,6 +102,7 @@ BUILD_CONTEXT_RESULT = {
                 "title": "Test Note",
                 "permalink": "notes/test-note",
                 "file_path": "notes/Test Note.md",
+                "content": "Primary note prose that must stay visible.",
                 "created_at": "2025-01-01T00:00:00",
             },
             "observations": [
@@ -157,6 +158,11 @@ RECENT_ACTIVITY_RESULT = [
         "file_path": "notes/Note B.md",
         "created_at": "2025-01-02 00:00:00",
     },
+]
+
+RECENT_ACTIVITY_PROJECT_RESULT = [
+    {**RECENT_ACTIVITY_RESULT[0], "project": "research"},
+    {**RECENT_ACTIVITY_RESULT[1], "project": "work"},
 ]
 
 
@@ -372,6 +378,7 @@ def test_build_context_rich_output_default(mock_mcp):
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"
     assert "notes/test-note" in result.output
+    assert "Primary note prose that must stay visible." in result.output
     assert "Related Note" in result.output
     # Not raw JSON
     with pytest.raises((json.JSONDecodeError, ValueError)):
@@ -443,6 +450,21 @@ def test_recent_activity_rich_output_default(mock_mcp):
     # Not raw JSON
     with pytest.raises((json.JSONDecodeError, ValueError)):
         json.loads(result.output)
+
+
+@patch(
+    "basic_memory.mcp.tools.recent_activity",
+    new_callable=AsyncMock,
+    return_value=RECENT_ACTIVITY_PROJECT_RESULT,
+)
+def test_recent_activity_rich_includes_project_when_present(mock_mcp):
+    """Cross-project activity remains attributable in the Rich table."""
+    result = _tty_runner(["tool", "recent-activity"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "Project" in result.output
+    assert "research" in result.output
+    assert "work" in result.output
 
 
 @patch(
@@ -702,6 +724,12 @@ SEARCH_RESULT_ZERO_TOTAL = {
     ],
 }
 
+SEARCH_RESULT_UNKNOWN_TOTAL_WITH_MORE = {
+    **SEARCH_RESULT_ZERO_TOTAL,
+    "page_size": 2,
+    "has_more": True,
+}
+
 
 @patch(
     "basic_memory.mcp.tools.search_notes",
@@ -725,6 +753,20 @@ def test_search_notes_rich_zero_total_falls_back_to_result_count(mock_mcp):
     # The subtitle must show the real count (2), not 0
     assert "2 result(s)" in result.output
     assert "0 result(s)" not in result.output
+
+
+@patch(
+    "basic_memory.mcp.tools.search_notes",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT_UNKNOWN_TOTAL_WITH_MORE,
+)
+def test_search_notes_rich_unknown_total_preserves_has_more(mock_mcp):
+    """Unknown totals never produce a false final-page claim when more results exist."""
+    result = _tty_runner(["tool", "search-notes", "found"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "page 1 of 1" not in result.output
+    assert "more results available" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -784,6 +826,20 @@ def test_search_notes_plain_zero_total_fallback(mock_mcp):
     assert result.exit_code == 0, f"CLI failed: {result.output}"
     assert "2 result(s)" in result.output
     assert "0 result(s)" not in result.output
+
+
+@patch(
+    "basic_memory.mcp.tools.search_notes",
+    new_callable=AsyncMock,
+    return_value=SEARCH_RESULT_UNKNOWN_TOTAL_WITH_MORE,
+)
+def test_search_notes_plain_unknown_total_preserves_has_more(mock_mcp):
+    """Plain output also reports that another page exists when totals are unknown."""
+    result = _tty_runner(["tool", "search-notes", "found", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "page 1 of 1" not in result.output
+    assert "more results available" in result.output
 
 
 @patch(
@@ -917,6 +973,7 @@ def test_build_context_plain_output(mock_mcp):
     assert result.exit_code == 0, f"CLI failed: {result.output}"
     assert "Context: notes/test-note" in result.output
     assert "Test Note" in result.output
+    assert "Primary note prose that must stay visible." in result.output
     # Observation rendered with literal bracketed category, indented
     assert "  [fact] This is a key fact about the test note" in result.output
     # Related item with relation type, indented
@@ -969,6 +1026,20 @@ def test_recent_activity_plain_output(mock_mcp):
     # Not JSON
     with pytest.raises((json.JSONDecodeError, ValueError)):
         json.loads(result.output)
+
+
+@patch(
+    "basic_memory.mcp.tools.recent_activity",
+    new_callable=AsyncMock,
+    return_value=RECENT_ACTIVITY_PROJECT_RESULT,
+)
+def test_recent_activity_plain_includes_project_when_present(mock_mcp):
+    """Cross-project activity remains attributable in plain output."""
+    result = _tty_runner(["tool", "recent-activity", "--plain"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert "[project: research]" in result.output
+    assert "[project: work]" in result.output
 
 
 @patch(

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -66,6 +66,7 @@ SEARCH_RESULT_EMPTY = {
 BUILD_CONTEXT_RESULT = {
     # Real GraphContext.model_dump() shape: results is a list of ContextResult dicts.
     # Each ContextResult has primary_result + observations + related_results.
+    # ObservationSummary fields: type, category, content, permalink, file_path, created_at.
     "results": [
         {
             "primary_result": {
@@ -76,7 +77,16 @@ BUILD_CONTEXT_RESULT = {
                 "file_path": "notes/Test Note.md",
                 "created_at": "2025-01-01T00:00:00",
             },
-            "observations": [],
+            "observations": [
+                {
+                    "type": "observation",
+                    "category": "fact",
+                    "content": "This is a key fact about the test note",
+                    "permalink": "notes/test-note",
+                    "file_path": "notes/Test Note.md",
+                    "created_at": "2025-01-01T00:00:00",
+                }
+            ],
             "related_results": [
                 {
                     "type": "relation",
@@ -398,3 +408,58 @@ def test_recent_activity_non_tty_gives_json(mock_mcp):
     data = json.loads(result.output)
     assert isinstance(data, list)
     assert len(data) == 2
+
+
+# ---------------------------------------------------------------------------
+# read-note – frontmatter rendering (issue #678)
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_read_note",
+    new_callable=AsyncMock,
+    return_value=READ_NOTE_RESULT,
+)
+def test_read_note_rich_include_frontmatter(mock_mcp):
+    """read-note --include-frontmatter renders frontmatter keys in Rich path.
+
+    Regression: previously the Rich renderer silently dropped frontmatter even
+    when --include-frontmatter was passed, requiring --json to see the data.
+    """
+    result = _tty_runner(["tool", "read-note", "test-note", "--include-frontmatter"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    # Frontmatter section header should appear
+    assert "frontmatter" in result.output
+    # The frontmatter key and value from READ_NOTE_RESULT should be visible
+    assert "tags" in result.output
+    assert "test" in result.output
+    # The note content should still appear
+    assert "hello world" in result.output
+
+
+# ---------------------------------------------------------------------------
+# build-context – observations rendering (issue #678)
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "basic_memory.cli.commands.tool.mcp_build_context",
+    new_callable=AsyncMock,
+    return_value=BUILD_CONTEXT_RESULT,
+)
+def test_build_context_rich_renders_observations(mock_mcp):
+    """build-context Rich tree includes observations under each primary node.
+
+    Regression: ContextResult.observations was exposed in JSON output but never
+    rendered in the Rich path, so interactive users lost core entity facts.
+    """
+    result = _tty_runner(["tool", "build-context", "memory://notes/test-note"])
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    # The observation category should appear in the tree
+    assert "fact" in result.output
+    # The observation content should appear (possibly truncated)
+    assert "key fact" in result.output
+    # The subtitle should include an observations count
+    assert "observations" in result.output


### PR DESCRIPTION
Closes #678

## Summary

Adds human-readable output to `bm tool search-notes`, `read-note`, `build-context`, and `recent-activity` while preserving machine-readable behavior.

| Mode | Selection |
|---|---|
| JSON | `--json`, or stdout is piped/redirected |
| Plain | `--plain` |
| Rich | Interactive TTY default |

`--json --plain` is rejected. Interactive users can set `cli_output_style: "rich" | "plain"`; the default remains Rich.

## Renderers

- `search-notes` renders a result table with scores and snippets.
- `read-note` renders Markdown and optional frontmatter in Rich mode; plain frontmatter mode writes the literal file byte-for-byte for redirection.
- `build-context` renders primary entities, observations, and related results as a tree.
- `recent-activity` renders a compact activity table.
- User-sourced Rich text is escaped so bracketed titles, categories, snippets, and metadata remain literal.
- Missing notes render a clear not-found result with related suggestions in Rich and plain modes; byte-faithful plain frontmatter output still emits no bytes on a miss.

The existing `--include-frontmatter` CLI spelling remains as a deprecated alias for the shorter `--frontmatter`; the MCP parameter is unchanged.

## Maintainer follow-through

- Rebased onto current `main` and updated tests to patch the deferred MCP import targets.
- Made `--plain --frontmatter` preserve all boundary newlines with exact-output coverage.
- Coalesced nullable read-note fields and added not-found rendering with markup-safe suggestions.
- Distinguished a missing note from an empty note in plain mode while keeping missing `--plain --frontmatter` output byte-faithful.

## Testing

- `uv run pytest -q tests/cli/test_cli_tool_rich_output.py` — 46 passed.
- All related CLI-tool tests — 88 passed.
- Ruff and targeted `ty` — passed.
- `just fast-check` — passed (with the repository's existing Python 3.14 asyncio deprecation diagnostics).

## Manual follow-up

- `manual/man3/read-note-3` already documents `--frontmatter` and its deprecated alias.
- At merge, expand the manual with the JSON/plain/Rich output-mode story and `cli_output_style`.

---

Generated with [Claude Code](https://claude.com/claude-code); maintainer hardening by Basic Machines.