### PR TITLE
fix(core): require line-anchored frontmatter fences in file_utils

### DIFF
--- a/src/basic_memory/file_utils.py
+++ b/src/basic_memory/file_utils.py
@@ -302,25 +302,75 @@ async def format_file(
         return None
 
 
+# A frontmatter fence is a line containing exactly `---`, optionally followed by
+# trailing horizontal whitespace. Anchoring to a full line (rather than a bare
+# substring/`startswith`) prevents single-line content like
+# `---\nstatus: active\n---\nBody` — where `\n` is a literal backslash-n, not a
+# newline — from being misread as frontmatter. See issue #972.
+_FENCE_RE = re.compile(r"^---[ \t]*$")
+
+
+def _split_frontmatter(content: str) -> Optional[tuple[str, str]]:
+    """Split content into (yaml_block, body) when it opens with a line-anchored fence.
+
+    The opening fence must be the very first line and the closing fence must be a
+    later line, each matching exactly `---` (with optional trailing whitespace).
+
+    Returns:
+        A `(yaml_block, body)` tuple when a complete fenced block is present, or
+        ``None`` when the content does not open with a frontmatter fence.
+
+    Raises:
+        ParseError: If the content opens with a fence but has no closing fence.
+    """
+    lines = content.splitlines(keepends=True)
+
+    # Skip leading blank lines: a document may begin with whitespace before the
+    # opening fence (e.g. a heredoc/dedented string starting with a newline). This
+    # does NOT relax line-anchoring — the opening fence must still be the first
+    # non-blank line, all on its own, so a single-line `---\\nstatus...` (literal
+    # backslash-n) is still rejected. See issue #972.
+    start = 0
+    while start < len(lines) and lines[start].strip() == "":
+        start += 1
+
+    if start >= len(lines) or not _FENCE_RE.match(lines[start].rstrip("\r\n")):
+        return None
+
+    # Find the closing fence on its own line somewhere after the opening fence.
+    for index in range(start + 1, len(lines)):
+        if _FENCE_RE.match(lines[index].rstrip("\r\n")):
+            yaml_block = "".join(lines[start + 1 : index])
+            body = "".join(lines[index + 1 :])
+            return yaml_block, body
+
+    raise ParseError("Invalid frontmatter format")
+
+
 def has_frontmatter(content: str) -> bool:
     """
     Check if content contains valid YAML frontmatter.
+
+    Frontmatter requires `---` fences on their own lines; an inline `---` (such as
+    a single-line string that merely starts with the characters `---`) is not
+    frontmatter.
 
     Args:
         content: Content to check
 
     Returns:
-        True if content has valid frontmatter markers (---), False otherwise
+        True if content has line-anchored frontmatter fences, False otherwise
     """
     if not content:
         return False
 
     # Strip BOM before checking for frontmatter markers
-    content = strip_bom(content).strip()
-    if not content.startswith("---"):
+    content = strip_bom(content)
+    try:
+        return _split_frontmatter(content) is not None
+    except ParseError:
+        # An opening fence with no closing fence is not usable frontmatter.
         return False
-
-    return "---" in content[3:]
 
 
 def parse_frontmatter(content: str) -> Dict[str, Any]:
@@ -339,17 +389,14 @@ def parse_frontmatter(content: str) -> Dict[str, Any]:
     try:
         # Strip BOM before parsing frontmatter
         content = strip_bom(content)
-        if not content.strip().startswith("---"):
+        split = _split_frontmatter(content)
+        if split is None:
             raise ParseError("Content has no frontmatter")
-
-        # Split on first two occurrences of ---
-        parts = content.split("---", 2)
-        if len(parts) < 3:
-            raise ParseError("Invalid frontmatter format")
+        yaml_block, _ = split
 
         # Parse YAML
         try:
-            frontmatter = yaml.safe_load(parts[1])
+            frontmatter = yaml.safe_load(yaml_block)
             # Handle empty frontmatter (None from yaml.safe_load)
             if frontmatter is None:
                 return {}
@@ -381,18 +428,17 @@ def remove_frontmatter(content: str) -> str:
         ParseError: If content starts with frontmatter marker but is malformed
     """
     # Strip BOM before processing
-    content = strip_bom(content).strip()
+    content = strip_bom(content)
 
-    # Return as-is if no frontmatter marker
-    if not content.startswith("---"):
-        return content
+    split = _split_frontmatter(content)
+    # Trigger: content does not open with a line-anchored fence
+    # Why: inline `---` is ordinary content, not frontmatter (issue #972)
+    # Outcome: return the content untouched (stripped to preserve prior behavior)
+    if split is None:
+        return content.strip()
 
-    # Split on first two occurrences of ---
-    parts = content.split("---", 2)
-    if len(parts) < 3:
-        raise ParseError("Invalid frontmatter format")
-
-    return parts[2].strip()
+    _, body = split
+    return body.strip()
 
 
 def dump_frontmatter(post: frontmatter.Post) -> str:

--- a/tests/mcp/test_tool_write_note.py
+++ b/tests/mcp/test_tool_write_note.py
@@ -495,6 +495,7 @@ async def test_write_note_single_line_inline_fence_is_body_issue_972(app, test_p
     )
 
     content = await read_note("meetings/meeting-notes", project=test_project.name)
+    assert isinstance(content, str)
 
     # The literal one-line string survives verbatim in the body...
     assert one_line in content

--- a/tests/mcp/test_tool_write_note.py
+++ b/tests/mcp/test_tool_write_note.py
@@ -477,6 +477,38 @@ async def test_write_note_preserves_content_frontmatter(app, test_project):
 
 
 @pytest.mark.asyncio
+async def test_write_note_single_line_inline_fence_is_body_issue_972(app, test_project):
+    """Single-line content starting with `---` must be stored as body, not frontmatter.
+
+    Reproduces issue #972: a one-line string where `\\n` are literal backslash-n
+    characters (a common CLI/agent input shape) was misread as frontmatter, merging a
+    garbage `\\nstatus` YAML key into the note and silently dropping the inline
+    `---...---` segment from the body.
+    """
+    one_line = r"---\nstatus: active\n---\nDiscussed Q3 roadmap with Anthony."
+
+    await write_note(
+        project=test_project.name,
+        title="Meeting Notes",
+        directory="meetings",
+        content=one_line,
+    )
+
+    content = await read_note("meetings/meeting-notes", project=test_project.name)
+
+    # The literal one-line string survives verbatim in the body...
+    assert one_line in content
+
+    # ...and no garbage `\nstatus` key leaked into the generated YAML frontmatter.
+    # Inspect only the frontmatter block (between the first pair of fence lines).
+    lines = content.splitlines()
+    assert lines[0] == "---"
+    closing = lines.index("---", 1)
+    frontmatter_block = lines[1:closing]
+    assert not any("status" in line for line in frontmatter_block)
+
+
+@pytest.mark.asyncio
 async def test_write_note_permalink_collision_fix_issue_139(app, test_project):
     """Test fix for GitHub Issue #139: UNIQUE constraint failed: entity.permalink.
 

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -111,6 +111,23 @@ title: Test
     assert not has_frontmatter("--title: test--")
 
 
+def test_has_frontmatter_requires_line_anchored_fences():
+    """Inline `---` must not be mistaken for frontmatter fences (issue #972)."""
+    # Exact one-line repro from the issue: `\n` are literal backslash-n, not newlines,
+    # so the whole string is a single line that merely starts with `---`.
+    one_line = r"---\nstatus: active\n---\nDiscussed Q3 roadmap with Anthony."
+    assert not has_frontmatter(one_line)
+
+    # An inline `---` later in the first line is not an opening fence either.
+    assert not has_frontmatter("--- not really frontmatter --- still content")
+
+    # Opening fence with no closing fence on its own line is not frontmatter.
+    assert not has_frontmatter("---\ntitle: Test\nbody without closing fence")
+
+    # A fence with trailing whitespace is still a valid fence.
+    assert has_frontmatter("---  \ntitle: Test\n---  \ncontent")
+
+
 def test_parse_frontmatter():
     """Test parsing frontmatter."""
     # Valid frontmatter
@@ -185,6 +202,33 @@ title: Test
         remove_frontmatter("""---
 title: Test""")
     assert "Invalid frontmatter format" in str(exc.value)
+
+
+def test_frontmatter_helpers_ignore_inline_fences():
+    """Single-line content starting with `---` is passed through unchanged (issue #972).
+
+    Previously the loose substring/split logic merged a garbage `\\nstatus` YAML key
+    into the note and silently stripped the inline `---...---` segment from the body.
+    """
+    one_line = r"---\nstatus: active\n---\nDiscussed Q3 roadmap with Anthony."
+
+    # Not detected as frontmatter...
+    assert not has_frontmatter(one_line)
+    # ...so parsing raises rather than inventing a `\nstatus` key...
+    with pytest.raises(ParseError):
+        parse_frontmatter(one_line)
+    # ...and the body survives intact through the merge path's removal step.
+    assert remove_frontmatter(one_line) == one_line
+
+    # An inline `---` later in the first line is also left untouched.
+    inline = "intro --- not frontmatter --- outro"
+    assert remove_frontmatter(inline) == inline
+
+    # Valid line-anchored frontmatter with trailing whitespace on the fences parses
+    # and is removed identically to clean fences.
+    padded = "---  \ntitle: Test\n---  \ncontent"
+    assert parse_frontmatter(padded) == {"title": "Test"}
+    assert remove_frontmatter(padded) == "content"
 
 
 def test_sanitize_for_filename_removes_invalid_characters():


### PR DESCRIPTION
Closes #972

## Problem

`has_frontmatter()`, `parse_frontmatter()`, and `remove_frontmatter()` in `src/basic_memory/file_utils.py` detected frontmatter by substring/split (`content.startswith("---")` plus `content.split("---", 2)`) rather than by line-anchored fences.

### Repro

A single-line string that merely starts with `---` — where `\n` are literal backslash-n characters, a very common CLI/agent input shape:

```bash
bm tool write-note --title "Meeting Notes" --folder meetings \
  --content "---\nstatus: active\n---\nDiscussed Q3 roadmap with Anthony."
```

The CLI receives the literal one-line string `---\nstatus: active\n---\nDiscussed Q3 roadmap with Anthony.`. The loose logic treated it as frontmatter:

1. yaml parsed `\nstatus` as a key, which got merged into the note's YAML and written to disk.
2. The body was silently transformed (the inline `---…---` segment was stripped).

## Fix

Shape chosen: **(b) anchor the parsing ourselves.** A new shared `_split_frontmatter()` helper requires both fences on their own line (`^---[ \t]*$`); all three public helpers delegate to it, so detection is consistent.

Why (b) over delegating to `python-frontmatter`: the existing helpers raise `ParseError` with specific messages that callers and tests assert on (`"Content has no frontmatter"`, `"Invalid frontmatter format"`, `"Frontmatter must be a YAML dictionary"`, `"Invalid YAML in frontmatter"`). Anchoring in-place keeps the diff minimal and preserves every one of those messages plus BOM stripping, empty-frontmatter -> `{}`, and non-dict -> `ParseError`.

The helper skips leading blank lines before the opening fence, so dedented heredoc-style content (a string beginning with a newline) still parses exactly as before — this does not relax line-anchoring, since the single-line repro's first line is not a bare `---`.

All callers were reviewed (markdown/utils.py merge path, entity_service, sync_service, file_service, batch_indexer); none relied on the loose substring behavior.

## Tests

- `tests/utils/test_file_utils.py`: line-anchored detection for the exact one-line repro, inline `---` later in the first line, opening fence with no closing fence, and fences with trailing whitespace (valid); plus a pass-through regression confirming `remove_frontmatter` leaves the one-liner intact and `parse_frontmatter` raises rather than inventing a `\nstatus` key.
- `tests/mcp/test_tool_write_note.py`: integration-level regression through `write_note` — the literal one-liner is stored verbatim as the body and no garbage key leaks into the generated YAML frontmatter.
- All pre-existing frontmatter tests stay green.

## Gates

- `uv run pytest tests/utils/test_file_utils.py tests/mcp/test_tool_write_note.py` — 90 passed
- caller suites (markdown, entity_service, sync, batch_indexer) — 159 passed
- `uv run ruff check` / `ruff format --check` on changed files — clean
- `uv run ty check src` — clean
- 100% coverage on changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)