### PR TITLE
fix(api): allow setting default project when none is currently set

### DIFF
--- a/src/basic_memory/api/v2/routers/project_router.py
+++ b/src/basic_memory/api/v2/routers/project_router.py
@@ -559,12 +559,10 @@ async def set_default_project_by_id(
     logger.info(f"API v2 request: set_default_project_by_id for project_id={project_id}")
 
     try:
-        # Get the old default project from database
+        # Get the old default project from database. It may be absent during
+        # bootstrap/recovery (no default row yet); that is a valid state, not an
+        # error, so we only echo it back when one exists.
         default_project = await project_repository.get_default_project()
-        if not default_project:
-            raise HTTPException(  # pragma: no cover
-                status_code=404, detail="No default project is currently set"
-            )
 
         # Get the new default project by external_id
         new_default_project = await project_repository.get_by_external_id(project_id)
@@ -576,17 +574,27 @@ async def set_default_project_by_id(
         # Set as default using project name (service layer still uses names internally)
         await project_service.set_default_project(new_default_project.name)
 
-        return ProjectStatusResponse(
-            message=f"Project '{new_default_project.name}' set as default successfully",
-            status="success",
-            default=True,
-            old_project=ProjectItem(
+        # Trigger: a previous default existed
+        # Why: ProjectStatusResponse.old_project is Optional; the no-default
+        #   bootstrap case must succeed with old_project=None
+        # Outcome: response echoes the prior default only when there was one
+        old_project = (
+            ProjectItem(
                 id=default_project.id,
                 external_id=default_project.external_id,
                 name=default_project.name,
                 path=default_project.path,
                 is_default=False,
-            ),
+            )
+            if default_project
+            else None
+        )
+
+        return ProjectStatusResponse(
+            message=f"Project '{new_default_project.name}' set as default successfully",
+            status="success",
+            default=True,
+            old_project=old_project,
             new_project=ProjectItem(
                 id=new_default_project.id,
                 external_id=new_default_project.external_id,

--- a/tests/api/v2/test_project_router.py
+++ b/tests/api/v2/test_project_router.py
@@ -138,6 +138,37 @@ async def test_set_default_project_by_id(
 
 
 @pytest.mark.asyncio
+async def test_set_default_project_when_none_is_set(
+    client: AsyncClient, test_project: Project, v2_projects_url, project_repository
+):
+    """Regression for #975: setting a default must succeed when none is set.
+
+    This is the bootstrap/recovery case: `bm project default <name>` is exactly
+    the command reached for when no default exists, so the endpoint must not 404.
+    """
+    # Clear any existing default so no row has is_default set.
+    await project_repository.update(test_project.id, {"is_default": None})
+    assert await project_repository.get_default_project() is None
+
+    response = await client.put(f"{v2_projects_url}/{test_project.external_id}/default")
+
+    assert response.status_code == 200
+    status_response = ProjectStatusResponse.model_validate(response.json())
+    assert status_response.status == "success"
+    assert status_response.default is True
+    # No previous default existed, so old_project must be None.
+    assert status_response.old_project is None
+    new_project = _project_item(status_response.new_project)
+    assert new_project.external_id == test_project.external_id
+    assert new_project.is_default is True
+
+    # A follow-up read-back must now return the newly set default.
+    default_project = await project_repository.get_default_project()
+    assert default_project is not None
+    assert default_project.external_id == test_project.external_id
+
+
+@pytest.mark.asyncio
 async def test_set_default_project_not_found(client: AsyncClient, v2_projects_url):
     """Test setting a non-existent project as default returns 404."""
     fake_uuid = "00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
Closes #975

## Problem

`bm project default <name>` failed with `No default project is currently set` — but setting the default is exactly the command you reach for when none is set, making a recoverable state unrecoverable from the CLI (the bootstrap/recovery case).

### Repro (before the fix)

```bash
export BASIC_MEMORY_CONFIG_DIR=/tmp/bm-975-test/config BASIC_MEMORY_HOME=/tmp/bm-975-test/home
bm project add qa /tmp/bm-975-test/notes --local   # only project; no default row in DB
bm project default qa
# Error setting default project: No default project is currently set
```

## Root cause

`src/basic_memory/api/v2/routers/project_router.py` `set_default_project_by_id` fetched the current default solely to echo it as `old_project` in the response, and raised `404` when there was none. That guard was marked `# pragma: no cover` — the no-current-default path was never tested. `ProjectStatusResponse.old_project` is already `Optional`, so the 404 served no schema requirement.

## Fix

Remove the 404 guard. Build `old_project=ProjectItem(...)` only when a previous default exists, otherwise pass `old_project=None`. The rest of the handler is unchanged. No schema change needed.

A check of the rest of `src/basic_memory/api/` confirmed there is no v1 router (only `v2/`) and the `"No default project is currently set"` string now appears nowhere in the tree, so there was no duplicate pattern to fix.

## Test coverage

Added `test_set_default_project_when_none_is_set`: clears `is_default` so no row is default, calls the set-default endpoint, and asserts `200`, `old_project is None`, the new project is default, and a follow-up `get_default_project()` returns it. All existing tests stay green. The removed `# pragma: no cover` guard is gone, and both branches of the new `old_project` construction are exercised by the existing and new tests.

## Verification

- `uv run pytest tests/api/v2/test_project_router.py tests/services/test_project_service.py tests/repository/test_project_repository.py tests/cli/test_project_list_and_ls.py` — 91 passed, 2 skipped
- `uv run ruff check` + `ruff format --check` on changed files — clean
- `uv run ty check src tests test-int` — All checks passed

### End-to-end (the user's actual repro)

```bash
export BASIC_MEMORY_CONFIG_DIR=/tmp/bm-975-test/config BASIC_MEMORY_HOME=/tmp/bm-975-test/home
uv run bm project add qa /tmp/bm-975-test/notes --local   # Project 'qa' added successfully
uv run bm project default qa                              # Project 'qa' set as default successfully (exit 0)
```

`bm project default qa` now succeeds where it previously failed with `No default project is currently set`. No #974-shaped config/DB drift was encountered on this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)