### PR TITLE
docs(ci): fix stale basicmachines.co post-release step

### DIFF
--- a/.claude/commands/release/release.md
+++ b/.claude/commands/release/release.md
@@ -116,22 +116,24 @@ After PyPI release is published, update the MCP registry:
 
 #### Website Updates
 
-**1. basicmachines.co** (sibling `basicmachines.co` repo)
-   - **Goal**: Update version number displayed on the homepage
-   - **Location**: Search for "Basic Memory v0." in the codebase to find version displays
-   - **What to update**:
-     - Hero section heading that shows "Basic Memory v{VERSION}"
-     - "What's New in v{VERSION}" section heading
-     - Feature highlights array (look for array of features with title/description)
-   - **Process**:
+**1. basicmemory.com** (sibling `basicmemory.com` repo —
+`basicmachines-co/basicmemory.com`, formerly `basicmachines.co`)
+   - **No version bump needed.** The marketing site is an Astro + React app and
+     carries **no hardcoded Basic Memory version number** anywhere in its UI
+     (`hero.tsx` and the rest of the site have no version string). The old
+     instruction to bump `src/components/sections/hero.tsx` is obsolete — that
+     file no longer holds a version. Release announcements are dated blog posts,
+     not an in-place edit.
+   - **Skip entirely for patch releases.**
+   - **Significant releases only — optional announcement post**:
      1. Pull latest from GitHub: `git pull origin main`
      2. Create release branch: `git checkout -b release/v{VERSION}`
-     3. Search codebase for current version number (e.g., "v0.16.1")
-     4. Update version numbers to new release version
-     5. Update feature highlights with 3-5 key features from this release (extract from CHANGELOG.md)
-     6. Commit changes: `git commit -m "chore: update to v{VERSION}"`
-     7. Push branch: `git push origin release/v{VERSION}`
-   - **Deploy**: Follow deployment process for basicmachines.co
+     3. Add a dated post under `src/content/blog/` modeled on an existing
+        release post (e.g. `basic-memory-v0-19-0-release.md`), summarizing 3–5
+        headline features from `CHANGELOG.md`
+     4. Commit (`git commit -s -m "..."`), push, and open a PR against
+        `basicmachines-co/basicmemory.com`
+   - **Deploy**: follow that repo's deployment process.
 
 **2. docs.basicmemory.com** (sibling `docs.basicmemory.com` repo)
    - **Goal**: Add a What's New page for the release and bump the homepage badge

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,7 +322,12 @@ The recipe runs `just lint` + `just typecheck`, then updates every release manif
 
 **Post-release tasks** the recipe surfaces but doesn't run:
 - `docs.basicmemory.com` — add a What's New page under `content/2.whats-new/` and bump the version badge in `content/index.md` (the changelog page auto-fetches GitHub releases; see that repo's CLAUDE.md version-bump checklist)
-- `basicmachines.co` — bump version in `src/components/sections/hero.tsx`
+- `basicmemory.com` — the marketing site (Astro + React, repo
+  `basicmachines-co/basicmemory.com`, formerly `basicmachines.co`) carries **no
+  hardcoded version number** in its UI, so there is nothing to bump. For a
+  significant release, optionally add a dated announcement post under
+  `src/content/blog/` (model it on an existing `basic-memory-vX-Y-Z-release.md`).
+  Skip entirely for routine patch releases.
 - MCP Registry — `mcp-publisher publish` from the repo root
 
 See `.claude/commands/release/release.md` (and `beta.md`, `release-check.md`, `changelog.md` alongside it) for the full release + post-release runbook, including the slash commands.

--- a/justfile
+++ b/justfile
@@ -468,7 +468,8 @@ release version:
     echo "📝 REMINDER: Post-release tasks:"
     echo "   1. docs.basicmemory.com - Add a What's New page under content/2.whats-new/"
     echo "      and bump the badge in content/index.md (see that repo's CLAUDE.md)"
-    echo "   2. basicmachines.co - Update version in src/components/sections/hero.tsx"
+    echo "   2. basicmemory.com - No version number in the site UI; for a significant"
+    echo "      release optionally add a post under src/content/blog/. Skip for patches."
     echo "   3. MCP Registry - Run: mcp-publisher publish"
     echo "   See: .claude/commands/release/release.md for detailed instructions"
 
@@ -585,7 +586,8 @@ beta version:
     echo "📝 REMINDER: For stable releases, update documentation sites:"
     echo "   1. docs.basicmemory.com - Add a What's New page under content/2.whats-new/"
     echo "      and bump the badge in content/index.md (see that repo's CLAUDE.md)"
-    echo "   2. basicmachines.co - Update version in src/components/sections/hero.tsx"
+    echo "   2. basicmemory.com - No version number in the site UI; for a significant"
+    echo "      release optionally add a post under src/content/blog/. Skip for patches."
     echo "   See: .claude/commands/release/release.md for detailed instructions"
 
 # List all available recipes


### PR DESCRIPTION
## What

The release runbook's post-release step still says to bump the Basic Memory version in `basicmachines.co` → `src/components/sections/hero.tsx`. That instruction is stale on two counts:

1. The marketing site repo was renamed `basicmachines.co` → **`basicmemory.com`** (`basicmachines-co/basicmemory.com`) and rebuilt as an Astro + React app.
2. The site no longer renders a hardcoded version number **anywhere** in its UI — `hero.tsx` and the rest of the components carry no version string (verified by sweeping the cloned repo). Release announcements are dated blog posts under `src/content/blog/`, not an in-place version edit.

## Changes

Updated all three sources that carried the stale step:
- `.claude/commands/release/release.md` — rewrote the Website Updates "basicmachines.co" block.
- `AGENTS.md` (→ `CLAUDE.md` symlink) — post-release tasks list.
- `justfile` — the reminder echoes printed by both the `release` and `beta` recipes.

New guidance: no version bump needed; for a significant release optionally add a dated post under `src/content/blog/`; skip for patch releases.

Surfaced while doing the v0.22.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)