### PR TITLE
fix(cli): show configured project in list when uncredentialed (#1003)

### DIFF
--- a/src/basic_memory/cli/commands/project.py
+++ b/src/basic_memory/cli/commands/project.py
@@ -495,6 +495,23 @@ def list_projects(
             generate_permalink(project_name): project_name for project_name in config.projects
         }
 
+        # Trigger: a project in config.projects was surfaced by neither query — the
+        #   cloud branch is skipped without credentials, and a cloud-mode project is
+        #   not returned by the local query.
+        # Why: without a fallback such a project is invisible in `bm project list`,
+        #   yet `bm project add` reads the DB and reports it already exists (#1003).
+        #   The two commands must agree on whether a configured project exists.
+        # Outcome: seed a local-keyed row from config so the project still renders;
+        #   the row-building logic below derives its display from the config entry.
+        # Constraint: only fill from config for the local-inclusive view. A pure
+        #   --cloud listing (no local_result) or a --workspace-filtered view is
+        #   deliberately scoped, so configured local projects must not leak into it.
+        if local_result is not None and not workspace_filter_requested:
+            seeded_permalinks = {permalink for _, permalink in row_names_by_key}
+            for permalink, project_name in configured_names_by_permalink.items():
+                if permalink not in seeded_permalinks:
+                    row_names_by_key[(None, permalink)] = project_name
+
         def _workspace_priority(row_key: tuple[str | None, str]) -> tuple[bool, int, str, str]:
             """Prefer the user's default/personal workspace when a project is duplicated."""
             workspace = cloud_workspaces_by_key.get(row_key)

--- a/src/basic_memory/cli/commands/project.py
+++ b/src/basic_memory/cli/commands/project.py
@@ -503,10 +503,10 @@ def list_projects(
         #   The two commands must agree on whether a configured project exists.
         # Outcome: seed a local-keyed row from config so the project still renders;
         #   the row-building logic below derives its display from the config entry.
-        # Constraint: only fill from config for the local-inclusive view. A pure
-        #   --cloud listing (no local_result) or a --workspace-filtered view is
-        #   deliberately scoped, so configured local projects must not leak into it.
-        if local_result is not None and not workspace_filter_requested:
+        # Constraint: only fill from config for the default combined view. Explicit
+        #   --local, --cloud, and --workspace listings are deliberately scoped, so
+        #   configured projects must not leak into them.
+        if not local and local_result is not None and not workspace_filter_requested:
             seeded_permalinks = {permalink for _, permalink in row_names_by_key}
             for permalink, project_name in configured_names_by_permalink.items():
                 if permalink not in seeded_permalinks:

--- a/tests/cli/test_project_list_and_ls.py
+++ b/tests/cli/test_project_list_and_ls.py
@@ -1108,3 +1108,33 @@ def test_project_list_shows_configured_project_without_cloud_credentials(
     # The configured project is now visible instead of an empty table.
     main_line = next(line for line in result.stdout.splitlines() if "│ main" in line)
     assert "cloud" in main_line  # cloud-mode projects route to the cloud CLI
+
+
+def test_project_list_local_excludes_cloud_mode_config_fallback(
+    runner: CliRunner, write_config, mock_client, tmp_path, monkeypatch
+):
+    """An explicit local listing must only contain projects returned by the local API."""
+    write_config(
+        {
+            "env": "dev",
+            "projects": {
+                "main": {
+                    "path": "",
+                    "mode": "cloud",
+                    "workspace_id": None,
+                    "local_sync_path": None,
+                }
+            },
+            "default_project": "main",
+        }
+    )
+
+    async def fake_list_projects(self):
+        return ProjectList.model_validate({"projects": [], "default_project": "main"})
+
+    monkeypatch.setattr(ProjectClient, "list_projects", fake_list_projects)
+
+    result = runner.invoke(app, ["project", "list", "--local", "--json"])
+
+    assert result.exit_code == 0, f"Exit code: {result.exit_code}, output: {result.stdout}"
+    assert json.loads(result.stdout) == {"projects": []}

--- a/tests/cli/test_project_list_and_ls.py
+++ b/tests/cli/test_project_list_and_ls.py
@@ -1066,3 +1066,45 @@ def test_project_ls_cloud_route_uses_cloud_listing(
     assert result.exit_code == 0, f"Exit code: {result.exit_code}, output: {result.stdout}"
     assert "Files in alpha (CLOUD)" in result.stdout
     assert "cloud.md" in result.stdout
+
+
+def test_project_list_shows_configured_project_without_cloud_credentials(
+    runner: CliRunner, write_config, mock_client, tmp_path, monkeypatch
+):
+    """A cloud-mode project in config must render even with no cloud credentials (#1003).
+
+    Regression: ``bm project list`` seeded rows only from live query results, so a
+    cloud-mode project was skipped by both the credential-gated cloud branch and the
+    local query — the table came up empty while ``bm project add`` reported the same
+    project already existed. The two commands must agree that the project exists.
+    """
+    write_config(
+        {
+            "env": "dev",
+            "projects": {
+                "main": {
+                    "path": "",
+                    "mode": "cloud",
+                    "workspace_id": None,
+                    "local_sync_path": None,
+                }
+            },
+            "default_project": "main",
+        }
+    )
+
+    # No credentials on this machine: the cloud branch is skipped entirely.
+    monkeypatch.setattr(project_cmd, "_has_cloud_credentials", lambda config: False)
+
+    # The local query does not surface a cloud-mode project, so it returns empty.
+    async def fake_list_projects(self):
+        return ProjectList.model_validate({"projects": [], "default_project": "main"})
+
+    monkeypatch.setattr(ProjectClient, "list_projects", fake_list_projects)
+
+    result = runner.invoke(app, ["project", "list"], env={"COLUMNS": "240"})
+
+    assert result.exit_code == 0, f"Exit code: {result.exit_code}, output: {result.stdout}"
+    # The configured project is now visible instead of an empty table.
+    main_line = next(line for line in result.stdout.splitlines() if "│ main" in line)
+    assert "cloud" in main_line  # cloud-mode projects route to the cloud CLI


### PR DESCRIPTION
## Why

`bm project list` could render an empty table for a cloud-mode project that is present in `config.json` when the machine has no cloud credentials. At the same time, `bm project add` reports that project already exists (#1003).

The cloud query is credential-gated, and the forced-local query does not surface a cloud-mode project, so neither live result seeded a display row.

## What changed

- Seed missing configured projects into the default combined `bm project list` view.
- Keep explicit `--local`, `--cloud`, and `--workspace` listings strictly scoped to their requested live results.
- Rebase the contributor branch onto current `main`.

## Tests

- Added a regression proving an uncredentialed configured cloud project remains visible in the default list.
- Added the complementary regression proving `project list --local --json` excludes that config fallback when the local API returns no projects.
- `uv run pytest -q tests/cli/test_project_list_and_ls.py` — 15 passed
- `uv run ruff format --check src/basic_memory/cli/commands/project.py tests/cli/test_project_list_and_ls.py`
- `uv run ruff check src/basic_memory/cli/commands/project.py tests/cli/test_project_list_and_ls.py`
- `uv run ty check src/basic_memory/cli/commands/project.py tests/cli/test_project_list_and_ls.py`
- `just fast-check`

Fixes #1003