### PR TITLE
ci(ci): validate Auto BM webhook

### DIFF
--- a/docs/auto-bm-webhook-test.md
+++ b/docs/auto-bm-webhook-test.md
@@ -1,0 +1,12 @@
+# Auto BM webhook test
+
+This documentation-only file exists to exercise the Auto BM GitHub webhook path.
+
+The expected flow is:
+
+1. Open a small pull request with this file.
+2. Merge the pull request.
+3. Let the GitHub `pull_request` webhook call the Hermes Auto BM endpoint.
+4. Confirm Basic Memory records a project-update note for the merged PR.
+
+No runtime code or product behavior changes here.


### PR DESCRIPTION
## Summary
- Adds a docs-only marker file to exercise the Auto BM GitHub webhook path.
- No runtime code or product behavior changes.

## Test Plan
- Docs-only change; no tests run.
- This PR is intended to be merged to verify the `pull_request.closed` + `merged=true` webhook creates a Basic Memory project-update note.
