### PR TITLE
docs: fix 3 broken links in README and cloud-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ multi-word ones.
 
 Bare `- [[Target]]` and prose `- Worth checking out [[Target]]` index as
 `links_to`. Full reference in the
-[docs](https://docs.basicmemory.com/getting-started/note-formatting/?utm_source=github&utm_medium=referral&utm_campaign=readme).
+[docs](https://docs.basicmemory.com/concepts/knowledge-format?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
 ## MCP tools
 
@@ -525,7 +525,7 @@ basic-memory import memory-json
 
 Routing flags (`--local` / `--cloud`) force a target when you're in mixed
 mode. Full CLI reference in the
-[docs](https://docs.basicmemory.com/guides/cli-reference/?utm_source=github&utm_medium=referral&utm_campaign=readme).
+[docs](https://docs.basicmemory.com/reference/cli-reference?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
 ## Auto-updates
 

--- a/docs/cloud-cli.md
+++ b/docs/cloud-cli.md
@@ -32,7 +32,7 @@ The transfer commands fall into two groups:
 Before using Basic Memory Cloud, you need:
 
 - **Active Subscription**: An active Basic Memory Cloud subscription is required to access cloud features
-- **Subscribe**: Visit [https://basicmemory.com/subscribe](https://basicmemory.com/subscribe) to sign up
+- **Subscribe**: Visit [https://basicmemory.com/pricing](https://basicmemory.com/pricing) to sign up
 - **Optional**: Cloud is optional. Local-first open-source usage continues without cloud.
 - **OSS Discount**: Use code `{{OSS_DISCOUNT_CODE}}` for 20% off for 3 months.
 


### PR DESCRIPTION
The basicmemory.com docs site restructured: `/getting-started/note-formatting` and `/guides/cli-reference` both 404. Canonical replacements are `/concepts/knowledge-format` and `/reference/cli-reference` (the old `/guides` prefix was renamed to `/reference`). The `basicmemory.com/subscribe` landing page was retired; replaced with `/pricing`.

Verified via curl GET: all three new URLs return 200.

2 files, +3/-3.