### PR TITLE
fix(mcp): set explicit destructive hints

### DIFF
--- a/src/basic_memory/mcp/tools/build_context.py
+++ b/src/basic_memory/mcp/tools/build_context.py
@@ -139,7 +139,12 @@ def _format_context_markdown(graph: GraphContext, project: str) -> str:
     https://docs.basicmemory.com/concepts/memory-urls
     """,
     tags={"navigation", "notes"},
-    annotations={"title": "Build Context", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "Build Context",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def build_context(
     url: Annotated[

--- a/src/basic_memory/mcp/tools/chatgpt_tools.py
+++ b/src/basic_memory/mcp/tools/chatgpt_tools.py
@@ -144,7 +144,12 @@ def _format_document_for_chatgpt(
     title="Search Knowledge Base",
     description="Search for content across the knowledge base",
     tags={"search"},
-    annotations={"title": "Search Knowledge Base", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "Search Knowledge Base",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def search(
     query: str,
@@ -212,7 +217,12 @@ async def search(
     title="Fetch Document",
     description="Fetch the full contents of a search result document",
     tags={"search", "notes"},
-    annotations={"title": "Fetch Document", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "Fetch Document",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def fetch(
     id: str,

--- a/src/basic_memory/mcp/tools/cloud_info.py
+++ b/src/basic_memory/mcp/tools/cloud_info.py
@@ -8,7 +8,12 @@ from basic_memory.mcp.server import mcp
     "cloud_info",
     title="Cloud Info",
     tags={"cloud"},
-    annotations={"title": "Cloud Info", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "Cloud Info",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 def cloud_info() -> str:
     """Return optional Basic Memory Cloud information and setup guidance."""

--- a/src/basic_memory/mcp/tools/list_directory.py
+++ b/src/basic_memory/mcp/tools/list_directory.py
@@ -14,7 +14,12 @@ from basic_memory.mcp.server import mcp
     title="List Directory",
     description="List directory contents with filtering and depth control.",
     tags={"navigation", "notes"},
-    annotations={"title": "List Directory", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "List Directory",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def list_directory(
     # `dir_name` is unusual; models reach for directory/folder/path/dir.

--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -359,7 +359,12 @@ def _format_project_list_json(
     "list_memory_projects",
     title="List Memory Projects",
     tags={"projects"},
-    annotations={"title": "List Memory Projects", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "List Memory Projects",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def list_memory_projects(
     output_format: Literal["text", "json"] = "text",

--- a/src/basic_memory/mcp/tools/read_content.py
+++ b/src/basic_memory/mcp/tools/read_content.py
@@ -161,7 +161,12 @@ def optimize_image(img, content_length, max_output_bytes=350000):
         "Memory knowledge base API — see https://docs.basicmemory.com/local/mcp-tools-local"
     ),
     tags={"notes"},
-    annotations={"title": "Read Content", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "Read Content",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def read_content(
     path: Annotated[

--- a/src/basic_memory/mcp/tools/read_note.py
+++ b/src/basic_memory/mcp/tools/read_note.py
@@ -79,7 +79,12 @@ def _parse_opening_frontmatter(content: str) -> tuple[str, dict | None]:
     tags={"notes"},
     # TODO: re-enable once MCP client rendering is working
     # meta={"ui/resourceUri": "ui://basic-memory/note-preview"},
-    annotations={"title": "Read Note", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "Read Note",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def read_note(
     identifier: str,

--- a/src/basic_memory/mcp/tools/recent_activity.py
+++ b/src/basic_memory/mcp/tools/recent_activity.py
@@ -38,7 +38,12 @@ from basic_memory.schemas.search import SearchItemType
     Or standard formats like "7d"
     """,
     tags={"navigation", "notes"},
-    annotations={"title": "Recent Activity", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "Recent Activity",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def recent_activity(
     type: Annotated[

--- a/src/basic_memory/mcp/tools/release_notes.py
+++ b/src/basic_memory/mcp/tools/release_notes.py
@@ -8,7 +8,12 @@ from basic_memory.mcp.server import mcp
     "release_notes",
     title="Release Notes",
     tags={"cloud"},
-    annotations={"title": "Release Notes", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "Release Notes",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 def release_notes() -> str:
     """Return the latest product release notes for optional user review."""

--- a/src/basic_memory/mcp/tools/schema.py
+++ b/src/basic_memory/mcp/tools/schema.py
@@ -207,7 +207,12 @@ def _no_schema_guidance(note_type: str, tool_name: str) -> str:
     title="Validate Schema",
     description="Validate notes against their Picoschema definitions.",
     tags={"schema"},
-    annotations={"title": "Validate Schema", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "Validate Schema",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def schema_validate(
     note_type: Optional[str] = None,
@@ -322,7 +327,12 @@ async def schema_validate(
     title="Infer Schema",
     description="Analyze existing notes and suggest a Picoschema definition.",
     tags={"schema"},
-    annotations={"title": "Infer Schema", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "Infer Schema",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def schema_infer(
     note_type: str,
@@ -445,7 +455,12 @@ async def schema_infer(
     title="Schema Diff",
     description="Detect drift between a schema definition and actual note usage.",
     tags={"schema"},
-    annotations={"title": "Schema Diff", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "Schema Diff",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def schema_diff(
     note_type: str,

--- a/src/basic_memory/mcp/tools/search.py
+++ b/src/basic_memory/mcp/tools/search.py
@@ -617,7 +617,12 @@ async def _search_all_projects(
     tags={"search"},
     # TODO: re-enable once MCP client rendering is working
     # meta={"ui/resourceUri": "ui://basic-memory/search-results"},
-    annotations={"title": "Search Notes", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "Search Notes",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def search_notes(
     # Accept common search-query aliases models reach for from training data.

--- a/src/basic_memory/mcp/tools/ui_sdk.py
+++ b/src/basic_memory/mcp/tools/ui_sdk.py
@@ -22,7 +22,12 @@ def _text_block(message: str) -> List[ContentBlock]:
     description="Search notes and return an embedded MCP-UI resource (raw HTML).",
     tags={"search", "ui"},
     output_schema=None,
-    annotations={"title": "Search Notes (UI)", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "Search Notes (UI)",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def search_notes_ui(
     query: str,
@@ -98,7 +103,12 @@ async def search_notes_ui(
     description="Read a note and return an embedded MCP-UI resource (raw HTML).",
     tags={"notes", "ui"},
     output_schema=None,
-    annotations={"title": "Read Note (UI)", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "Read Note (UI)",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def read_note_ui(
     identifier: str,

--- a/src/basic_memory/mcp/tools/view_note.py
+++ b/src/basic_memory/mcp/tools/view_note.py
@@ -14,7 +14,12 @@ from basic_memory.mcp.tools.read_note import read_note
     title="View Note",
     description="View a note as a formatted artifact for better readability.",
     tags={"notes"},
-    annotations={"title": "View Note", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "View Note",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def view_note(
     identifier: str,

--- a/src/basic_memory/mcp/tools/workspaces.py
+++ b/src/basic_memory/mcp/tools/workspaces.py
@@ -48,7 +48,12 @@ def _workspace_list_response(workspaces: list[WorkspaceInfo]) -> WorkspaceListRe
     title="List Workspaces",
     description="List available cloud workspaces (tenant_id, type, role, and name).",
     tags={"cloud", "projects"},
-    annotations={"title": "List Workspaces", "readOnlyHint": True, "openWorldHint": False},
+    annotations={
+        "title": "List Workspaces",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
 )
 async def list_workspaces(
     output_format: Literal["text", "json"] = "text",

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -120,26 +120,26 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
 }
 
 
-# Anthropic directory review requirements (connectors/building/review-criteria):
-# every tool must set annotations.title, read-only tools must set readOnlyHint=True,
-# and write tools must set an explicit readOnlyHint=False plus a destructiveHint.
+# Directory review requirements differ by client, so keep the stricter shared contract:
+# every tool must set annotations.title and explicit readOnlyHint, destructiveHint, and
+# openWorldHint values.
 EXPECTED_TOOL_ANNOTATIONS: dict[str, dict[str, bool]] = {
-    "build_context": {"readOnlyHint": True},
-    "cloud_info": {"readOnlyHint": True},
-    "fetch": {"readOnlyHint": True},
-    "list_directory": {"readOnlyHint": True},
-    "list_memory_projects": {"readOnlyHint": True},
-    "list_workspaces": {"readOnlyHint": True},
-    "read_content": {"readOnlyHint": True},
-    "read_note": {"readOnlyHint": True},
-    "recent_activity": {"readOnlyHint": True},
-    "release_notes": {"readOnlyHint": True},
-    "schema_diff": {"readOnlyHint": True},
-    "schema_infer": {"readOnlyHint": True},
-    "schema_validate": {"readOnlyHint": True},
-    "search": {"readOnlyHint": True},
-    "search_notes": {"readOnlyHint": True},
-    "view_note": {"readOnlyHint": True},
+    "build_context": {"readOnlyHint": True, "destructiveHint": False},
+    "cloud_info": {"readOnlyHint": True, "destructiveHint": False},
+    "fetch": {"readOnlyHint": True, "destructiveHint": False},
+    "list_directory": {"readOnlyHint": True, "destructiveHint": False},
+    "list_memory_projects": {"readOnlyHint": True, "destructiveHint": False},
+    "list_workspaces": {"readOnlyHint": True, "destructiveHint": False},
+    "read_content": {"readOnlyHint": True, "destructiveHint": False},
+    "read_note": {"readOnlyHint": True, "destructiveHint": False},
+    "recent_activity": {"readOnlyHint": True, "destructiveHint": False},
+    "release_notes": {"readOnlyHint": True, "destructiveHint": False},
+    "schema_diff": {"readOnlyHint": True, "destructiveHint": False},
+    "schema_infer": {"readOnlyHint": True, "destructiveHint": False},
+    "schema_validate": {"readOnlyHint": True, "destructiveHint": False},
+    "search": {"readOnlyHint": True, "destructiveHint": False},
+    "search_notes": {"readOnlyHint": True, "destructiveHint": False},
+    "view_note": {"readOnlyHint": True, "destructiveHint": False},
     # canvas falls back to PUT when the file already exists, replacing its content.
     "canvas": {"readOnlyHint": False, "destructiveHint": True},
     # create_memory_project is purely additive: it creates a new project and errors
@@ -161,8 +161,8 @@ EXPECTED_TOOL_ANNOTATIONS: dict[str, dict[str, bool]] = {
 # server whenever tests import their module directly, so tolerate their presence
 # without requiring it — keeps this contract independent of test execution order.
 OPTIONAL_TOOL_ANNOTATIONS: dict[str, dict[str, bool]] = {
-    "read_note_ui": {"readOnlyHint": True},
-    "search_notes_ui": {"readOnlyHint": True},
+    "read_note_ui": {"readOnlyHint": True, "destructiveHint": False},
+    "search_notes_ui": {"readOnlyHint": True, "destructiveHint": False},
 }
 
 
@@ -211,11 +211,11 @@ def test_mcp_tool_signatures_are_stable():
 
 @pytest.mark.asyncio
 async def test_mcp_tool_annotations_meet_directory_requirements():
-    """Every tool's wire-level ToolAnnotations must satisfy Anthropic directory review.
+    """Every tool's wire-level ToolAnnotations must satisfy app directory review.
 
-    The directory validator reads ToolAnnotations (not FastMCP's top-level title), so
-    each tool needs annotations.title, an explicit readOnlyHint, and — for write
-    tools — a destructiveHint. openWorldHint is False across the board because every
+    Directory validators read ToolAnnotations (not FastMCP's top-level title), so
+    each tool needs annotations.title plus explicit readOnlyHint, destructiveHint,
+    and openWorldHint values. openWorldHint is False across the board because every
     tool operates on the user's own knowledge base.
     """
     tool_list = await mcp.list_tools()
@@ -242,10 +242,9 @@ async def test_mcp_tool_annotations_meet_directory_requirements():
         assert annotations.readOnlyHint is expected["readOnlyHint"], (
             f"Tool '{tool_name}' readOnlyHint should be {expected['readOnlyHint']}"
         )
-        if expected["readOnlyHint"] is False:
-            assert annotations.destructiveHint is expected["destructiveHint"], (
-                f"Tool '{tool_name}' destructiveHint should be {expected['destructiveHint']}"
-            )
+        assert annotations.destructiveHint is expected["destructiveHint"], (
+            f"Tool '{tool_name}' destructiveHint should be {expected['destructiveHint']}"
+        )
         assert annotations.openWorldHint is False, (
             f"Tool '{tool_name}' openWorldHint should be False"
         )


### PR DESCRIPTION
## Why

ChatGPT Apps submission import expects every MCP tool annotation to set `readOnlyHint`, `destructiveHint`, and `openWorldHint` explicitly. Basic Memory's existing contract passed the Claude audit, but read-only tools still emitted `destructiveHint: null` in their wire descriptors.

## What Changed

- Added explicit `destructiveHint=False` metadata to read-only MCP tool registrations, including ChatGPT search/fetch adapters and optional MCP-UI tools.
- Tightened `tests/mcp/test_tool_contracts.py` so every tool must provide an explicit `destructiveHint`, not only write tools.
- Preserved the existing destructive classifications for write/delete/move/project tools.

## Implementation Details

This is a metadata-only change. Read-only tools continue to read, list, search, format, or analyze workspace data without mutating content. Existing write and destructive tools keep their current explicit classifications.

## Testing

- `uv run pytest tests/mcp/test_tool_contracts.py -q` passed.
- Runtime descriptor check confirmed no registered tool has a missing `destructiveHint`.
- `git diff --check` passed.
- `just fast-check` passed lint/format/typecheck, then failed during pytest-testmon on existing/environmental failures:
  - `test-int/cli/test_cli_tool_write_note_type_integration.py::test_write_note_type_flag_round_trip` hit semantic search disabled while defaulting to hybrid search.
  - `test-int/semantic/test_semantic_quality.py::test_semantic_quality[asyncio-postgres-openai]` hit OpenAI `429 insufficient_quota`.

## Risks / Follow-ups

- Cloud still needs to consume this commit via its pinned `basic-memory` git revision before the hosted Cloud MCP app inherits these upstream annotation fixes.
