### PR TITLE
fix(mcp): expose edit_note operation enum

### DIFF
--- a/src/basic_memory/mcp/tools/edit_note.py
+++ b/src/basic_memory/mcp/tools/edit_note.py
@@ -1,6 +1,6 @@
 """Edit note tool for Basic Memory MCP server."""
 
-from typing import TYPE_CHECKING, Annotated, Optional, Literal
+from typing import TYPE_CHECKING, Annotated, Literal, Optional
 
 import logfire
 from httpx import HTTPStatusError
@@ -30,6 +30,15 @@ from basic_memory.services.link_resolver import (
     is_workspace_qualified_plain_identifier,
 )
 from basic_memory.utils import normalize_project_reference, validate_project_path
+
+EDIT_OPERATIONS = (
+    "append",
+    "prepend",
+    "find_replace",
+    "replace_section",
+    "insert_before_section",
+    "insert_after_section",
+)
 
 
 def _parse_identifier_to_title_and_directory(identifier: str) -> tuple[str, str]:
@@ -318,7 +327,7 @@ Error editing note '{identifier}': {error_message}
 )
 async def edit_note(
     identifier: str,
-    operation: str,
+    operation: Annotated[str, Field(json_schema_extra={"enum": list(EDIT_OPERATIONS)})],
     # Accept common replacement-content aliases. Models trained on diff/patch
     # APIs reach for new_content/replacement/replace_with on first try.
     content: Annotated[
@@ -512,17 +521,9 @@ async def edit_note(
             )
 
             # Validate operation
-            valid_operations = [
-                "append",
-                "prepend",
-                "find_replace",
-                "replace_section",
-                "insert_before_section",
-                "insert_after_section",
-            ]
-            if operation not in valid_operations:
+            if operation not in EDIT_OPERATIONS:
                 raise ValueError(
-                    f"Invalid operation '{operation}'. Must be one of: {', '.join(valid_operations)}"
+                    f"Invalid operation '{operation}'. Must be one of: {', '.join(EDIT_OPERATIONS)}"
                 )
 
             # Validate required parameters for specific operations

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -165,6 +165,15 @@ OPTIONAL_TOOL_ANNOTATIONS: dict[str, dict[str, bool]] = {
     "search_notes_ui": {"readOnlyHint": True, "destructiveHint": False},
 }
 
+EXPECTED_EDIT_NOTE_OPERATIONS = [
+    "append",
+    "prepend",
+    "find_replace",
+    "replace_section",
+    "insert_before_section",
+    "insert_after_section",
+]
+
 
 TOOL_FUNCTIONS: dict[str, object] = {
     "build_context": tools.build_context,
@@ -248,6 +257,19 @@ async def test_mcp_tool_annotations_meet_directory_requirements():
         assert annotations.openWorldHint is False, (
             f"Tool '{tool_name}' openWorldHint should be False"
         )
+
+
+@pytest.mark.asyncio
+async def test_edit_note_operation_schema_exposes_supported_operations():
+    """The edit operation is a fixed choice set, not a free-form string."""
+    tool_list = await mcp.list_tools()
+    edit_note_tool = next(tool for tool in tool_list if tool.name == "edit_note")
+
+    input_schema = edit_note_tool.to_mcp_tool().inputSchema
+    operation_schema = input_schema["properties"]["operation"]
+
+    assert operation_schema["type"] == "string"
+    assert operation_schema["enum"] == EXPECTED_EDIT_NOTE_OPERATIONS
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

- OpenAI's app submission review flagged `edit_note.operation` as a free-form string even though Basic Memory only supports a fixed set of edit operations.
- Exposing the supported operations in the MCP tool schema lowers incorrect-call risk without changing runtime behavior.

## What Changed

- Added a single `EDIT_OPERATIONS` source of truth in `src/basic_memory/mcp/tools/edit_note.py`.
- Annotated the `edit_note.operation` parameter with JSON schema enum metadata while keeping the existing string runtime validation.
- Added a tool-contract regression that asserts the protocol-level `edit_note.operation` schema advertises the supported enum values.

## Implementation Details

- Kept the Python parameter type as `str` instead of a `Literal` so direct Python callers, CLI paths, and invalid-operation tests do not need casts.
- The enum is emitted through `Field(json_schema_extra={"enum": ...})`, which FastMCP includes in `tools/list` while preserving the existing docstring-derived description.
- Runtime validation still rejects unsupported operations before the edit request is sent.

## Testing

### Automated

- `uv run pytest tests/mcp/test_tool_contracts.py -q`: passed, 4 passed.
- `just fast-check`: passed; cold testmon selected a broad run, 3397 passed, 43 skipped, 20 warnings.
- `uv run ruff check src/basic_memory/mcp/tools/edit_note.py tests/mcp/test_tool_contracts.py`: passed.
- `uv run ruff format --check src/basic_memory/mcp/tools/edit_note.py tests/mcp/test_tool_contracts.py`: passed.
- `uv run ty check src tests test-int`: passed.

### Manual

- Inspected `mcp.list_tools()` for `edit_note` and confirmed `inputSchema.properties.operation.enum` contains `append`, `prepend`, `find_replace`, `replace_section`, `insert_before_section`, and `insert_after_section`.

## Risks / Follow-ups

- Low risk: this changes schema metadata and reuses the existing validation path.
- Follow-up: once merged, Basic Memory Cloud should bump its `basic-memory` dependency so the hosted MCP endpoint advertises the new schema.
