### PR TITLE
fix(core): chunk select_by_ids to stay under SQLite bound-parameter limit

### DIFF
--- a/src/basic_memory/repository/repository.py
+++ b/src/basic_memory/repository/repository.py
@@ -23,6 +23,12 @@ from basic_memory.models import Base
 
 T = TypeVar("T", bound=Base)
 
+# SQLite caps the number of bound parameters per statement (999 on builds older
+# than 3.32.0), so id-list queries must stay below that floor. 500 leaves
+# headroom for additional binds (e.g. the project_id filter) while keeping the
+# number of round-trips low.
+SELECT_BY_IDS_CHUNK_SIZE = 500
+
 
 class Repository[T: Base]:
     """Base repository implementation with explicit caller-owned sessions."""
@@ -83,15 +89,25 @@ class Repository[T: Base]:
         return result.scalars().one_or_none()
 
     async def select_by_ids(self, session: AsyncSession, ids: List[int]) -> Sequence[T]:
-        """Select multiple entities by IDs using an existing session."""
-        query = (
-            select(self.Model).where(self.primary_key.in_(ids)).options(*self.get_load_options())
-        )
-        # Add project filter if applicable
-        query = self._add_project_filter(query)
+        """Select multiple entities by IDs using an existing session.
 
-        result = await session.execute(query)
-        return result.scalars().all()
+        Queries in chunks so callers can pass arbitrarily large id lists
+        without hitting SQLite's bound-parameter limit (issue #1045).
+        """
+        results: list[T] = []
+        for start in range(0, len(ids), SELECT_BY_IDS_CHUNK_SIZE):
+            chunk = ids[start : start + SELECT_BY_IDS_CHUNK_SIZE]
+            query = (
+                select(self.Model)
+                .where(self.primary_key.in_(chunk))
+                .options(*self.get_load_options())
+            )
+            # Add project filter if applicable
+            query = self._add_project_filter(query)
+
+            result = await session.execute(query)
+            results.extend(result.scalars().all())
+        return results
 
     async def add(self, session: AsyncSession, model: T) -> T:
         """

--- a/tests/repository/test_repository.py
+++ b/tests/repository/test_repository.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from basic_memory import db
 from basic_memory.models import Base
-from basic_memory.repository.repository import Repository
+from basic_memory.repository.repository import SELECT_BY_IDS_CHUNK_SIZE, Repository
 
 
 class ModelTest(Base):
@@ -131,6 +131,25 @@ async def test_find_by_ids(repository, session_maker):
         # Test with all non-existent IDs
         not_found = await repository.find_by_ids(session, ["fake1", "fake2"])
         assert len(not_found) == 0
+
+
+@pytest.mark.asyncio
+async def test_find_by_ids_exceeds_sqlite_bound_parameter_limit(repository, session_maker):
+    """Regression test for #1045: reindex --embeddings passes every entity id at once.
+
+    Id lists larger than SQLite's bound-parameter cap (999 on builds older than
+    3.32.0) must be queried in chunks instead of a single IN clause.
+    """
+    # More than two full chunks so the loop and the tail slice are both exercised.
+    total = SELECT_BY_IDS_CHUNK_SIZE * 2 + 100
+    instances = [ModelTest(id=f"test_{i}", name=f"Test {i}") for i in range(total)]
+    async with db.scoped_session(session_maker) as session:
+        await repository.add_all_no_return(session, instances)
+
+        ids_to_find = [f"test_{i}" for i in range(total)]
+        found = await repository.find_by_ids(session, ids_to_find)
+        assert len(found) == total
+        assert sorted(e.id for e in found) == sorted(ids_to_find)
 
 
 @pytest.mark.asyncio

--- a/tests/repository/test_repository.py
+++ b/tests/repository/test_repository.py
@@ -1,13 +1,15 @@
 """Test repository implementation."""
 
 from datetime import datetime, UTC
+from unittest.mock import AsyncMock
+
 import pytest
 from sqlalchemy import String, DateTime
 from sqlalchemy.orm import Mapped, mapped_column
 
 from basic_memory import db
 from basic_memory.models import Base
-from basic_memory.repository.repository import SELECT_BY_IDS_CHUNK_SIZE, Repository
+from basic_memory.repository.repository import Repository
 
 
 class ModelTest(Base):
@@ -134,21 +136,25 @@ async def test_find_by_ids(repository, session_maker):
 
 
 @pytest.mark.asyncio
-async def test_find_by_ids_exceeds_sqlite_bound_parameter_limit(repository, session_maker):
-    """Regression test for #1045: reindex --embeddings passes every entity id at once.
-
-    Id lists larger than SQLite's bound-parameter cap (999 on builds older than
-    3.32.0) must be queried in chunks instead of a single IN clause.
-    """
-    # More than two full chunks so the loop and the tail slice are both exercised.
-    total = SELECT_BY_IDS_CHUNK_SIZE * 2 + 100
-    instances = [ModelTest(id=f"test_{i}", name=f"Test {i}") for i in range(total)]
+async def test_find_by_ids_chunks_large_requests(repository, session_maker, monkeypatch):
+    """Regression test for #1045: bulk id hydration must issue bounded queries."""
+    instances = [ModelTest(id=f"test_{i}", name=f"Test {i}") for i in range(5)]
     async with db.scoped_session(session_maker) as session:
         await repository.add_all_no_return(session, instances)
 
-        ids_to_find = [f"test_{i}" for i in range(total)]
+        # Use a tiny deterministic chunk size so this test proves the query is
+        # split even on SQLite builds whose real parameter cap exceeds 1,100.
+        monkeypatch.setattr(
+            "basic_memory.repository.repository.SELECT_BY_IDS_CHUNK_SIZE",
+            2,
+        )
+        execute = AsyncMock(wraps=session.execute)
+        monkeypatch.setattr(session, "execute", execute)
+
+        ids_to_find = [instance.id for instance in instances]
         found = await repository.find_by_ids(session, ids_to_find)
-        assert len(found) == total
+
+        assert execute.await_count == 3
         assert sorted(e.id for e in found) == sorted(ids_to_find)
 
 


### PR DESCRIPTION
## Summary

`reindex --embeddings` crashed with `sqlite3.OperationalError: too many SQL variables` at 0% on large projects, before any embedding work started.

## Root cause

`Repository.select_by_ids()` built one `WHERE primary_key IN (...)` query for the entire id list. `reindex_vectors()` passes all entity ids at once, while older SQLite builds cap bound parameters at 999.

## Fix

Chunk `select_by_ids()` into slices of 500 ids, leaving headroom for the `project_id` bind, execute one query per slice, and concatenate the results. Return type and empty-list behavior are unchanged.

Fixing the shared repository helper protects all bulk-id callers, including `indexing/project_index_maintenance.py` and `indexing/note_content_batch_reconciliation.py`.

## Test plan

- A deterministic regression test lowers `SELECT_BY_IDS_CHUNK_SIZE` to 2, queries five rows, and asserts the real repository path issues exactly three statements and returns every row. This proves both full chunks and the tail without depending on the SQLite build parameter limit.
- `uv run pytest -q tests/repository/test_repository.py` — 14 passed.
- Ruff check and format — clean.
- `just fast-check` — passed.

Fixes #1045

🤖 Generated with [Claude Code](https://claude.com/claude-code)