### PR TITLE
fix(cli): never print a blank doctor failure message

### DIFF
--- a/src/basic_memory/cli/commands/doctor.py
+++ b/src/basic_memory/cli/commands/doctor.py
@@ -214,9 +214,13 @@ def doctor(
         with force_routing(local=local, cloud=cloud):
             run_with_cleanup(run_doctor())
     except (ToolError, ValueError) as e:
-        console.print(f"[red]Doctor failed: {e}[/red]")
+        # str() of a message-less exception (e.g. httpx.ReadTimeout) is empty;
+        # fall back to repr so the failure line always names the error (#1027).
+        error_detail = str(e) or repr(e)
+        console.print(f"[red]Doctor failed: {error_detail}[/red]")
         raise typer.Exit(code=1)
     except Exception as e:
-        logger.error(f"Doctor failed: {e}")
-        typer.echo(f"Doctor failed: {e}", err=True)
+        error_detail = str(e) or repr(e)
+        logger.error(f"Doctor failed: {error_detail}")
+        typer.echo(f"Doctor failed: {error_detail}", err=True)
         raise typer.Exit(code=1)  # pragma: no cover

--- a/tests/cli/test_doctor_command.py
+++ b/tests/cli/test_doctor_command.py
@@ -1,0 +1,51 @@
+"""Regression tests for doctor CLI failure output (#1027).
+
+str() of a message-less exception (e.g. httpx.ReadTimeout, bare RuntimeError)
+is empty, which used to leave users with a blank "Doctor failed:" line.
+"""
+
+from typing import Callable, NoReturn
+
+from typer.testing import CliRunner
+
+from basic_memory.cli.app import app
+import basic_memory.cli.commands.doctor as doctor_cmd
+
+runner = CliRunner()
+
+
+def _raise(exc: Exception) -> Callable[[], NoReturn]:
+    def raiser() -> NoReturn:
+        raise exc
+
+    return raiser
+
+
+def test_doctor_failure_prints_error_message(monkeypatch):
+    """Exceptions with a message keep printing that message."""
+    monkeypatch.setattr(doctor_cmd, "run_doctor", _raise(ValueError("doctor project missing")))
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 1
+    assert "Doctor failed: doctor project missing" in result.output
+
+
+def test_doctor_failure_message_never_blank(monkeypatch):
+    """A message-less expected error falls back to the repr instead of blank output."""
+    monkeypatch.setattr(doctor_cmd, "run_doctor", _raise(ValueError()))
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 1
+    assert "Doctor failed: ValueError()" in result.output
+
+
+def test_doctor_unexpected_failure_message_never_blank(monkeypatch):
+    """A message-less unexpected error (generic handler) also shows its repr on stderr."""
+    monkeypatch.setattr(doctor_cmd, "run_doctor", _raise(RuntimeError()))
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 1
+    assert "Doctor failed: RuntimeError()" in result.stderr


### PR DESCRIPTION
## Summary

Remnant of #1027: the main event-loop bug was fixed in #1018, but the `doctor` command's failure handlers rendered `f"Doctor failed: {e}"` directly. For message-less exceptions (e.g. `httpx.ReadTimeout`, a bare `RuntimeError`), `str(e)` is empty, so users saw a blank `Doctor failed:` line with no diagnostic.

Both handlers in `src/basic_memory/cli/commands/doctor.py` now fall back to `repr(e)` when `str(e)` is empty, so the failure line always names the error (the reporter explicitly asked for the repr). These two sites are the only exception renderings in the file; all other error paths raise with explicit messages.

## Tests

New `tests/cli/test_doctor_command.py` (the doctor CLI previously had no test coverage — `*/cli/**` is omitted from unit coverage) exercises the real command path via `CliRunner`, stubbing only `run_doctor`:

- exceptions with a message keep printing that message
- a message-less `ValueError` (expected-error handler) prints `Doctor failed: ValueError()`
- a message-less `RuntimeError` (generic handler) prints `Doctor failed: RuntimeError()` on stderr

All 3 pass; `ruff check`/`ruff format` clean on touched files; `just typecheck` exits 0 (only pre-existing Python 3.14 event-loop-policy deprecation warnings in unrelated files).

Refs #1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)