### PR TITLE
fix(integrations): stop leaking bm mcp children from the Hermes provider

### DIFF
--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -550,17 +550,23 @@ class _BmMcpActor:
         self._ready = threading.Event()
         self._init_error: BaseException | None = None
         self._stop_future: asyncio.Future | None = None
+        self._main_task: asyncio.Task[None] | None = None
+        self._shutdown_requested = threading.Event()
         self._tools_cache: list[dict[str, Any]] = []
         self._running = False
 
     def start(self, timeout: float = 25.0) -> None:
         if self._thread and self._thread.is_alive():
             return
+        self._shutdown_requested.clear()
         self._running = True
         self._thread = threading.Thread(target=self._run, daemon=True, name="bm-mcp-actor")
         self._thread.start()
         if not self._ready.wait(timeout=timeout):
-            self._running = False
+            # Trigger: startup timed out before _main created its stop future.
+            # Why: joining alone cannot exit the stdio context or reap its child.
+            # Outcome: cancel the actor task and wait for its async contexts to close.
+            self.shutdown(timeout=5.0)
             raise TimeoutError(f"basic-memory MCP server didn't initialize within {timeout}s")
         if self._init_error is not None:
             self._running = False
@@ -571,7 +577,16 @@ class _BmMcpActor:
         asyncio.set_event_loop(loop)
         self._loop = loop
         try:
-            loop.run_until_complete(self._main())
+            self._main_task = loop.create_task(self._main())
+            if self._shutdown_requested.is_set():
+                self._main_task.cancel()
+            loop.run_until_complete(self._main_task)
+        except asyncio.CancelledError:
+            # Cancellation is the intentional pre-ready shutdown path. Wake a
+            # concurrent start() without logging an expected cleanup as a crash.
+            if not self._ready.is_set() and self._init_error is None:
+                self._init_error = RuntimeError("basic-memory MCP actor stopped during startup")
+            self._ready.set()
         except BaseException as e:
             if self._init_error is None:
                 self._init_error = e
@@ -579,6 +594,7 @@ class _BmMcpActor:
             logger.exception("basic-memory MCP actor terminated with error")
         finally:
             self._running = False
+            self._main_task = None
             try:
                 loop.close()
             except Exception:
@@ -647,14 +663,21 @@ class _BmMcpActor:
 
     def shutdown(self, timeout: float = 5.0) -> None:
         self._running = False
-        if self._loop is not None and self._stop_future is not None:
+        self._shutdown_requested.set()
+        if self._loop is not None:
             try:
-                self._loop.call_soon_threadsafe(
-                    lambda: (
-                        (self._stop_future and not self._stop_future.done())
-                        and self._stop_future.set_result(None)
-                    )
-                )
+
+                def request_stop() -> None:
+                    if not self._ready.is_set():
+                        if self._main_task is not None and not self._main_task.done():
+                            self._main_task.cancel()
+                        return
+                    if self._stop_future is not None and not self._stop_future.done():
+                        self._stop_future.set_result(None)
+                    elif self._main_task is not None and not self._main_task.done():
+                        self._main_task.cancel()
+
+                self._loop.call_soon_threadsafe(request_stop)
             except Exception:
                 # Loop may already be closed; safe to ignore.
                 pass
@@ -822,7 +845,7 @@ class BasicMemoryProvider(MemoryProvider):
 
     # ---- Lifecycle ----
     def initialize(self, session_id: str, **kwargs: Any) -> None:
-        self._session_id = session_id or ""
+        requested_session_id = session_id or ""
         self._hermes_home = kwargs.get("hermes_home") or os.path.expanduser("~/.hermes")
         cfg = _load_config(self._hermes_home)
         self._mode = cfg.get("mode") or "local"
@@ -880,8 +903,7 @@ class BasicMemoryProvider(MemoryProvider):
         # invalidates the connection. A dead actor is shut down first (joining
         # its thread reaps the child) and then replaced below.
         if self._actor is not None and self._actor.is_alive():
-            self._session_started_at = datetime.now(timezone.utc)
-            self._initialized = True
+            self._mark_session_ready(requested_session_id)
             logger.info(
                 "basic-memory provider ready (reusing running MCP actor): mode=%s project=%s",
                 self._mode,
@@ -912,15 +934,21 @@ class BasicMemoryProvider(MemoryProvider):
         try:
             actor.start(timeout=25.0)
         except Exception as e:
-            logger.error("basic-memory: MCP server failed to start: %s", e)
-            # A failed start can still have spawned the child (e.g. the ready
-            # timeout fired after `bm mcp` launched) — shut the actor down so
-            # the child is reaped instead of lingering until process exit.
             try:
                 actor.shutdown(timeout=5.0)
             except Exception as shutdown_error:
-                logger.debug("failed-start actor shutdown: %s", shutdown_error)
-            self._actor = None
+                logger.debug("actor shutdown after failed start: %s", shutdown_error)
+            if self._actor is actor:
+                self._actor = None
+            logger.error("basic-memory: MCP server failed to start: %s", e)
+            return
+        if self._actor is not actor:
+            # Signal/atexit cleanup detached the actor while start() was
+            # waiting. Do not resurrect a provider whose process cleanup ran.
+            try:
+                actor.shutdown(timeout=5.0)
+            except Exception as e:
+                logger.debug("actor shutdown after interrupted start: %s", e)
             return
 
         tools = actor.list_tools()
@@ -933,14 +961,29 @@ class BasicMemoryProvider(MemoryProvider):
                 sorted(names),
             )
 
-        self._session_started_at = datetime.now(timezone.utc)
-        self._initialized = True
+        self._mark_session_ready(requested_session_id)
         logger.info(
             "basic-memory provider ready: mode=%s project=%s tools=%d",
             self._mode,
             self._project,
             len(tools),
         )
+
+    def _mark_session_ready(self, session_id: str) -> None:
+        """Publish a successful session boundary while retaining the MCP actor."""
+        if session_id != self._session_id:
+            # Trigger: Hermes starts a distinct session on a reused provider.
+            # Why: these fields identify one transcript and its opening turn;
+            # retaining them appends the new session to the previous note.
+            # Outcome: only session-scoped capture state resets. Reconnecting a
+            # dead actor for the same session preserves the in-progress note.
+            self._session_id = session_id
+            self._session_note_id = None
+            self._first_user_msg = None
+            self._session_started_at = datetime.now(timezone.utc)
+        elif self._session_started_at is None:
+            self._session_started_at = datetime.now(timezone.utc)
+        self._initialized = True
 
     def _ensure_local_project(self) -> None:
         bm = _bm_binary_path()

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -901,13 +901,27 @@ class BasicMemoryProvider(MemoryProvider):
             logger.error("basic-memory: cannot determine server argv: %s", e)
             return
 
+        # Expose the actor to cleanup BEFORE start() blocks (up to 25s):
+        # _atexit_cleanup and the SIGTERM handler only reach actors through
+        # provider.shutdown() → self._actor, so a local-only actor would leak
+        # its freshly spawned `bm mcp` child if a signal lands mid-start.
+        # Callers can't observe the half-started actor: every tool/capture
+        # path gates on _initialized, which stays False until start() returns.
         actor = _BmMcpActor(argv)
+        self._actor = actor
         try:
             actor.start(timeout=25.0)
         except Exception as e:
             logger.error("basic-memory: MCP server failed to start: %s", e)
+            # A failed start can still have spawned the child (e.g. the ready
+            # timeout fired after `bm mcp` launched) — shut the actor down so
+            # the child is reaped instead of lingering until process exit.
+            try:
+                actor.shutdown(timeout=5.0)
+            except Exception as shutdown_error:
+                logger.debug("failed-start actor shutdown: %s", shutdown_error)
+            self._actor = None
             return
-        self._actor = actor
 
         tools = actor.list_tools()
         names = {t["name"] for t in tools}

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import re
+import signal
 import socket
 import subprocess
 import threading
@@ -640,6 +641,10 @@ class _BmMcpActor:
     def list_tools(self) -> list[dict[str, Any]]:
         return list(self._tools_cache)
 
+    def is_alive(self) -> bool:
+        """True while the actor loop thread is up and accepting calls."""
+        return self._running and self._thread is not None and self._thread.is_alive()
+
     def shutdown(self, timeout: float = 5.0) -> None:
         self._running = False
         if self._loop is not None and self._stop_future is not None:
@@ -863,6 +868,32 @@ class BasicMemoryProvider(MemoryProvider):
         if not self._verify_project_registered():
             self._log_missing_project()
             return
+
+        # Trigger: initialize() called while a previous actor is still running
+        # (Hermes re-initializes providers per session; _ensure_slash_ready's
+        # lazy init can also precede a later session initialize).
+        # Why: every _BmMcpActor owns one `bm mcp` child process. Allocating a
+        # fresh actor without stopping the old one orphans that child — issue
+        # #1017 saw 18 idle `bm mcp` processes (~2.3 GB) accumulate this way.
+        # Outcome: a healthy actor is reused — its argv is always `bm mcp` and
+        # project routing happens per call, so the config re-read above never
+        # invalidates the connection. A dead actor is shut down first (joining
+        # its thread reaps the child) and then replaced below.
+        if self._actor is not None and self._actor.is_alive():
+            self._session_started_at = datetime.now(timezone.utc)
+            self._initialized = True
+            logger.info(
+                "basic-memory provider ready (reusing running MCP actor): mode=%s project=%s",
+                self._mode,
+                self._project,
+            )
+            return
+        if self._actor is not None:
+            try:
+                self._actor.shutdown(timeout=5.0)
+            except Exception as e:
+                logger.debug("stale actor shutdown during initialize: %s", e)
+            self._actor = None
 
         try:
             argv = self._server_argv()
@@ -1802,7 +1833,7 @@ def _register_via_plugin_manager(
 
 
 # ---------------------------------------------------------------------------
-# atexit safety net (mirrors plugins/memory/openviking pattern)
+# atexit + SIGTERM safety nets (mirrors plugins/memory/openviking pattern)
 # ---------------------------------------------------------------------------
 
 _active_providers: list[BasicMemoryProvider] = []
@@ -1817,6 +1848,60 @@ def _atexit_cleanup() -> None:
 
 
 atexit.register(_atexit_cleanup)
+
+
+_sigterm_installed = False
+
+
+def _install_sigterm_cleanup() -> None:
+    """
+    Run _atexit_cleanup on SIGTERM as well as at interpreter exit.
+
+    atexit alone doesn't cover SIGTERM: Python's default action terminates the
+    process without unwinding, so gateway restarts (systemd stop, docker stop,
+    supervisor reload) orphan every `bm mcp` child (issue #1017).
+
+    Constraint: this plugin is a library embedded in a host process (Hermes),
+    so it must not stomp the host's signal handling:
+      - existing Python handler → chain: run our cleanup, then the host's
+        handler, preserving its semantics.
+      - SIG_DFL → install: run cleanup, restore SIG_DFL, and re-deliver the
+        signal so the process still dies by SIGTERM exactly as before.
+      - SIG_IGN, or None (a C-level handler unreachable from Python, so
+        chaining is impossible) → leave untouched.
+    signal.signal only works from the main thread and SIGTERM only exists on
+    platforms that define it, so this no-ops cleanly everywhere else.
+    """
+    global _sigterm_installed
+    if _sigterm_installed:
+        return
+    sigterm = getattr(signal, "SIGTERM", None)
+    if sigterm is None:  # pragma: no cover - every supported platform defines SIGTERM
+        return
+    if threading.current_thread() is not threading.main_thread():
+        return
+    previous = signal.getsignal(sigterm)
+    if previous is signal.SIG_IGN or previous is None:
+        return
+
+    def _handler(signum: int, frame: Any) -> None:
+        _atexit_cleanup()
+        if callable(previous):
+            previous(signum, frame)
+            return
+        # previous is SIG_DFL: restore it and re-deliver so the process
+        # terminates by SIGTERM exactly as it would have without us.
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    try:
+        signal.signal(sigterm, _handler)
+    except (ValueError, OSError):  # pragma: no cover - main-thread race at shutdown
+        return
+    _sigterm_installed = True
+
+
+_install_sigterm_cleanup()
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/hermes/tests/test_actor.py
+++ b/integrations/hermes/tests/test_actor.py
@@ -67,7 +67,7 @@ def test_start_init_error_raises(bm):
 
 
 def test_start_timeout_raises(bm):
-    """If _ready never gets set within the timeout, start() raises TimeoutError."""
+    """A startup timeout cancels the actor task instead of leaking its thread."""
     import asyncio
 
     actor = bm._BmMcpActor(["fake-bm", "mcp"])
@@ -81,6 +81,8 @@ def test_start_timeout_raises(bm):
     with pytest.raises(TimeoutError):
         actor.start(timeout=0.5)
     assert actor._running is False
+    assert actor._thread is not None
+    assert not actor._thread.is_alive()
 
 
 # ---- Shutdown ----

--- a/integrations/hermes/tests/test_actor.py
+++ b/integrations/hermes/tests/test_actor.py
@@ -45,6 +45,19 @@ def test_start_is_idempotent_when_thread_alive(bm):
         actor.shutdown(timeout=2.0)
 
 
+def test_is_alive_tracks_actor_lifecycle(bm):
+    """is_alive() is the reuse signal for initialize() — it must be False
+    before start, True while the loop thread runs, and False after shutdown."""
+    actor = make_scripted_actor(bm)
+    assert actor.is_alive() is False
+    actor.start(timeout=5.0)
+    try:
+        assert actor.is_alive() is True
+    finally:
+        actor.shutdown(timeout=2.0)
+    assert actor.is_alive() is False
+
+
 def test_start_init_error_raises(bm):
     boom = ValueError("BM unreachable")
     actor = make_scripted_actor(bm, raise_at_init=boom)

--- a/integrations/hermes/tests/test_lifecycle.py
+++ b/integrations/hermes/tests/test_lifecycle.py
@@ -1,0 +1,235 @@
+"""
+Process-leak regression tests (issue #1017).
+
+Two leak paths, two guards:
+1. initialize() called twice on one provider must not allocate a second
+   _BmMcpActor (each actor owns a `bm mcp` child process).
+2. SIGTERM must run the same cleanup that atexit runs — Python's default
+   SIGTERM action skips atexit, orphaning every `bm mcp` child on gateway
+   restarts.
+"""
+
+from __future__ import annotations
+
+import json
+import signal
+import threading
+
+
+class TrackingActor:
+    """Stand-in for _BmMcpActor that records lifecycle calls, no threads."""
+
+    instances: list["TrackingActor"] = []
+
+    def __init__(self, argv, env=None):
+        self.argv = list(argv)
+        self.started = False
+        self.alive = False
+        self.shutdown_calls: list[float] = []
+        self.shutdown_raises = False
+        TrackingActor.instances.append(self)
+
+    def start(self, timeout: float = 25.0) -> None:
+        self.started = True
+        self.alive = True
+
+    def is_alive(self) -> bool:
+        return self.alive
+
+    def list_tools(self):
+        return [{"name": n, "description": ""} for n in ("search_notes", "read_note")]
+
+    def shutdown(self, timeout: float = 5.0) -> None:
+        self.shutdown_calls.append(timeout)
+        self.alive = False
+        if self.shutdown_raises:
+            raise RuntimeError("shutdown boom")
+
+    def call(self, tool_name, arguments, timeout: float = 30.0) -> str:
+        return json.dumps({"ok": True})
+
+
+def _make_initializable_provider(bm, monkeypatch, tmp_path):
+    """Route initialize() past the environment checks to actor allocation."""
+    TrackingActor.instances = []
+    monkeypatch.setattr(bm, "_MCP_AVAILABLE", True)
+    monkeypatch.setattr(bm, "_bm_binary_path", lambda: "/fake/bm")
+    monkeypatch.setattr(bm, "_bm_known_projects", lambda: None)
+    monkeypatch.setattr(bm, "_BmMcpActor", TrackingActor)
+    # Cloud mode skips _ensure_local_project's `bm project add` subprocess.
+    (tmp_path / "basic-memory.json").write_text(
+        json.dumps({"mode": "cloud", "project": "test-proj"})
+    )
+    return bm.BasicMemoryProvider()
+
+
+# ---- Duplicate initialize() ----
+
+
+def test_double_initialize_reuses_running_actor(bm, monkeypatch, tmp_path):
+    """Regression #1017: a second initialize() must not spawn a second bm mcp."""
+    p = _make_initializable_provider(bm, monkeypatch, tmp_path)
+
+    p.initialize(session_id="one", hermes_home=str(tmp_path))
+    assert p._initialized is True
+    assert len(TrackingActor.instances) == 1
+    first = TrackingActor.instances[0]
+    assert p._actor is first
+
+    p.initialize(session_id="two", hermes_home=str(tmp_path))
+    assert p._initialized is True
+    assert len(TrackingActor.instances) == 1, "second initialize() allocated a new actor"
+    assert p._actor is first
+    assert first.shutdown_calls == [], "healthy actor must be reused, not restarted"
+
+
+def test_initialize_replaces_dead_actor_after_shutdown(bm, monkeypatch, tmp_path):
+    """A crashed actor is shut down (child reaped) before a replacement starts."""
+    p = _make_initializable_provider(bm, monkeypatch, tmp_path)
+
+    p.initialize(session_id="one", hermes_home=str(tmp_path))
+    first = TrackingActor.instances[0]
+    first.alive = False  # simulate actor loop death (bm mcp crashed)
+
+    p.initialize(session_id="two", hermes_home=str(tmp_path))
+    assert first.shutdown_calls, "dead actor was replaced without shutdown"
+    assert len(TrackingActor.instances) == 2
+    assert p._actor is TrackingActor.instances[1]
+    assert p._initialized is True
+
+
+def test_initialize_replaces_dead_actor_even_if_shutdown_raises(bm, monkeypatch, tmp_path):
+    """Shutdown failures on the stale actor must not block re-initialization."""
+    p = _make_initializable_provider(bm, monkeypatch, tmp_path)
+
+    p.initialize(session_id="one", hermes_home=str(tmp_path))
+    first = TrackingActor.instances[0]
+    first.alive = False
+    first.shutdown_raises = True
+
+    p.initialize(session_id="two", hermes_home=str(tmp_path))
+    assert first.shutdown_calls
+    assert len(TrackingActor.instances) == 2
+    assert p._actor is TrackingActor.instances[1]
+
+
+# ---- SIGTERM cleanup chain ----
+
+
+class _FakeProviderActor:
+    def __init__(self):
+        self.shutdown_calls = 0
+
+    def shutdown(self, timeout: float = 5.0) -> None:
+        self.shutdown_calls += 1
+
+
+def _provider_with_fake_actor(bm):
+    p = bm.BasicMemoryProvider()
+    p._actor = _FakeProviderActor()
+    p._initialized = True
+    return p
+
+
+def test_sigterm_handler_chains_to_previous_python_handler(bm, monkeypatch):
+    """Host-installed Python handler keeps running after our cleanup."""
+    chained: list[int] = []
+
+    def host_handler(signum, frame):
+        chained.append(signum)
+
+    original = signal.getsignal(signal.SIGTERM)
+    provider = _provider_with_fake_actor(bm)
+    monkeypatch.setattr(bm, "_sigterm_installed", False)
+    monkeypatch.setattr(bm, "_active_providers", [provider])
+    try:
+        signal.signal(signal.SIGTERM, host_handler)
+        bm._install_sigterm_cleanup()
+        assert signal.getsignal(signal.SIGTERM) is not host_handler
+
+        signal.raise_signal(signal.SIGTERM)
+
+        assert provider._actor is None, "SIGTERM did not run provider cleanup"
+        assert chained == [signal.SIGTERM], "previous handler was not chained"
+    finally:
+        signal.signal(signal.SIGTERM, original)
+
+
+def test_sigterm_handler_with_sig_dfl_restores_and_redelivers(bm, monkeypatch):
+    """With SIG_DFL, cleanup runs and the signal is re-delivered to die-by-SIGTERM."""
+    kills: list[tuple[int, int]] = []
+    original = signal.getsignal(signal.SIGTERM)
+    provider = _provider_with_fake_actor(bm)
+    monkeypatch.setattr(bm, "_sigterm_installed", False)
+    monkeypatch.setattr(bm, "_active_providers", [provider])
+    monkeypatch.setattr(bm.os, "kill", lambda pid, sig: kills.append((pid, sig)))
+    try:
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        bm._install_sigterm_cleanup()
+
+        signal.raise_signal(signal.SIGTERM)
+
+        assert provider._actor is None
+        # Handler restored SIG_DFL and re-sent SIGTERM so termination
+        # semantics match a process without this plugin loaded.
+        assert signal.getsignal(signal.SIGTERM) == signal.SIG_DFL
+        assert kills == [(bm.os.getpid(), signal.SIGTERM)]
+    finally:
+        signal.signal(signal.SIGTERM, original)
+
+
+def test_sigterm_install_respects_sig_ign(bm, monkeypatch):
+    """Host deliberately ignores SIGTERM — the plugin must not resurrect it."""
+    original = signal.getsignal(signal.SIGTERM)
+    monkeypatch.setattr(bm, "_sigterm_installed", False)
+    try:
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        bm._install_sigterm_cleanup()
+        assert signal.getsignal(signal.SIGTERM) == signal.SIG_IGN
+        assert bm._sigterm_installed is False
+    finally:
+        signal.signal(signal.SIGTERM, original)
+
+
+def test_sigterm_install_noops_off_main_thread(bm, monkeypatch):
+    """signal.signal only works from the main thread; installer must not blow up."""
+    original = signal.getsignal(signal.SIGTERM)
+    monkeypatch.setattr(bm, "_sigterm_installed", False)
+    try:
+        t = threading.Thread(target=bm._install_sigterm_cleanup)
+        t.start()
+        t.join(timeout=5.0)
+        assert not t.is_alive()
+        assert bm._sigterm_installed is False
+        assert signal.getsignal(signal.SIGTERM) is original
+    finally:
+        signal.signal(signal.SIGTERM, original)
+
+
+def test_sigterm_install_is_idempotent(bm, monkeypatch):
+    """A second install call must not re-wrap the handler."""
+    original = signal.getsignal(signal.SIGTERM)
+    monkeypatch.setattr(bm, "_sigterm_installed", False)
+    try:
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        bm._install_sigterm_cleanup()
+        assert bm._sigterm_installed is True
+        installed = signal.getsignal(signal.SIGTERM)
+
+        bm._install_sigterm_cleanup()
+        assert signal.getsignal(signal.SIGTERM) is installed
+    finally:
+        signal.signal(signal.SIGTERM, original)
+
+
+def test_module_import_installed_sigterm_cleanup(bm):
+    """The safety net is armed at plugin load, alongside atexit registration.
+
+    If the surrounding environment ignores SIGTERM (SIG_IGN inherited across
+    exec) or owns it at the C level, install is skipped by design — assert the
+    invariant rather than unconditional installation.
+    """
+    if bm._sigterm_installed:
+        assert callable(signal.getsignal(signal.SIGTERM))
+    else:  # pragma: no cover - only in environments that pre-own SIGTERM
+        assert signal.getsignal(signal.SIGTERM) in (signal.SIG_IGN, None)

--- a/integrations/hermes/tests/test_lifecycle.py
+++ b/integrations/hermes/tests/test_lifecycle.py
@@ -113,6 +113,45 @@ def test_initialize_replaces_dead_actor_even_if_shutdown_raises(bm, monkeypatch,
     assert p._actor is TrackingActor.instances[1]
 
 
+def test_initialize_exposes_actor_to_cleanup_before_start(bm, monkeypatch, tmp_path):
+    """Regression (PR #1059 review): SIGTERM during actor.start() — which can
+    block up to 25s — must be able to reach the starting actor. Cleanup only
+    sees provider._actor, so it has to be assigned before start() blocks."""
+    p = _make_initializable_provider(bm, monkeypatch, tmp_path)
+    actor_visible_at_start: list[bool] = []
+
+    class ObservingActor(TrackingActor):
+        def start(self, timeout: float = 25.0) -> None:
+            actor_visible_at_start.append(p._actor is self)
+            super().start(timeout)
+
+    monkeypatch.setattr(bm, "_BmMcpActor", ObservingActor)
+    p.initialize(session_id="one", hermes_home=str(tmp_path))
+    assert actor_visible_at_start == [True], "actor must be reachable by cleanup during start()"
+    assert p._initialized is True
+    assert p._actor is TrackingActor.instances[0]
+
+
+def test_initialize_reaps_actor_when_start_fails(bm, monkeypatch, tmp_path):
+    """A failed start (e.g. the 25s ready timeout) can still have spawned the
+    `bm mcp` child — the actor must be shut down, not dropped on the floor."""
+    p = _make_initializable_provider(bm, monkeypatch, tmp_path)
+
+    class FailingActor(TrackingActor):
+        def start(self, timeout: float = 25.0) -> None:
+            self.started = True
+            self.alive = True  # child spawned before the ready wait timed out
+            raise TimeoutError("didn't initialize within 25s")
+
+    monkeypatch.setattr(bm, "_BmMcpActor", FailingActor)
+    p.initialize(session_id="one", hermes_home=str(tmp_path))
+
+    assert p._initialized is False
+    assert p._actor is None, "failed-start actor must not remain attached"
+    failed = TrackingActor.instances[0]
+    assert failed.shutdown_calls, "failed-start actor must be shut down to reap its child"
+
+
 # ---- SIGTERM cleanup chain ----
 
 

--- a/integrations/hermes/tests/test_lifecycle.py
+++ b/integrations/hermes/tests/test_lifecycle.py
@@ -75,12 +75,17 @@ def test_double_initialize_reuses_running_actor(bm, monkeypatch, tmp_path):
     assert len(TrackingActor.instances) == 1
     first = TrackingActor.instances[0]
     assert p._actor is first
+    p._session_note_id = "hermes-sessions/session-one"
+    p._first_user_msg = "first session opener"
 
     p.initialize(session_id="two", hermes_home=str(tmp_path))
     assert p._initialized is True
     assert len(TrackingActor.instances) == 1, "second initialize() allocated a new actor"
     assert p._actor is first
     assert first.shutdown_calls == [], "healthy actor must be reused, not restarted"
+    assert p._session_id == "two"
+    assert p._session_note_id is None
+    assert p._first_user_msg is None
 
 
 def test_initialize_replaces_dead_actor_after_shutdown(bm, monkeypatch, tmp_path):
@@ -90,12 +95,16 @@ def test_initialize_replaces_dead_actor_after_shutdown(bm, monkeypatch, tmp_path
     p.initialize(session_id="one", hermes_home=str(tmp_path))
     first = TrackingActor.instances[0]
     first.alive = False  # simulate actor loop death (bm mcp crashed)
+    p._session_note_id = "hermes-sessions/session-one"
+    p._first_user_msg = "session opener"
 
-    p.initialize(session_id="two", hermes_home=str(tmp_path))
+    p.initialize(session_id="one", hermes_home=str(tmp_path))
     assert first.shutdown_calls, "dead actor was replaced without shutdown"
     assert len(TrackingActor.instances) == 2
     assert p._actor is TrackingActor.instances[1]
     assert p._initialized is True
+    assert p._session_note_id == "hermes-sessions/session-one"
+    assert p._first_user_msg == "session opener"
 
 
 def test_initialize_replaces_dead_actor_even_if_shutdown_raises(bm, monkeypatch, tmp_path):
@@ -150,6 +159,27 @@ def test_initialize_reaps_actor_when_start_fails(bm, monkeypatch, tmp_path):
     assert p._actor is None, "failed-start actor must not remain attached"
     failed = TrackingActor.instances[0]
     assert failed.shutdown_calls, "failed-start actor must be shut down to reap its child"
+
+
+def test_initialize_does_not_resurrect_actor_detached_during_start(bm, monkeypatch, tmp_path):
+    """SIGTERM cleanup must own and detach an actor even while start() is waiting."""
+    p = _make_initializable_provider(bm, monkeypatch, tmp_path)
+
+    class CleanupDuringStartActor(TrackingActor):
+        def start(self, timeout: float = 25.0) -> None:
+            self.started = True
+            self.alive = True
+            monkeypatch.setattr(bm, "_active_providers", [p])
+            bm._atexit_cleanup()
+
+    monkeypatch.setattr(bm, "_BmMcpActor", CleanupDuringStartActor)
+
+    p.initialize(session_id="one", hermes_home=str(tmp_path))
+
+    actor = TrackingActor.instances[0]
+    assert actor.shutdown_calls
+    assert p._actor is None
+    assert p._initialized is False
 
 
 # ---- SIGTERM cleanup chain ----


### PR DESCRIPTION
## Summary

The Hermes memory-provider plugin (`integrations/hermes/__init__.py`) leaked `bm mcp` child processes two ways (a production box accumulated 18 orphans / ~2.3 GB RSS):

**Defect 1 — duplicate `initialize()` allocates a duplicate actor.** `BasicMemoryProvider.initialize()` created a fresh `_BmMcpActor(argv)` unconditionally and overwrote `self._actor` without shutting the previous actor down. `_BmMcpActor.start()` has an internal re-entry guard, but it lives on the instance — a new instance per call means it never triggers, and each orphaned actor keeps its `bm mcp` child alive.

**Fix:** `initialize()` now checks `self._actor.is_alive()` (new accessor on the actor). A healthy actor is **reused** — its argv is always `bm mcp` and project routing happens per call, so the config re-read at the top of `initialize()` never invalidates the connection. A dead actor is shut down first (joining its loop thread reaps the child) and only then replaced.

**Defect 2 — cleanup only ran via `atexit`, which SIGTERM skips.** Python's default SIGTERM action terminates without unwinding, so gateway restarts (systemd/docker stop) never ran `_atexit_cleanup()` and every `bm mcp` child was orphaned.

**Fix:** `_install_sigterm_cleanup()` (armed at plugin load, next to the existing `atexit` hook) runs the same cleanup on SIGTERM and then defers to the host — this is a library embedded in a host process, so it must not stomp the host's signal handling:
- existing Python handler → chain: our cleanup, then the host's handler
- `SIG_DFL` → cleanup, restore `SIG_DFL`, re-deliver the signal so die-by-SIGTERM semantics are exactly preserved
- `SIG_IGN` or `None` (C-level handler unreachable from Python) → left untouched
- main-thread-only install; no-ops cleanly on platforms without SIGTERM

## Upstream half

The remaining gateway scenario — `_SlashWorker` processes killed in ways no Python handler can observe (SIGKILL) leaving `bm mcp` grandchildren — needs a process-group death-link (`os.killpg` / `prctl(PR_SET_PDEATHSIG)`) in `_SlashWorker.close()`, which belongs in the upstream hermes-agent repo, not this plugin.

## Tests

New hermetic `tests/test_lifecycle.py` (no Hermes install, no real `bm`):
- double-`initialize()` reuses the running actor (no second allocation, no shutdown)
- a dead actor is shut down and replaced; shutdown failures don't block re-init
- SIGTERM chains to a previously installed Python handler after running cleanup
- SIGTERM with `SIG_DFL` restores the default and re-delivers the signal
- `SIG_IGN` is respected; off-main-thread install no-ops; install is idempotent

Plus `is_alive()` lifecycle coverage in `tests/test_actor.py`.

`just package-check-hermes`: 254 passed, 12 skipped (gated integration tests), coverage 88% (floor 85%). `ruff check` / `ruff format` clean.

Fixes #1017

🤖 Generated with [Claude Code](https://claude.com/claude-code)