### PR TITLE
fix(mcp): surface cloud project delete errors and support delete_notes

### DIFF
--- a/src/basic_memory/cli/commands/project.py
+++ b/src/basic_memory/cli/commands/project.py
@@ -962,7 +962,8 @@ def remove_project(
                 console.print(f"[yellow]Note: Local files remain at {local_path_config}[/yellow]")
 
     except Exception as e:
-        console.print(f"[red]Error removing project: {str(e)}[/red]")
+        # str() of httpx transport errors is often empty (#1034) — never print a blank error.
+        console.print(f"[red]Error removing project: {str(e) or repr(e)}[/red]")
         raise typer.Exit(1)
 
 

--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -18,6 +18,7 @@ from basic_memory.config import (
 )
 from basic_memory.mcp.async_client import (
     _explicit_routing,
+    _force_cloud_mode,
     _force_local_mode,
     get_client,
     is_factory_mode,
@@ -654,6 +655,23 @@ async def create_memory_project(
         return result
 
 
+def _delete_routes_to_cloud(workspace_id: str | None) -> bool:
+    """Mirror get_client's non-project routing to describe where a delete landed.
+
+    Trigger: delete_project's result text must say whether the project's note
+        files live on local disk or in cloud storage.
+    Why: the previous text always claimed "Files remain on disk", which is
+        wrong for cloud-routed deletes (#1034).
+    Outcome: True when get_client(workspace=...) serves the request from a
+        cloud backend (factory mode, explicit --cloud, or a workspace selector).
+    """
+    if is_factory_mode():
+        return True
+    if _explicit_routing():
+        return _force_cloud_mode()
+    return workspace_id is not None
+
+
 @mcp.tool(
     title="Delete Project",
     tags={"projects"},
@@ -666,17 +684,22 @@ async def create_memory_project(
 )
 async def delete_project(
     project_name: str,
+    delete_notes: bool = False,
     workspace: str | None = None,
     context: Context | None = None,
 ) -> str:
     """Delete a Basic Memory project.
 
-    Removes a project from the configuration and database. This does NOT delete
-    the actual files on disk - only removes the project from Basic Memory's
-    configuration and database records.
+    Removes a project from Basic Memory's configuration and database records.
+    By default the project's note files are retained: local projects keep
+    their files on disk, cloud projects keep their files in cloud storage.
+    Pass delete_notes=True to also delete the note files themselves.
 
     Args:
         project_name: Name of the project to delete
+        delete_notes: Also delete the project's note files (from local disk
+            for local projects, from cloud storage for cloud projects).
+            Defaults to False, which only stops tracking the project.
         workspace: Optional cloud workspace selector to delete the project from.
             Slug is preferred for AI callers, but tenant_id and unique name are
             also accepted. When omitted, the connection's default workspace is
@@ -685,15 +708,18 @@ async def delete_project(
             behavior (#954).
 
     Returns:
-        Confirmation message about project deletion
+        Confirmation message describing what was deleted and whether note
+        files were removed or retained.
 
     Example:
         delete_project("old-project")
+        delete_project("old-project", delete_notes=True)
         delete_project("team-project", workspace="team-paul")
 
     Warning:
-        This action cannot be undone. The project will need to be re-added
-        to access its content through Basic Memory again.
+        This action cannot be undone. With delete_notes=False the project must
+        be re-added to access its content through Basic Memory again; with
+        delete_notes=True the note files themselves are permanently deleted.
     """
     # Trigger: MCP server is constrained to a single project.
     # Why: constrained sessions cannot delete projects, and workspace selectors
@@ -735,7 +761,9 @@ async def delete_project(
             )
 
         # Delete project using project external_id
-        status_response = await project_client.delete_project(target_project.external_id)
+        status_response = await project_client.delete_project(
+            target_project.external_id, delete_notes=delete_notes
+        )
         from basic_memory.mcp.project_context import invalidate_workspace_project_index
 
         await invalidate_workspace_project_index(context)
@@ -748,7 +776,14 @@ async def delete_project(
             if hasattr(status_response.old_project, "path"):
                 result += f"• Path: {status_response.old_project.path}\n"
 
-        result += "Files remain on disk but project is no longer tracked by Basic Memory.\n"
-        result += "Re-add the project to access its content again.\n"
+        files_location = "in cloud storage" if _delete_routes_to_cloud(workspace_id) else "on disk"
+        if delete_notes:
+            result += f"Note files {files_location} were deleted along with the project.\n"
+        else:
+            result += (
+                f"Note files remain {files_location} but the project is no longer "
+                "tracked by Basic Memory.\n"
+            )
+            result += "Re-add the project to access its content again.\n"
 
         return result

--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -672,6 +672,28 @@ def _delete_routes_to_cloud(workspace_id: str | None) -> bool:
     return workspace_id is not None
 
 
+def _format_note_file_delete_result(
+    status: Literal["pending", "skipped", "complete", "failed"] | None,
+    *,
+    files_location: str,
+    cloud_routed: bool,
+) -> str:
+    """Describe note-file deletion without overstating backend completion."""
+    if status == "pending":
+        return f"Note-file deletion {files_location} was queued and is pending.\n"
+    if status == "complete" or (status is None and not cloud_routed):
+        # Local deletion is synchronous and older local responses omit the status.
+        return f"Note files {files_location} were deleted along with the project.\n"
+    if status == "failed":
+        return f"Note-file deletion {files_location} failed; note files may remain.\n"
+    if status == "skipped":
+        return f"Note-file deletion {files_location} was skipped; note files remain.\n"
+    return (
+        f"Note-file deletion {files_location} did not report a completion status; "
+        "note files may remain.\n"
+    )
+
+
 @mcp.tool(
     title="Delete Project",
     tags={"projects"},
@@ -776,12 +798,14 @@ async def delete_project(
             if hasattr(status_response.old_project, "path"):
                 result += f"• Path: {status_response.old_project.path}\n"
 
-        files_location = "in cloud storage" if _delete_routes_to_cloud(workspace_id) else "on disk"
+        cloud_routed = _delete_routes_to_cloud(workspace_id)
+        files_location = "in cloud storage" if cloud_routed else "on disk"
         if delete_notes:
-            if status_response.file_delete_status == "pending":
-                result += f"Note-file deletion {files_location} was queued and is pending.\n"
-            else:
-                result += f"Note files {files_location} were deleted along with the project.\n"
+            result += _format_note_file_delete_result(
+                status_response.file_delete_status,
+                files_location=files_location,
+                cloud_routed=cloud_routed,
+            )
         else:
             result += (
                 f"Note files remain {files_location} but the project is no longer "

--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -778,7 +778,10 @@ async def delete_project(
 
         files_location = "in cloud storage" if _delete_routes_to_cloud(workspace_id) else "on disk"
         if delete_notes:
-            result += f"Note files {files_location} were deleted along with the project.\n"
+            if status_response.file_delete_status == "pending":
+                result += f"Note-file deletion {files_location} was queued and is pending.\n"
+            else:
+                result += f"Note files {files_location} were deleted along with the project.\n"
         else:
             result += (
                 f"Note files remain {files_location} but the project is no longer "

--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -676,13 +676,11 @@ def _format_note_file_delete_result(
     status: Literal["pending", "skipped", "complete", "failed"] | None,
     *,
     files_location: str,
-    cloud_routed: bool,
 ) -> str:
     """Describe note-file deletion without overstating backend completion."""
     if status == "pending":
         return f"Note-file deletion {files_location} was queued and is pending.\n"
-    if status == "complete" or (status is None and not cloud_routed):
-        # Local deletion is synchronous and older local responses omit the status.
+    if status == "complete":
         return f"Note files {files_location} were deleted along with the project.\n"
     if status == "failed":
         return f"Note-file deletion {files_location} failed; note files may remain.\n"
@@ -804,7 +802,6 @@ async def delete_project(
             result += _format_note_file_delete_result(
                 status_response.file_delete_status,
                 files_location=files_location,
-                cloud_routed=cloud_routed,
             )
         else:
             result += (

--- a/src/basic_memory/mcp/tools/utils.py
+++ b/src/basic_memory/mcp/tools/utils.py
@@ -8,7 +8,15 @@ import typing
 from typing import Any, Optional
 
 import logfire
-from httpx import Response, URL, AsyncClient, HTTPStatusError, Headers
+from httpx import (
+    Response,
+    URL,
+    AsyncClient,
+    HTTPStatusError,
+    Headers,
+    TimeoutException,
+    TransportError,
+)
 from httpx._client import UseClientDefault, USE_CLIENT_DEFAULT
 from httpx._types import (
     RequestContent,
@@ -122,6 +130,35 @@ def get_error_message(
     # Fallback for any other status code
     else:  # pragma: no cover
         return f"HTTP error {status_code}: {method} request to '{path}' failed"
+
+
+def _transport_error_message(exc: TransportError, url: URL | str, method: str) -> str:
+    """Build an actionable message for transport failures that produced no response.
+
+    httpx transport errors often stringify to an empty string (e.g. ReadTimeout),
+    which is how blank errors like "Error removing project:" reached users (#1034),
+    so the message always names the exception type explicitly.
+    """
+    # Extract path from URL for cleaner error messages
+    if isinstance(url, str):
+        path = url.split("/")[-1]
+    else:
+        path = str(url).split("/")[-1] if url else "resource"
+
+    detail = str(exc).strip()
+    described = f"{type(exc).__name__}: {detail}" if detail else type(exc).__name__
+
+    if isinstance(exc, TimeoutException):
+        return (
+            f"Request timed out ({described}): the server did not respond to "
+            f"{method} '{path}' in time. Long-running operations (such as deleting a "
+            f"large project) may still be completing server-side — check the result "
+            f"(e.g. `bm project list` for project deletes) before retrying."
+        )
+    return (
+        f"Connection failed ({described}): the {method} request to '{path}' did not "
+        f"complete. Check that the server is reachable, then retry."
+    )
 
 
 def _extract_response_data(response: Response) -> Any:
@@ -274,6 +311,11 @@ async def call_get(
 
     except HTTPStatusError as e:
         raise ToolError(error_message) from e
+    except TransportError as e:
+        # No HTTP response arrived (timeout, connect failure) — wrap with actionable text (#1034)
+        if request_span is not None:
+            request_span.set_attributes(_transport_error_span_attrs(e))
+        raise ToolError(_transport_error_message(e, url, "GET")) from e
     except Exception as e:
         if request_span is not None:
             request_span.set_attributes(_transport_error_span_attrs(e))
@@ -379,6 +421,11 @@ async def call_put(
 
     except HTTPStatusError as e:
         raise ToolError(error_message) from e
+    except TransportError as e:
+        # No HTTP response arrived (timeout, connect failure) — wrap with actionable text (#1034)
+        if request_span is not None:
+            request_span.set_attributes(_transport_error_span_attrs(e))
+        raise ToolError(_transport_error_message(e, url, "PUT")) from e
     except Exception as e:
         if request_span is not None:
             request_span.set_attributes(_transport_error_span_attrs(e))
@@ -488,6 +535,11 @@ async def call_patch(
         error_message = _resolve_error_message(status_code, url, "PATCH", response_data)
 
         raise ToolError(error_message) from e
+    except TransportError as e:
+        # No HTTP response arrived (timeout, connect failure) — wrap with actionable text (#1034)
+        if request_span is not None:
+            request_span.set_attributes(_transport_error_span_attrs(e))
+        raise ToolError(_transport_error_message(e, url, "PATCH")) from e
     except Exception as e:
         if request_span is not None:
             request_span.set_attributes(_transport_error_span_attrs(e))
@@ -593,6 +645,11 @@ async def call_post(
 
     except HTTPStatusError as e:
         raise ToolError(error_message) from e
+    except TransportError as e:
+        # No HTTP response arrived (timeout, connect failure) — wrap with actionable text (#1034)
+        if request_span is not None:
+            request_span.set_attributes(_transport_error_span_attrs(e))
+        raise ToolError(_transport_error_message(e, url, "POST")) from e
     except Exception as e:
         if request_span is not None:
             request_span.set_attributes(_transport_error_span_attrs(e))
@@ -717,6 +774,11 @@ async def call_delete(
 
     except HTTPStatusError as e:
         raise ToolError(error_message) from e
+    except TransportError as e:
+        # No HTTP response arrived (timeout, connect failure) — wrap with actionable text (#1034)
+        if request_span is not None:
+            request_span.set_attributes(_transport_error_span_attrs(e))
+        raise ToolError(_transport_error_message(e, url, "DELETE")) from e
     except Exception as e:
         if request_span is not None:
             request_span.set_attributes(_transport_error_span_attrs(e))

--- a/src/basic_memory/schemas/project_info.py
+++ b/src/basic_memory/schemas/project_info.py
@@ -3,7 +3,7 @@
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import Field, BaseModel
 
@@ -240,4 +240,10 @@ class ProjectStatusResponse(BaseModel):
     )
     new_project: Optional[ProjectItem] = Field(
         None, description="Information about the project being switched to"
+    )
+    deletion_status: Optional[Literal["pending", "complete", "failed"]] = Field(
+        None, description="Background project deletion status when returned by the backend"
+    )
+    file_delete_status: Optional[Literal["pending", "skipped", "complete", "failed"]] = Field(
+        None, description="Background note-file deletion status when returned by the backend"
     )

--- a/test-int/mcp/test_project_management_integration.py
+++ b/test-int/mcp/test_project_management_integration.py
@@ -204,7 +204,10 @@ async def test_delete_project_basic_operation(mcp_server, app, test_project, tmp
         assert "removed successfully" in delete_text
         assert "Removed project details:" in delete_text
         assert "Name: to-be-deleted" in delete_text
-        assert "Files remain on disk but project is no longer tracked" in delete_text
+        assert (
+            "Note files remain on disk but the project is no longer tracked by Basic Memory."
+            in delete_text
+        )
 
         # Verify project no longer appears in list
         list_result_after = await client.call_tool("list_memory_projects", {})

--- a/tests/cli/test_project_remove_errors.py
+++ b/tests/cli/test_project_remove_errors.py
@@ -1,0 +1,91 @@
+"""Tests for bm project remove error surfacing (#1034).
+
+Large cloud project deletes can fail with httpx transport errors whose str() is
+empty, which used to print a detail-free "Error removing project:". The CLI must
+never print a blank error.
+"""
+
+import json
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from basic_memory.cli.app import app
+from basic_memory.mcp.clients.project import ProjectClient
+
+# Importing registers project subcommands on the shared app instance.
+import basic_memory.cli.commands.project as project_cmd  # noqa: F401
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_config(tmp_path, monkeypatch):
+    """Create a minimal config in an isolated HOME."""
+    from basic_memory import config as config_module
+
+    config_module._CONFIG_CACHE = None
+    config_module._CONFIG_MTIME = None
+    config_module._CONFIG_SIZE = None
+
+    config_dir = tmp_path / ".basic-memory"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_file = config_dir / "config.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "env": "dev",
+                "projects": {},
+                "default_project": "main",
+            },
+            indent=2,
+        )
+    )
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    yield config_file
+
+
+@pytest.fixture
+def failing_resolve(monkeypatch):
+    """Stub the API client so project resolution raises a chosen exception."""
+
+    @asynccontextmanager
+    async def fake_get_client(*, project_name=None, workspace=None):
+        yield object()
+
+    state: dict[str, Exception] = {}
+
+    async def fake_resolve_project(self, identifier):
+        raise state["error"]
+
+    monkeypatch.setattr(project_cmd, "get_client", fake_get_client)
+    monkeypatch.setattr(ProjectClient, "resolve_project", fake_resolve_project)
+    return state
+
+
+def test_project_remove_blank_transport_error_renders_repr(runner, mock_config, failing_resolve):
+    """str(ReadTimeout('')) is empty — the CLI must fall back to repr (#1034)."""
+    failing_resolve["error"] = httpx.ReadTimeout("")
+
+    result = runner.invoke(app, ["project", "remove", "big-project"])
+
+    assert result.exit_code == 1
+    assert "Error removing project:" in result.stdout
+    # repr fallback: the exception type must be visible instead of a blank message
+    assert "ReadTimeout" in result.stdout
+
+
+def test_project_remove_error_with_message_renders_str(runner, mock_config, failing_resolve):
+    """Exceptions with a message keep rendering str(e)."""
+    failing_resolve["error"] = ValueError("project is busy")
+
+    result = runner.invoke(app, ["project", "remove", "big-project"])
+
+    assert result.exit_code == 1
+    assert "Error removing project: project is busy" in result.stdout

--- a/tests/mcp/test_client_telemetry.py
+++ b/tests/mcp/test_client_telemetry.py
@@ -157,7 +157,8 @@ async def test_call_get_emits_transport_error_outcome(monkeypatch) -> None:
 
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport, base_url="https://example.test") as client:
-        with pytest.raises(httpx.ConnectError, match="boom"):
+        # Transport errors are wrapped in ToolError so callers never see blank messages (#1034)
+        with pytest.raises(ToolError, match="boom"):
             await utils_module.call_get(
                 client,
                 "/boom",

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -34,7 +34,7 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "output_format",
     ],
     "delete_note": ["identifier", "is_directory", "project", "project_id", "output_format"],
-    "delete_project": ["project_name", "workspace"],
+    "delete_project": ["project_name", "delete_notes", "workspace"],
     "edit_note": [
         "identifier",
         "operation",

--- a/tests/mcp/test_tool_project_management.py
+++ b/tests/mcp/test_tool_project_management.py
@@ -10,7 +10,11 @@ from sqlalchemy import select
 from basic_memory import db
 from basic_memory.mcp.tools import list_memory_projects, create_memory_project, delete_project
 from basic_memory.config import BasicMemoryConfig, ProjectEntry
-from basic_memory.mcp.tools.project_management import _merge_projects, _merge_workspace_projects
+from basic_memory.mcp.tools.project_management import (
+    _format_note_file_delete_result,
+    _merge_projects,
+    _merge_workspace_projects,
+)
 from basic_memory.models.project import Project
 from basic_memory.schemas.project_info import ProjectItem, ProjectList
 
@@ -592,6 +596,30 @@ def test_delete_routes_to_cloud_honors_explicit_routing_flags(monkeypatch):
     monkeypatch.setenv("BASIC_MEMORY_FORCE_LOCAL", "true")
     # Explicit local wins even when a workspace selector was supplied.
     assert _delete_routes_to_cloud("some-workspace") is False
+
+
+@pytest.mark.parametrize(
+    ("status", "cloud_routed", "expected"),
+    [
+        ("pending", True, "queued and is pending"),
+        ("complete", True, "were deleted along with the project"),
+        ("failed", True, "failed; note files may remain"),
+        ("skipped", True, "was skipped; note files remain"),
+        (None, True, "did not report a completion status"),
+        (None, False, "were deleted along with the project"),
+    ],
+)
+def test_format_note_file_delete_result_reports_backend_status(status, cloud_routed, expected):
+    """Only explicit completion (or synchronous local deletion) reports success."""
+    result = _format_note_file_delete_result(
+        status,
+        files_location="in cloud storage" if cloud_routed else "on disk",
+        cloud_routed=cloud_routed,
+    )
+
+    assert expected in result
+    if status in {"failed", "skipped"} or (status is None and cloud_routed):
+        assert "were deleted" not in result
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_tool_project_management.py
+++ b/tests/mcp/test_tool_project_management.py
@@ -134,6 +134,31 @@ async def test_create_and_delete_project_and_name_match_branch(
 
     delete_result = await delete_project("My Project")
     assert delete_result.startswith("✓")
+    # Local routing with delete_notes=False: files are retained on disk.
+    assert "Note files remain on disk" in delete_result
+    assert "Re-add the project" in delete_result
+    assert project_root.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_project_delete_notes_removes_local_files(app, tmp_path_factory):
+    """delete_notes=True flows through to the API and removes the project files (#1034)."""
+    project_root = tmp_path_factory.mktemp("delete-notes-project-home")
+    (project_root / "note.md").write_text("# Note\n\ncontent\n")
+
+    result = await create_memory_project(
+        project_name="Delete Notes Project",
+        project_path=str(project_root),
+        set_default=False,
+    )
+    assert isinstance(result, str)
+    assert result.startswith("✓")
+
+    delete_result = await delete_project("Delete Notes Project", delete_notes=True)
+    assert delete_result.startswith("✓")
+    assert "Note files on disk were deleted" in delete_result
+    assert "Re-add the project" not in delete_result
+    assert not project_root.exists()
 
 
 @pytest.mark.asyncio
@@ -353,8 +378,10 @@ async def test_create_memory_project_constrained_with_workspace_returns_disabled
 
 
 @pytest.mark.asyncio
-async def test_delete_project_resolves_workspace_slug(app):
-    """A friendly workspace slug resolves to the tenant id used for delete routing."""
+@pytest.mark.parametrize("delete_notes", [False, True])
+async def test_delete_project_resolves_workspace_slug(app, delete_notes):
+    """A friendly workspace slug resolves to the tenant id used for delete routing,
+    and delete_notes is passed through to the typed client (#1034)."""
     from basic_memory.mcp.clients import ProjectClient
     from basic_memory.schemas.project_info import ProjectStatusResponse
 
@@ -414,12 +441,20 @@ async def test_delete_project_resolves_workspace_slug(app):
             new_callable=AsyncMock,
         ),
     ):
-        result = await delete_project("WS Project", workspace="team-paul")
+        result = await delete_project(
+            "WS Project", delete_notes=delete_notes, workspace="team-paul"
+        )
 
     mock_resolve_workspace.assert_awaited_once_with(workspace="team-paul", context=None)
     assert captured["workspace"] == "tenant-abc-123"
-    mock_delete_project.assert_awaited_once_with("project-uuid")
+    mock_delete_project.assert_awaited_once_with("project-uuid", delete_notes=delete_notes)
     assert result.startswith("✓")
+    # Cloud-routed delete: result text must not claim "files remain on disk" (#1034).
+    if delete_notes:
+        assert "Note files in cloud storage were deleted" in result
+    else:
+        assert "Note files remain in cloud storage" in result
+        assert "Re-add the project" in result
 
 
 @pytest.mark.asyncio
@@ -539,6 +574,21 @@ async def test_delete_project_default_workspace_is_none(app):
         await delete_project("Default WS Project")
 
     assert captured["workspace"] is None
+
+
+def test_delete_routes_to_cloud_honors_explicit_routing_flags(monkeypatch):
+    """Explicit --cloud/--local routing decides where the delete's files live (#1034)."""
+    from basic_memory.mcp.tools.project_management import _delete_routes_to_cloud
+
+    monkeypatch.setenv("BASIC_MEMORY_EXPLICIT_ROUTING", "true")
+
+    monkeypatch.setenv("BASIC_MEMORY_FORCE_CLOUD", "true")
+    assert _delete_routes_to_cloud(None) is True
+
+    monkeypatch.setenv("BASIC_MEMORY_FORCE_CLOUD", "false")
+    monkeypatch.setenv("BASIC_MEMORY_FORCE_LOCAL", "true")
+    # Explicit local wins even when a workspace selector was supplied.
+    assert _delete_routes_to_cloud("some-workspace") is False
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_tool_project_management.py
+++ b/tests/mcp/test_tool_project_management.py
@@ -403,6 +403,8 @@ async def test_delete_project_resolves_workspace_slug(app, delete_notes):
         status="success",
         default=False,
         old_project=target_project,
+        deletion_status="pending",
+        file_delete_status="pending" if delete_notes else "skipped",
     )
 
     with (
@@ -451,7 +453,8 @@ async def test_delete_project_resolves_workspace_slug(app, delete_notes):
     assert result.startswith("✓")
     # Cloud-routed delete: result text must not claim "files remain on disk" (#1034).
     if delete_notes:
-        assert "Note files in cloud storage were deleted" in result
+        assert "Note-file deletion in cloud storage was queued and is pending" in result
+        assert "were deleted" not in result
     else:
         assert "Note files remain in cloud storage" in result
         assert "Re-add the project" in result

--- a/tests/mcp/test_tool_project_management.py
+++ b/tests/mcp/test_tool_project_management.py
@@ -160,7 +160,8 @@ async def test_delete_project_delete_notes_removes_local_files(app, tmp_path_fac
 
     delete_result = await delete_project("Delete Notes Project", delete_notes=True)
     assert delete_result.startswith("✓")
-    assert "Note files on disk were deleted" in delete_result
+    assert "did not report a completion status" in delete_result
+    assert "Note files on disk were deleted" not in delete_result
     assert "Re-add the project" not in delete_result
     assert not project_root.exists()
 
@@ -606,7 +607,7 @@ def test_delete_routes_to_cloud_honors_explicit_routing_flags(monkeypatch):
         ("failed", True, "failed; note files may remain"),
         ("skipped", True, "was skipped; note files remain"),
         (None, True, "did not report a completion status"),
-        (None, False, "were deleted along with the project"),
+        (None, False, "did not report a completion status"),
     ],
 )
 def test_format_note_file_delete_result_reports_backend_status(status, cloud_routed, expected):
@@ -614,11 +615,10 @@ def test_format_note_file_delete_result_reports_backend_status(status, cloud_rou
     result = _format_note_file_delete_result(
         status,
         files_location="in cloud storage" if cloud_routed else "on disk",
-        cloud_routed=cloud_routed,
     )
 
     assert expected in result
-    if status in {"failed", "skipped"} or (status is None and cloud_routed):
+    if status in {"failed", "skipped"} or status is None:
         assert "were deleted" not in result
 
 

--- a/tests/mcp/test_tool_utils.py
+++ b/tests/mcp/test_tool_utils.py
@@ -2,6 +2,7 @@
 
 from typing import Any, cast
 
+import httpx
 import pytest
 from httpx import HTTPStatusError, Request
 from mcp.server.fastmcp.exceptions import ToolError
@@ -9,6 +10,7 @@ from mcp.server.fastmcp.exceptions import ToolError
 from basic_memory.mcp.tools.utils import (
     call_delete,
     call_get,
+    call_patch,
     call_post,
     call_put,
     get_error_message,
@@ -193,6 +195,71 @@ async def test_call_post_adds_workspace_permalink_headers_at_request_time(mock_r
     assert request_headers["X-Existing"] == "value"
     assert request_headers[WORKSPACE_SLUG_HEADER] == "team-paul"
     assert request_headers[WORKSPACE_TYPE_HEADER] == "organization"
+
+
+_ALL_CALL_HELPERS = [
+    (call_get, "GET"),
+    (call_post, "POST"),
+    (call_put, "PUT"),
+    (call_patch, "PATCH"),
+    (call_delete, "DELETE"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("call_fn,method", _ALL_CALL_HELPERS)
+async def test_transport_timeout_wrapped_in_tool_error(call_fn, method):
+    """httpx timeouts stringify to '' — they must surface as actionable ToolErrors (#1034)."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("", request=request)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        with pytest.raises(ToolError) as exc:
+            await call_fn(client, "/v2/projects/project-uuid")
+
+    message = str(exc.value)
+    assert message  # never blank, even though str(ReadTimeout("")) is empty
+    assert "Request timed out" in message
+    assert "ReadTimeout" in message
+    assert f"{method} 'project-uuid'" in message
+    assert "may still be completing server-side" in message
+    assert "bm project list" in message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("call_fn,method", _ALL_CALL_HELPERS)
+async def test_transport_connect_error_wrapped_in_tool_error(call_fn, method):
+    """Non-timeout transport failures are wrapped with the exception type and detail."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        with pytest.raises(ToolError) as exc:
+            # httpx.URL object (not str) also exercises the URL-object path extraction
+            await call_fn(client, httpx.URL("http://test/v2/projects/project-uuid"))
+
+    message = str(exc.value)
+    assert "Connection failed" in message
+    assert "ConnectError: connection refused" in message
+    assert f"{method} request to 'project-uuid'" in message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("call_fn,method", _ALL_CALL_HELPERS)
+async def test_non_transport_error_reraised_unwrapped(call_fn, method):
+    """Errors that are neither HTTP-status nor transport failures pass through untouched."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise RuntimeError("unexpected failure")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        with pytest.raises(RuntimeError, match="unexpected failure"):
+            await call_fn(client, "/v2/projects/project-uuid")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Client-side half of #1034: deleting a large cloud project failed with a detail-free `Error removing project:` because httpx transport errors (e.g. `ReadTimeout`) often stringify to an empty string, and the MCP delete tool both lacked `delete_notes` and always claimed files remained "on disk".

### Defect (a): transport errors re-raised unwrapped in `call_*` helpers
`call_delete` (and its siblings `call_get`/`call_put`/`call_patch`/`call_post` had the same gap) only wrapped `HTTPStatusError` in `ToolError`; transport errors escaped raw with often-empty messages. All five helpers now wrap `httpx.TransportError` (which includes `httpx.TimeoutException`) in a `ToolError` that always names the exception type. Timeout messages note that long-running operations (such as deleting a large project) may still be completing server-side and point at `bm project list` before retrying.

### Defect (b): CLI printed a blank error
`bm project remove` rendered `str(e)`, which is empty for httpx timeouts. It now renders `str(e) or repr(e)` so the error line is never blank.

### Defect (c): MCP `delete_project` lacked `delete_notes` and misreported file state
The MCP tool now accepts `delete_notes: bool = False` and passes it through to the typed `ProjectClient` (which, like the CLI, already supported it). The result text now reflects reality: local vs cloud file location (mirroring `get_client` routing) and deleted vs retained note files, instead of unconditionally printing "Files remain on disk". The LLM-facing docstring was updated to match.

## Tests
- `tests/mcp/test_tool_utils.py`: parametrized over all five `call_*` helpers via real `httpx.MockTransport` code paths — timeout wrapping (blank `str()`), connect-error wrapping, and non-transport errors still passing through unwrapped.
- `tests/mcp/test_tool_project_management.py`: real create/delete flow asserting `delete_notes=True` removes the project directory on disk and `delete_notes=False` retains it; cloud-routed delete asserts the `delete_notes` passthrough and "cloud storage" wording; unit test for explicit-routing-flag handling.
- `tests/cli/test_project_remove_errors.py` (new): `bm project remove` renders `repr()` for blank-message exceptions and `str()` otherwise.
- `tests/mcp/test_client_telemetry.py` / `test_tool_contracts.py`: updated for the new wrapping and tool signature.

`ruff check`, `ruff format`, and `just typecheck` pass; 69 tests across the touched files pass, plus full `tests/mcp` + `tests/cli` runs.

## Notes
The server-side half (purging large cloud projects without timing out) is tracked in the cloud repo.

Refs #1034 (server half remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)