### PR TITLE
fix(core): make replace_section level-aware with replace_subsections opt-out

### DIFF
--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -321,6 +321,14 @@ def edit_note(
         "--expected-replacements",
         help="Expected replacement count for find_replace operation",
     ),
+    replace_subsections: bool = typer.Option(
+        True,
+        "--replace-subsections/--no-replace-subsections",
+        help=(
+            "For replace_section, replace nested subsections too; use "
+            "--no-replace-subsections to preserve them"
+        ),
+    ),
     project: Annotated[
         Optional[str],
         typer.Option(
@@ -346,6 +354,7 @@ def edit_note(
     bm tool edit-note my-note --operation append --content "new content"
     bm tool edit-note my-note --operation find_replace --find-text "old" --content "new"
     bm tool edit-note my-note --operation replace_section --section "## Notes" --content "updated"
+    bm tool edit-note my-note --operation replace_section --section "## Notes" --content "updated" --no-replace-subsections
     """
     # Deferred: loading the MCP tool stack at module import slows CLI startup (#886).
     from basic_memory.mcp.tools import edit_note as mcp_edit_note
@@ -364,6 +373,7 @@ def edit_note(
                     section=section,
                     find_text=find_text,
                     expected_replacements=expected_replacements,
+                    replace_subsections=replace_subsections,
                     output_format="json",
                 )
             )

--- a/src/basic_memory/indexing/accepted_note_mutation_runner.py
+++ b/src/basic_memory/indexing/accepted_note_mutation_runner.py
@@ -674,6 +674,7 @@ async def _run_accepted_note_edit(
             section=request.data.section,
             find_text=request.data.find_text,
             expected_replacements=request.data.expected_replacements,
+            replace_subsections=request.data.replace_subsections,
             now=now,
             user_profile_value=user_profile_value,
         )

--- a/src/basic_memory/indexing/accepted_note_write_runner.py
+++ b/src/basic_memory/indexing/accepted_note_write_runner.py
@@ -139,6 +139,7 @@ class AcceptedNoteEditPreparer(Protocol):
         section: str | None = ...,
         find_text: str | None = ...,
         expected_replacements: int = ...,
+        replace_subsections: bool = ...,
         session: AsyncSession | None = ...,
     ) -> AcceptedPreparedMarkdownWriteSource: ...
 
@@ -367,6 +368,7 @@ async def prepare_accepted_note_edit(
     section: str | None,
     find_text: str | None,
     expected_replacements: int,
+    replace_subsections: bool,
     now: datetime,
     user_profile_value: str | None,
 ) -> AcceptedPreparedNoteWrite:
@@ -379,6 +381,7 @@ async def prepare_accepted_note_edit(
         section=section,
         find_text=find_text,
         expected_replacements=expected_replacements,
+        replace_subsections=replace_subsections,
         session=session,
     )
     result = AcceptedPreparedNoteWrite(

--- a/src/basic_memory/mcp/tools/edit_note.py
+++ b/src/basic_memory/mcp/tools/edit_note.py
@@ -357,6 +357,7 @@ async def edit_note(
         ),
     ] = None,
     expected_replacements: Optional[int] = None,
+    replace_subsections: Optional[bool] = None,
     output_format: Literal["text", "json"] = "text",
     context: Context | None = None,
 ) -> str | dict:
@@ -376,7 +377,9 @@ async def edit_note(
                   - "append": Add content to the end of the note (creates the note if it doesn't exist)
                   - "prepend": Add content to the beginning of the note (creates the note if it doesn't exist)
                   - "find_replace": Replace occurrences of find_text with content (note must exist)
-                  - "replace_section": Replace content under a specific markdown header (note must exist)
+                  - "replace_section": Replace a markdown section identified by its header (note must exist).
+                    By default the section spans through the next heading of the same or higher
+                    level, so its subsections are replaced too; see replace_subsections.
                   - "insert_before_section": Insert content before a section heading without consuming it (note must exist)
                   - "insert_after_section": Insert content after a section heading without consuming it (note must exist)
         content: The content to add or use for replacement
@@ -391,6 +394,12 @@ async def edit_note(
         section: For replace_section operation - the markdown header to replace content under (e.g., "## Notes", "### Implementation")
         find_text: For find_replace operation - the text to find and replace
         expected_replacements: For find_replace operation - the expected number of replacements (validation will fail if actual doesn't match)
+        replace_subsections: For replace_section operation. Default (true): the section
+            spans everything through the next heading of the same or higher level in the
+            original note, so replacing "## Section" also replaces its "###" subsections —
+            the replacement content may freely introduce new headings. Set to false to
+            replace only the immediate content under the header, stopping at the next
+            heading of any level and preserving subsections.
         output_format: "text" returns the existing markdown summary. "json" returns
             machine-readable edit metadata.
         context: Optional FastMCP context for performance caching.
@@ -415,8 +424,11 @@ async def edit_note(
         # Replace text that appears multiple times - validate count first
         edit_note("team-docs", "docs/guide", "find_replace", "new-api", find_text="old-api", expected_replacements=5)
 
-        # Replace implementation section
+        # Replace implementation section (subsections under it are replaced too)
         edit_note("specs", "api-spec", "replace_section", "New implementation approach...\\n", section="## Implementation")
+
+        # Replace only the intro text under a header, keeping its subsections
+        edit_note("specs", "api-spec", "replace_section", "New intro...\\n", section="## Implementation", replace_subsections=False)
 
         # Replace subsection with more specific header
         edit_note("docs", "docs/setup", "replace_section", "Updated install steps\\n", section="### Installation")
@@ -447,8 +459,9 @@ async def edit_note(
         indexes that file automatically and retries the edit. The tool provides detailed
         error messages with suggestions if operations fail.
     """
-    # Resolve effective default: allow MCP clients to send null for optional int field
+    # Resolve effective defaults: allow MCP clients to send null for optional scalar fields
     effective_replacements = expected_replacements if expected_replacements is not None else 1
+    effective_replace_subsections = replace_subsections if replace_subsections is not None else True
     project = _compose_workspace_project_route(
         workspace=workspace,
         project=project,
@@ -510,6 +523,7 @@ async def edit_note(
         has_section=bool(section),
         has_find_text=bool(find_text),
         expected_replacements=effective_replacements,
+        replace_subsections=effective_replace_subsections,
     ):
         async with get_project_client(project, context=context, project_id=project_id) as (
             client,
@@ -635,6 +649,8 @@ async def edit_note(
                         edit_data["find_text"] = find_text
                     if effective_replacements != 1:  # Only send if different from default
                         edit_data["expected_replacements"] = str(effective_replacements)
+                    if not effective_replace_subsections:  # Only send if different from default
+                        edit_data["replace_subsections"] = False
 
                     # Call the PATCH endpoint
                     result = await knowledge_client.patch_entity(entity_id, edit_data)

--- a/src/basic_memory/schemas/request.py
+++ b/src/basic_memory/schemas/request.py
@@ -77,6 +77,10 @@ class EditEntityRequest(BaseModel):
     section: Optional[str] = None
     find_text: Optional[str] = None
     expected_replacements: int = 1
+    # replace_section boundary control (issue #1012): True replaces the whole
+    # level-aware section including subsections; False stops at the first heading
+    # of any level, preserving them.
+    replace_subsections: bool = True
 
     @field_validator("section")
     @classmethod

--- a/src/basic_memory/services/entity_service.py
+++ b/src/basic_memory/services/entity_service.py
@@ -188,6 +188,43 @@ def reconcile_prepared_edit_title_from_h1(
     )
 
 
+def _markdown_heading_level(line: str) -> int | None:
+    """Return the ATX heading level of a line, or None when it is not a heading.
+
+    Only 1-6 leading '#' characters followed by whitespace (or nothing) form a
+    heading, per CommonMark. '#hashtag' text and 7+ '#' runs are ordinary
+    content, so section boundaries never land on tag lines.
+    """
+    if not line.startswith("#"):
+        return None
+    level = len(line) - len(line.lstrip("#"))
+    if level > 6:
+        return None
+    rest = line[level:]
+    if rest and not rest.startswith((" ", "\t")):
+        return None
+    return level
+
+
+def _fenced_code_line_flags(lines: list[str]) -> list[bool]:
+    """Mark which lines sit inside (or delimit) ``` fenced code blocks.
+
+    Fenced code often contains '# comment' lines that look exactly like markdown
+    headings. Section matching and boundary detection must skip those lines, or a
+    code comment would match or terminate a section.
+    """
+    flags: list[bool] = []
+    in_fence = False
+    for line in lines:
+        # Delimiter lines are marked as fenced too: they can never be headings or
+        # section matches, and treating them uniformly keeps the scan branch-free.
+        is_delimiter = line.lstrip().startswith("```")
+        flags.append(in_fence or is_delimiter)
+        if is_delimiter:
+            in_fence = not in_fence
+    return flags
+
+
 class EntityService(BaseService[EntityModel]):
     """Service for managing entities in the database."""
 
@@ -686,6 +723,7 @@ class EntityService(BaseService[EntityModel]):
         section: Optional[str] = None,
         find_text: Optional[str] = None,
         expected_replacements: int = 1,
+        replace_subsections: bool = True,
         skip_conflict_check: bool = False,
         session: AsyncSession | None = None,
     ) -> PreparedEntityWrite:
@@ -707,6 +745,7 @@ class EntityService(BaseService[EntityModel]):
             section,
             find_text,
             expected_replacements,
+            replace_subsections,
         )
 
         title = entity.title
@@ -1348,6 +1387,7 @@ class EntityService(BaseService[EntityModel]):
         section: Optional[str] = None,
         find_text: Optional[str] = None,
         expected_replacements: int = 1,
+        replace_subsections: bool = True,
     ) -> EntityModel:
         """Edit an existing entity's content using various operations.
 
@@ -1358,6 +1398,9 @@ class EntityService(BaseService[EntityModel]):
             section: For replace_section operation - the markdown header
             find_text: For find_replace operation - the text to find and replace
             expected_replacements: For find_replace operation - expected number of replacements (default: 1)
+            replace_subsections: For replace_section operation - replace nested
+                subsections along with the section body (default True); False stops
+                at the first heading of any level, preserving them
 
         Returns:
             The updated entity model
@@ -1374,6 +1417,7 @@ class EntityService(BaseService[EntityModel]):
                 section=section,
                 find_text=find_text,
                 expected_replacements=expected_replacements,
+                replace_subsections=replace_subsections,
             )
         ).entity
 
@@ -1385,6 +1429,7 @@ class EntityService(BaseService[EntityModel]):
         section: Optional[str] = None,
         find_text: Optional[str] = None,
         expected_replacements: int = 1,
+        replace_subsections: bool = True,
     ) -> EntityWriteResult:
         """Edit an entity and return both the entity row and written markdown."""
         logger.debug(f"Editing entity: {identifier}, operation: {operation}")
@@ -1411,6 +1456,7 @@ class EntityService(BaseService[EntityModel]):
                 section=section,
                 find_text=find_text,
                 expected_replacements=expected_replacements,
+                replace_subsections=replace_subsections,
                 session=session,
             )
 
@@ -1448,6 +1494,7 @@ class EntityService(BaseService[EntityModel]):
         section: Optional[str] = None,
         find_text: Optional[str] = None,
         expected_replacements: int = 1,
+        replace_subsections: bool = True,
     ) -> str:
         """Apply the specified edit operation to the current content."""
 
@@ -1487,7 +1534,12 @@ class EntityService(BaseService[EntityModel]):
                 raise ValueError("section is required for replace_section operation")
             if not section.strip():
                 raise ValueError("section cannot be empty or whitespace only")
-            return self.replace_section_content(current_content, section, content)
+            return self.replace_section_content(
+                current_content,
+                section,
+                content,
+                replace_subsections=replace_subsections,
+            )
 
         elif operation in ("insert_before_section", "insert_after_section"):
             if not section:
@@ -1501,22 +1553,36 @@ class EntityService(BaseService[EntityModel]):
             raise ValueError(f"Unsupported operation: {operation}")
 
     def replace_section_content(
-        self, current_content: str, section_header: str, new_content: str
+        self,
+        current_content: str,
+        section_header: str,
+        new_content: str,
+        replace_subsections: bool = True,
     ) -> str:
         """Replace content under a specific markdown section header.
 
-        This method uses a simple, safe approach: when replacing a section, it only
-        replaces the immediate content under that header until it encounters the next
-        header of ANY level. This means:
+        By default a section owns everything through the next heading of the same
+        or higher level in the original document (issue #1012):
 
-        - Replacing "# Header" replaces content until "## Subsection" (preserves subsections)
-        - Replacing "## Section" replaces content until "### Subsection" (preserves subsections)
-        - More predictable and safer than trying to consume entire hierarchies
+        - Replacing "## Section" replaces its body and all "###"+ subsections,
+          stopping at the next "##" or "#" heading — how Obsidian and most
+          markdown tools scope a section.
+        - Passing replace_subsections=False restores the earlier conservative
+          behavior: only the immediate content under the header is replaced and
+          consumption stops at the next heading of ANY level, preserving
+          subsections.
+
+        The boundary is always computed from the original document, so new_content
+        may freely introduce new headings without shifting where the replaced span
+        ends. Heading detection ignores lines inside ``` fenced code blocks, so a
+        '# comment' in a code sample never matches or terminates a section.
 
         Args:
             current_content: The current markdown content
             section_header: The section header to find and replace (e.g., "## Section Name")
             new_content: The new content to replace the section with (should not include the header itself)
+            replace_subsections: Replace nested subsections along with the section
+                body (default True); False stops at the first heading of any level.
 
         Returns:
             The updated content with the section replaced
@@ -1535,13 +1601,18 @@ class EntityService(BaseService[EntityModel]):
             # Remove the duplicate header line
             new_content = "\n".join(new_content_lines[1:]).lstrip()
 
-        # First pass: count matching sections to check for duplicates
         lines = current_content.split("\n")
-        matching_sections = []
+        # Fenced code can contain lines identical to the requested header, so section
+        # matching must skip fenced lines or a code sample would trigger the
+        # duplicate-header error (or match as the section itself).
+        fenced = _fenced_code_line_flags(lines)
 
-        for i, line in enumerate(lines):
-            if line.strip() == section_header.strip():
-                matching_sections.append(i)
+        # First pass: count matching sections to check for duplicates
+        matching_sections = [
+            i
+            for i, line in enumerate(lines)
+            if not fenced[i] and line.strip() == section_header.strip()
+        ]
 
         # Handle multiple sections error
         if len(matching_sections) > 1:
@@ -1556,36 +1627,29 @@ class EntityService(BaseService[EntityModel]):
             separator = "\n\n" if current_content and not current_content.endswith("\n\n") else ""
             return current_content + separator + section_header + "\n" + new_content
 
-        # Replace the single matching section
-        result_lines = []
+        # Replace the single matching section. The replaced span always ends at a
+        # boundary computed from the ORIGINAL lines, so headings inside new_content
+        # cannot extend or shorten what gets consumed (issue #1012).
         section_line_idx = matching_sections[0]
+        target_level = len(section_header) - len(section_header.lstrip("#"))
 
-        i = 0
-        while i < len(lines):
-            line = lines[i]
-
-            # Check if this is our target section header
-            if i == section_line_idx:
-                # Add the section header and new content
-                result_lines.append(line)
-                result_lines.append(new_content)
-                i += 1
-
-                # Skip the original section content until next header or end
-                while i < len(lines):
-                    next_line = lines[i]
-                    # Stop consuming when we hit any header (preserve subsections)
-                    if next_line.startswith("#"):
-                        # We found another header - continue processing from here
-                        break
-                    i += 1
-                # Continue processing from the next header (don't increment i again)
+        end_idx = len(lines)
+        for i in range(section_line_idx + 1, len(lines)):
+            if fenced[i]:
                 continue
+            heading_level = _markdown_heading_level(lines[i])
+            if heading_level is None:
+                continue
+            # Level-aware default: an h2 section owns its h3+ subsections, so only a
+            # heading at the same or higher level ends it. The opt-out stops at any
+            # heading, preserving subsections (pre-#1012 behavior).
+            if not replace_subsections or heading_level <= target_level:
+                end_idx = i
+                break
 
-            # Add all other lines (including subsequent sections)
-            result_lines.append(line)
-            i += 1
-
+        result_lines = lines[: section_line_idx + 1]
+        result_lines.append(new_content)
+        result_lines.extend(lines[end_idx:])
         return "\n".join(result_lines)
 
     def insert_relative_to_section(
@@ -1618,8 +1682,13 @@ class EntityService(BaseService[EntityModel]):
             section_header = "## " + section_header
 
         lines = current_content.split("\n")
+        # Fenced code can contain a line identical to the requested heading; skip
+        # fenced lines so a code sample never anchors (or duplicates) the section.
+        fenced = _fenced_code_line_flags(lines)
         matching_indices = [
-            i for i, line in enumerate(lines) if line.strip() == section_header.strip()
+            i
+            for i, line in enumerate(lines)
+            if not fenced[i] and line.strip() == section_header.strip()
         ]
 
         if len(matching_indices) == 0:

--- a/src/basic_memory/services/entity_service.py
+++ b/src/basic_memory/services/entity_service.py
@@ -206,22 +206,64 @@ def _markdown_heading_level(line: str) -> int | None:
     return level
 
 
+def _fence_marker(line: str) -> tuple[str, int, str] | None:
+    """Return a CommonMark fence marker, length, and suffix for a delimiter candidate."""
+    indent = len(line) - len(line.lstrip(" "))
+    if indent > 3:
+        return None
+
+    candidate = line[indent:]
+    if not candidate or candidate[0] not in ("`", "~"):
+        return None
+
+    marker = candidate[0]
+    marker_length = len(candidate) - len(candidate.lstrip(marker))
+    if marker_length < 3:
+        return None
+    return marker, marker_length, candidate[marker_length:]
+
+
 def _fenced_code_line_flags(lines: list[str]) -> list[bool]:
-    """Mark which lines sit inside (or delimit) ``` fenced code blocks.
+    """Mark which lines sit inside (or delimit) CommonMark fenced code blocks.
 
     Fenced code often contains '# comment' lines that look exactly like markdown
     headings. Section matching and boundary detection must skip those lines, or a
-    code comment would match or terminate a section.
+    code comment would match or terminate a section. CommonMark permits backtick
+    and tilde fences indented by at most three spaces; four-space-indented markers
+    are literal code and must not hide later real headings.
     """
     flags: list[bool] = []
-    in_fence = False
+    open_marker: str | None = None
+    open_length = 0
     for line in lines:
-        # Delimiter lines are marked as fenced too: they can never be headings or
-        # section matches, and treating them uniformly keeps the scan branch-free.
-        is_delimiter = line.lstrip().startswith("```")
-        flags.append(in_fence or is_delimiter)
-        if is_delimiter:
-            in_fence = not in_fence
+        marker = _fence_marker(line)
+
+        if open_marker is None:
+            if marker is None:
+                flags.append(False)
+                continue
+
+            marker_char, marker_length, suffix = marker
+            # Backtick fence info strings cannot contain a backtick. Treat such a
+            # line as ordinary text instead of opening a fence that never closes.
+            if marker_char == "`" and "`" in suffix:
+                flags.append(False)
+                continue
+
+            flags.append(True)
+            open_marker = marker_char
+            open_length = marker_length
+            continue
+
+        # Every line inside a fence, including its closing delimiter, is skipped
+        # by heading detection. A close must use the same marker, be at least as
+        # long as the opener, and contain only trailing whitespace.
+        flags.append(True)
+        if marker is not None:
+            marker_char, marker_length, suffix = marker
+            if marker_char == open_marker and marker_length >= open_length and not suffix.strip():
+                open_marker = None
+                open_length = 0
     return flags
 
 

--- a/src/basic_memory/services/entity_service.py
+++ b/src/basic_memory/services/entity_service.py
@@ -191,16 +191,21 @@ def reconcile_prepared_edit_title_from_h1(
 def _markdown_heading_level(line: str) -> int | None:
     """Return the ATX heading level of a line, or None when it is not a heading.
 
-    Only 1-6 leading '#' characters followed by whitespace (or nothing) form a
-    heading, per CommonMark. '#hashtag' text and 7+ '#' runs are ordinary
-    content, so section boundaries never land on tag lines.
+    After up to three leading spaces, only 1-6 '#' characters followed by
+    whitespace (or nothing) form a heading, per CommonMark. '#hashtag' text and
+    7+ '#' runs are ordinary content, so boundaries never land on tag lines.
     """
-    if not line.startswith("#"):
+    indent = len(line) - len(line.lstrip(" "))
+    if indent > 3:
         return None
-    level = len(line) - len(line.lstrip("#"))
+
+    candidate = line[indent:]
+    if not candidate.startswith("#"):
+        return None
+    level = len(candidate) - len(candidate.lstrip("#"))
     if level > 6:
         return None
-    rest = line[level:]
+    rest = candidate[level:]
     if rest and not rest.startswith((" ", "\t")):
         return None
     return level

--- a/tests/cli/test_cli_tool_json_output.py
+++ b/tests/cli/test_cli_tool_json_output.py
@@ -443,6 +443,34 @@ def test_edit_note_json_output(mock_mcp_edit):
     assert data["operation"] == "append"
     mock_mcp_edit.assert_called_once()
     assert mock_mcp_edit.call_args.kwargs["output_format"] == "json"
+    assert mock_mcp_edit.call_args.kwargs["replace_subsections"] is True
+
+
+@patch(
+    "basic_memory.mcp.tools.edit_note",
+    new_callable=AsyncMock,
+    return_value=EDIT_NOTE_RESULT,
+)
+def test_edit_note_no_replace_subsections_passthrough(mock_mcp_edit):
+    """--no-replace-subsections forwards the conservative section boundary mode."""
+    result = runner.invoke(
+        cli_app,
+        [
+            "tool",
+            "edit-note",
+            "test-note",
+            "--operation",
+            "replace_section",
+            "--section",
+            "## Notes",
+            "--content",
+            "new content",
+            "--no-replace-subsections",
+        ],
+    )
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}"
+    assert mock_mcp_edit.call_args.kwargs["replace_subsections"] is False
 
 
 @patch(

--- a/tests/indexing/test_accepted_note_mutation_runner.py
+++ b/tests/indexing/test_accepted_note_mutation_runner.py
@@ -109,7 +109,7 @@ class _CreatePreparer:
         self.calls: list[tuple[EntitySchema, bool, AsyncSession | None]] = []
         self.replace_calls: list[tuple[Entity, EntitySchema, str, AsyncSession | None]] = []
         self.edit_calls: list[
-            tuple[Entity, str, str, str, str | None, str | None, int, AsyncSession | None]
+            tuple[Entity, str, str, str, str | None, str | None, int, bool, AsyncSession | None]
         ] = []
         self.move_calls: list[tuple[Entity, str, str, AsyncSession | None]] = []
 
@@ -144,6 +144,7 @@ class _CreatePreparer:
         section: str | None = None,
         find_text: str | None = None,
         expected_replacements: int = 1,
+        replace_subsections: bool = True,
         session: AsyncSession | None = None,
     ) -> _PreparedWrite:
         self.edit_calls.append(
@@ -155,6 +156,7 @@ class _CreatePreparer:
                 section,
                 find_text,
                 expected_replacements,
+                replace_subsections,
                 session,
             )
         )
@@ -951,6 +953,7 @@ async def test_run_accepted_note_edit_applies_patch_against_db_content() -> None
             None,
             "# Old",
             1,
+            True,
             cast(AsyncSession, session),
         )
     ]

--- a/tests/indexing/test_accepted_note_write_runner.py
+++ b/tests/indexing/test_accepted_note_write_runner.py
@@ -201,7 +201,7 @@ class _EditPreparer:
     def __init__(self, prepared: _PreparedWrite) -> None:
         self.prepared = prepared
         self.calls: list[
-            tuple[Entity, str, str, str, str | None, str | None, int, AsyncSession | None]
+            tuple[Entity, str, str, str, str | None, str | None, int, bool, AsyncSession | None]
         ] = []
 
     async def prepare_edit_entity_content(
@@ -214,6 +214,7 @@ class _EditPreparer:
         section: str | None = None,
         find_text: str | None = None,
         expected_replacements: int = 1,
+        replace_subsections: bool = True,
         session: AsyncSession | None = None,
     ) -> _PreparedWrite:
         self.calls.append(
@@ -225,6 +226,7 @@ class _EditPreparer:
                 section,
                 find_text,
                 expected_replacements,
+                replace_subsections,
                 session,
             )
         )
@@ -451,6 +453,7 @@ async def test_prepare_accepted_note_edit_applies_entity_fields() -> None:
         section=None,
         find_text="# Accepted",
         expected_replacements=1,
+        replace_subsections=True,
         now=now,
         user_profile_value=None,
     )
@@ -466,6 +469,7 @@ async def test_prepare_accepted_note_edit_applies_entity_fields() -> None:
             None,
             "# Accepted",
             1,
+            True,
             cast(AsyncSession, session),
         )
     ]

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -45,6 +45,7 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "section",
         "find_text",
         "expected_replacements",
+        "replace_subsections",
         "output_format",
     ],
     "fetch": ["id"],

--- a/tests/mcp/test_tool_edit_note.py
+++ b/tests/mcp/test_tool_edit_note.py
@@ -189,6 +189,83 @@ async def test_edit_note_replace_section_operation(client, test_project):
 
 
 @pytest.mark.asyncio
+async def test_edit_note_replace_section_consumes_subsections_by_default(client, test_project):
+    """replace_section is level-aware by default: h3 subsections go with their h2 (#1012)."""
+    await write_note(
+        project=test_project.name,
+        title="Level Aware Spec",
+        directory="specs",
+        content=(
+            "# Spec\n\n"
+            "## Implementation\n"
+            "Old details.\n\n"
+            "### Internals\n"
+            "Old internals.\n\n"
+            "## Testing\n"
+            "Test info here."
+        ),
+    )
+
+    result = await edit_note(
+        project=test_project.name,
+        identifier="specs/level-aware-spec",
+        operation="replace_section",
+        content="New details.\n\n## Rollout\nShip behind a flag.\n",
+        section="## Implementation",
+    )
+
+    assert isinstance(result, str)
+    assert "Edited note (replace_section)" in result
+
+    # The h2 section was replaced through the next h2, subsections included, and the
+    # replacement's new h2 caused no duplicated re-emitted content
+    content = await read_note("specs/level-aware-spec", project=test_project.name)
+    assert "New details." in content
+    assert "## Rollout" in content
+    assert "### Internals" not in content
+    assert "Old internals." not in content
+    assert "Test info here." in content  # next h2 section untouched
+
+
+@pytest.mark.asyncio
+async def test_edit_note_replace_section_opt_out_preserves_subsections(client, test_project):
+    """replace_subsections=False keeps h3 subsections, replacing only the immediate body."""
+    await write_note(
+        project=test_project.name,
+        title="Opt Out Spec",
+        directory="specs",
+        content=(
+            "# Spec\n\n"
+            "## Implementation\n"
+            "Old details.\n\n"
+            "### Internals\n"
+            "Internals stay.\n\n"
+            "## Testing\n"
+            "Test info here."
+        ),
+    )
+
+    result = await edit_note(
+        project=test_project.name,
+        identifier="specs/opt-out-spec",
+        operation="replace_section",
+        content="New details.\n",
+        section="## Implementation",
+        replace_subsections=False,
+    )
+
+    assert isinstance(result, str)
+    assert "Edited note (replace_section)" in result
+
+    content = await read_note("specs/opt-out-spec", project=test_project.name)
+    assert "New details." in content
+    assert "Old details." not in content
+    assert "### Internals" in content  # subsections preserved by the opt-out
+    assert "Internals stay." in content
+    assert "Test info here." in content
+
+
+@pytest.mark.asyncio
 async def test_edit_note_nonexistent_note_find_replace(client, test_project):
     """Test find_replace on a note that doesn't exist - should return helpful guidance."""
     result = await edit_note(

--- a/tests/mcp/test_tool_telemetry.py
+++ b/tests/mcp/test_tool_telemetry.py
@@ -219,6 +219,7 @@ async def test_edit_note_emits_root_operation_and_project_context(
             "has_section": False,
             "has_find_text": False,
             "expected_replacements": 1,
+            "replace_subsections": True,
         },
     )
     span_names = [name for name, _ in spans]

--- a/tests/services/test_entity_service.py
+++ b/tests/services/test_entity_service.py
@@ -16,7 +16,7 @@ from basic_memory.models import Entity as EntityModel
 from basic_memory.repository import EntityRepository
 from basic_memory.schemas import Entity as EntitySchema
 from basic_memory.services import FileService
-from basic_memory.services.entity_service import EntityService
+from basic_memory.services.entity_service import EntityService, _fenced_code_line_flags
 from basic_memory.services.exceptions import EntityCreationError, EntityNotFoundError
 from basic_memory.services.search_service import SearchService
 from basic_memory.utils import generate_permalink
@@ -26,6 +26,25 @@ def _permalink(entity: EntityModel | EntitySchema) -> str:
     permalink = entity.permalink
     assert permalink is not None
     return permalink
+
+
+@pytest.mark.parametrize(
+    ("lines", "expected"),
+    [
+        (["", "ordinary", "``", "## Heading"], [False, False, False, False]),
+        (["    ```", "## Heading"], [False, False]),
+        (["```bad`info", "## Heading"], [False, False]),
+        (["```python", "## Fake", "```", "## Real"], [True, True, True, False]),
+        (["~~~python", "## Fake", "~~~~", "## Real"], [True, True, True, False]),
+        (
+            ["````python", "~~~", "```", "## Still fenced", "````", "## Real"],
+            [True, True, True, True, True, False],
+        ),
+    ],
+)
+def test_fenced_code_line_flags_follow_commonmark(lines: list[str], expected: list[bool]) -> None:
+    """Fence flags honor indentation, marker type, and closing-marker length."""
+    assert _fenced_code_line_flags(lines) == expected
 
 
 class _DeleteTestEmbeddingProvider:
@@ -1623,6 +1642,47 @@ async def test_edit_entity_replace_section_ignores_fenced_code_headings(
     # The next real h2 section is intact, including its fenced '## Usage' decoy
     assert "Reference content" in file_content
     assert "```python\n## Usage\n```" in file_content
+
+
+@pytest.mark.asyncio
+async def test_edit_entity_replace_section_does_not_open_four_space_indented_fence(
+    entity_service: EntityService, file_service: FileService
+):
+    """A four-space-indented backtick line must not hide the next real heading."""
+    content = dedent("""
+        # Main Title
+
+        ## Usage
+        Old usage content.
+
+            ```
+
+        ## Reference
+        Reference content.
+        """).strip()
+
+    entity = await entity_service.create_entity(
+        EntitySchema(
+            title="Indented Fence Note",
+            directory="docs",
+            note_type="note",
+            content=content,
+        )
+    )
+
+    updated = await entity_service.edit_entity(
+        identifier=_permalink(entity),
+        operation="replace_section",
+        content="Updated usage instructions.",
+        section="## Usage",
+    )
+
+    file_path = file_service.get_entity_path(updated)
+    file_content, _ = await file_service.read_file(file_path)
+    assert "Updated usage instructions." in file_content
+    assert "Old usage content." not in file_content
+    assert "## Reference" in file_content
+    assert "Reference content." in file_content
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_entity_service.py
+++ b/tests/services/test_entity_service.py
@@ -1357,12 +1357,13 @@ async def test_edit_entity_replace_section_header_variations(
         section="Section Name",  # No ## prefix
     )
 
-    # Verify replacement worked
+    # Verify replacement worked (level-aware default consumes the h3 subsection too)
     file_path = file_service.get_entity_path(updated)
     file_content, _ = await file_service.read_file(file_path)
     assert "New section content" in file_content
     assert "Original content" not in file_content
-    assert "### Subsection" in file_content  # Subsection preserved
+    assert "### Subsection" not in file_content  # Subsection replaced with the section
+    assert "Sub content" not in file_content
 
 
 @pytest.mark.asyncio
@@ -1409,7 +1410,7 @@ async def test_edit_entity_replace_section_at_end_of_document(
 async def test_edit_entity_replace_section_with_subsections(
     entity_service: EntityService, file_service: FileService
 ):
-    """Test replace_section preserves subsections (stops at any header)."""
+    """Test replace_section consumes subsections by default (level-aware, issue #1012)."""
     # Create test entity with nested sections
     content = dedent("""
         # Main Title
@@ -1436,7 +1437,7 @@ async def test_edit_entity_replace_section_with_subsections(
         )
     )
 
-    # Replace parent section (should only replace content until first subsection)
+    # Replace parent section (level-aware: consumes h3 subsections, stops at next h2)
     updated = await entity_service.edit_entity(
         identifier=_permalink(entity),
         operation="replace_section",
@@ -1444,15 +1445,225 @@ async def test_edit_entity_replace_section_with_subsections(
         section="## Parent Section",
     )
 
-    # Verify replacement worked - only immediate content replaced, subsections preserved
+    # Verify the whole level-aware section was replaced, subsections included (#1012)
     file_path = file_service.get_entity_path(updated)
     file_content, _ = await file_service.read_file(file_path)
     assert "New parent content" in file_content
     assert "Parent content" not in file_content  # Original content replaced
-    assert "Child 1 content" in file_content  # Child sections preserved
-    assert "Child 2 content" in file_content  # Child sections preserved
-    assert "## Another Section" in file_content  # Next section preserved
+    assert "### Child Section 1" not in file_content  # Subsections replaced with the section
+    assert "Child 1 content" not in file_content
+    assert "### Child Section 2" not in file_content
+    assert "Child 2 content" not in file_content
+    assert "## Another Section" in file_content  # Next same-level section preserved
     assert "Other content" in file_content
+
+
+@pytest.mark.asyncio
+async def test_edit_entity_replace_section_new_headings_no_duplication(
+    entity_service: EntityService, file_service: FileService
+):
+    """Replacement introducing new headings must not duplicate re-emitted content (#1012).
+
+    The old any-heading boundary stopped at the first h3 subsection and re-emitted it
+    (and everything after it) behind the replacement, so a replacement that restated
+    that material produced silent duplicate sections.
+    """
+    content = dedent("""
+        # Ticket
+
+        ## Observations
+        - [status] open
+        - [priority] high
+
+        ### Follow-up
+        - call Jamie back
+
+        ## Relations
+        - reported_by [[Jamie Rivera]]
+        """).strip()
+
+    entity = await entity_service.create_entity(
+        EntitySchema(
+            title="Ticket Note",
+            directory="tickets",
+            note_type="note",
+            content=content,
+        )
+    )
+
+    # The replacement rewrites the subsection and adds a brand-new h2 of its own
+    updated = await entity_service.edit_entity(
+        identifier=_permalink(entity),
+        operation="replace_section",
+        content=(
+            "- [status] resolved\n"
+            "\n"
+            "### Follow-up\n"
+            "- called Jamie back\n"
+            "\n"
+            "## Resolution\n"
+            "Restarted the sync worker."
+        ),
+        section="## Observations",
+    )
+
+    file_path = file_service.get_entity_path(updated)
+    file_content, _ = await file_service.read_file(file_path)
+    # The whole level-aware section was consumed, so the replacement's headings appear
+    # exactly once — no original content re-emitted after the new sections
+    assert file_content.count("### Follow-up") == 1
+    assert file_content.count("## Resolution") == 1
+    assert "- called Jamie back" in file_content
+    assert "- call Jamie back" not in file_content
+    assert "Restarted the sync worker." in file_content
+    # The true boundary — the next h2 in the original — is untouched
+    assert "## Relations" in file_content
+    assert "reported_by" in file_content
+
+
+@pytest.mark.asyncio
+async def test_edit_entity_replace_section_opt_out_preserves_subsections(
+    entity_service: EntityService, file_service: FileService
+):
+    """replace_subsections=False restores the pre-#1012 stop-at-any-heading behavior."""
+    content = dedent("""
+        # Main Title
+
+        ## Parent Section
+        Parent content
+
+        ### Child Section
+        Child content
+
+        ## Another Section
+        Other content
+        """).strip()
+
+    entity = await entity_service.create_entity(
+        EntitySchema(
+            title="Opt Out Note",
+            directory="docs",
+            note_type="note",
+            content=content,
+        )
+    )
+
+    updated = await entity_service.edit_entity(
+        identifier=_permalink(entity),
+        operation="replace_section",
+        content="New parent content",
+        section="## Parent Section",
+        replace_subsections=False,
+    )
+
+    file_path = file_service.get_entity_path(updated)
+    file_content, _ = await file_service.read_file(file_path)
+    assert "New parent content" in file_content
+    assert "Parent content" not in file_content  # Immediate content replaced
+    assert "### Child Section" in file_content  # Subsections preserved
+    assert "Child content" in file_content
+    assert "## Another Section" in file_content
+    assert "Other content" in file_content
+
+
+@pytest.mark.asyncio
+async def test_edit_entity_replace_section_ignores_fenced_code_headings(
+    entity_service: EntityService, file_service: FileService
+):
+    """Heading-like lines inside ``` fences neither match nor terminate a section."""
+    content = dedent("""
+        # Main Title
+
+        ## Usage
+        Run the setup script:
+
+        ```bash
+        # install dependencies
+        ./setup.sh
+
+        ## this comment looks like a heading
+        ```
+
+        More usage notes.
+
+        ## Reference
+        Reference content
+
+        ```python
+        ## Usage
+        ```
+        """).strip()
+
+    entity = await entity_service.create_entity(
+        EntitySchema(
+            title="Fenced Note",
+            directory="docs",
+            note_type="note",
+            content=content,
+        )
+    )
+
+    # The fenced '## Usage' under '## Reference' must not count as a duplicate
+    # section, and the fenced '# install dependencies' comment must not end the
+    # '## Usage' section early.
+    updated = await entity_service.edit_entity(
+        identifier=_permalink(entity),
+        operation="replace_section",
+        content="Updated usage instructions.",
+        section="## Usage",
+    )
+
+    file_path = file_service.get_entity_path(updated)
+    file_content, _ = await file_service.read_file(file_path)
+    assert "Updated usage instructions." in file_content
+    # The fenced block belonged to the section, so it was consumed with it
+    assert "./setup.sh" not in file_content
+    assert "# install dependencies" not in file_content
+    assert "More usage notes." not in file_content
+    # The next real h2 section is intact, including its fenced '## Usage' decoy
+    assert "Reference content" in file_content
+    assert "```python\n## Usage\n```" in file_content
+
+
+@pytest.mark.asyncio
+async def test_edit_entity_insert_after_section_ignores_fenced_code_headings(
+    entity_service: EntityService, file_service: FileService
+):
+    """Section insertion must anchor on the real heading, not a fenced code copy."""
+    content = dedent("""
+        # Main Title
+
+        ```markdown
+        ## Target Section
+        ```
+
+        ## Target Section
+        Target content
+        """).strip()
+
+    entity = await entity_service.create_entity(
+        EntitySchema(
+            title="Fenced Insert Note",
+            directory="docs",
+            note_type="note",
+            content=content,
+        )
+    )
+
+    # Without fence awareness this would fail with a multiple-sections error
+    updated = await entity_service.edit_entity(
+        identifier=_permalink(entity),
+        operation="insert_after_section",
+        content="Inserted after the real heading",
+        section="## Target Section",
+    )
+
+    file_path = file_service.get_entity_path(updated)
+    file_content, _ = await file_service.read_file(file_path)
+    assert "Inserted after the real heading" in file_content
+    assert "Target content" in file_content
+    # Inserted content lands after the real heading, which follows the fenced decoy
+    assert file_content.index("```markdown") < file_content.index("Inserted after the real heading")
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_entity_service_heading_boundaries.py
+++ b/tests/services/test_entity_service_heading_boundaries.py
@@ -1,0 +1,26 @@
+"""Focused CommonMark section-boundary regressions for EntityService."""
+
+import pytest
+
+from basic_memory.services.entity_service import EntityService
+
+
+@pytest.mark.parametrize("indent", [" ", "  ", "   "])
+def test_replace_section_stops_at_indented_atx_heading(indent: str) -> None:
+    """One-to-three leading spaces still form a CommonMark ATX heading."""
+    service = EntityService.__new__(EntityService)
+    current = f"## A\nold body\n{indent}## B\nkeep body"
+
+    result = service.replace_section_content(current, "## A", "new body")
+
+    assert result == f"## A\nnew body\n{indent}## B\nkeep body"
+
+
+def test_replace_section_does_not_stop_at_four_space_indented_heading() -> None:
+    """A four-space-indented heading is code, so the section consumes it."""
+    service = EntityService.__new__(EntityService)
+    current = "## A\nold body\n    ## code heading\nstill old body\n## B\nkeep body"
+
+    result = service.replace_section_content(current, "## A", "new body")
+
+    assert result == "## A\nnew body\n## B\nkeep body"


### PR DESCRIPTION
## Summary

`replace_section` is now **level-aware by default**: a section spans everything through the next heading of the same or higher level in the original document, so replacing an h2 section replaces its h3+ subsections too. The old stop-at-any-heading behavior remains available via a new `replace_subsections` parameter (default `true`), threaded from the `edit_note` MCP tool through the API v2 PATCH endpoint and accepted-note runners down to `EntityService`.

Implements the maintainer decision recorded on the issue: https://github.com/basicmachines-co/basic-memory/issues/1012#issuecomment-4976705383

## Old vs new semantics

| | Old (any-heading boundary) | New default (`replace_subsections=true`) | Opt-out (`replace_subsections=false`) |
|---|---|---|---|
| Replacing `## Section` with `### Sub` children | Stops at `### Sub`; subsections re-emitted after the replacement | Consumes through the next `##`/`#` heading; subsections replaced with their section | Stops at `### Sub`; subsections preserved |
| Replacement content containing new headings | Re-emitted original content collides with the new headings → silent duplicates / orphaned subsections | Boundary computed from the original document; replacement may freely introduce new headings | Same boundary rule as old behavior |
| `# comment` lines inside ``` fenced code blocks | Treated as headings: could terminate a section early or trigger the duplicate-section error | Ignored for both section finding and boundary detection (also fixed for `insert_before_section`/`insert_after_section`) | Ignored (same fence rule) |
| Heading detection | Any line starting with `#` | CommonMark ATX headings (1-6 `#` + whitespace); `#hashtag` lines are content | Same as new default |

## Breaking change

The flipped default changes behavior for existing callers: replacing a section that contains subsections now replaces those subsections as well. Callers that relied on the old "preserve subsections" behavior must pass `replace_subsections=false`. The previously locked test (`test_edit_entity_replace_section_with_subsections`) has been flipped to the new default, with the old behavior covered by a dedicated opt-out test.

## Tests

- Flipped: `test_edit_entity_replace_section_with_subsections` (locks new level-aware default)
- New: issue-scenario regression — replacement introducing new headings produces no duplicated/re-emitted content
- New: `replace_subsections=False` preserves the old immediate-content behavior (service + MCP tool level)
- New: fenced-code-block immunity for section boundary, section finding, and insert-section anchoring
- Updated: runner fakes/contract snapshot for the new threaded parameter

`tests/services/test_entity_service.py` (78 passed), `tests/mcp/test_tool_edit_note.py` (61 passed), indexing runners + knowledge router (93 passed), contracts + schemas (55 passed), `test-int` edit-note MCP/CLI integration (26 passed). `ruff check`, `ruff format`, `just typecheck` clean (no new diagnostics vs main).

Fixes #1012

🤖 Generated with [Claude Code](https://claude.com/claude-code)
