### PR TITLE
ci(skills): publish onboarding archive on main pushes

### DIFF
--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -1,0 +1,57 @@
+name: Publish Skills
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+concurrency:
+  group: publish-skills
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Validate skills
+        run: python scripts/validate_skills.py skills
+
+      - name: Package skills
+        run: python scripts/build_skills_dist.py
+
+      - name: Publish rolling skill archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: skills-latest
+        run: |
+          set -euo pipefail
+
+          asset="dist/skills/memory-onboarding.zip"
+          test -f "$asset"
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" "$asset" --clobber
+            gh release edit "$RELEASE_TAG" \
+              --notes "Rolling skill archives built from ${GITHUB_SHA}." \
+              --latest=false
+          else
+            gh release create "$RELEASE_TAG" "$asset" \
+              --target "$GITHUB_SHA" \
+              --title "Latest Basic Memory skills" \
+              --notes "Rolling skill archives built from ${GITHUB_SHA}." \
+              --latest=false
+          fi


### PR DESCRIPTION
## Why

`memory-onboarding` includes supporting files, so chat clients need a packaged ZIP rather than a single `SKILL.md`. That archive should track `main` continuously instead of waiting for a Basic Memory product release.

## What Changed

- add a dedicated skills publishing workflow triggered by every push to `main` and by manual dispatch
- validate and package the canonical `skills/` sources
- create or update a rolling `skills-latest` GitHub release
- replace `memory-onboarding.zip` on each run without marking the rolling release as the product's latest release

## Implementation Details

The workflow uses the existing dependency-free validation and packaging scripts. A concurrency group cancels stale runs, and `gh release upload --clobber` keeps this download URL stable:

`https://github.com/basicmachines-co/basic-memory/releases/download/skills-latest/memory-onboarding.zip`

## Testing

- `uv run python scripts/validate_skills.py skills`
- `uv run python scripts/build_skills_dist.py`
- `unzip -t dist/skills/memory-onboarding.zip`
- parsed `.github/workflows/publish-skills.yml` as YAML
- `just package-check`

All checks passed.

## Risks / Follow-ups

The stable download URL becomes available after this workflow lands on `main` and completes its first run. The workflow requires `contents: write` solely to manage the rolling release asset.
