### PR TITLE
fix(mcp): expose unknown search totals

### DIFF
--- a/src/basic_memory/api/v2/routers/search_router.py
+++ b/src/basic_memory/api/v2/routers/search_router.py
@@ -106,7 +106,7 @@ async def search(
             else:
                 # Trigger: semantic modes would need another vector/hybrid retrieval to count.
                 # Why: search requests should not pay for a second semantic pass.
-                # Outcome: preserve probe pagination for semantic search and leave total at 0.
+                # Outcome: preserve probe pagination, leave total at 0, and mark it unknown.
                 has_more = len(results) > page_size
                 if has_more:
                     results = results[:page_size]
@@ -131,6 +131,7 @@ async def search(
                 current_page=page,
                 page_size=page_size,
                 total=total,
+                total_is_exact=exact_count_available,
                 has_more=has_more,
             )
 

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -116,7 +116,13 @@ def _search_result_summary(result: dict[str, Any]) -> str:
     """Describe search count and pagination without inventing a final page."""
     results = result.get("results", [])
     raw_total = result.get("total")
-    total_is_known = isinstance(raw_total, int) and raw_total > 0
+    raw_total_is_exact = result.get("total_is_exact")
+    if isinstance(raw_total_is_exact, bool):
+        total_is_known = raw_total_is_exact and isinstance(raw_total, int)
+    else:
+        # Older payloads used a positive total for exact counts and zero as the
+        # unknown-total sentinel, so retain that fallback during compatibility.
+        total_is_known = isinstance(raw_total, int) and raw_total > 0
     total = raw_total if total_is_known else len(results)
     page = result.get("current_page") or result.get("page", 1)
     page_size = result.get("page_size", len(results)) or 1
@@ -140,6 +146,7 @@ def _display_search_results(result: dict[str, Any], query: str = "") -> None:
       current_page: int   (NOT "page")
       page_size: int
       total: int
+      total_is_exact: bool
       has_more: bool
     """
     results = result.get("results", [])

--- a/src/basic_memory/mcp/clients/search.py
+++ b/src/basic_memory/mcp/clients/search.py
@@ -12,7 +12,7 @@ import logfire
 # call_* helpers live in basic_memory.mcp.tools.utils; importing that at module
 # level executes the whole tools package (fastmcp + mcp SDK) during CLI startup,
 # so each method defers the import to call time instead (#886).
-from basic_memory.schemas.search import SearchResponse
+from basic_memory.schemas.search import SearchResponse, SearchRetrievalMode
 
 
 class SearchClient:
@@ -78,4 +78,13 @@ class SearchClient:
                 operation="search",
                 path_template="/v2/projects/{project_id}/search/",
             )
-        return SearchResponse.model_validate(response.json())
+        payload = response.json()
+
+        # Trigger: an older API server omits the exactness field.
+        # Why: the request mode still identifies whether that server used an exact count.
+        # Outcome: legacy semantic responses stay unknown instead of becoming exact zeroes.
+        if "total_is_exact" not in payload:
+            retrieval_mode = query.get("retrieval_mode", SearchRetrievalMode.FTS)
+            payload["total_is_exact"] = retrieval_mode == SearchRetrievalMode.FTS
+
+        return SearchResponse.model_validate(payload)

--- a/src/basic_memory/mcp/tools/search.py
+++ b/src/basic_memory/mcp/tools/search.py
@@ -490,6 +490,11 @@ def _result_total(results: dict[str, Any], raw_results: list[SearchResult | dict
     return len(raw_results) + (1 if results.get("has_more") is True else 0)
 
 
+def _result_total_is_exact(results: dict[str, Any]) -> bool:
+    """Return whether a per-project payload explicitly guarantees an exact total."""
+    return results.get("total_is_exact") is True
+
+
 def _project_ref_label(project_ref: dict[str, str | None]) -> str:
     """Return a stable log label for a project search ref."""
     return project_ref.get("project") or project_ref.get("project_id") or "<unknown project>"
@@ -522,6 +527,7 @@ async def _search_all_projects(
             current_page=requested_page,
             page_size=requested_page_size,
             total=0,
+            total_is_exact=True,
             has_more=False,
         )
         if output_format == "json":
@@ -531,6 +537,7 @@ async def _search_all_projects(
     per_project_page_size = requested_page * requested_page_size
     merged_results: list[dict[str, Any]] = []
     total = 0
+    total_is_exact = True
     any_project_has_more = False
 
     # Trigger: caller asked for an account-wide search.
@@ -576,6 +583,7 @@ async def _search_all_projects(
             logger.warning(
                 f"Multi-project search failed for project {_project_ref_label(project_ref)}: {exc}"
             )
+            total_is_exact = False
             continue
 
         if isinstance(results, str):
@@ -585,10 +593,12 @@ async def _search_all_projects(
                 "Multi-project search failed for project "
                 f"{_project_ref_label(project_ref)}: {results}"
             )
+            total_is_exact = False
             continue
 
         raw_results = _raw_results_from_search_payload(results)
         total += _result_total(results, raw_results)
+        total_is_exact = total_is_exact and _result_total_is_exact(results)
         any_project_has_more = any_project_has_more or results.get("has_more") is True
         merged_results.extend(_qualify_results_for_project(raw_results, project_ref))
 
@@ -602,6 +612,7 @@ async def _search_all_projects(
             "current_page": requested_page,
             "page_size": requested_page_size,
             "total": total,
+            "total_is_exact": total_is_exact,
             "has_more": any_project_has_more or total > end or len(sorted_results) > end,
         }
     )
@@ -833,10 +844,10 @@ async def search_notes(
         Formatted markdown text (output_format="text"), dict (output_format="json"),
         or helpful error guidance string if search fails
 
-        Pagination note: `total` is exact only for text/title/permalink searches.
+        Pagination note: use `total` as a count only when `total_is_exact` is true.
         Vector and hybrid searches skip the count query (it would cost a second
-        semantic retrieval pass) and report `total: 0` even when results are
-        returned — use `has_more` for pagination in those modes.
+        semantic retrieval pass), report `total: 0` with `total_is_exact: false`,
+        and use `has_more` for pagination.
 
     Examples:
         # Basic text search

--- a/src/basic_memory/schemas/search.py
+++ b/src/basic_memory/schemas/search.py
@@ -9,7 +9,7 @@ The search system supports three primary modes:
 from typing import Optional, List, Union, Any
 from datetime import datetime
 from enum import Enum
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from basic_memory.schemas.base import Permalink
 
@@ -146,5 +146,12 @@ class SearchResponse(BaseModel):
     results: List[SearchResult]
     current_page: int
     page_size: int
-    total: int = 0
+    total: int = Field(
+        default=0,
+        description="Total matching results when total_is_exact is true; otherwise a sentinel or estimate",
+    )
+    total_is_exact: bool = Field(
+        default=True,
+        description="Whether total is an exact count that clients can use for pagination",
+    )
     has_more: bool = False

--- a/tests/api/v2/test_search_router.py
+++ b/tests/api/v2/test_search_router.py
@@ -105,6 +105,7 @@ async def test_search_with_pagination(
     assert data["current_page"] == 1
     assert data["page_size"] == 3
     assert data["total"] == 5
+    assert data["total_is_exact"] is True
     assert data["has_more"] is True
 
     response = await client.post(
@@ -118,6 +119,7 @@ async def test_search_with_pagination(
     assert data["current_page"] == 2
     assert data["page_size"] == 3
     assert data["total"] == 5
+    assert data["total_is_exact"] is True
     assert data["has_more"] is False
     assert len(data["results"]) == 2
 
@@ -153,6 +155,7 @@ async def test_search_with_item_type_filter_returns_total(
     assert response.status_code == 200
     data = response.json()
     assert data["total"] == 5
+    assert data["total_is_exact"] is True
     assert data["has_more"] is True
     assert len(data["results"]) == 3
 
@@ -325,6 +328,7 @@ async def test_search_whitespace_text_is_treated_as_empty(
     assert response.status_code == 200
     data = response.json()
     assert data["total"] == 0
+    assert data["total_is_exact"] is True
     assert data["has_more"] is False
     assert data["results"] == []
 
@@ -459,10 +463,12 @@ async def test_search_router_returns_400_for_invalid_vector_query(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("retrieval_mode", ["vector", "hybrid"])
 async def test_semantic_search_uses_probe_pagination_without_count(
     client: AsyncClient,
     app,
     v2_project_url: str,
+    retrieval_mode: str,
 ):
     """Semantic searches should not run an extra count query."""
     now = datetime.now(timezone.utc)
@@ -483,7 +489,7 @@ async def test_semantic_search_uses_probe_pagination_without_count(
 
     class FakeSearchService:
         async def search(self, query, *, limit, offset):
-            assert query.retrieval_mode.value == "vector"
+            assert query.retrieval_mode.value == retrieval_mode
             assert limit == 3
             assert offset == 0
             return fake_rows
@@ -495,7 +501,7 @@ async def test_semantic_search_uses_probe_pagination_without_count(
     try:
         response = await client.post(
             f"{v2_project_url}/search/",
-            json={"text": "semantic query", "retrieval_mode": "vector"},
+            json={"text": "semantic query", "retrieval_mode": retrieval_mode},
             params={"page": 1, "page_size": 2},
         )
     finally:
@@ -504,6 +510,7 @@ async def test_semantic_search_uses_probe_pagination_without_count(
     assert response.status_code == 200
     data = response.json()
     assert data["total"] == 0
+    assert data["total_is_exact"] is False
     assert data["has_more"] is True
     assert len(data["results"]) == 2
 

--- a/tests/cli/test_cli_tool_rich_output.py
+++ b/tests/cli/test_cli_tool_rich_output.py
@@ -57,6 +57,7 @@ SEARCH_RESULT = {
     # Real SearchResponse.model_dump() uses "current_page", not "page".
     # No "query" key in the response -- the query comes from the CLI argument.
     "total": 2,
+    "total_is_exact": True,
     "current_page": 1,
     "page_size": 10,
     "has_more": False,
@@ -84,6 +85,7 @@ SEARCH_RESULT = {
 
 SEARCH_RESULT_EMPTY = {
     "total": 0,
+    "total_is_exact": True,
     "current_page": 1,
     "page_size": 10,
     "has_more": False,
@@ -241,6 +243,7 @@ def test_search_notes_json_flag_overrides_tty(mock_mcp):
     assert result.exit_code == 0, f"CLI failed: {result.output}"
     data = json.loads(result.output)
     assert data["total"] == 2
+    assert data["total_is_exact"] is True
     assert data["results"][0]["title"] == "Test Note"
 
 
@@ -599,6 +602,7 @@ def test_build_context_rich_renders_observations(mock_mcp):
 # Search result whose title contains a bracket expression like "[draft]".
 SEARCH_RESULT_BRACKETED_TITLE = {
     "total": 1,
+    "total_is_exact": True,
     "current_page": 1,
     "page_size": 10,
     "has_more": False,
@@ -696,9 +700,10 @@ def test_build_context_rich_observation_category_bracket_survives(mock_mcp):
 # search-notes – total=0 with non-empty results subtitle (Bug 3, issue #678)
 # ---------------------------------------------------------------------------
 
-# Fixture that mirrors the upstream quirk: total=0 but results is non-empty.
+# Semantic-search payload: total=0 is an unknown sentinel, made explicit by the flag.
 SEARCH_RESULT_ZERO_TOTAL = {
     "total": 0,
+    "total_is_exact": False,
     "current_page": 1,
     "page_size": 10,
     "has_more": False,
@@ -724,17 +729,26 @@ SEARCH_RESULT_ZERO_TOTAL = {
     ],
 }
 
+SEARCH_RESULT_LEGACY_ZERO_TOTAL = {
+    key: value for key, value in SEARCH_RESULT_ZERO_TOTAL.items() if key != "total_is_exact"
+}
+
 SEARCH_RESULT_UNKNOWN_TOTAL_WITH_MORE = {
     **SEARCH_RESULT_ZERO_TOTAL,
     "page_size": 2,
     "has_more": True,
 }
 
+SEARCH_RESULT_APPROXIMATE_TOTAL_WITH_MORE = {
+    **SEARCH_RESULT_UNKNOWN_TOTAL_WITH_MORE,
+    "total": 2,
+}
+
 
 @patch(
     "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
-    return_value=SEARCH_RESULT_ZERO_TOTAL,
+    return_value=SEARCH_RESULT_LEGACY_ZERO_TOTAL,
 )
 def test_search_notes_rich_zero_total_falls_back_to_result_count(mock_mcp):
     """When the API returns total=0 but results is non-empty, subtitle shows real count.
@@ -758,10 +772,10 @@ def test_search_notes_rich_zero_total_falls_back_to_result_count(mock_mcp):
 @patch(
     "basic_memory.mcp.tools.search_notes",
     new_callable=AsyncMock,
-    return_value=SEARCH_RESULT_UNKNOWN_TOTAL_WITH_MORE,
+    return_value=SEARCH_RESULT_APPROXIMATE_TOTAL_WITH_MORE,
 )
 def test_search_notes_rich_unknown_total_preserves_has_more(mock_mcp):
-    """Unknown totals never produce a false final-page claim when more results exist."""
+    """An explicit unknown flag overrides a positive aggregate estimate."""
     result = _tty_runner(["tool", "search-notes", "found"])
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"

--- a/tests/mcp/clients/test_clients.py
+++ b/tests/mcp/clients/test_clients.py
@@ -11,6 +11,7 @@ from basic_memory.mcp.clients import (
     ResourceClient,
     ProjectClient,
 )
+from basic_memory.schemas.search import SearchRetrievalMode
 
 
 class TestKnowledgeClient:
@@ -225,6 +226,65 @@ class TestSearchClient:
         result = await client.search({"text": "query"}, page=1, page_size=10)
         assert result.results == []
         assert result.current_page == 1
+        assert result.total_is_exact is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "retrieval_mode",
+        [SearchRetrievalMode.VECTOR, SearchRetrievalMode.HYBRID],
+    )
+    async def test_search_infers_unknown_total_for_legacy_semantic_response(
+        self,
+        monkeypatch,
+        retrieval_mode,
+    ):
+        """Legacy semantic responses preserve their unknown total semantics."""
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [],
+            "current_page": 1,
+            "page_size": 10,
+            "total": 0,
+            "has_more": False,
+        }
+
+        async def mock_call_post(client, url, **kwargs):
+            return mock_response
+
+        monkeypatch.setattr("basic_memory.mcp.tools.utils.call_post", mock_call_post)
+
+        client = SearchClient(MagicMock(), "proj-123")
+        result = await client.search({"text": "query", "retrieval_mode": retrieval_mode})
+
+        assert result.total == 0
+        assert result.total_is_exact is False
+
+    @pytest.mark.asyncio
+    async def test_search_preserves_explicit_total_exactness(self, monkeypatch):
+        """Server-provided exactness remains authoritative."""
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [],
+            "current_page": 1,
+            "page_size": 10,
+            "total": 0,
+            "total_is_exact": True,
+            "has_more": False,
+        }
+
+        async def mock_call_post(client, url, **kwargs):
+            return mock_response
+
+        monkeypatch.setattr("basic_memory.mcp.tools.utils.call_post", mock_call_post)
+
+        client = SearchClient(MagicMock(), "proj-123")
+        result = await client.search(
+            {"text": "query", "retrieval_mode": SearchRetrievalMode.VECTOR}
+        )
+
+        assert result.total_is_exact is True
 
 
 class TestMemoryClient:

--- a/tests/mcp/test_search_total_exactness.py
+++ b/tests/mcp/test_search_total_exactness.py
@@ -1,0 +1,76 @@
+"""Tests for the structured search total exactness contract."""
+
+from contextlib import asynccontextmanager
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from basic_memory.schemas.search import SearchItemType, SearchResponse, SearchResult
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("search_type", "retrieval_mode", "total", "total_is_exact"),
+    [
+        ("text", "fts", 1, True),
+        ("vector", "vector", 0, False),
+        ("hybrid", "hybrid", 0, False),
+    ],
+)
+async def test_search_notes_json_exposes_total_exactness(
+    monkeypatch,
+    search_type: str,
+    retrieval_mode: str,
+    total: int,
+    total_is_exact: bool,
+) -> None:
+    """MCP JSON preserves the API's exact-versus-unknown total distinction."""
+    search_mod = importlib.import_module("basic_memory.mcp.tools.search")
+    clients_mod = importlib.import_module("basic_memory.mcp.clients")
+    captured_payload: dict[str, object] = {}
+
+    @asynccontextmanager
+    async def fake_get_project_client(*args, **kwargs):
+        yield object(), SimpleNamespace(name="test-project", external_id="test-project-id")
+
+    async def fake_resolve_project_and_path(client, identifier, project=None, context=None):
+        return None, identifier, False
+
+    class MockSearchClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def search(self, payload, *, page, page_size):
+            captured_payload.update(payload)
+            return SearchResponse(
+                results=[
+                    SearchResult(
+                        title="Result",
+                        type=SearchItemType.ENTITY,
+                        score=1.0,
+                        permalink="notes/result",
+                        file_path="notes/result.md",
+                    )
+                ],
+                current_page=page,
+                page_size=page_size,
+                total=total,
+                total_is_exact=total_is_exact,
+            )
+
+    monkeypatch.setattr(search_mod, "get_project_client", fake_get_project_client)
+    monkeypatch.setattr(search_mod, "resolve_project_and_path", fake_resolve_project_and_path)
+    monkeypatch.setattr(clients_mod, "SearchClient", MockSearchClient)
+
+    result = await search_mod.search_notes(
+        project="test-project",
+        query="query",
+        search_type=search_type,
+        output_format="json",
+    )
+
+    assert isinstance(result, dict)
+    assert captured_payload["retrieval_mode"] == retrieval_mode
+    assert result["total"] == total
+    assert result["total_is_exact"] is total_is_exact

--- a/tests/mcp/tools/test_search_notes_multi_project.py
+++ b/tests/mcp/tools/test_search_notes_multi_project.py
@@ -119,6 +119,7 @@ async def test_search_notes_search_all_projects_qualifies_result_permalinks(
         "team-paul/main/tests/mcp-test-note",
         "personal/main/tests/mcp-test-note",
     ]
+    assert result["total_is_exact"] is True
 
 
 @pytest.mark.asyncio
@@ -193,6 +194,7 @@ async def test_search_notes_search_all_projects_with_no_refs_returns_empty_all_p
         "current_page": 1,
         "page_size": 10,
         "total": 0,
+        "total_is_exact": True,
         "has_more": False,
     }
 
@@ -282,6 +284,7 @@ async def test_search_notes_search_all_projects_continues_after_project_failure(
         "personal/main/tests/mcp-test-note",
     ]
     assert result["total"] == 1
+    assert result["total_is_exact"] is False
     assert any("team-paul/main" in warning for warning in warnings)
     assert any("team index unavailable" in warning for warning in warnings)
 
@@ -364,3 +367,4 @@ async def test_search_notes_search_all_projects_local_omits_project_id(monkeypat
         "take the name-routed path."
     )
     assert result["total"] == 2
+    assert result["total_is_exact"] is True

--- a/tests/schemas/test_search.py
+++ b/tests/schemas/test_search.py
@@ -131,3 +131,8 @@ def test_search_response():
     assert len(response.results) == 2
     assert response.results[0].score > response.results[1].score
     assert response.total == 2
+    assert response.total_is_exact is True
+
+    unknown_response = response.model_copy(update={"total": 0, "total_is_exact": False})
+    assert unknown_response.total == 0
+    assert unknown_response.total_is_exact is False


### PR DESCRIPTION
## Why

Semantic and hybrid search intentionally use a probe row instead of a second vector retrieval, so `total: 0` means unknown rather than no matches. Structured clients could not distinguish that sentinel from an exact zero, which made working pagination look broken.

Closes #1068.

## What Changed

- Added additive `total_is_exact` metadata to structured search responses.
- Marked FTS, title, and permalink counts exact while vector and hybrid totals remain unknown.
- Preserved the probe-row strategy and existing `total: 0` compatibility value for semantic modes.
- Propagated exactness through MCP JSON and account-wide aggregation, including partial-project failures.
- Updated Rich and plain CLI pagination summaries to consume the explicit flag while retaining legacy payload behavior.

## Implementation Details

`SearchResponse` defaults `total_is_exact` to true for compatibility with existing exact-count constructors. The HTTP router sets it from the retrieval mode. Multi-project MCP search only claims an exact aggregate when every project supplied an exact total; otherwise its aggregate is explicitly unknown. When an older API omits the new field, the typed client infers exactness from the outbound retrieval mode so legacy semantic responses remain unknown. No additional vector or hybrid retrieval is performed.

## Testing

- `uv run pytest tests/mcp/clients/test_clients.py tests/schemas/test_search.py tests/api/v2/test_search_router.py tests/mcp/test_search_total_exactness.py tests/mcp/tools/test_search_notes_multi_project.py tests/cli/test_cli_tool_rich_output.py -q` — 109 passed.
- `just fast-check` — passed; type checking reported only the existing Python 3.14 asyncio deprecation warnings.
- `just doctor` — passed.
- `just test-smoke` — passed.
- `just fast-test` — 4,278 passed and 41 skipped; one unrelated live OpenAI semantic-quality case failed because the configured provider returned HTTP 429 `insufficient_quota`.

## Risks / Follow-ups

The response change is additive, existing clients can ignore the new field, and semantic retrieval cost and pagination behavior are unchanged. No follow-up is required.