### PR TITLE
fix(core): search complete SQLite note content

### DIFF
--- a/src/basic_memory/repository/sqlite_search_repository.py
+++ b/src/basic_memory/repository/sqlite_search_repository.py
@@ -779,8 +779,11 @@ class SQLiteSearchRepository(SearchRepositoryBase):
                 # Use _prepare_search_term to handle both Boolean and non-Boolean queries
                 processed_text = self._prepare_search_term(search_text.strip())
                 params["text"] = processed_text
+                # content_stems is capped for Postgres index-row compatibility, while
+                # SQLite stores the complete note body in its FTS5 content_snippet column.
                 match_conditions.append(
-                    "(search_index.title MATCH :text OR search_index.content_stems MATCH :text)"
+                    "(search_index.title MATCH :text OR search_index.content_stems MATCH :text "
+                    "OR search_index.content_snippet MATCH :text)"
                 )
 
         # Handle title match search

--- a/tests/repository/test_search_repository.py
+++ b/tests/repository/test_search_repository.py
@@ -254,6 +254,35 @@ async def test_index_item(search_repository, search_entity):
 
 
 @pytest.mark.asyncio
+async def test_sqlite_text_search_matches_full_content_snippet(search_repository, search_entity):
+    """SQLite finds terms beyond the Postgres-sized content_stems prefix (#1065)."""
+    if is_postgres_backend(search_repository):
+        pytest.skip("The full content_snippet FTS column is SQLite-specific")
+
+    marker = "latecontentmarker"
+    search_row = SearchIndexRow(
+        id=search_entity.id,
+        type=SearchItemType.ENTITY.value,
+        title=search_entity.title,
+        content_stems="prefix content only",
+        content_snippet=f"{'x' * 7000} {marker}",
+        permalink=search_entity.permalink,
+        file_path=search_entity.file_path,
+        entity_id=search_entity.id,
+        metadata={"note_type": search_entity.note_type},
+        created_at=search_entity.created_at,
+        updated_at=search_entity.updated_at,
+        project_id=search_repository.project_id,
+    )
+    await search_repository.index_item(search_row)
+
+    results = await search_repository.search(search_text=marker)
+
+    assert [result.id for result in results] == [search_entity.id]
+    assert await search_repository.count(search_text=marker) == 1
+
+
+@pytest.mark.asyncio
 async def test_index_item_upsert_on_duplicate_permalink(search_repository, search_entity):
     """Test that indexing the same permalink twice uses upsert instead of failing.
 


### PR DESCRIPTION
## Why

SQLite text search only matched `title` and the Postgres-sized `content_stems` prefix. Because `content_stems` is capped near 6,000 characters while the full note is already indexed in FTS5 as `content_snippet`, exact terms later in large notes were invisible.

Closes #1065.

## What Changed

- Include SQLite's full `content_snippet` FTS5 column in text-search matching.
- Add a regression test with a marker after 7,000 characters that is absent from `content_stems`.
- Verify both result retrieval and count use the complete content.

## Implementation Details

The existing SQLite query builder is shared by `search()` and `count()`, including the metadata-filter subquery path. Extending that single match predicate fixes all SQLite keyword consumers without changing the stored index or requiring users to reindex.

Postgres behavior is unchanged; its indexed `content_stems` remains capped for the 8 KB index-row constraint.

## Testing

- `uv run pytest tests/repository/test_search_repository.py -q` — 48 passed.
- `just fast-check` — passed (ruff, format, and type checking; existing Python 3.14 deprecation warnings only).
- `just fast-test` — 123 passed and 1 skipped before the selected live OpenAI/Postgres benchmark failed with external `429 insufficient_quota`.
- `env OPENAI_API_KEY= just fast-test` — the remaining live OpenAI case skipped as intended.

## Risks / Follow-ups

SQLite BM25 ranking can shift slightly because terms present in both `content_stems` and `content_snippet` contribute from both columns. That is preferable to silently dropping exact matches in long notes, and no migration or reindex is required.