### PR TITLE
fix(mcp): surface cloud project deletion job

### DIFF
--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -796,6 +796,13 @@ async def delete_project(
             if hasattr(status_response.old_project, "path"):
                 result += f"• Path: {status_response.old_project.path}\n"
 
+        if status_response.deletion_status or status_response.job_id:
+            result += "\nDeletion tracking:\n"
+            if status_response.deletion_status:
+                result += f"• Project deletion status: {status_response.deletion_status}\n"
+            if status_response.job_id:
+                result += f"• Deletion job ID: {status_response.job_id}\n"
+
         cloud_routed = _delete_routes_to_cloud(workspace_id)
         files_location = "in cloud storage" if cloud_routed else "on disk"
         if delete_notes:

--- a/src/basic_memory/schemas/project_info.py
+++ b/src/basic_memory/schemas/project_info.py
@@ -249,3 +249,6 @@ class ProjectStatusResponse(BaseModel):
     file_delete_status: Optional[Literal["pending", "skipped", "complete", "failed"]] = Field(
         None, description="Background note-file deletion status when returned by the backend"
     )
+    job_id: Optional[str] = Field(
+        None, description="Background project deletion job identifier returned by the backend"
+    )

--- a/tests/mcp/test_tool_project_management.py
+++ b/tests/mcp/test_tool_project_management.py
@@ -410,6 +410,7 @@ async def test_delete_project_resolves_workspace_slug(app, delete_notes):
         old_project=target_project,
         deletion_status="pending",
         file_delete_status="pending" if delete_notes else "skipped",
+        job_id="28993",
     )
 
     with (
@@ -456,6 +457,8 @@ async def test_delete_project_resolves_workspace_slug(app, delete_notes):
     assert captured["workspace"] == "tenant-abc-123"
     mock_delete_project.assert_awaited_once_with("project-uuid", delete_notes=delete_notes)
     assert result.startswith("✓")
+    assert "Project deletion status: pending" in result
+    assert "Deletion job ID: 28993" in result
     # Cloud-routed delete: result text must not claim "files remain on disk" (#1034).
     if delete_notes:
         assert "Note-file deletion in cloud storage was queued and is pending" in result


### PR DESCRIPTION
## Why

Hosted project deletion is asynchronous, but the typed core response model discarded the cloud backend's `job_id` and the MCP tool omitted both deletion status and job identity. Callers could only see that note-file deletion was pending, with no handle for tracing the accepted job.

## What changed

- preserve the backend `job_id` in `ProjectStatusResponse`
- include project deletion status and job ID in the MCP `delete_project` result when supplied
- cover both retained-file and purge-file cloud deletion responses

## Verification

- `just fast-check`
- `uv run pytest tests/mcp/test_tool_project_management.py -q` — 38 passed
- `just fast-test` — 13 passed, 1 skipped

This complements the full storage-prefix purge in basicmachines-co/basic-memory-cloud#1508.

Addresses #1034.