### PR TITLE
fix(core): reject conflicting note filenames

### DIFF
--- a/src/basic_memory/services/entity_service.py
+++ b/src/basic_memory/services/entity_service.py
@@ -658,6 +658,18 @@ class EntityService(BaseService[EntityModel]):
                 f"file for entity {schema.directory}/{schema.title} already exists: {file_path}"
             )
 
+        if not skip_conflict_check:
+            conflicts = await self.detect_file_path_conflicts(
+                file_path.as_posix(),
+                session=session,
+            )
+            if conflicts:
+                raise EntityAlreadyExistsError(
+                    f"file path conflicts with existing note(s): {', '.join(conflicts)}"
+                )
+            # The create path has completed the same check resolve_permalink would perform.
+            skip_conflict_check = True
+
         content_markdown = self._apply_schema_frontmatter_overrides(schema)
         permalink = await self._resolve_schema_permalink(
             schema,

--- a/src/basic_memory/services/entity_service.py
+++ b/src/basic_memory/services/entity_service.py
@@ -34,6 +34,7 @@ from basic_memory.repository import ObservationRepository, RelationRepository
 from basic_memory.repository.project_repository import ProjectRepository
 from basic_memory.repository.entity_repository import EntityRepository
 from basic_memory.runtime.note_move import normalize_note_move_destination_path
+from basic_memory.runtime.storage import runtime_file_path_is_markdown_note
 from basic_memory.schemas import Entity as EntitySchema
 from basic_memory.schemas.base import Permalink
 from basic_memory.schemas.response import (
@@ -659,10 +660,14 @@ class EntityService(BaseService[EntityModel]):
             )
 
         if not skip_conflict_check:
-            conflicts = await self.detect_file_path_conflicts(
-                file_path.as_posix(),
-                session=session,
-            )
+            conflicts = [
+                conflict
+                for conflict in await self.detect_file_path_conflicts(
+                    file_path.as_posix(),
+                    session=session,
+                )
+                if runtime_file_path_is_markdown_note(conflict)
+            ]
             if conflicts:
                 raise EntityAlreadyExistsError(
                     f"file path conflicts with existing note(s): {', '.join(conflicts)}"

--- a/test-int/mcp/test_write_note_integration.py
+++ b/test-int/mcp/test_write_note_integration.py
@@ -6,6 +6,7 @@ tag handling, error conditions, and edge cases from bug reports.
 """
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from textwrap import dedent
 from typing import Any
@@ -13,7 +14,9 @@ from typing import Any
 import pytest
 from fastmcp import Client
 
+from basic_memory import db
 from basic_memory.config import ConfigManager
+from basic_memory.models import Entity
 from basic_memory.schemas.project_info import ProjectItem
 
 
@@ -501,6 +504,46 @@ async def test_write_note_rejects_existing_note_with_legacy_filename(
         project_path = Path(test_project.path)
         assert (project_path / "site-roadmap.md").exists()
         assert not (project_path / "Site Roadmap.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_write_note_allows_note_beside_non_markdown_resource(
+    mcp_server, app, test_project, engine_factory
+):
+    """A resource permalink collision is not a note-path conflict."""
+    resource_path = Path(test_project.path) / "foo.png"
+    resource_path.write_bytes(b"not-a-real-png")
+    _, session_maker = engine_factory
+    now = datetime.now(tz=UTC)
+    async with db.scoped_session(session_maker) as session:
+        session.add(
+            Entity(
+                project_id=test_project.id,
+                title="foo.png",
+                note_type="resource",
+                permalink="foo",
+                file_path="foo.png",
+                content_type="image/png",
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+    async with Client(mcp_server) as client:
+        created = await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Foo",
+                "directory": "",
+                "content": "A valid note beside foo.png.",
+            },
+        )
+
+    response_text = created.content[0].text  # pyright: ignore [reportAttributeAccessIssue]
+    assert "# Created note" in response_text
+    assert "file_path: Foo.md" in response_text
+    assert (Path(test_project.path) / "Foo.md").exists()
 
 
 @pytest.mark.asyncio

--- a/test-int/mcp/test_write_note_integration.py
+++ b/test-int/mcp/test_write_note_integration.py
@@ -462,6 +462,48 @@ async def test_write_note_kebab_filenames_repeat_invalid(mcp_server, app, test_p
 
 
 @pytest.mark.asyncio
+async def test_write_note_rejects_existing_note_with_legacy_filename(
+    mcp_server, app, test_project, app_config
+):
+    """A naming-convention change must not create a second note with the same title."""
+    app_config.kebab_filenames = True
+    app_config.permalinks_include_project = False
+    ConfigManager().save_config(app_config)
+
+    async with Client(mcp_server) as client:
+        created = await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Site Roadmap",
+                "directory": "",
+                "content": "Legacy content.",
+            },
+        )
+        assert "file_path: site-roadmap.md" in created.content[0].text  # pyright: ignore [reportAttributeAccessIssue]
+
+        app_config.kebab_filenames = False
+        app_config.permalinks_include_project = True
+        ConfigManager().save_config(app_config)
+
+        duplicate = await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Site Roadmap",
+                "directory": "",
+                "content": "Replacement content.",
+            },
+        )
+
+        response_text = duplicate.content[0].text  # pyright: ignore [reportAttributeAccessIssue]
+        assert "# Error: Note already exists" in response_text
+        project_path = Path(test_project.path)
+        assert (project_path / "site-roadmap.md").exists()
+        assert not (project_path / "Site Roadmap.md").exists()
+
+
+@pytest.mark.asyncio
 async def test_write_note_file_path_os_path_join(mcp_server, app, test_project, app_config):
     """Test that os.path.join logic in Entity.file_path works for various folder/title combinations."""
 

--- a/test-int/mcp/test_write_note_integration.py
+++ b/test-int/mcp/test_write_note_integration.py
@@ -505,6 +505,23 @@ async def test_write_note_rejects_existing_note_with_legacy_filename(
         assert (project_path / "site-roadmap.md").exists()
         assert not (project_path / "Site Roadmap.md").exists()
 
+        overwritten = await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Site Roadmap",
+                "directory": "",
+                "content": "Replacement content.",
+                "overwrite": True,
+            },
+        )
+
+        overwrite_text = overwritten.content[0].text  # pyright: ignore [reportAttributeAccessIssue]
+        assert "# Updated note" in overwrite_text
+        assert "file_path: Site Roadmap.md" in overwrite_text
+        assert not (project_path / "site-roadmap.md").exists()
+        assert (project_path / "Site Roadmap.md").read_text().endswith("Replacement content.")
+
 
 @pytest.mark.asyncio
 async def test_write_note_allows_note_beside_non_markdown_resource(


### PR DESCRIPTION
Fixes #1077.

Reject create requests when the existing filename-conflict detector finds an equivalent indexed path, instead of logging the conflict and creating a duplicate note. The regression covers a legacy kebab-case note after switching to title-case filenames and project-prefixed permalinks.

Tested with 100 focused tests, Ruff, formatting, and Pyright.
