### PR TITLE
fix(core): avoid phantom project directory on config load

### DIFF
--- a/src/basic_memory/config.py
+++ b/src/basic_memory/config.py
@@ -1068,25 +1068,18 @@ class ConfigManager:
                                 needs_resave = True
                                 break
 
-                # First, create config from environment variables (Pydantic will read them)
-                # Then overlay with file data for fields that aren't set via env vars
-                # This ensures env vars take precedence
-
-                # Get env-based config fields that are actually set
-                env_config = BasicMemoryConfig()
-                env_dict = env_config.model_dump()
-
-                # Merge: file data as base, but only use it for fields not set by env
-                # We detect env-set fields by comparing to default values
                 merged_data = file_data.copy()
-
-                # For fields that have env var overrides, use those instead of file values
-                # The env_prefix is "BASIC_MEMORY_" so we check those
                 for field_name in BasicMemoryConfig.model_fields.keys():
                     env_var_name = f"BASIC_MEMORY_{field_name.upper()}"
                     if env_var_name in os.environ:
-                        # Environment variable is set, use it
-                        merged_data[field_name] = env_dict[field_name]
+                        # Trigger: the file and environment both configure this field.
+                        # Why: BaseSettings only gives environment values precedence when the
+                        # field is absent from constructor data. Removing the file value lets
+                        # Pydantic parse the environment value without constructing a throwaway
+                        # config that seeds and creates an unused default project directory.
+                        # Outcome: environment keeps precedence and config loading has no phantom
+                        # filesystem side effect before the real merged config is validated.
+                        merged_data.pop(field_name, None)
 
                 _CONFIG_CACHE = BasicMemoryConfig(**merged_data)
 

--- a/tests/test_config_load_side_effects.py
+++ b/tests/test_config_load_side_effects.py
@@ -1,0 +1,86 @@
+"""Regression tests for side effects while loading existing configuration."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from basic_memory import config as config_module
+from basic_memory.config import ConfigManager
+
+
+def test_existing_config_load_does_not_create_default_project_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reading a custom project config must not materialize the unused default path."""
+    home = tmp_path / "home"
+    config_dir = tmp_path / "config"
+    project_dir = tmp_path / "custom-project"
+    home.mkdir()
+    config_dir.mkdir()
+    project_dir.mkdir()
+
+    monkeypatch.setenv("HOME", str(home))
+    if os.name == "nt":
+        monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("BASIC_MEMORY_CONFIG_DIR", str(config_dir))
+    monkeypatch.delenv("BASIC_MEMORY_HOME", raising=False)
+    monkeypatch.setattr(config_module, "_CONFIG_CACHE", None)
+    monkeypatch.setattr(config_module, "_CONFIG_MTIME", None)
+    monkeypatch.setattr(config_module, "_CONFIG_SIZE", None)
+
+    config_path = config_dir / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "projects": {
+                    "custom": {
+                        "path": str(project_dir),
+                        "mode": "local",
+                    }
+                },
+                "default_project": "custom",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = ConfigManager().load_config()
+
+    assert loaded.projects["custom"].path == str(project_dir)
+    assert not (home / "basic-memory").exists()
+
+
+def test_existing_config_load_keeps_environment_precedence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Removing overridden file fields still delegates environment parsing to BaseSettings."""
+    config_dir = tmp_path / "config"
+    project_dir = tmp_path / "custom-project"
+    config_dir.mkdir()
+    project_dir.mkdir()
+
+    monkeypatch.setenv("BASIC_MEMORY_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("BASIC_MEMORY_LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("BASIC_MEMORY_FORMATTERS", '{"md":"formatter --write {file}"}')
+    monkeypatch.setattr(config_module, "_CONFIG_CACHE", None)
+    monkeypatch.setattr(config_module, "_CONFIG_MTIME", None)
+    monkeypatch.setattr(config_module, "_CONFIG_SIZE", None)
+
+    (config_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "projects": {"custom": {"path": str(project_dir)}},
+                "default_project": "custom",
+                "log_level": "INFO",
+                "formatters": {"md": "old-formatter {file}"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = ConfigManager().load_config()
+
+    assert loaded.log_level == "DEBUG"
+    assert loaded.formatters == {"md": "formatter --write {file}"}


### PR DESCRIPTION
## Why

Loading an existing config currently constructs a throwaway `BasicMemoryConfig()` just to parse environment overrides. With no `BASIC_MEMORY_HOME`, that temporary model seeds and creates `~/basic-memory` even when the configured project lives elsewhere.

This is an independent maintainer implementation for #1029 because contributor PR #1030 cannot pass the CLA gate.

## What changed

- remove the throwaway environment-only config construction
- drop file-backed fields that have explicit environment overrides, allowing `BaseSettings` to parse those environment values directly
- add a regression proving an existing custom project config does not create the unused default directory
- prove scalar and JSON environment overrides still take precedence

## Verification

- `just fast-check`
- `uv run pytest tests/test_config.py tests/test_config_load_side_effects.py -q` — 136 passed

Fixes #1029
Supersedes #1030