### PR TITLE
fix(core): reject equivalent note filenames

### DIFF
--- a/src/basic_memory/indexing/accepted_note_mutation_runner.py
+++ b/src/basic_memory/indexing/accepted_note_mutation_runner.py
@@ -50,6 +50,7 @@ from basic_memory.runtime.storage import (
     RuntimeNoteActorName,
     RuntimeNoteChangeSource,
     runtime_content_type_is_markdown,
+    runtime_file_path_is_markdown_note,
 )
 from basic_memory.schemas.base import Entity as EntitySchema
 from basic_memory.schemas.request import EditEntityRequest
@@ -246,6 +247,13 @@ class AcceptedNoteMutationPreparer(
     Protocol,
 ):
     """Combined Basic Memory prepare capability for accepted note mutations."""
+
+    async def detect_file_path_conflicts(
+        self,
+        file_path: RuntimeFilePath,
+        skip_check: bool = ...,
+        session: AsyncSession | None = ...,
+    ) -> list[str]: ...
 
 
 class AcceptedNoteMutationPreparerFactory(Protocol):
@@ -463,20 +471,12 @@ async def _run_accepted_note_create(
     )
 
     preparer = dependencies.preparer_factory.create_note_preparer(project)
-    try:
-        prepared_write = await prepare_accepted_note_create(
-            preparer,
-            request.data,
-            check_storage_exists=dependencies.verify_storage_absent_on_create,
-            session=session,
-        )
-    except EntityAlreadyExistsError as error:
-        # An unindexed file already occupies this path (local source-of-truth
-        # runtimes only). Reject instead of committing DB state that the next
-        # watcher pass would overwrite with the stale file content.
-        reject_accepted_note_mutation(AcceptedNoteMutationRejectKind.conflict, str(error))
-    except (ParseError, ValueError) as error:
-        reject_accepted_note_mutation(AcceptedNoteMutationRejectKind.bad_request, str(error))
+    prepared_write = await prepare_create_or_reject(
+        preparer,
+        request.data,
+        check_storage_exists=dependencies.verify_storage_absent_on_create,
+        session=session,
+    )
 
     prepared = prepared_write.prepared
     entity = await create_accepted_pending_entity(
@@ -953,7 +953,7 @@ async def reject_conflicting_accepted_note_file_path(
 
 
 async def prepare_create_or_reject(
-    preparer: AcceptedNoteCreatePreparer,
+    preparer: AcceptedNoteMutationPreparer,
     data: EntitySchema,
     *,
     check_storage_exists: bool,
@@ -961,10 +961,30 @@ async def prepare_create_or_reject(
 ) -> AcceptedPreparedNoteWrite:
     """Prepare a new accepted note or raise a typed mutation rejection."""
     try:
+        conflicting_note_paths = [
+            path
+            for path in await preparer.detect_file_path_conflicts(
+                data.file_path,
+                session=session,
+            )
+            if runtime_file_path_is_markdown_note(path)
+        ]
+        if conflicting_note_paths:
+            joined_paths = ", ".join(sorted(conflicting_note_paths))
+            reject_accepted_note_mutation(
+                AcceptedNoteMutationRejectKind.conflict,
+                "A note with an equivalent filename already exists: "
+                f"{joined_paths}. Address the existing note explicitly to modify it.",
+            )
+
         return await prepare_accepted_note_create(
             preparer,
             data,
             check_storage_exists=check_storage_exists,
+            # The explicit check above rejects only Markdown note conflicts.
+            # EntityService's broader detector also reports similarly named
+            # binary resources, which are valid alongside Markdown notes.
+            skip_conflict_check=True,
             session=session,
         )
     except EntityAlreadyExistsError as error:

--- a/src/basic_memory/indexing/accepted_note_write_runner.py
+++ b/src/basic_memory/indexing/accepted_note_write_runner.py
@@ -119,6 +119,7 @@ class AcceptedNoteCreatePreparer(Protocol):
         schema: EntitySchema,
         *,
         check_storage_exists: bool = ...,
+        skip_conflict_check: bool = ...,
         session: AsyncSession | None = ...,
     ) -> AcceptedPreparedMarkdownWriteSource: ...
 
@@ -365,12 +366,14 @@ async def prepare_accepted_note_create(
     data: EntitySchema,
     *,
     check_storage_exists: bool,
+    skip_conflict_check: bool = False,
     session: AsyncSession | None = None,
 ) -> AcceptedPreparedNoteWrite:
     """Prepare one DB-first note create and checksum the accepted markdown."""
     prepared = await preparer.prepare_create_entity_content(
         data,
         check_storage_exists=check_storage_exists,
+        skip_conflict_check=skip_conflict_check,
         session=session,
     )
     return AcceptedPreparedNoteWrite(

--- a/test-int/mcp/test_write_note_integration.py
+++ b/test-int/mcp/test_write_note_integration.py
@@ -462,6 +462,54 @@ async def test_write_note_kebab_filenames_repeat_invalid(mcp_server, app, test_p
 
 
 @pytest.mark.asyncio
+async def test_write_note_rejects_equivalent_legacy_markdown_filename(
+    mcp_server,
+    app,
+    test_project,
+    app_config,
+):
+    """A filename-mode change must not silently create a duplicate note (issue #1077)."""
+    app_config.kebab_filenames = True
+    app_config.permalinks_include_project = False
+    ConfigManager().save_config(app_config)
+
+    async with Client(mcp_server) as client:
+        created = await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Site Roadmap",
+                "directory": "filename-conflicts",
+                "content": "# Site Roadmap\n\nLegacy body.",
+            },
+        )
+        assert "# Created note" in created.content[0].text  # pyright: ignore [reportAttributeAccessIssue]
+        assert "file_path: filename-conflicts/site-roadmap.md" in created.content[0].text  # pyright: ignore [reportAttributeAccessIssue]
+
+        app_config.kebab_filenames = False
+        ConfigManager().save_config(app_config)
+
+        rejected = await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Site Roadmap",
+                "directory": "filename-conflicts",
+                "content": "# Site Roadmap\n\nReplacement body.",
+            },
+        )
+        rejected_text = rejected.content[0].text  # pyright: ignore [reportAttributeAccessIssue]
+        assert "# Error: Note already exists" in rejected_text
+        assert "edit_note" in rejected_text
+
+    note_paths = sorted(
+        path.relative_to(test_project.path).as_posix()
+        for path in Path(test_project.path).rglob("*.md")
+    )
+    assert note_paths == ["filename-conflicts/site-roadmap.md"]
+
+
+@pytest.mark.asyncio
 async def test_write_note_file_path_os_path_join(mcp_server, app, test_project, app_config):
     """Test that os.path.join logic in Entity.file_path works for various folder/title combinations."""
 

--- a/tests/indexing/test_accepted_note_mutation_runner.py
+++ b/tests/indexing/test_accepted_note_mutation_runner.py
@@ -104,9 +104,11 @@ class _CreatePreparer:
         *,
         prepared_move: _PreparedMove | None = None,
         move_destination_error: EntityAlreadyExistsError | None = None,
+        filename_conflicts: list[str] | None = None,
     ) -> None:
         self.prepared = prepared
         self.move_destination_error = move_destination_error
+        self.filename_conflicts = filename_conflicts or []
         self.prepared_move = prepared_move or _PreparedMove(
             file_path=Path(prepared.entity_fields.file_path),
             markdown_content=prepared.markdown_content,
@@ -114,6 +116,8 @@ class _CreatePreparer:
             permalink=prepared.entity_fields.permalink,
         )
         self.calls: list[tuple[EntitySchema, bool, AsyncSession | None]] = []
+        self.skip_conflict_checks: list[bool] = []
+        self.conflict_calls: list[tuple[str, bool, AsyncSession | None]] = []
         self.replace_calls: list[tuple[Entity, EntitySchema, str, AsyncSession | None]] = []
         self.edit_calls: list[
             tuple[Entity, str, str, str, str | None, str | None, int, bool, AsyncSession | None]
@@ -126,10 +130,21 @@ class _CreatePreparer:
         schema: EntitySchema,
         *,
         check_storage_exists: bool = True,
+        skip_conflict_check: bool = False,
         session: AsyncSession | None = None,
     ) -> _PreparedWrite:
         self.calls.append((schema, check_storage_exists, session))
+        self.skip_conflict_checks.append(skip_conflict_check)
         return self.prepared
+
+    async def detect_file_path_conflicts(
+        self,
+        file_path: str,
+        skip_check: bool = False,
+        session: AsyncSession | None = None,
+    ) -> list[str]:
+        self.conflict_calls.append((file_path, skip_check, session))
+        return self.filename_conflicts
 
     async def prepare_update_entity_content(
         self,
@@ -593,7 +608,9 @@ async def test_run_accepted_note_create_persists_prepared_markdown() -> None:
     assert project_repository.calls == [(session, "project-123")]
     assert entity_lookup_repository.file_path_calls == [(session, "notes/Accepted.md", False)]
     assert preparer_factory.projects == [project]
+    assert preparer.conflict_calls == [("notes/Accepted.md", False, session)]
     assert preparer.calls == [(schema, False, session)]
+    assert preparer.skip_conflict_checks == [True]
     assert pending_entity_repository.calls[0][1].created_by == str(_ACTOR_ID)
     assert note_content_accept_repository.calls[0][1].markdown_content == "# Accepted\n"
     assert note_content_accept_repository.calls[0][1].db_version == 1
@@ -608,6 +625,80 @@ async def test_run_accepted_note_create_persists_prepared_markdown() -> None:
     assert change.materialization.actor_kind == "user"
     assert change.materialization.actor_name == "Ada"
     assert change.materialization.previous_file_path is None
+
+
+@pytest.mark.asyncio
+async def test_run_accepted_note_create_rejects_equivalent_markdown_file_path() -> None:
+    session = cast(AsyncSession, object())
+    schema = _schema()
+    project = _project()
+    preparer = _CreatePreparer(
+        _prepared(),
+        filename_conflicts=["notes/accepted.md"],
+    )
+
+    with pytest.raises(AcceptedNoteMutationRejected) as exc_info:
+        await run_accepted_note_create(
+            session,
+            request=AcceptedNoteCreateMutation(
+                project_external_id="project-123",
+                data=schema,
+                actor=AcceptedNoteMutationActor(user_profile_id=_ACTOR_ID),
+                source="api",
+            ),
+            dependencies=_dependencies(
+                project_repository=_ProjectRepository(project),
+                entity_lookup_repository=_EntityLookupRepository(),
+                note_content_lookup_repository=_NoteContentLookupRepository(),
+                preparer_factory=_PreparerFactory(preparer),
+                pending_entity_repository=_PendingEntityRepository(_entity()),
+                note_content_accept_repository=_NoteContentAcceptRepository(
+                    _note_content(_entity())
+                ),
+                search_repository=_SearchRepository(),
+            ),
+        )
+
+    assert exc_info.value.rejection.kind is AcceptedNoteMutationRejectKind.conflict
+    assert "notes/accepted.md" in str(exc_info.value.rejection.detail)
+    assert preparer.conflict_calls == [("notes/Accepted.md", False, session)]
+    assert preparer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_run_accepted_note_create_allows_equivalent_non_markdown_resource_path() -> None:
+    session = cast(AsyncSession, object())
+    schema = _schema()
+    project = _project()
+    prepared = _prepared()
+    entity = _entity()
+    preparer = _CreatePreparer(
+        prepared,
+        filename_conflicts=["notes/accepted.png"],
+    )
+
+    change = await run_accepted_note_create(
+        session,
+        request=AcceptedNoteCreateMutation(
+            project_external_id="project-123",
+            data=schema,
+            actor=AcceptedNoteMutationActor(user_profile_id=_ACTOR_ID),
+            source="api",
+        ),
+        dependencies=_dependencies(
+            project_repository=_ProjectRepository(project),
+            entity_lookup_repository=_EntityLookupRepository(),
+            note_content_lookup_repository=_NoteContentLookupRepository(),
+            preparer_factory=_PreparerFactory(preparer),
+            pending_entity_repository=_PendingEntityRepository(entity),
+            note_content_accept_repository=_NoteContentAcceptRepository(_note_content(entity)),
+            search_repository=_SearchRepository(),
+        ),
+    )
+
+    assert change.status_code == 201
+    assert preparer.conflict_calls == [("notes/Accepted.md", False, session)]
+    assert preparer.skip_conflict_checks == [True]
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_accepted_note_write_runner.py
+++ b/tests/indexing/test_accepted_note_write_runner.py
@@ -227,15 +227,18 @@ class _CreatePreparer:
     def __init__(self, prepared: _PreparedWrite) -> None:
         self.prepared = prepared
         self.calls: list[tuple[EntitySchema, bool, AsyncSession | None]] = []
+        self.skip_conflict_checks: list[bool] = []
 
     async def prepare_create_entity_content(
         self,
         schema: EntitySchema,
         *,
         check_storage_exists: bool = True,
+        skip_conflict_check: bool = False,
         session: AsyncSession | None = None,
     ) -> _PreparedWrite:
         self.calls.append((schema, check_storage_exists, session))
+        self.skip_conflict_checks.append(skip_conflict_check)
         return self.prepared
 
 
@@ -467,6 +470,7 @@ async def test_prepare_accepted_note_create_hashes_prepared_markdown() -> None:
     assert result.prepared is prepared
     assert result.db_checksum == sha256(b"# Created\n").hexdigest()
     assert preparer.calls == [(schema, False, session)]
+    assert preparer.skip_conflict_checks == [False]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Changing filename conventions can make an existing Markdown note resolve to an equivalent path with different case, spacing, or hyphenation. The create path previously logged that conflict and continued, so `write_note` could silently create a duplicate.

This is an independent maintainer implementation. It does not incorporate code from the CLA-blocked contribution in #1078.

## What changed

- reject equivalent Markdown note paths with a 409 before persistence
- keep similarly named non-Markdown resources valid alongside notes
- reuse the completed conflict scan during create preparation
- add unit coverage and an MCP regression that switches filename conventions and proves no duplicate file is created

## Verification

- `just fast-check`
- `uv run pytest tests/indexing/test_accepted_note_mutation_runner.py tests/indexing/test_accepted_note_write_runner.py test-int/mcp/test_write_note_integration.py -q` (55 passed)

Fixes #1077
Supersedes #1078
