### PR TITLE
fix(mcp): paginate directory listings

### DIFF
--- a/src/basic_memory/api/v2/routers/directory_router.py
+++ b/src/basic_memory/api/v2/routers/directory_router.py
@@ -9,12 +9,17 @@ Key improvements:
 - Better performance through indexed queries
 """
 
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Query, Path
 
 from basic_memory.deps import DirectoryServiceV2ExternalDep
-from basic_memory.schemas.directory import DirectoryNode
+from basic_memory.schemas.directory import (
+    DEFAULT_DIRECTORY_PAGE_SIZE,
+    MAX_DIRECTORY_PAGE_SIZE,
+    DirectoryListResponse,
+    DirectoryNode,
+)
 
 router = APIRouter(prefix="/directory", tags=["directory-v2"])
 
@@ -61,7 +66,11 @@ async def get_directory_structure(
     return structure
 
 
-@router.get("/list", response_model=List[DirectoryNode], response_model_exclude_none=True)
+@router.get(
+    "/list",
+    response_model=DirectoryListResponse,
+    response_model_exclude_none=True,
+)
 async def list_directory(
     directory_service: DirectoryServiceV2ExternalDep,
     project_id: str = Path(..., description="Project external UUID"),
@@ -69,6 +78,13 @@ async def list_directory(
     depth: int = Query(1, ge=1, le=10, description="Recursion depth (1-10)"),
     file_name_glob: Optional[str] = Query(
         None, description="Glob pattern for filtering file names"
+    ),
+    page: int = Query(1, ge=1, description="One-indexed result page"),
+    page_size: int = Query(
+        DEFAULT_DIRECTORY_PAGE_SIZE,
+        ge=1,
+        le=MAX_DIRECTORY_PAGE_SIZE,
+        description="Number of nodes per page",
     ),
 ):
     """List directory contents with filtering and depth control.
@@ -79,15 +95,17 @@ async def list_directory(
         dir_name: Directory path to list (default: root "/")
         depth: Recursion depth (1-10, default: 1 for immediate children only)
         file_name_glob: Optional glob pattern for filtering file names (e.g., "*.md", "*meeting*")
+        page: One-indexed result page
+        page_size: Number of nodes per page (1-200)
 
     Returns:
-        List of DirectoryNode objects matching the criteria
+        Bounded page of DirectoryNode objects matching the criteria
     """
     # Get directory listing with filtering
-    nodes = await directory_service.list_directory(
+    return await directory_service.list_directory(
         dir_name=dir_name,
         depth=depth,
         file_name_glob=file_name_glob,
+        page=page,
+        page_size=page_size,
     )
-
-    return nodes

--- a/src/basic_memory/mcp/clients/directory.py
+++ b/src/basic_memory/mcp/clients/directory.py
@@ -3,9 +3,11 @@
 Encapsulates all /v2/projects/{project_id}/directory/* endpoints.
 """
 
-from typing import Optional, Any
+from typing import Optional
 
 from httpx import AsyncClient
+
+from basic_memory.schemas.directory import DEFAULT_DIRECTORY_PAGE_SIZE, DirectoryListResponse
 
 # call_* helpers live in basic_memory.mcp.tools.utils; importing that at module
 # level executes the whole tools package (fastmcp + mcp SDK) during CLI startup,
@@ -43,16 +45,20 @@ class DirectoryClient:
         *,
         depth: int = 1,
         file_name_glob: Optional[str] = None,
-    ) -> list[dict[str, Any]]:
+        page: int = 1,
+        page_size: int = DEFAULT_DIRECTORY_PAGE_SIZE,
+    ) -> DirectoryListResponse:
         """List directory contents.
 
         Args:
             dir_name: Directory path to list (default: root)
             depth: How deep to traverse (default: 1)
             file_name_glob: Optional glob pattern to filter files
+            page: One-indexed result page
+            page_size: Number of nodes per page
 
         Returns:
-            List of directory nodes with their contents
+            Bounded directory nodes with pagination metadata
 
         Raises:
             ToolError: If the request fails
@@ -62,6 +68,8 @@ class DirectoryClient:
         params: dict = {
             "dir_name": dir_name,
             "depth": depth,
+            "page": page,
+            "page_size": page_size,
         }
         if file_name_glob:
             params["file_name_glob"] = file_name_glob
@@ -71,4 +79,4 @@ class DirectoryClient:
             f"{self._base_path}/list",
             params=params,
         )
-        return response.json()
+        return DirectoryListResponse.model_validate(response.json())

--- a/src/basic_memory/mcp/tools/list_directory.py
+++ b/src/basic_memory/mcp/tools/list_directory.py
@@ -139,7 +139,7 @@ async def list_directory(
 
         nodes = [node.model_dump(mode="json", exclude_none=True) for node in listing.nodes]
 
-        if not nodes:
+        if listing.total == 0:
             filter_desc = ""
             if file_name_glob:
                 filter_desc = f" matching '{file_name_glob}'"
@@ -161,6 +161,9 @@ async def list_directory(
         # Group by type and sort
         directories = [n for n in nodes if n["type"] == "directory"]
         files = [n for n in nodes if n["type"] == "file"]
+
+        if not nodes:
+            output_lines.append("No items on this page.")
 
         # Sort by name
         directories.sort(key=lambda x: x["name"])
@@ -222,7 +225,17 @@ async def list_directory(
         if files:
             summary_parts.append(f"{len(files)} file{'s' if len(files) != 1 else ''}")
 
-        output_lines.append(f"Total: {total_count} items ({', '.join(summary_parts)})")
+        if summary_parts:
+            output_lines.append(f"Total: {total_count} items ({', '.join(summary_parts)})")
+        else:
+            output_lines.append("Total: 0 items")
+
+        if not nodes:
+            last_page = (listing.total + listing.page_size - 1) // listing.page_size
+            output_lines.append(
+                f"Requested page {listing.page} is beyond the available results; "
+                f"the last available page is {last_page}."
+            )
 
         if listing.has_more:
             next_page = listing.page + 1
@@ -234,7 +247,9 @@ async def list_directory(
             ]
             if file_name_glob:
                 continuation_args.append(f"file_name_glob={file_name_glob!r}")
-            if project:
+            if project_id:
+                continuation_args.append(f"project_id={project_id!r}")
+            elif project:
                 continuation_args.append(f"project={project!r}")
             output_lines.extend(
                 [

--- a/src/basic_memory/mcp/tools/list_directory.py
+++ b/src/basic_memory/mcp/tools/list_directory.py
@@ -1,6 +1,6 @@
 """List directory tool for Basic Memory MCP server."""
 
-from typing import Annotated, Optional
+from typing import Annotated, Any, Literal, Optional
 
 from loguru import logger
 from fastmcp import Context
@@ -8,6 +8,10 @@ from pydantic import AliasChoices, Field
 
 from basic_memory.mcp.project_context import get_project_client
 from basic_memory.mcp.server import mcp
+from basic_memory.schemas.directory import (
+    DEFAULT_DIRECTORY_PAGE_SIZE,
+    MAX_DIRECTORY_PAGE_SIZE,
+)
 
 
 @mcp.tool(
@@ -38,10 +42,19 @@ async def list_directory(
             validation_alias=AliasChoices("file_name_glob", "glob", "pattern", "filter"),
         ),
     ] = None,
+    page: int = 1,
+    page_size: Annotated[
+        int,
+        Field(
+            default=DEFAULT_DIRECTORY_PAGE_SIZE,
+            validation_alias=AliasChoices("page_size", "limit", "per_page"),
+        ),
+    ] = DEFAULT_DIRECTORY_PAGE_SIZE,
+    output_format: Literal["text", "json"] = "text",
     project: Optional[str] = None,
     project_id: Optional[str] = None,
     context: Context | None = None,
-) -> str:
+) -> str | dict[str, Any]:
     """List directory contents from the knowledge base with optional filtering.
 
     This tool provides 'ls' functionality for browsing the knowledge base directory structure.
@@ -55,6 +68,9 @@ async def list_directory(
                Higher values show subdirectory contents recursively
         file_name_glob: Optional glob pattern for filtering file names
                        Examples: "*.md", "*meeting*", "project_*"
+        page: One-indexed result page (default: 1)
+        page_size: Number of nodes per page (default: 10, maximum: 200)
+        output_format: "text" for a readable listing or "json" for structured pagination data
         project: Project name to list directory from. Optional - server will resolve using hierarchy.
                 If unknown, use list_memory_projects() to discover available projects.
         project_id: Project external_id (UUID). Prefer this over `project` when known —
@@ -81,12 +97,22 @@ async def list_directory(
         # Find meeting notes in projects folder
         list_directory(dir_name="/projects", file_name_glob="*meeting*")
 
+        # Continue a large listing
+        list_directory(dir_name="/projects", page=2, page_size=10)
+
         # Explicit project specification
         list_directory(project="work-docs", dir_name="/projects")
 
     Raises:
         ToolError: If project doesn't exist or directory path is invalid
     """
+    if page < 1:
+        raise ValueError(f"page must be >= 1, got {page}")
+    if page_size < 1:
+        raise ValueError(f"page_size must be >= 1, got {page_size}")
+    if page_size > MAX_DIRECTORY_PAGE_SIZE:
+        raise ValueError(f"page_size must be <= {MAX_DIRECTORY_PAGE_SIZE}, got {page_size}")
+
     async with get_project_client(project, context=context, project_id=project_id) as (
         client,
         active_project,
@@ -100,7 +126,18 @@ async def list_directory(
 
         # Use typed DirectoryClient for API calls
         directory_client = DirectoryClient(client, active_project.external_id)
-        nodes = await directory_client.list(dir_name, depth=depth, file_name_glob=file_name_glob)
+        listing = await directory_client.list(
+            dir_name,
+            depth=depth,
+            file_name_glob=file_name_glob,
+            page=page,
+            page_size=page_size,
+        )
+
+        if output_format == "json":
+            return listing.model_dump(mode="json")
+
+        nodes = [node.model_dump(mode="json", exclude_none=True) for node in listing.nodes]
 
         if not nodes:
             filter_desc = ""
@@ -116,6 +153,9 @@ async def list_directory(
             )
         else:
             output_lines.append(f"Contents of '{dir_name}' (depth {depth}):")
+        output_lines.append(
+            f"Page {listing.page} (page size {listing.page_size}, {listing.total} total items)"
+        )
         output_lines.append("")
 
         # Group by type and sort
@@ -183,5 +223,25 @@ async def list_directory(
             summary_parts.append(f"{len(files)} file{'s' if len(files) != 1 else ''}")
 
         output_lines.append(f"Total: {total_count} items ({', '.join(summary_parts)})")
+
+        if listing.has_more:
+            next_page = listing.page + 1
+            continuation_args = [
+                f"dir_name={dir_name!r}",
+                f"depth={depth}",
+                f"page={next_page}",
+                f"page_size={listing.page_size}",
+            ]
+            if file_name_glob:
+                continuation_args.append(f"file_name_glob={file_name_glob!r}")
+            if project:
+                continuation_args.append(f"project={project!r}")
+            output_lines.extend(
+                [
+                    "",
+                    "More results available. Call "
+                    f"list_directory({', '.join(continuation_args)}) to continue.",
+                ]
+            )
 
         return "\n".join(output_lines)

--- a/src/basic_memory/schemas/directory.py
+++ b/src/basic_memory/schemas/directory.py
@@ -5,6 +5,9 @@ from typing import List, Optional, Literal
 
 from pydantic import BaseModel
 
+DEFAULT_DIRECTORY_PAGE_SIZE = 10
+MAX_DIRECTORY_PAGE_SIZE = 200
+
 
 class DirectoryNode(BaseModel):
     """Directory node in file system."""
@@ -25,6 +28,16 @@ class DirectoryNode(BaseModel):
     @property
     def has_children(self) -> bool:
         return bool(self.children)
+
+
+class DirectoryListResponse(BaseModel):
+    """One bounded page of directory-listing results."""
+
+    nodes: List[DirectoryNode]
+    page: int
+    page_size: int
+    total: int
+    has_more: bool
 
 
 # Support for recursive model

--- a/src/basic_memory/services/directory_service.py
+++ b/src/basic_memory/services/directory_service.py
@@ -240,7 +240,9 @@ class DirectoryService:
         total = len(result)
         start = (page - 1) * page_size
         end = start + page_size
-        nodes = result[start:end]
+        # Directory nodes in the collection still reference their complete child trees.
+        # Returning those trees would bypass the page bound when the response is serialized.
+        nodes = [node.model_copy(update={"children": []}) for node in result[start:end]]
         return DirectoryListResponse(
             nodes=nodes,
             page=page,

--- a/src/basic_memory/services/directory_service.py
+++ b/src/basic_memory/services/directory_service.py
@@ -12,7 +12,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from basic_memory import db
 from basic_memory.models import Entity
 from basic_memory.repository import EntityRepository
-from basic_memory.schemas.directory import DirectoryNode
+from basic_memory.schemas.directory import (
+    DEFAULT_DIRECTORY_PAGE_SIZE,
+    MAX_DIRECTORY_PAGE_SIZE,
+    DirectoryListResponse,
+    DirectoryNode,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -162,17 +167,28 @@ class DirectoryService:
         dir_name: str = "/",
         depth: int = 1,
         file_name_glob: Optional[str] = None,
-    ) -> List[DirectoryNode]:
+        page: int = 1,
+        page_size: int = DEFAULT_DIRECTORY_PAGE_SIZE,
+    ) -> DirectoryListResponse:
         """List directory contents with filtering and depth control.
 
         Args:
             dir_name: Directory path to list (default: root "/")
             depth: Recursion depth (1 = immediate children only)
             file_name_glob: Glob pattern for filtering file names
+            page: One-indexed result page
+            page_size: Number of nodes per page
 
         Returns:
-            List of DirectoryNode objects matching the criteria
+            Bounded page of DirectoryNode objects matching the criteria
         """
+        if page < 1:
+            raise ValueError(f"page must be >= 1, got {page}")
+        if page_size < 1:
+            raise ValueError(f"page_size must be >= 1, got {page_size}")
+        if page_size > MAX_DIRECTORY_PAGE_SIZE:
+            raise ValueError(f"page_size must be <= {MAX_DIRECTORY_PAGE_SIZE}, got {page_size}")
+
         # Normalize directory path
         # Strip ./ prefix if present (handles relative path notation)
         if dir_name.startswith("./"):
@@ -198,13 +214,40 @@ class DirectoryService:
         # Find the target directory node
         target_node = self._find_directory_node(root_tree, dir_name)
         if not target_node:
-            return []  # pragma: no cover
+            return DirectoryListResponse(  # pragma: no cover
+                nodes=[],
+                page=page,
+                page_size=page_size,
+                total=0,
+                has_more=False,
+            )
 
         # Collect nodes with depth and glob filtering
         result = []
         self._collect_nodes_recursive(target_node, result, depth, file_name_glob, 0)
 
-        return result
+        # Stable ordering is required before slicing so repeated page requests
+        # neither skip nor duplicate nodes when repository row order changes.
+        result.sort(
+            key=lambda node: (
+                0 if node.type == "directory" else 1,
+                node.name.casefold(),
+                node.directory_path.casefold(),
+                node.directory_path,
+            )
+        )
+
+        total = len(result)
+        start = (page - 1) * page_size
+        end = start + page_size
+        nodes = result[start:end]
+        return DirectoryListResponse(
+            nodes=nodes,
+            page=page,
+            page_size=page_size,
+            total=total,
+            has_more=end < total,
+        )
 
     def _build_directory_tree_from_entities(
         self, entity_rows: Sequence[Entity], root_path: str

--- a/test-int/mcp/test_list_directory_integration.py
+++ b/test-int/mcp/test_list_directory_integration.py
@@ -4,6 +4,8 @@ Integration tests for list_directory MCP tool.
 Tests the complete list directory workflow: MCP client -> MCP server -> FastAPI -> database -> file system
 """
 
+import json
+
 import pytest
 from fastmcp import Client
 
@@ -70,6 +72,55 @@ async def test_list_directory_basic_operation(mcp_server, app, test_project):
         assert "Total:" in list_text
         assert "directories" in list_text
         assert "file" in list_text
+
+
+@pytest.mark.asyncio
+async def test_list_directory_pagination_text_and_json(mcp_server, app, test_project):
+    """MCP pagination stays bounded and exposes continuation metadata in both formats."""
+    async with Client(mcp_server) as client:
+        for title in ["Alpha", "Bravo", "Charlie", "Delta", "Echo"]:
+            await client.call_tool(
+                "write_note",
+                {
+                    "project": test_project.name,
+                    "title": title,
+                    "directory": "paged",
+                    "content": f"# {title}\n\nPaged note.",
+                },
+            )
+
+        text_result = await client.call_tool(
+            "list_directory",
+            {
+                "project": test_project.name,
+                "dir_name": "/paged",
+                "page": 1,
+                "page_size": 2,
+            },
+        )
+        text_result_value = text_result.content[0].text
+        assert "Page 1 (page size 2, 5 total items)" in text_result_value
+        assert "Alpha.md" in text_result_value
+        assert "Bravo.md" in text_result_value
+        assert "Charlie.md" not in text_result_value
+        assert "page=2" in text_result_value
+
+        json_result = await client.call_tool(
+            "list_directory",
+            {
+                "project": test_project.name,
+                "dir_name": "/paged",
+                "page": 2,
+                "page_size": 2,
+                "output_format": "json",
+            },
+        )
+        payload = json.loads(json_result.content[0].text)
+        assert payload["page"] == 2
+        assert payload["page_size"] == 2
+        assert payload["total"] == 5
+        assert payload["has_more"] is True
+        assert [node["name"] for node in payload["nodes"]] == ["Charlie.md", "Delta.md"]
 
 
 @pytest.mark.asyncio

--- a/tests/api/v2/test_directory_router.py
+++ b/tests/api/v2/test_directory_router.py
@@ -4,7 +4,7 @@ import pytest
 from httpx import AsyncClient
 
 from basic_memory.models import Project
-from basic_memory.schemas.directory import DirectoryNode
+from basic_memory.schemas.directory import DirectoryListResponse, DirectoryNode
 
 
 @pytest.mark.asyncio
@@ -49,8 +49,9 @@ async def test_list_directory_default(
     response = await client.get(f"{v2_project_url}/directory/list")
 
     assert response.status_code == 200
-    nodes = response.json()
-    assert isinstance(nodes, list)
+    listing = DirectoryListResponse.model_validate(response.json())
+    assert listing.page == 1
+    assert listing.page_size == 10
 
 
 @pytest.mark.asyncio
@@ -63,8 +64,8 @@ async def test_list_directory_with_depth(
     response = await client.get(f"{v2_project_url}/directory/list?depth=2")
 
     assert response.status_code == 200
-    nodes = response.json()
-    assert isinstance(nodes, list)
+    listing = DirectoryListResponse.model_validate(response.json())
+    assert listing.page == 1
 
 
 @pytest.mark.asyncio
@@ -77,12 +78,11 @@ async def test_list_directory_with_glob(
     response = await client.get(f"{v2_project_url}/directory/list?file_name_glob=*.md")
 
     assert response.status_code == 200
-    nodes = response.json()
-    assert isinstance(nodes, list)
+    listing = DirectoryListResponse.model_validate(response.json())
     # All file nodes should have .md extension
-    for node in nodes:
-        if node.get("type") == "file":
-            assert node.get("path", "").endswith(".md")
+    for node in listing.nodes:
+        if node.type == "file":
+            assert (node.file_path or "").endswith(".md")
 
 
 @pytest.mark.asyncio
@@ -95,8 +95,36 @@ async def test_list_directory_with_custom_path(
     response = await client.get(f"{v2_project_url}/directory/list?dir_name=/")
 
     assert response.status_code == 200
-    nodes = response.json()
-    assert isinstance(nodes, list)
+    listing = DirectoryListResponse.model_validate(response.json())
+    assert listing.page == 1
+
+
+@pytest.mark.asyncio
+async def test_list_directory_with_pagination(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+):
+    """Directory list accepts bounded pagination and returns metadata."""
+    response = await client.get(f"{v2_project_url}/directory/list?page=2&page_size=3")
+
+    assert response.status_code == 200
+    listing = DirectoryListResponse.model_validate(response.json())
+    assert listing.page == 2
+    assert listing.page_size == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query", ["page=0", "page_size=0", "page_size=201"])
+async def test_list_directory_rejects_invalid_pagination(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    query: str,
+):
+    response = await client.get(f"{v2_project_url}/directory/list?{query}")
+
+    assert response.status_code == 422
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/clients/test_clients.py
+++ b/tests/mcp/clients/test_clients.py
@@ -423,19 +423,40 @@ class TestDirectoryClient:
         """Test list calls correct endpoint."""
 
         mock_response = MagicMock()
-        mock_response.json.return_value = [{"name": "folder", "type": "directory"}]
+        mock_response.json.return_value = {
+            "nodes": [
+                {
+                    "name": "folder",
+                    "directory_path": "/folder",
+                    "type": "directory",
+                }
+            ],
+            "page": 2,
+            "page_size": 4,
+            "total": 5,
+            "has_more": False,
+        }
 
         async def mock_call_get(client, url, **kwargs):
             assert "/v2/projects/proj-123/directory/list" in url
+            assert kwargs["params"] == {
+                "dir_name": "/",
+                "depth": 2,
+                "page": 2,
+                "page_size": 4,
+                "file_name_glob": "*.md",
+            }
             return mock_response
 
         monkeypatch.setattr("basic_memory.mcp.tools.utils.call_get", mock_call_get)
 
         mock_http = MagicMock()
         client = DirectoryClient(mock_http, "proj-123")
-        result = await client.list("/")
-        assert len(result) == 1
-        assert result[0]["name"] == "folder"
+        result = await client.list("/", depth=2, file_name_glob="*.md", page=2, page_size=4)
+        assert len(result.nodes) == 1
+        assert result.nodes[0].name == "folder"
+        assert result.page == 2
+        assert result.total == 5
 
 
 class TestResourceClient:

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -50,7 +50,16 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "output_format",
     ],
     "fetch": ["id"],
-    "list_directory": ["dir_name", "depth", "file_name_glob", "project", "project_id"],
+    "list_directory": [
+        "dir_name",
+        "depth",
+        "file_name_glob",
+        "page",
+        "page_size",
+        "output_format",
+        "project",
+        "project_id",
+    ],
     "list_memory_projects": ["output_format"],
     "list_workspaces": ["output_format"],
     "move_note": [

--- a/tests/mcp/test_tool_list_directory.py
+++ b/tests/mcp/test_tool_list_directory.py
@@ -241,3 +241,76 @@ async def test_list_directory_file_rows_include_external_id(client, test_graph, 
     assert file_lines, f"no file rows in: {result!r}"
     for line in file_lines:
         assert re.search(uuid_pattern, line), f"file row missing external_id: {line!r}"
+
+
+@pytest.mark.asyncio
+async def test_list_directory_text_pagination_includes_continuation(
+    client,
+    test_graph,
+    test_project,
+):
+    result = await list_directory(
+        project=test_project.name,
+        dir_name="/test",
+        page=1,
+        page_size=2,
+    )
+
+    assert isinstance(result, str)
+    assert "Page 1 (page size 2, 5 total items)" in result
+    assert "📄 Connected Entity 1.md" in result
+    assert "📄 Connected Entity 2.md" in result
+    assert "Deep Entity.md" not in result
+    assert "page=2" in result
+    assert "page_size=2" in result
+
+
+@pytest.mark.asyncio
+async def test_list_directory_json_pagination_preserves_glob_and_depth(
+    client,
+    test_graph,
+    test_project,
+):
+    result = await list_directory(
+        project=test_project.name,
+        dir_name="/test",
+        depth=2,
+        file_name_glob="*Entity*",
+        page=2,
+        page_size=2,
+        output_format="json",
+    )
+
+    assert isinstance(result, dict)
+    assert result["page"] == 2
+    assert result["page_size"] == 2
+    assert result["total"] == 4
+    assert result["has_more"] is False
+    assert [node["name"] for node in result["nodes"]] == [
+        "Deep Entity.md",
+        "Deeper Entity.md",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("page", "page_size", "message"),
+    [
+        (0, 10, "page must be >= 1"),
+        (1, 0, "page_size must be >= 1"),
+        (1, 201, "page_size must be <= 200"),
+    ],
+)
+async def test_list_directory_rejects_invalid_pagination(
+    client,
+    test_project,
+    page: int,
+    page_size: int,
+    message: str,
+):
+    with pytest.raises(ValueError, match=message):
+        await list_directory(
+            project=test_project.name,
+            page=page,
+            page_size=page_size,
+        )

--- a/tests/mcp/test_tool_list_directory.py
+++ b/tests/mcp/test_tool_list_directory.py
@@ -266,6 +266,47 @@ async def test_list_directory_text_pagination_includes_continuation(
 
 
 @pytest.mark.asyncio
+async def test_list_directory_continuation_preserves_project_id(
+    client,
+    test_graph,
+    test_project,
+):
+    result = await list_directory(
+        project_id=test_project.external_id,
+        dir_name="/test",
+        file_name_glob="*Entity*",
+        page=1,
+        page_size=2,
+    )
+
+    assert isinstance(result, str)
+    assert "file_name_glob='*Entity*'" in result
+    assert f"project_id={test_project.external_id!r}" in result
+    assert "project=" not in result
+
+
+@pytest.mark.asyncio
+async def test_list_directory_out_of_range_page_reports_pagination(
+    client,
+    test_graph,
+    test_project,
+):
+    result = await list_directory(
+        project=test_project.name,
+        dir_name="/test",
+        page=4,
+        page_size=2,
+    )
+
+    assert isinstance(result, str)
+    assert "Page 4 (page size 2, 5 total items)" in result
+    assert "No items on this page." in result
+    assert "Total: 0 items" in result
+    assert "the last available page is 3" in result
+    assert "No files found" not in result
+
+
+@pytest.mark.asyncio
 async def test_list_directory_json_pagination_preserves_glob_and_depth(
     client,
     test_graph,

--- a/tests/services/test_directory_service.py
+++ b/tests/services/test_directory_service.py
@@ -64,7 +64,9 @@ async def test_directory_tree(directory_service: DirectoryService, test_graph):
 async def test_list_directory_empty(directory_service: DirectoryService):
     """Test listing directory with no entities."""
     result = await directory_service.list_directory()
-    assert result == []
+    assert result.nodes == []
+    assert result.total == 0
+    assert result.has_more is False
 
 
 @pytest.mark.asyncio
@@ -73,10 +75,10 @@ async def test_list_directory_root(directory_service: DirectoryService, test_gra
     result = await directory_service.list_directory(dir_name="/")
 
     # Should return immediate children of root (the "test" directory)
-    assert len(result) == 1
-    assert result[0].name == "test"
-    assert result[0].type == "directory"
-    assert result[0].directory_path == "/test"
+    assert len(result.nodes) == 1
+    assert result.nodes[0].name == "test"
+    assert result.nodes[0].type == "directory"
+    assert result.nodes[0].directory_path == "/test"
 
 
 @pytest.mark.asyncio
@@ -85,8 +87,8 @@ async def test_list_directory_specific_path(directory_service: DirectoryService,
     result = await directory_service.list_directory(dir_name="/test")
 
     # Should return the 5 files in the test directory
-    assert len(result) == 5
-    file_names = {node.name for node in result}
+    assert len(result.nodes) == 5
+    file_names = {node.name for node in result.nodes}
     expected_files = {
         "Connected Entity 1.md",
         "Connected Entity 2.md",
@@ -97,7 +99,7 @@ async def test_list_directory_specific_path(directory_service: DirectoryService,
     assert file_names == expected_files
 
     # All should be files
-    for node in result:
+    for node in result.nodes:
         assert node.type == "file"
 
 
@@ -105,7 +107,7 @@ async def test_list_directory_specific_path(directory_service: DirectoryService,
 async def test_list_directory_nonexistent_path(directory_service: DirectoryService, test_graph):
     """Test listing nonexistent directory."""
     result = await directory_service.list_directory(dir_name="/nonexistent")
-    assert result == []
+    assert result.nodes == []
 
 
 @pytest.mark.asyncio
@@ -114,8 +116,8 @@ async def test_list_directory_with_glob_filter(directory_service: DirectoryServi
     # Filter for files containing "Connected"
     result = await directory_service.list_directory(dir_name="/test", file_name_glob="*Connected*")
 
-    assert len(result) == 2
-    file_names = {node.name for node in result}
+    assert len(result.nodes) == 2
+    file_names = {node.name for node in result.nodes}
     assert file_names == {"Connected Entity 1.md", "Connected Entity 2.md"}
 
 
@@ -125,7 +127,7 @@ async def test_list_directory_with_markdown_filter(directory_service: DirectoryS
     result = await directory_service.list_directory(dir_name="/test", file_name_glob="*.md")
 
     # All files in test_graph are markdown files
-    assert len(result) == 5
+    assert len(result.nodes) == 5
 
 
 @pytest.mark.asyncio
@@ -135,8 +137,8 @@ async def test_list_directory_with_specific_file_filter(
     """Test listing directory with specific file pattern."""
     result = await directory_service.list_directory(dir_name="/test", file_name_glob="Root.*")
 
-    assert len(result) == 1
-    assert result[0].name == "Root.md"
+    assert len(result.nodes) == 1
+    assert result.nodes[0].name == "Root.md"
 
 
 @pytest.mark.asyncio
@@ -144,11 +146,11 @@ async def test_list_directory_depth_control(directory_service: DirectoryService,
     """Test listing directory with depth control."""
     # Depth 1 should only return immediate children
     result_depth_1 = await directory_service.list_directory(dir_name="/", depth=1)
-    assert len(result_depth_1) == 1  # Just the "test" directory
+    assert len(result_depth_1.nodes) == 1  # Just the "test" directory
 
     # Depth 2 should return directory + its contents
     result_depth_2 = await directory_service.list_directory(dir_name="/", depth=2)
-    assert len(result_depth_2) == 6  # "test" directory + 5 files in it
+    assert len(result_depth_2.nodes) == 6  # "test" directory + 5 files in it
 
 
 @pytest.mark.asyncio
@@ -161,10 +163,10 @@ async def test_list_directory_path_normalization(directory_service: DirectorySer
 
     for path in paths_to_test:
         result = await directory_service.list_directory(dir_name=path)
-        assert len(result) == len(base_result)
+        assert len(result.nodes) == len(base_result.nodes)
         # Compare by name since the objects might be different instances
-        result_names = {node.name for node in result}
-        base_names = {node.name for node in base_result}
+        result_names = {node.name for node in result.nodes}
+        base_names = {node.name for node in base_result.nodes}
         assert result_names == base_names
 
 
@@ -181,12 +183,12 @@ async def test_list_directory_dot_slash_prefix_normalization(
 
     for path in dot_paths_to_test:
         result = await directory_service.list_directory(dir_name=path)
-        assert len(result) == len(base_result), (
-            f"Path '{path}' returned {len(result)} results, expected {len(base_result)}"
+        assert len(result.nodes) == len(base_result.nodes), (
+            f"Path '{path}' returned {len(result.nodes)} results, expected {len(base_result.nodes)}"
         )
         # Compare by name since the objects might be different instances
-        result_names = {node.name for node in result}
-        base_names = {node.name for node in base_result}
+        result_names = {node.name for node in result.nodes}
+        base_names = {node.name for node in base_result.nodes}
         assert result_names == base_names, f"Path '{path}' returned different files than expected"
 
 
@@ -196,7 +198,7 @@ async def test_list_directory_glob_no_matches(directory_service: DirectoryServic
     result = await directory_service.list_directory(
         dir_name="/test", file_name_glob="*.nonexistent"
     )
-    assert result == []
+    assert result.nodes == []
 
 
 @pytest.mark.asyncio
@@ -205,9 +207,73 @@ async def test_list_directory_default_parameters(directory_service: DirectorySer
     # Should default to root directory, depth 1, no glob filter
     result = await directory_service.list_directory()
 
-    assert len(result) == 1
-    assert result[0].name == "test"
-    assert result[0].type == "directory"
+    assert len(result.nodes) == 1
+    assert result.nodes[0].name == "test"
+    assert result.nodes[0].type == "directory"
+
+
+@pytest.mark.asyncio
+async def test_list_directory_paginates_with_stable_order(
+    directory_service: DirectoryService,
+    test_graph,
+):
+    """Pages use one stable order and expose exact continuation metadata."""
+    first = await directory_service.list_directory(dir_name="/test", page=1, page_size=2)
+    second = await directory_service.list_directory(dir_name="/test", page=2, page_size=2)
+    third = await directory_service.list_directory(dir_name="/test", page=3, page_size=2)
+
+    assert [node.name for node in first.nodes] == [
+        "Connected Entity 1.md",
+        "Connected Entity 2.md",
+    ]
+    assert [node.name for node in second.nodes] == ["Deep Entity.md", "Deeper Entity.md"]
+    assert [node.name for node in third.nodes] == ["Root.md"]
+    assert first.model_dump(exclude={"nodes"}) == {
+        "page": 1,
+        "page_size": 2,
+        "total": 5,
+        "has_more": True,
+    }
+    assert second.has_more is True
+    assert third.has_more is False
+
+
+@pytest.mark.asyncio
+async def test_list_directory_orders_directories_before_files_across_depth(
+    directory_service: DirectoryService,
+    test_graph,
+):
+    """Recursive pages keep directories before files regardless of repository row order."""
+    result = await directory_service.list_directory(dir_name="/", depth=2, page_size=10)
+
+    assert [node.type for node in result.nodes] == [
+        "directory",
+        "file",
+        "file",
+        "file",
+        "file",
+        "file",
+    ]
+    assert result.nodes[0].name == "test"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("page", "page_size", "message"),
+    [
+        (0, 10, "page must be >= 1"),
+        (1, 0, "page_size must be >= 1"),
+        (1, 201, "page_size must be <= 200"),
+    ],
+)
+async def test_list_directory_rejects_invalid_pagination(
+    directory_service: DirectoryService,
+    page: int,
+    page_size: int,
+    message: str,
+):
+    with pytest.raises(ValueError, match=message):
+        await directory_service.list_directory(page=page, page_size=page_size)
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_directory_service.py
+++ b/tests/services/test_directory_service.py
@@ -79,6 +79,21 @@ async def test_list_directory_root(directory_service: DirectoryService, test_gra
     assert result.nodes[0].name == "test"
     assert result.nodes[0].type == "directory"
     assert result.nodes[0].directory_path == "/test"
+    assert result.nodes[0].children == []
+
+
+@pytest.mark.asyncio
+async def test_list_directory_page_does_not_embed_descendants(
+    directory_service: DirectoryService,
+    test_graph,
+):
+    """A paginated directory node must not smuggle its full child tree into JSON."""
+    result = await directory_service.list_directory(dir_name="/", depth=1, page_size=1)
+
+    assert len(result.nodes) == 1
+    assert result.nodes[0].name == "test"
+    assert result.nodes[0].children == []
+    assert "Connected Entity 1.md" not in result.model_dump_json()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

`list_directory` returned every matching node, so large projects could generate oversized MCP responses. Cloud-side decorations are bounded, but the core listing itself was not.

## What changed

- default directory pages to 10 nodes and cap requests at 200
- sort directories before files with deterministic name/path tie-breakers before slicing
- return exact `page`, `page_size`, `total`, and `has_more` metadata through the service, v2 API, and typed client
- add `page`, `page_size`, and `output_format` to the MCP tool
- preserve the existing readable rows while adding page status and explicit continuation guidance
- cover text and JSON output, recursive depth, glob filtering, stable ordering, validation, and end-to-end MCP behavior

The v2 `/directory/list` response changes from a bare array to a paginated object, so this should ship with the normal Basic Memory release and ChatGPT app review path. No manual deployment is part of this PR.

## Verification

- `just fast-check`
- `uv run pytest tests/services/test_directory_service.py tests/api/v2/test_directory_router.py tests/mcp/clients/test_clients.py::TestDirectoryClient tests/mcp/test_tool_list_directory.py test-int/mcp/test_list_directory_integration.py -q` (64 passed)

Fixes #1048
