### PR TITLE
fix(cli): replace retired Basic Memory links

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ multi-word ones.
 
 Bare `- [[Target]]` and prose `- Worth checking out [[Target]]` index as
 `links_to`. Full reference in the
-[docs](https://docs.basicmemory.com/getting-started/note-formatting/?utm_source=github&utm_medium=referral&utm_campaign=readme).
+[docs](https://docs.basicmemory.com/concepts/knowledge-format?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
 ## MCP tools
 
@@ -525,7 +525,7 @@ basic-memory import memory-json
 
 Routing flags (`--local` / `--cloud`) force a target when you're in mixed
 mode. Full CLI reference in the
-[docs](https://docs.basicmemory.com/guides/cli-reference/?utm_source=github&utm_medium=referral&utm_campaign=readme).
+[docs](https://docs.basicmemory.com/reference/cli-reference?utm_source=github&utm_medium=referral&utm_campaign=readme).
 
 ## Auto-updates
 

--- a/docs/cloud-cli.md
+++ b/docs/cloud-cli.md
@@ -32,7 +32,7 @@ The transfer commands fall into two groups:
 Before using Basic Memory Cloud, you need:
 
 - **Active Subscription**: An active Basic Memory Cloud subscription is required to access cloud features
-- **Subscribe**: Visit [https://basicmemory.com/subscribe](https://basicmemory.com/subscribe) to sign up
+- **Subscribe**: Visit [https://basicmemory.com/pricing](https://basicmemory.com/pricing) to sign up
 - **Optional**: Cloud is optional. Local-first open-source usage continues without cloud.
 - **OSS Discount**: Use code `{{OSS_DISCOUNT_CODE}}` for 20% off for 3 months.
 

--- a/src/basic_memory/cli/commands/cloud/api_client.py
+++ b/src/basic_memory/cli/commands/cloud/api_client.py
@@ -121,7 +121,7 @@ async def make_api_request(
                 ):
                     message = detail_obj.get("message", "Active subscription required")
                     subscribe_url = detail_obj.get(
-                        "subscribe_url", "https://basicmemory.com/subscribe"
+                        "subscribe_url", "https://basicmemory.com/pricing"
                     )
                     raise SubscriptionRequiredError(
                         message=message, subscribe_url=subscribe_url

--- a/tests/cli/test_cloud_authentication.py
+++ b/tests/cli/test_cloud_authentication.py
@@ -102,6 +102,31 @@ class TestAPIClientErrorHandling:
         assert err.subscribe_url == "https://basicmemory.com/subscribe"
 
     @pytest.mark.asyncio
+    async def test_subscription_required_error_defaults_to_pricing(self):
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                403,
+                json={
+                    "detail": {
+                        "error": "subscription_required",
+                        "message": "Active subscription required",
+                    }
+                },
+                request=request,
+            )
+
+        auth = _StubAuth()
+        with pytest.raises(SubscriptionRequiredError) as exc_info:
+            await make_api_request(
+                "GET",
+                "https://test.com/api/endpoint",
+                auth=_auth(auth),
+                http_client_factory=_make_http_client_factory(handler),
+            )
+
+        assert exc_info.value.subscribe_url == "https://basicmemory.com/pricing"
+
+    @pytest.mark.asyncio
     async def test_parse_generic_403_error(self):
         async def handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(


### PR DESCRIPTION
## Why

The link fixes proposed in #1026 are valid, but that external-contributor PR remains blocked on the CLA. This is an independent maintainer implementation; no contributor commit was copied.

The retired documentation paths and subscription URL return 404s. The CLI also retained the retired subscription URL as its fallback when the cloud API omits a `subscribe_url`.

## What changed

- update the README knowledge-format and CLI-reference links to their canonical documentation paths
- update the cloud CLI guide to use the pricing page
- update the CLI subscription-required fallback to use the pricing page
- add a regression test for the missing-`subscribe_url` fallback

Server-provided subscription URLs still take precedence.

## Validation

- `uv run pytest tests/cli/test_cloud_authentication.py -q` — 10 passed
- `just fast-check`
- verified the three replacement URLs return HTTP 200

## Risk

Low. The runtime change only affects the fallback URL when the cloud API does not provide one.

Supersedes #1026.