### PR TITLE
fix(mcp): index recreated projects

### DIFF
--- a/src/basic_memory/mcp/project_context.py
+++ b/src/basic_memory/mcp/project_context.py
@@ -749,6 +749,12 @@ async def invalidate_workspace_project_index(context: Optional[Context] = None) 
         await context.set_state(_WORKSPACE_PROJECT_INDEX_STATE_KEY, None)
 
 
+async def invalidate_project_caches(context: Optional[Context] = None) -> None:
+    """Invalidate project identity caches after a project lifecycle change."""
+    await _clear_cached_active_project(context)
+    await invalidate_workspace_project_index(context)
+
+
 async def _fetch_workspace_project_entries(
     workspace: WorkspaceInfo,
     context: Optional[Context] = None,

--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -621,47 +621,83 @@ async def create_memory_project(
             )
 
         status_response = await project_client.create_project(project_request.model_dump())
-        from basic_memory.mcp.project_context import invalidate_workspace_project_index
+        from basic_memory.mcp.project_context import invalidate_project_caches
 
-        await invalidate_workspace_project_index(context)
+        await invalidate_project_caches(context)
+
+        new_project = status_response.new_project
+        if new_project is None:
+            raise RuntimeError("Project creation succeeded without returning the new project")
+
+        # Local indexing can finish inline, so retained files are immediately
+        # available. Cloud must use its durable background workflow; that route
+        # awaits the PGQueuer handoff before acknowledging the request (#1084).
+        index_in_background = _routes_to_cloud(workspace_id)
+        index_response = await project_client.index(
+            new_project.external_id,
+            run_in_background=index_in_background,
+        )
+        indexing = {
+            **index_response,
+            "state": "accepted" if index_in_background else "completed",
+        }
 
         if output_format == "json":
-            new_project = status_response.new_project
             return {
-                "name": new_project.name if new_project else project_name,
-                "external_id": new_project.external_id if new_project else None,
-                "path": new_project.path if new_project else project_path,
-                "is_default": bool(
-                    (new_project.is_default if new_project else False) or set_default
-                ),
+                "name": new_project.name,
+                "external_id": new_project.external_id,
+                "path": new_project.path,
+                "is_default": bool(new_project.is_default or set_default),
                 "created": True,
                 "already_exists": False,
+                "indexing": indexing,
             }
 
         result = f"✓ {status_response.message}\n\n"
 
-        if status_response.new_project:
-            result += "Project Details:\n"
-            result += f"• Name: {status_response.new_project.name}\n"
-            result += f"• External ID: {status_response.new_project.external_id}\n"
-            result += f"• Path: {status_response.new_project.path}\n"
+        result += "Project Details:\n"
+        result += f"• Name: {new_project.name}\n"
+        result += f"• External ID: {new_project.external_id}\n"
+        result += f"• Path: {new_project.path}\n"
 
-            if set_default:
-                result += "• Set as default project\n"
+        if set_default:
+            result += "• Set as default project\n"
 
-        result += "\nProject is now available for use in tool calls.\n"
+        result += "\nIndexing:\n"
+        result += f"• State: {indexing['state']}\n"
+        if status := indexing.get("status"):
+            result += f"• Status: {status}\n"
+        if message := indexing.get("message"):
+            result += f"• Message: {message}\n"
+        if job_id := indexing.get("job_id"):
+            result += f"• Job ID: {job_id}\n"
+        for key, label in (
+            ("total_files", "Files discovered"),
+            ("enqueued_files", "Files enqueued"),
+            ("enqueued_batches", "Batches enqueued"),
+            ("deleted_files", "Orphans deleted"),
+        ):
+            if key in indexing:
+                result += f"• {label}: {indexing[key]}\n"
+
+        if index_in_background:
+            result += (
+                "\nProject created. Retained content will become readable and searchable "
+                "when indexing completes.\n"
+            )
+        else:
+            result += "\nProject is now available for use in tool calls; indexing completed.\n"
         result += f"Use '{project_name}' as the project parameter in MCP tool calls.\n"
 
         return result
 
 
-def _delete_routes_to_cloud(workspace_id: str | None) -> bool:
-    """Mirror get_client's non-project routing to describe where a delete landed.
+def _routes_to_cloud(workspace_id: str | None) -> bool:
+    """Mirror get_client's non-project routing for project lifecycle operations.
 
-    Trigger: delete_project's result text must say whether the project's note
-        files live on local disk or in cloud storage.
-    Why: the previous text always claimed "Files remain on disk", which is
-        wrong for cloud-routed deletes (#1034).
+    Trigger: project creation and deletion need backend-specific behavior.
+    Why: cloud indexing must be asynchronous, and delete output must describe
+        whether retained files live on local disk or in cloud storage.
     Outcome: True when get_client(workspace=...) serves the request from a
         cloud backend (factory mode, explicit --cloud, or a workspace selector).
     """
@@ -784,9 +820,9 @@ async def delete_project(
         status_response = await project_client.delete_project(
             target_project.external_id, delete_notes=delete_notes
         )
-        from basic_memory.mcp.project_context import invalidate_workspace_project_index
+        from basic_memory.mcp.project_context import invalidate_project_caches
 
-        await invalidate_workspace_project_index(context)
+        await invalidate_project_caches(context)
 
         result = f"✓ {status_response.message}\n\n"
 
@@ -803,7 +839,7 @@ async def delete_project(
             if status_response.job_id:
                 result += f"• Deletion job ID: {status_response.job_id}\n"
 
-        cloud_routed = _delete_routes_to_cloud(workspace_id)
+        cloud_routed = _routes_to_cloud(workspace_id)
         files_location = "in cloud storage" if cloud_routed else "on disk"
         if delete_notes:
             result += _format_note_file_delete_result(

--- a/src/basic_memory/mcp/tools/project_management.py
+++ b/src/basic_memory/mcp/tools/project_management.py
@@ -505,6 +505,39 @@ async def _resolve_workspace_routing(
     return resolved_workspace.tenant_id
 
 
+def _normalize_indexing_response(
+    index_response: dict[str, object],
+    *,
+    run_in_background: bool,
+) -> dict[str, object]:
+    """Add a stable lifecycle state to backend-specific indexing details."""
+    return {
+        **index_response,
+        "state": "accepted" if run_in_background else "completed",
+    }
+
+
+def _format_indexing_details(indexing: dict[str, object]) -> str:
+    """Format indexing state and the details returned by either backend."""
+    result = "Indexing:\n"
+    result += f"• State: {indexing['state']}\n"
+    if status := indexing.get("status"):
+        result += f"• Status: {status}\n"
+    if message := indexing.get("message"):
+        result += f"• Message: {message}\n"
+    if job_id := indexing.get("job_id"):
+        result += f"• Job ID: {job_id}\n"
+    for key, label in (
+        ("total_files", "Files discovered"),
+        ("enqueued_files", "Files enqueued"),
+        ("enqueued_batches", "Batches enqueued"),
+        ("deleted_files", "Orphans deleted"),
+    ):
+        if key in indexing:
+            result += f"• {label}: {indexing[key]}\n"
+    return result
+
+
 @mcp.tool(
     "create_memory_project",
     title="Create Memory Project",
@@ -597,9 +630,23 @@ async def create_memory_project(
             (p for p in existing.projects if p.name.casefold() == project_name.casefold()),
             None,
         )
+        index_in_background = _routes_to_cloud(workspace_id)
         if existing_match:
             is_default = bool(
                 existing_match.is_default or existing.default_project == existing_match.name
+            )
+            # Trigger: a previous create may have committed the project record
+            # before its indexing request failed or timed out.
+            # Why: create retries must repair that partial success instead of
+            # permanently short-circuiting on the existing project record.
+            # Outcome: idempotently request indexing again on the current backend.
+            index_response = await project_client.index(
+                existing_match.external_id,
+                run_in_background=index_in_background,
+            )
+            indexing = _normalize_indexing_response(
+                index_response,
+                run_in_background=index_in_background,
             )
             if output_format == "json":
                 return {
@@ -609,16 +656,28 @@ async def create_memory_project(
                     "is_default": is_default,
                     "created": False,
                     "already_exists": True,
+                    "indexing": indexing,
                 }
-            return (
+            result = (
                 f"✓ Project already exists: {existing_match.name}\n\n"
                 f"Project Details:\n"
                 f"• Name: {existing_match.name}\n"
                 f"• External ID: {existing_match.external_id}\n"
                 f"• Path: {existing_match.path}\n"
                 f"{'• Set as default project\n' if is_default else ''}"
-                "\nProject is already available for use in tool calls.\n"
+                "\n"
             )
+            result += _format_indexing_details(indexing)
+            if index_in_background:
+                result += (
+                    "\nProject already existed. Retained content will become readable and "
+                    "searchable when indexing completes.\n"
+                )
+            else:
+                result += (
+                    "\nProject is already available for use in tool calls; indexing completed.\n"
+                )
+            return result
 
         status_response = await project_client.create_project(project_request.model_dump())
         from basic_memory.mcp.project_context import invalidate_project_caches
@@ -632,15 +691,14 @@ async def create_memory_project(
         # Local indexing can finish inline, so retained files are immediately
         # available. Cloud must use its durable background workflow; that route
         # awaits the PGQueuer handoff before acknowledging the request (#1084).
-        index_in_background = _routes_to_cloud(workspace_id)
         index_response = await project_client.index(
             new_project.external_id,
             run_in_background=index_in_background,
         )
-        indexing = {
-            **index_response,
-            "state": "accepted" if index_in_background else "completed",
-        }
+        indexing = _normalize_indexing_response(
+            index_response,
+            run_in_background=index_in_background,
+        )
 
         if output_format == "json":
             return {
@@ -663,22 +721,8 @@ async def create_memory_project(
         if set_default:
             result += "• Set as default project\n"
 
-        result += "\nIndexing:\n"
-        result += f"• State: {indexing['state']}\n"
-        if status := indexing.get("status"):
-            result += f"• Status: {status}\n"
-        if message := indexing.get("message"):
-            result += f"• Message: {message}\n"
-        if job_id := indexing.get("job_id"):
-            result += f"• Job ID: {job_id}\n"
-        for key, label in (
-            ("total_files", "Files discovered"),
-            ("enqueued_files", "Files enqueued"),
-            ("enqueued_batches", "Batches enqueued"),
-            ("deleted_files", "Orphans deleted"),
-        ):
-            if key in indexing:
-                result += f"• {label}: {indexing[key]}\n"
+        result += "\n"
+        result += _format_indexing_details(indexing)
 
         if index_in_background:
             result += (

--- a/test-int/mcp/test_recreate_project_indexing_integration.py
+++ b/test-int/mcp/test_recreate_project_indexing_integration.py
@@ -1,0 +1,91 @@
+"""Regression coverage for retained-project recreation (#1084)."""
+
+import json
+from typing import Any
+
+import pytest
+from fastmcp import Client
+
+
+def _json_content(tool_result) -> Any:
+    assert len(tool_result.content) == 1
+    assert tool_result.content[0].type == "text"
+    return json.loads(tool_result.content[0].text)  # pyright: ignore [reportAttributeAccessIssue]
+
+
+@pytest.mark.asyncio
+async def test_recreate_retained_project_indexes_existing_notes(
+    mcp_server,
+    app,
+    test_project,
+    tmp_path,
+):
+    """Re-adding a retained local project restores read and search access."""
+    project_name = "retained-project"
+    project_path = tmp_path.parent / f"{tmp_path.name}-projects" / project_name
+    marker = "RETAINED_PROJECT_INDEX_MARKER"
+
+    async with Client(mcp_server) as client:
+        initial_create = await client.call_tool(
+            "create_memory_project",
+            {
+                "project_name": project_name,
+                "project_path": str(project_path),
+                "output_format": "json",
+            },
+        )
+        initial_payload = _json_content(initial_create)
+        assert initial_payload["indexing"]["state"] == "completed"
+        assert initial_payload["indexing"]["total_files"] == 0
+
+        await client.call_tool(
+            "write_note",
+            {
+                "project": project_name,
+                "title": "Retained Note",
+                "directory": "retained",
+                "content": f"# Retained Note\n\n{marker}",
+            },
+        )
+
+        await client.call_tool(
+            "delete_project",
+            {"project_name": project_name, "delete_notes": False},
+        )
+        assert list(project_path.rglob("*.md")), "delete_notes=false removed retained notes"
+
+        recreated = await client.call_tool(
+            "create_memory_project",
+            {
+                "project_name": project_name,
+                "project_path": str(project_path),
+                "output_format": "json",
+            },
+        )
+        recreated_payload = _json_content(recreated)
+        assert recreated_payload["created"] is True
+        assert recreated_payload["indexing"]["state"] == "completed"
+        assert recreated_payload["indexing"]["total_files"] >= 1
+        assert recreated_payload["indexing"]["enqueued_files"] >= 1
+
+        read_result = await client.call_tool(
+            "read_note",
+            {
+                "project": project_name,
+                "identifier": "retained/retained-note",
+                "output_format": "json",
+            },
+        )
+        assert marker in _json_content(read_result)["content"]
+
+        search_result = await client.call_tool(
+            "search_notes",
+            {
+                "project": project_name,
+                "query": marker,
+                "search_type": "text",
+                "output_format": "json",
+            },
+        )
+        search_payload = _json_content(search_result)
+        assert any(result["title"] == "Retained Note" for result in search_payload["results"])

--- a/tests/mcp/test_tool_project_management.py
+++ b/tests/mcp/test_tool_project_management.py
@@ -219,19 +219,36 @@ async def test_create_memory_project_resolves_workspace_slug(app, tmp_path_facto
             new_callable=AsyncMock,
             return_value=fake_status,
         ),
+        patch.object(
+            ProjectClient,
+            "index",
+            new_callable=AsyncMock,
+            return_value={"status": "index_started", "message": "Indexing accepted"},
+        ) as mock_index,
         patch(
-            "basic_memory.mcp.project_context.invalidate_workspace_project_index",
+            "basic_memory.mcp.project_context.invalidate_project_caches",
             new_callable=AsyncMock,
         ),
     ):
-        await create_memory_project(
+        result = await create_memory_project(
             project_name="WS Project",
             project_path=str(project_root),
             workspace="team-paul",
+            output_format="json",
         )
 
     mock_resolve_workspace.assert_awaited_once_with(workspace="team-paul", context=None)
     assert captured["workspace"] == "tenant-abc-123"
+    assert isinstance(result, dict)
+    assert result["indexing"] == {
+        "status": "index_started",
+        "message": "Indexing accepted",
+        "state": "accepted",
+    }
+    mock_index.assert_awaited_once_with(
+        "00000000-0000-0000-0000-000000000001",
+        run_in_background=True,
+    )
 
 
 @pytest.mark.asyncio
@@ -285,12 +302,22 @@ async def test_create_memory_project_workspace_is_local_noop(app, tmp_path_facto
             new_callable=AsyncMock,
             return_value=fake_status,
         ),
+        patch.object(
+            ProjectClient,
+            "index",
+            new_callable=AsyncMock,
+            return_value={
+                "status": "index_started",
+                "message": "Indexing accepted",
+                "job_id": "index-job-123",
+            },
+        ),
         patch(
-            "basic_memory.mcp.project_context.invalidate_workspace_project_index",
+            "basic_memory.mcp.project_context.invalidate_project_caches",
             new_callable=AsyncMock,
         ),
     ):
-        await create_memory_project(
+        result = await create_memory_project(
             project_name="Local WS Project",
             project_path=str(project_root),
             workspace="team-paul",
@@ -298,6 +325,53 @@ async def test_create_memory_project_workspace_is_local_noop(app, tmp_path_facto
 
     mock_resolve_workspace.assert_not_awaited()
     assert captured["workspace"] == "team-paul"
+    assert "State: accepted" in result
+    assert "Job ID: index-job-123" in result
+
+
+@pytest.mark.asyncio
+async def test_create_memory_project_requires_created_project(app, tmp_path_factory):
+    """A malformed create response fails before attempting to index."""
+    from basic_memory.mcp.clients import ProjectClient
+    from basic_memory.schemas.project_info import ProjectStatusResponse
+
+    project_root = tmp_path_factory.mktemp("missing-created-project-home")
+    fake_status = ProjectStatusResponse(
+        message="Project created",
+        status="success",
+        default=False,
+        new_project=None,
+    )
+
+    with (
+        patch.object(
+            ProjectClient,
+            "list_projects",
+            new_callable=AsyncMock,
+            return_value=_make_list([], default=None),
+        ),
+        patch.object(
+            ProjectClient,
+            "create_project",
+            new_callable=AsyncMock,
+            return_value=fake_status,
+        ),
+        patch.object(ProjectClient, "index", new_callable=AsyncMock) as mock_index,
+        patch(
+            "basic_memory.mcp.project_context.invalidate_project_caches",
+            new_callable=AsyncMock,
+        ),
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="Project creation succeeded without returning the new project",
+        ):
+            await create_memory_project(
+                project_name="Missing Created Project",
+                project_path=str(project_root),
+            )
+
+    mock_index.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -339,8 +413,19 @@ async def test_create_memory_project_default_workspace_is_none(app, tmp_path_fac
             new_callable=AsyncMock,
             return_value=fake_status,
         ),
+        patch.object(
+            ProjectClient,
+            "index",
+            new_callable=AsyncMock,
+            return_value={
+                "total_files": 0,
+                "enqueued_files": 0,
+                "enqueued_batches": 0,
+                "deleted_files": 0,
+            },
+        ) as mock_index,
         patch(
-            "basic_memory.mcp.project_context.invalidate_workspace_project_index",
+            "basic_memory.mcp.project_context.invalidate_project_caches",
             new_callable=AsyncMock,
         ),
     ):
@@ -350,6 +435,10 @@ async def test_create_memory_project_default_workspace_is_none(app, tmp_path_fac
         )
 
     assert captured["workspace"] is None
+    mock_index.assert_awaited_once_with(
+        "00000000-0000-0000-0000-000000000001",
+        run_in_background=False,
+    )
 
 
 @pytest.mark.asyncio
@@ -445,7 +534,7 @@ async def test_delete_project_resolves_workspace_slug(app, delete_notes):
             return_value=fake_status,
         ) as mock_delete_project,
         patch(
-            "basic_memory.mcp.project_context.invalidate_workspace_project_index",
+            "basic_memory.mcp.project_context.invalidate_project_caches",
             new_callable=AsyncMock,
         ),
     ):
@@ -524,7 +613,7 @@ async def test_delete_project_workspace_is_local_noop(app):
             return_value=fake_status,
         ),
         patch(
-            "basic_memory.mcp.project_context.invalidate_workspace_project_index",
+            "basic_memory.mcp.project_context.invalidate_project_caches",
             new_callable=AsyncMock,
         ),
     ):
@@ -578,7 +667,7 @@ async def test_delete_project_default_workspace_is_none(app):
             return_value=fake_status,
         ),
         patch(
-            "basic_memory.mcp.project_context.invalidate_workspace_project_index",
+            "basic_memory.mcp.project_context.invalidate_project_caches",
             new_callable=AsyncMock,
         ),
     ):
@@ -587,19 +676,19 @@ async def test_delete_project_default_workspace_is_none(app):
     assert captured["workspace"] is None
 
 
-def test_delete_routes_to_cloud_honors_explicit_routing_flags(monkeypatch):
-    """Explicit --cloud/--local routing decides where the delete's files live (#1034)."""
-    from basic_memory.mcp.tools.project_management import _delete_routes_to_cloud
+def test_routes_to_cloud_honors_explicit_routing_flags(monkeypatch):
+    """Explicit --cloud/--local routing decides the project lifecycle backend."""
+    from basic_memory.mcp.tools.project_management import _routes_to_cloud
 
     monkeypatch.setenv("BASIC_MEMORY_EXPLICIT_ROUTING", "true")
 
     monkeypatch.setenv("BASIC_MEMORY_FORCE_CLOUD", "true")
-    assert _delete_routes_to_cloud(None) is True
+    assert _routes_to_cloud(None) is True
 
     monkeypatch.setenv("BASIC_MEMORY_FORCE_CLOUD", "false")
     monkeypatch.setenv("BASIC_MEMORY_FORCE_LOCAL", "true")
     # Explicit local wins even when a workspace selector was supplied.
-    assert _delete_routes_to_cloud("some-workspace") is False
+    assert _routes_to_cloud("some-workspace") is False
 
 
 @pytest.mark.parametrize(

--- a/tests/mcp/test_tool_project_management.py
+++ b/tests/mcp/test_tool_project_management.py
@@ -145,6 +145,45 @@ async def test_create_and_delete_project_and_name_match_branch(
 
 
 @pytest.mark.asyncio
+async def test_create_memory_project_retry_indexes_partial_create(app, tmp_path_factory):
+    """Retrying after a post-create index failure repairs the existing project."""
+    from basic_memory.mcp.clients import ProjectClient
+
+    project_root = tmp_path_factory.mktemp("partial-create-project-home")
+    completed_index = {
+        "total_files": 0,
+        "enqueued_files": 0,
+        "enqueued_batches": 0,
+        "deleted_files": 0,
+    }
+
+    with patch.object(
+        ProjectClient,
+        "index",
+        new_callable=AsyncMock,
+        side_effect=[RuntimeError("index timeout"), completed_index],
+    ) as mock_index:
+        with pytest.raises(RuntimeError, match="index timeout"):
+            await create_memory_project(
+                project_name="Partial Create Project",
+                project_path=str(project_root),
+                output_format="json",
+            )
+
+        retry_result = await create_memory_project(
+            project_name="Partial Create Project",
+            project_path=str(project_root),
+            output_format="json",
+        )
+
+    assert isinstance(retry_result, dict)
+    assert retry_result["created"] is False
+    assert retry_result["already_exists"] is True
+    assert retry_result["indexing"]["state"] == "completed"
+    assert mock_index.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_delete_project_delete_notes_removes_local_files(app, tmp_path_factory):
     """delete_notes=True flows through to the API and removes the project files (#1034)."""
     project_root = tmp_path_factory.mktemp("delete-notes-project-home")


### PR DESCRIPTION
## Why

Re-adding a project after deleting its database record with retained note files created a fresh project identity but never indexed the retained content. The same MCP session could also retain the deleted project identity in its context cache.

Closes #1084

## What changed

- Request project indexing immediately after a successful project creation.
- Run local indexing synchronously so retained notes are available when creation returns.
- Use the durable Cloud background indexing handoff and expose accepted state, backend status, message, job ID, and counts.
- Clear active/default project identity and workspace project-index caches after both project creation and deletion.
- Add a local end-to-end regression for delete with retained notes, recreate, read, and search.
- Add unit coverage for local versus Cloud indexing mode and malformed create responses.
- ## Verification
- uv run pytest -q --cov-report=term-missing:skip-covered tests/mcp/test_tool_project_management.py tests/mcp/test_tool_json_output_modes.py test-int/mcp/test_project_management_integration.py test-int/mcp/test_output_format_json_integration.py test-int/mcp/test_recreate_project_indexing_integration.py (81 passed)
- just fast-check
- just doctor

- basic-memory-cloud CloudProjectIndexCommand scheduler tests (3 passed)

## Cloud rollout
No Cloud source change is required: the existing Cloud project-index command already requires background mode and waits for the PGQueuer handoff before returning. After this core PR merges, basic-memory-cloud will need its pinned Basic Memory revision bumped to deploy the fix.