### PR TITLE
fix(ci): keep issue triage focused on triage

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -77,7 +77,8 @@ jobs:
                - Complex: Major feature work, architectural changes
 
             **Actions to Take:**
-            1. Add appropriate labels using: `gh issue edit ${{ github.event.issue.number }} --add-label "label1,label2"`
+            1. Add appropriate labels using:
+               `./scripts/edit-issue-labels.sh --add-label label1 --add-label label2`
             2. Check for duplicates using: `gh search issues`
             3. If duplicate found, comment mentioning the original issue
             4. For feature requests, ask clarifying questions if needed
@@ -94,4 +95,4 @@ jobs:
             and then stop. Do not begin implementation work.
           claude_args: |
             --permission-mode dontAsk
-            --allowedTools "Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh search issues:*),Read,Grep,Glob"
+            --allowedTools "Bash(./scripts/edit-issue-labels.sh:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh search issues:*),Read,Grep,Glob"

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -24,8 +24,29 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true  # Show triage progress
+          settings: |
+            {
+              "includeGitInstructions": false,
+              "permissions": {
+                "deny": [
+                  "Edit",
+                  "Write",
+                  "NotebookEdit",
+                  "Bash(git add *)",
+                  "Bash(git commit *)",
+                  "Bash(git rm *)",
+                  "Bash(git push *)",
+                  "Bash(*git-push.sh *)"
+                ]
+              }
+            }
           prompt: |
-            Analyze this new Basic Memory issue and perform triage:
+            Analyze this new Basic Memory issue and perform triage only.
+
+            **Scope Boundary:**
+            - Do not implement a fix, edit repository files, run tests, create a branch, commit, or push.
+            - The only permitted write actions are adding issue labels and posting issue comments.
+            - Even when the issue includes a root cause, suggested fix, or acceptance criteria, stop after triage.
 
             **Issue Analysis:**
             1. **Type Classification:**
@@ -69,5 +90,8 @@ jobs:
             - Complexity: simple, medium, complex
             - Status: needs-reproduction, needs-clarification, duplicate
 
-            Read the issue carefully and provide helpful triage with appropriate labels.
-          claude_args: '--allowed-tools "Bash(gh issue:*),Bash(gh search:*),Read"'
+            Read the issue carefully, apply appropriate labels, post any necessary triage comment,
+            and then stop. Do not begin implementation work.
+          claude_args: |
+            --permission-mode dontAsk
+            --allowedTools "Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue comment:*),Bash(gh search issues:*),Read,Grep,Glob"

--- a/scripts/edit-issue-labels.sh
+++ b/scripts/edit-issue-labels.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Limit automated issue triage to labels on the issue that triggered the workflow.
+set -euo pipefail
+
+issue_number=$(jq -r '.issue.number // empty' "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH not set}")
+if ! [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+    echo "Error: no issue number in event payload" >&2
+    exit 1
+fi
+
+labels=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --add-label)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --add-label requires a label" >&2
+                exit 1
+            fi
+            labels+=("$2")
+            shift 2
+            ;;
+        *)
+            echo "Error: only --add-label is accepted" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ${#labels[@]} -eq 0 ]]; then
+    echo "Error: at least one label is required" >&2
+    exit 1
+fi
+
+valid_labels=$(gh label list --limit 500 --json name --jq '.[].name')
+filtered_labels=()
+for label in "${labels[@]}"; do
+    if grep -qxF "$label" <<<"$valid_labels"; then
+        filtered_labels+=("$label")
+    else
+        echo "Ignoring unknown label: $label" >&2
+    fi
+done
+
+if [[ ${#filtered_labels[@]} -eq 0 ]]; then
+    exit 0
+fi
+
+repository=${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}
+labels_url="repos/$repository/issues/$issue_number/labels"
+api_args=(--method POST "$labels_url")
+for label in "${filtered_labels[@]}"; do
+    api_args+=(-f "labels[]=$label")
+done
+
+gh api "${api_args[@]}" --silent
+echo "Added: ${filtered_labels[*]}"


### PR DESCRIPTION
## Why

The automatic Claude issue-triage workflow is intended to classify, label, and comment on new issues. While processing #1084, Claude instead began implementing the reported fix, then became stranded because the triage runner could neither run the required validation nor push its commit. A second explicit request reproduced the same failure.

The workflow should make its triage-only boundary explicit and enforce it at the tool layer so detailed issue reports do not turn into unpublished implementation work.

## What Changed

- Explicitly instruct Claude to stop after labels and any necessary triage comment.
- Disable Claude Code's built-in git instructions for the triage run.
- Deny repository edits and git add, commit, remove, and push operations.
- Use non-interactive `dontAsk` mode so unavailable approvals cannot wedge the run.
- Route label writes through a label-only helper bound to the triggering issue.
- Narrow shell access to the label helper, issue viewing/commenting, and duplicate searches.

## Implementation Details

The workflow keeps its existing read-only repository and issue-write permissions. Prompt guidance establishes the intended behavior, while settings-level deny rules prevent the action's automatically supplied git tools from overriding that boundary. Claude can still inspect repository context with `Read`, `Grep`, and `Glob` when useful for accurate triage.

The `scripts/edit-issue-labels.sh` helper reads the issue number from the trusted workflow event, validates requested labels against the repository, rejects every operation except `--add-label`, and calls only GitHub's issue-label endpoint. Claude does not receive direct `gh issue edit` access.

This deliberately does not add an implementation or PR-creation path to issue triage.

## Testing

- Parsed `.github/workflows/claude-issue-triage.yml` with PyYAML and parsed the embedded `settings` value with `json.loads`.
- Ran `bash -n` on the label helper.
- Exercised the helper with a stubbed `gh` command to verify valid label additions, unknown-label filtering, and rejection of unsupported operations.
- Ran `git diff --check` successfully.

No Python application tests were run because this changes only GitHub Actions configuration.

## Risks / Follow-ups

The next newly opened issue will provide the live end-to-end verification of the Claude action behavior. The job retains `issues: write` so it can add labels and post comments, while the tool boundary prevents Claude from directly mutating other issue metadata.

Related: #1084
