### PR TITLE
test(skills): add issue-derived Pythonic code evals

### DIFF
--- a/.agents/skills/pythonic-code/SKILL.md
+++ b/.agents/skills/pythonic-code/SKILL.md
@@ -41,7 +41,9 @@ Let local project rules override generic style advice.
   another object.
 - Use `functools.singledispatch` only when behavior genuinely varies by the first argument's
   runtime type and open registration is an intentional extension point.
-- Use a narrow `Protocol` when callers need a capability instead of a concrete implementation.
+- Use a narrow `Protocol` for genuine replaceable behavior. Do not use property-only protocols to
+  describe internal result data; return a concrete frozen dataclass unless callers truly require
+  structural interoperability.
 - Use a concrete class when identity, cohesive mutable state, lifecycle, or resource ownership
   requires one.
 - Use an abstract base class only when runtime-enforced subclassing or shared skeletal behavior

--- a/.agents/skills/pythonic-code/evals/context/AGENTS.md
+++ b/.agents/skills/pythonic-code/evals/context/AGENTS.md
@@ -1,0 +1,7 @@
+# Evaluation Workspace
+
+- Use Python 3.12 or newer.
+- Read each target file completely before editing it.
+- Keep changes scoped and preserve observable behavior unless the task says otherwise.
+- Use full type annotations and prefer direct functions and typed values over unnecessary classes.
+- Run the focused tests under `evals/files` and the configured Ruff checks for changed Python.

--- a/.agents/skills/pythonic-code/evals/context/pyproject.toml
+++ b/.agents/skills/pythonic-code/evals/context/pyproject.toml
@@ -1,3 +1,15 @@
+[project]
+name = "pythonic-code-eval"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = []
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.9",
+]
+
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["evals/files"]

--- a/.agents/skills/pythonic-code/evals/context/pyproject.toml
+++ b/.agents/skills/pythonic-code/evals/context/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["evals/files"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"

--- a/.agents/skills/pythonic-code/evals/evals.json
+++ b/.agents/skills/pythonic-code/evals/evals.json
@@ -1,0 +1,58 @@
+{
+  "skill_name": "pythonic-code",
+  "evals": [
+    {
+      "id": 1096,
+      "eval_name": "shared-runtime-ownership",
+      "source_issue": "https://github.com/basicmachines-co/basic-memory/issues/1096",
+      "prompt": "Review evals/files/shared_runtime_ownership.md. Describe the runtime-neutral target package ownership and dependency direction, then recommend the smallest first cleanup PR within an incremental rollout that does not change runtime behavior. Account for each misplaced portable facade, project-scoped repository bundle, and search persistence type or helper in the snapshot, even when deferring it from the first PR. Do not edit the fixture. Be concrete about moves or renames, compatibility during the paired cloud rollout, documentation, and validation.",
+      "expected_output": "A staged architecture recommendation that moves portable note behavior out of cloud-named ownership, gives project-scoped repositories a runtime-neutral name, lowers search DTO/SQL dependencies beneath repositories, uses temporary compatibility exports for the paired cloud revision, and records the dependency direction without proposing another manager or all-at-once package rewrite.",
+      "files": [
+        "evals/files/shared_runtime_ownership.md"
+      ],
+      "assertions": [
+        "The response identifies basic_memory.cloud as misleading ownership for portable core note behavior and proposes a neutral core destination.",
+        "The response gives LocalAcceptedNoteRepositories a runtime-neutral project-scoped name rather than preserving origin-based naming.",
+        "The response moves or re-homes AcceptedNoteSearchRow and vector-delete behavior so repository modules do not depend upward on indexing orchestration.",
+        "The rollout is incremental and includes temporary compatibility exports or an equivalent coordinated core/cloud migration strategy.",
+        "The response records the intended dependency direction and names concrete core plus cloud validation without introducing managers, registries, or an all-at-once package rewrite."
+      ]
+    },
+    {
+      "id": 1097,
+      "eval_name": "accepted-snapshot-persistence",
+      "source_issue": "https://github.com/basicmachines-co/basic-memory/issues/1097",
+      "prompt": "Refactor evals/files/accepted_snapshot.py and its tests. A previous mutation path returned success after persisting content and search but before observations and relations existed. Make that class of omission structurally difficult for future full-note mutations while preserving the intentionally narrower move behavior. Keep transaction ownership explicit and add the regression coverage needed to prove the change.",
+      "expected_output": "One direct accepted-snapshot persistence operation writes content, search, observations, and relations through the caller-owned session. Create and edit use it; move uses an explicitly narrower private or move-specific operation. Tests prove create and edit persist the full snapshot immediately while move does not replace unchanged graph state.",
+      "files": [
+        "evals/files/accepted_snapshot.py",
+        "evals/files/test_accepted_snapshot.py"
+      ],
+      "assertions": [
+        "One clearly named production operation persists content, search, observations, and relations for a full accepted snapshot.",
+        "Both create_note and edit_note use the complete snapshot operation rather than separately remembering a graph call.",
+        "The content/search-only operation is private, move-specific, or otherwise unavailable as the tempting default for full-note mutations.",
+        "The caller-owned session is passed through explicitly and the refactor does not create a hidden transaction or service hierarchy.",
+        "Focused tests prove complete create and edit persistence plus the intentionally narrower move behavior."
+      ]
+    },
+    {
+      "id": 1098,
+      "eval_name": "accepted-preparation-surface",
+      "source_issue": "https://github.com/basicmachines-co/basic-memory/issues/1098",
+      "prompt": "Refactor evals/files/accepted_preparation.py and its tests to make the accepted-note preparation path easier to trace and cheaper to compose. Preserve create preparation and full EntityService behavior, keep genuine replaceable capabilities typed, and avoid changing the observable Markdown, permalink, conflict, or parsing semantics.",
+      "expected_output": "Preparation becomes direct module-level behavior over frozen typed values and narrow behavioral capabilities. The accepted path no longer constructs the full EntityService merely to call prepare_create_entity_content, property-only source protocols disappear, and the existing service can delegate to the same function without a replacement manager or registry.",
+      "files": [
+        "evals/files/accepted_preparation.py",
+        "evals/files/test_accepted_preparation.py"
+      ],
+      "assertions": [
+        "Property-only prepared-data protocols are replaced by a small number of frozen typed values.",
+        "Behavioral protocols remain only for genuine replaceable capabilities such as storage existence, permalink resolution, or Markdown parsing.",
+        "The accepted-note composition path does not construct the full EntityService solely to prepare a create.",
+        "Preparation is expressed with direct module-level functions and ordinary arguments or partial binding, without a replacement Manager, strategy hierarchy, or registry.",
+        "Focused tests preserve create preparation and EntityService delegation semantics, including the existing-file conflict."
+      ]
+    }
+  ]
+}

--- a/.agents/skills/pythonic-code/evals/files/accepted_preparation.py
+++ b/.agents/skills/pythonic-code/evals/files/accepted_preparation.py
@@ -1,0 +1,150 @@
+"""Condensed accepted-note preparation composition based on Basic Memory issue #1098."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class NoteSchema:
+    title: str
+    file_path: str
+    body: str
+
+
+class PreparedEntityFieldsSource(Protocol):
+    @property
+    def title(self) -> str: ...
+
+    @property
+    def file_path(self) -> str: ...
+
+    @property
+    def permalink(self) -> str: ...
+
+
+class PreparedMarkdownSource(Protocol):
+    @property
+    def markdown(self) -> str: ...
+
+    @property
+    def search_text(self) -> str: ...
+
+    @property
+    def entity_fields(self) -> PreparedEntityFieldsSource: ...
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedEntityFields:
+    title: str
+    file_path: str
+    permalink: str
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedMarkdown:
+    markdown: str
+    search_text: str
+    entity_fields: PreparedEntityFields
+
+
+class FileStore(Protocol):
+    async def exists(self, file_path: str) -> bool: ...
+
+
+class PermalinkResolver(Protocol):
+    async def resolve(self, file_path: str, title: str) -> str: ...
+
+
+class MarkdownParser(Protocol):
+    async def parse(self, file_path: str, markdown: str) -> None: ...
+
+
+class EntityService:
+    """Full file/DB service; accepted composition currently builds it only to prepare."""
+
+    def __init__(
+        self,
+        *,
+        file_store: FileStore,
+        permalink_resolver: PermalinkResolver,
+        markdown_parser: MarkdownParser,
+        entity_repository: object,
+        observation_repository: object,
+        relation_repository: object,
+        search_service: object,
+    ) -> None:
+        self.file_store = file_store
+        self.permalink_resolver = permalink_resolver
+        self.markdown_parser = markdown_parser
+        self.entity_repository = entity_repository
+        self.observation_repository = observation_repository
+        self.relation_repository = relation_repository
+        self.search_service = search_service
+
+    def _build_fields(
+        self,
+        schema: NoteSchema,
+        permalink: str,
+    ) -> PreparedEntityFields:
+        return PreparedEntityFields(
+            title=schema.title,
+            file_path=schema.file_path,
+            permalink=permalink,
+        )
+
+    async def _build_prepared(
+        self,
+        schema: NoteSchema,
+        fields: PreparedEntityFields,
+    ) -> PreparedMarkdown:
+        markdown = f"---\npermalink: {fields.permalink}\n---\n# {schema.title}\n\n{schema.body}\n"
+        await self.markdown_parser.parse(schema.file_path, markdown)
+        return PreparedMarkdown(
+            markdown=markdown,
+            search_text=f"{schema.title}\n\n{schema.body}",
+            entity_fields=fields,
+        )
+
+    async def prepare_create_entity_content(
+        self,
+        schema: NoteSchema,
+    ) -> PreparedMarkdownSource:
+        if await self.file_store.exists(schema.file_path):
+            raise FileExistsError(schema.file_path)
+        permalink = await self.permalink_resolver.resolve(schema.file_path, schema.title)
+        fields = self._build_fields(schema, permalink)
+        return await self._build_prepared(schema, fields)
+
+    async def create_entity(self, schema: NoteSchema) -> PreparedMarkdownSource:
+        prepared = await self.prepare_create_entity_content(schema)
+        return prepared
+
+
+@dataclass(frozen=True, slots=True)
+class LocalAcceptedNotePreparerFactory:
+    file_store: FileStore
+    permalink_resolver: PermalinkResolver
+    markdown_parser: MarkdownParser
+    entity_repository: object
+    observation_repository: object
+    relation_repository: object
+    search_service: object
+
+    def create_note_preparer(self) -> EntityService:
+        return EntityService(
+            file_store=self.file_store,
+            permalink_resolver=self.permalink_resolver,
+            markdown_parser=self.markdown_parser,
+            entity_repository=self.entity_repository,
+            observation_repository=self.observation_repository,
+            relation_repository=self.relation_repository,
+            search_service=self.search_service,
+        )
+
+
+async def prepare_accepted_note_create(
+    factory: LocalAcceptedNotePreparerFactory,
+    schema: NoteSchema,
+) -> PreparedMarkdownSource:
+    preparer = factory.create_note_preparer()
+    return await preparer.prepare_create_entity_content(schema)

--- a/.agents/skills/pythonic-code/evals/files/accepted_snapshot.py
+++ b/.agents/skills/pythonic-code/evals/files/accepted_snapshot.py
@@ -1,0 +1,130 @@
+"""Condensed accepted-note persistence flow based on Basic Memory issue #1097."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class Entity:
+    id: int
+    project_id: int
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedNoteSnapshot:
+    markdown: str
+    search_text: str
+    observations: tuple[str, ...]
+    relations: tuple[str, ...]
+
+
+class AcceptedNoteRepositories(Protocol):
+    async def accept_content(
+        self,
+        session: object,
+        entity: Entity,
+        markdown: str,
+    ) -> None: ...
+
+    async def refresh_search(
+        self,
+        session: object,
+        entity: Entity,
+        search_text: str,
+    ) -> None: ...
+
+    async def replace_observations(
+        self,
+        session: object,
+        entity: Entity,
+        observations: tuple[str, ...],
+    ) -> None: ...
+
+    async def replace_relations(
+        self,
+        session: object,
+        entity: Entity,
+        relations: tuple[str, ...],
+    ) -> None: ...
+
+
+async def persist_accepted_note_write(
+    session: object,
+    *,
+    entity: Entity,
+    prepared: PreparedNoteSnapshot,
+    repositories: AcceptedNoteRepositories,
+) -> None:
+    """Persist accepted content and hot search state in the caller's transaction."""
+    await repositories.accept_content(session, entity, prepared.markdown)
+    await repositories.refresh_search(session, entity, prepared.search_text)
+
+
+async def replace_accepted_note_graph(
+    session: object,
+    *,
+    entity: Entity,
+    prepared: PreparedNoteSnapshot,
+    repositories: AcceptedNoteRepositories,
+) -> None:
+    """Replace observations and outgoing relations for parsed accepted Markdown."""
+    await repositories.replace_observations(session, entity, prepared.observations)
+    await repositories.replace_relations(session, entity, prepared.relations)
+
+
+async def create_note(
+    session: object,
+    *,
+    entity: Entity,
+    prepared: PreparedNoteSnapshot,
+    repositories: AcceptedNoteRepositories,
+) -> None:
+    await persist_accepted_note_write(
+        session,
+        entity=entity,
+        prepared=prepared,
+        repositories=repositories,
+    )
+    await replace_accepted_note_graph(
+        session,
+        entity=entity,
+        prepared=prepared,
+        repositories=repositories,
+    )
+
+
+async def edit_note(
+    session: object,
+    *,
+    entity: Entity,
+    prepared: PreparedNoteSnapshot,
+    repositories: AcceptedNoteRepositories,
+) -> None:
+    await persist_accepted_note_write(
+        session,
+        entity=entity,
+        prepared=prepared,
+        repositories=repositories,
+    )
+    await replace_accepted_note_graph(
+        session,
+        entity=entity,
+        prepared=prepared,
+        repositories=repositories,
+    )
+
+
+async def move_note(
+    session: object,
+    *,
+    entity: Entity,
+    prepared: PreparedNoteSnapshot,
+    repositories: AcceptedNoteRepositories,
+) -> None:
+    """A move changes content/search paths but preserves the parsed note graph."""
+    await persist_accepted_note_write(
+        session,
+        entity=entity,
+        prepared=prepared,
+        repositories=repositories,
+    )

--- a/.agents/skills/pythonic-code/evals/files/shared_runtime_ownership.md
+++ b/.agents/skills/pythonic-code/evals/files/shared_runtime_ownership.md
@@ -1,0 +1,60 @@
+# Shared Local/Cloud Runtime Package Snapshot
+
+This snapshot condenses current imports and responsibilities from the paired Basic Memory
+repositories. The packages are released separately, and the cloud repository pins a Basic Memory
+revision during coordinated changes.
+
+## Core callers
+
+```python
+# basic_memory/deps/services.py and basic_memory/mcp/server.py
+from basic_memory.cloud.note_content_writes import NoteContentMutationService
+from basic_memory.cloud.note_content_materialization import drain_pending_materializations
+
+# basic_memory/repository/accepted_note_search_repository.py
+from basic_memory.indexing.accepted_note_search import AcceptedNoteSearchRow
+from basic_memory.indexing.project_index_maintenance import delete_project_index_vector_rows
+```
+
+`basic_memory.cloud` contains portable note mutation, read, materialization, project-delete, and
+directory-delete facades. Local API, CLI, and MCP entrypoints use them directly. The facades accept
+storage, queue, repository, and scheduler capabilities supplied by the composition root; they do
+not require a hosted runtime.
+
+The accepted-note search repository owns explicit-session SQL for hot search rows, but its row
+value and semantic-vector deletion helper live in `basic_memory.indexing`, which also contains
+workflow orchestration and batch indexing.
+
+## Cloud callers
+
+```python
+# basic_memory_cloud/api/deps/note_content_gateway.py
+from basic_memory.cloud import NoteContentMutationService, NoteContentQueryService
+from basic_memory.index.local_notes import LocalAcceptedNoteRepositories
+
+# basic_memory_cloud/services/index/project_indexing.py
+from basic_memory.index.local_project import LocalProjectIndexObservation, ProjectIndexRouteRequest
+
+# basic_memory_cloud/api/deps/task_schedulers.py
+from basic_memory.index.local_schedulers import LocalTaskScheduler
+```
+
+`LocalAcceptedNoteRepositories` creates project-scoped core repository objects that use the
+caller's `AsyncSession`. It contains no filesystem behavior and is used unchanged by both local and
+cloud composition roots.
+
+The symbols imported from `local_project` and `local_schedulers` include runtime-neutral request,
+observation, and scheduling contracts alongside actual filesystem-backed implementations.
+
+## Current package roles
+
+- `basic_memory.runtime`: storage-neutral identifiers, payloads, cleanup plans, and job values.
+- `basic_memory.index`: local composition plus project-index route contracts and schedulers.
+- `basic_memory.indexing`: accepted-note orchestration, materialization workflows, batch indexing,
+  and some persistence values/helpers.
+- `basic_memory.repository`: explicit-session data access, with a few upward imports from
+  `indexing`.
+- `basic_memory.cloud`: portable service facades used by both local and hosted entrypoints.
+
+Behavior is stable and must remain so. A single package-tree rewrite would require a risky paired
+release; small moves can use temporary re-exports while the cloud pin advances.

--- a/.agents/skills/pythonic-code/evals/files/test_accepted_preparation.py
+++ b/.agents/skills/pythonic-code/evals/files/test_accepted_preparation.py
@@ -1,0 +1,79 @@
+import asyncio
+from dataclasses import dataclass, field
+
+import pytest
+
+from accepted_preparation import (
+    EntityService,
+    LocalAcceptedNotePreparerFactory,
+    NoteSchema,
+    prepare_accepted_note_create,
+)
+
+
+@dataclass
+class FakeFileStore:
+    existing_paths: set[str] = field(default_factory=set)
+
+    async def exists(self, file_path: str) -> bool:
+        return file_path in self.existing_paths
+
+
+@dataclass
+class FakePermalinkResolver:
+    async def resolve(self, file_path: str, title: str) -> str:
+        return f"notes/{title.lower().replace(' ', '-')}"
+
+
+@dataclass
+class RecordingMarkdownParser:
+    parsed: list[tuple[str, str]] = field(default_factory=list)
+
+    async def parse(self, file_path: str, markdown: str) -> None:
+        self.parsed.append((file_path, markdown))
+
+
+def build_factory(file_store: FakeFileStore) -> LocalAcceptedNotePreparerFactory:
+    return LocalAcceptedNotePreparerFactory(
+        file_store=file_store,
+        permalink_resolver=FakePermalinkResolver(),
+        markdown_parser=RecordingMarkdownParser(),
+        entity_repository=object(),
+        observation_repository=object(),
+        relation_repository=object(),
+        search_service=object(),
+    )
+
+
+def note_schema() -> NoteSchema:
+    return NoteSchema(title="Project Plan", file_path="plans/project-plan.md", body="Ship it.")
+
+
+def test_accepted_create_prepares_the_canonical_markdown() -> None:
+    prepared = asyncio.run(
+        prepare_accepted_note_create(build_factory(FakeFileStore()), note_schema())
+    )
+
+    assert prepared.entity_fields.permalink == "notes/project-plan"
+    assert prepared.search_text == "Project Plan\n\nShip it."
+    assert prepared.markdown == (
+        "---\npermalink: notes/project-plan\n---\n# Project Plan\n\nShip it.\n"
+    )
+
+
+def test_entity_service_uses_the_same_prepare_semantics() -> None:
+    factory = build_factory(FakeFileStore())
+    service = factory.create_note_preparer()
+    assert isinstance(service, EntityService)
+
+    prepared = asyncio.run(service.create_entity(note_schema()))
+
+    assert prepared.entity_fields.file_path == "plans/project-plan.md"
+    assert prepared.entity_fields.permalink == "notes/project-plan"
+
+
+def test_existing_file_is_rejected_before_permalink_resolution() -> None:
+    factory = build_factory(FakeFileStore(existing_paths={"plans/project-plan.md"}))
+
+    with pytest.raises(FileExistsError, match="plans/project-plan.md"):
+        asyncio.run(prepare_accepted_note_create(factory, note_schema()))

--- a/.agents/skills/pythonic-code/evals/files/test_accepted_snapshot.py
+++ b/.agents/skills/pythonic-code/evals/files/test_accepted_snapshot.py
@@ -1,0 +1,88 @@
+import asyncio
+from dataclasses import dataclass, field
+
+from accepted_snapshot import Entity, PreparedNoteSnapshot, create_note, move_note
+
+
+@dataclass
+class RecordingRepositories:
+    operations: list[str] = field(default_factory=list)
+
+    async def accept_content(
+        self,
+        session: object,
+        entity: Entity,
+        markdown: str,
+    ) -> None:
+        self.operations.append(f"content:{entity.id}:{markdown}")
+
+    async def refresh_search(
+        self,
+        session: object,
+        entity: Entity,
+        search_text: str,
+    ) -> None:
+        self.operations.append(f"search:{entity.id}:{search_text}")
+
+    async def replace_observations(
+        self,
+        session: object,
+        entity: Entity,
+        observations: tuple[str, ...],
+    ) -> None:
+        self.operations.append(f"observations:{entity.id}:{','.join(observations)}")
+
+    async def replace_relations(
+        self,
+        session: object,
+        entity: Entity,
+        relations: tuple[str, ...],
+    ) -> None:
+        self.operations.append(f"relations:{entity.id}:{','.join(relations)}")
+
+
+def prepared_note() -> PreparedNoteSnapshot:
+    return PreparedNoteSnapshot(
+        markdown="# Note\n",
+        search_text="Note",
+        observations=("fact",),
+        relations=("links-to:target",),
+    )
+
+
+def test_create_persists_the_complete_snapshot() -> None:
+    repositories = RecordingRepositories()
+
+    asyncio.run(
+        create_note(
+            object(),
+            entity=Entity(id=7, project_id=3),
+            prepared=prepared_note(),
+            repositories=repositories,
+        )
+    )
+
+    assert [operation.split(":", 1)[0] for operation in repositories.operations] == [
+        "content",
+        "search",
+        "observations",
+        "relations",
+    ]
+
+
+def test_move_preserves_the_existing_graph() -> None:
+    repositories = RecordingRepositories()
+
+    asyncio.run(
+        move_note(
+            object(),
+            entity=Entity(id=7, project_id=3),
+            prepared=prepared_note(),
+            repositories=repositories,
+        )
+    )
+
+    assert [operation.split(":", 1)[0] for operation in repositories.operations] == [
+        "content",
+        "search",
+    ]

--- a/.agents/skills/pythonic-code/justfile
+++ b/.agents/skills/pythonic-code/justfile
@@ -1,0 +1,29 @@
+# Pythonic Code skill evaluations
+
+skill_dir := justfile_directory()
+
+# Show the available evaluation cases.
+list:
+    uv run python {{skill_dir}}/scripts/run_evals.py --list
+
+# Validate the eval specification, fixtures, and runner formatting.
+validate:
+    uv run python {{skill_dir}}/scripts/run_evals.py --validate
+    uv run ruff check {{skill_dir}}/scripts/run_evals.py {{skill_dir}}/evals/files
+    uv run ruff format --check {{skill_dir}}/scripts/run_evals.py {{skill_dir}}/evals/files
+
+# Run paired with-skill and baseline trials for every case or one case id/name.
+eval case="all":
+    uv run python {{skill_dir}}/scripts/run_evals.py --case "{{case}}"
+
+# Preview the selected trials without invoking Codex.
+eval-dry-run case="all":
+    uv run python {{skill_dir}}/scripts/run_evals.py --case "{{case}}" --dry-run
+
+# Run trials and keep their iteration under a chosen workspace directory.
+eval-to workspace case="all":
+    uv run python {{skill_dir}}/scripts/run_evals.py --case "{{case}}" --workspace "{{workspace}}"
+
+# Show available recipes.
+default:
+    @just --list

--- a/.agents/skills/pythonic-code/scripts/run_evals.py
+++ b/.agents/skills/pythonic-code/scripts/run_evals.py
@@ -46,6 +46,12 @@ class EvalCase:
     assertions: tuple[str, ...]
 
 
+@dataclass(frozen=True, slots=True)
+class TrialResult:
+    exit_code: int
+    artifacts: tuple[tuple[Path, bytes], ...]
+
+
 def load_eval_cases() -> tuple[EvalCase, ...]:
     payload: object = json.loads(EVALS_PATH.read_text())
     if not isinstance(payload, dict):
@@ -196,62 +202,87 @@ def read_total_tokens(events_path: Path) -> int | None:
     return total_tokens
 
 
+def collect_trial_artifacts(run_dir: Path) -> tuple[tuple[Path, bytes], ...]:
+    artifacts: list[tuple[Path, bytes]] = []
+    for path in sorted(run_dir.rglob("*")):
+        relative_path = path.relative_to(run_dir)
+        if path.is_file() and relative_path.parts[0] != "work":
+            artifacts.append((relative_path, path.read_bytes()))
+    return tuple(artifacts)
+
+
+def write_trial_artifacts(
+    iteration_dir: Path,
+    case: EvalCase,
+    mode: str,
+    trial: TrialResult,
+) -> None:
+    destination = iteration_dir / f"eval-{case.id}-{case.name}" / mode
+    destination.mkdir(parents=True, exist_ok=False)
+    for relative_path, content in trial.artifacts:
+        artifact_path = destination / relative_path
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_bytes(content)
+
+
 def run_codex_trial(
     codex_path: str,
-    iteration_dir: Path,
     case: EvalCase,
     *,
     with_skill: bool,
     model: str | None,
-) -> int:
+) -> TrialResult:
     mode = "with_skill" if with_skill else "without_skill"
-    run_dir = iteration_dir / f"eval-{case.id}-{case.name}" / mode
-    work_dir = prepare_work_directory(run_dir, case, with_skill)
-    events_path = run_dir / "events.jsonl"
-    stderr_path = run_dir / "stderr.txt"
-    final_path = run_dir / "final.txt"
+    with tempfile.TemporaryDirectory(prefix="pythonic-code-eval-trial-") as trial_directory:
+        run_dir = Path(trial_directory)
+        work_dir = prepare_work_directory(run_dir, case, with_skill)
+        events_path = run_dir / "events.jsonl"
+        stderr_path = run_dir / "stderr.txt"
+        final_path = run_dir / "final.txt"
 
-    prompt = f"Use $pythonic-code. {case.prompt}" if with_skill else case.prompt
-    command = [
-        codex_path,
-        "exec",
-        "--ephemeral",
-        "--ignore-user-config",
-        "--skip-git-repo-check",
-        "--sandbox",
-        "workspace-write",
-        "--json",
-        "-C",
-        str(work_dir),
-        "-o",
-        str(final_path),
-    ]
-    if model:
-        command.extend(["--model", model])
-    command.append(prompt)
+        prompt = f"Use $pythonic-code. {case.prompt}" if with_skill else case.prompt
+        command = [
+            codex_path,
+            "exec",
+            "--ephemeral",
+            "--ignore-user-config",
+            "--skip-git-repo-check",
+            "--sandbox",
+            "workspace-write",
+            "--json",
+            "-C",
+            str(work_dir),
+            "-o",
+            str(final_path),
+        ]
+        if model:
+            command.extend(["--model", model])
+        command.append(prompt)
 
-    print(f"Running eval {case.id} ({case.name}) [{mode}]", flush=True)
-    started_at = time.perf_counter()
-    with events_path.open("w") as events_file, stderr_path.open("w") as stderr_file:
-        result = subprocess.run(
-            command,
-            stdout=events_file,
-            stderr=stderr_file,
-            text=True,
-            check=False,
-        )
-    duration_ms = round((time.perf_counter() - started_at) * 1000)
+        print(f"Running eval {case.id} ({case.name}) [{mode}]", flush=True)
+        started_at = time.perf_counter()
+        with events_path.open("w") as events_file, stderr_path.open("w") as stderr_file:
+            result = subprocess.run(
+                command,
+                stdout=events_file,
+                stderr=stderr_file,
+                text=True,
+                check=False,
+            )
+        duration_ms = round((time.perf_counter() - started_at) * 1000)
 
-    copy_run_outputs(work_dir, run_dir / "outputs")
-    timing = {
-        "total_tokens": read_total_tokens(events_path),
-        "duration_ms": duration_ms,
-        "exit_code": result.returncode,
-    }
-    (run_dir / "timing.json").write_text(json.dumps(timing, indent=2) + "\n")
+        copy_run_outputs(work_dir, run_dir / "outputs")
+        timing = {
+            "total_tokens": read_total_tokens(events_path),
+            "duration_ms": duration_ms,
+            "exit_code": result.returncode,
+        }
+        (run_dir / "timing.json").write_text(json.dumps(timing, indent=2) + "\n")
+        artifacts = collect_trial_artifacts(run_dir)
+
     if result.returncode != 0:
-        print(f"Trial failed; see {stderr_path}", file=sys.stderr)
-    return result.returncode
+        print(f"Eval {case.id} ({case.name}) [{mode}] failed", file=sys.stderr)
+    return TrialResult(exit_code=result.returncode, artifacts=artifacts)
 
 
 def write_case_metadata(iteration_dir: Path, case: EvalCase) -> None:
@@ -321,27 +352,23 @@ def main() -> int:
     failures = 0
     print(f"Eval workspace: {iteration_dir}", flush=True)
     for case in selected_cases:
+        with_skill_result = run_codex_trial(
+            codex_path,
+            case,
+            with_skill=True,
+            model=args.model,
+        )
+        without_skill_result = run_codex_trial(
+            codex_path,
+            case,
+            with_skill=False,
+            model=args.model,
+        )
+        write_trial_artifacts(iteration_dir, case, "with_skill", with_skill_result)
+        write_trial_artifacts(iteration_dir, case, "without_skill", without_skill_result)
         write_case_metadata(iteration_dir, case)
-        failures += (
-            run_codex_trial(
-                codex_path,
-                iteration_dir,
-                case,
-                with_skill=True,
-                model=args.model,
-            )
-            != 0
-        )
-        failures += (
-            run_codex_trial(
-                codex_path,
-                iteration_dir,
-                case,
-                with_skill=False,
-                model=args.model,
-            )
-            != 0
-        )
+        failures += with_skill_result.exit_code != 0
+        failures += without_skill_result.exit_code != 0
 
     if failures:
         print(f"Completed with {failures} failed trial(s): {iteration_dir}", file=sys.stderr)

--- a/.agents/skills/pythonic-code/scripts/run_evals.py
+++ b/.agents/skills/pythonic-code/scripts/run_evals.py
@@ -171,6 +171,13 @@ def prepare_work_directory(run_dir: Path, case: EvalCase, with_skill: bool) -> P
 
 
 def copy_run_outputs(work_dir: Path, outputs_dir: Path) -> None:
+    symlinks = tuple(
+        path.relative_to(work_dir) for path in work_dir.rglob("*") if path.is_symlink()
+    )
+    if symlinks:
+        paths = ", ".join(str(path) for path in symlinks)
+        raise ValueError(f"trial workspace contains unsupported symlink(s): {paths}")
+
     def ignore_runtime_files(_directory: str, names: list[str]) -> list[str]:
         return [name for name in names if name in IGNORED_OUTPUT_NAMES or name.endswith(".pyc")]
 
@@ -271,18 +278,24 @@ def run_codex_trial(
             )
         duration_ms = round((time.perf_counter() - started_at) * 1000)
 
-        copy_run_outputs(work_dir, run_dir / "outputs")
+        trial_exit_code = result.returncode
+        try:
+            copy_run_outputs(work_dir, run_dir / "outputs")
+        except ValueError as error:
+            with stderr_path.open("a") as stderr_file:
+                stderr_file.write(f"\nArtifact collection error: {error}\n")
+            trial_exit_code = trial_exit_code or 2
         timing = {
             "total_tokens": read_total_tokens(events_path),
             "duration_ms": duration_ms,
-            "exit_code": result.returncode,
+            "exit_code": trial_exit_code,
         }
         (run_dir / "timing.json").write_text(json.dumps(timing, indent=2) + "\n")
         artifacts = collect_trial_artifacts(run_dir)
 
-    if result.returncode != 0:
+    if trial_exit_code != 0:
         print(f"Eval {case.id} ({case.name}) [{mode}] failed", file=sys.stderr)
-    return TrialResult(exit_code=result.returncode, artifacts=artifacts)
+    return TrialResult(exit_code=trial_exit_code, artifacts=artifacts)
 
 
 def write_case_metadata(iteration_dir: Path, case: EvalCase) -> None:

--- a/.agents/skills/pythonic-code/scripts/run_evals.py
+++ b/.agents/skills/pythonic-code/scripts/run_evals.py
@@ -31,6 +31,7 @@ IGNORED_OUTPUT_NAMES = {
     ".mypy_cache",
     ".pytest_cache",
     ".ruff_cache",
+    ".venv",
     "__pycache__",
 }
 

--- a/.agents/skills/pythonic-code/scripts/run_evals.py
+++ b/.agents/skills/pythonic-code/scripts/run_evals.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Run isolated paired evaluations for the pythonic-code skill."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+EVALS_PATH = SKILL_DIR / "evals" / "evals.json"
+WORKSPACE_CONTEXT_PATHS = (
+    Path("evals/context/AGENTS.md"),
+    Path("evals/context/pyproject.toml"),
+)
+EVAL_NAME_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+IGNORED_OUTPUT_NAMES = {
+    ".agents",
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "__pycache__",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class EvalCase:
+    id: int
+    name: str
+    prompt: str
+    expected_output: str
+    files: tuple[Path, ...]
+    assertions: tuple[str, ...]
+
+
+def load_eval_cases() -> tuple[EvalCase, ...]:
+    payload: object = json.loads(EVALS_PATH.read_text())
+    if not isinstance(payload, dict):
+        raise ValueError(f"{EVALS_PATH} must contain a JSON object")
+    if payload.get("skill_name") != "pythonic-code":
+        raise ValueError("eval skill_name must be 'pythonic-code'")
+
+    raw_cases = payload.get("evals")
+    if not isinstance(raw_cases, list) or not raw_cases:
+        raise ValueError("evals must be a non-empty list")
+
+    cases: list[EvalCase] = []
+    for position, raw_case in enumerate(raw_cases, start=1):
+        if not isinstance(raw_case, dict):
+            raise ValueError(f"eval at position {position} must be an object")
+
+        case_id = raw_case.get("id")
+        name = raw_case.get("eval_name")
+        prompt = raw_case.get("prompt")
+        expected_output = raw_case.get("expected_output")
+        raw_files = raw_case.get("files")
+        raw_assertions = raw_case.get("assertions")
+
+        if not isinstance(case_id, int) or isinstance(case_id, bool):
+            raise ValueError(f"eval at position {position} must have an integer id")
+        if not isinstance(name, str) or EVAL_NAME_PATTERN.fullmatch(name) is None:
+            raise ValueError(f"eval {case_id} must have a lowercase hyphenated eval_name")
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError(f"eval {case_id} must have a non-empty prompt")
+        if not isinstance(expected_output, str) or not expected_output.strip():
+            raise ValueError(f"eval {case_id} must have a non-empty expected_output")
+        if not isinstance(raw_files, list) or not raw_files:
+            raise ValueError(f"eval {case_id} must have at least one input file")
+        if not all(isinstance(value, str) and value for value in raw_files):
+            raise ValueError(f"eval {case_id} files must be non-empty strings")
+        if not isinstance(raw_assertions, list) or not raw_assertions:
+            raise ValueError(f"eval {case_id} must have at least one assertion")
+        if not all(isinstance(value, str) and value for value in raw_assertions):
+            raise ValueError(f"eval {case_id} assertions must be non-empty strings")
+
+        files = tuple(Path(value) for value in raw_files)
+        assertions = tuple(raw_assertions)
+        cases.append(
+            EvalCase(
+                id=case_id,
+                name=name,
+                prompt=prompt,
+                expected_output=expected_output,
+                files=files,
+                assertions=assertions,
+            )
+        )
+
+    validate_eval_cases(cases)
+    return tuple(cases)
+
+
+def validate_eval_cases(cases: list[EvalCase]) -> None:
+    ids = [case.id for case in cases]
+    names = [case.name for case in cases]
+    if len(ids) != len(set(ids)):
+        raise ValueError("eval ids must be unique")
+    if len(names) != len(set(names)):
+        raise ValueError("eval names must be unique")
+
+    for relative_path in WORKSPACE_CONTEXT_PATHS:
+        if not (SKILL_DIR / relative_path).is_file():
+            raise ValueError(f"eval workspace context does not exist: {relative_path}")
+
+    for case in cases:
+        for relative_path in case.files:
+            if relative_path.is_absolute() or ".." in relative_path.parts:
+                raise ValueError(f"eval {case.id} has unsafe file path: {relative_path}")
+            source_path = SKILL_DIR / relative_path
+            if not source_path.is_file():
+                raise ValueError(f"eval {case.id} input does not exist: {relative_path}")
+            if source_path.suffix == ".py":
+                ast.parse(source_path.read_text(), filename=str(source_path))
+
+
+def select_eval_cases(cases: tuple[EvalCase, ...], selector: str) -> tuple[EvalCase, ...]:
+    if selector == "all":
+        return cases
+
+    selected = tuple(case for case in cases if str(case.id) == selector or case.name == selector)
+    if selected:
+        return selected
+
+    options = ", ".join(f"{case.id} ({case.name})" for case in cases)
+    raise ValueError(f"unknown eval case {selector!r}; choose all or one of: {options}")
+
+
+def copy_skill_without_eval_answers(work_dir: Path) -> None:
+    destination = work_dir / ".agents" / "skills" / "pythonic-code"
+
+    def exclude_eval_material(directory: str, names: list[str]) -> list[str]:
+        excluded = {"evals", "justfile", "Justfile", "__pycache__"}
+        if Path(directory).resolve() == (SKILL_DIR / "scripts").resolve():
+            excluded.add("run_evals.py")
+        return [name for name in names if name in excluded or name.endswith(".pyc")]
+
+    shutil.copytree(SKILL_DIR, destination, ignore=exclude_eval_material)
+
+
+def prepare_work_directory(run_dir: Path, case: EvalCase, with_skill: bool) -> Path:
+    work_dir = run_dir / "work"
+    work_dir.mkdir(parents=True)
+    for relative_path in WORKSPACE_CONTEXT_PATHS:
+        shutil.copy2(SKILL_DIR / relative_path, work_dir / relative_path.name)
+    for relative_path in case.files:
+        destination = work_dir / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(SKILL_DIR / relative_path, destination)
+    if with_skill:
+        copy_skill_without_eval_answers(work_dir)
+    return work_dir
+
+
+def copy_run_outputs(work_dir: Path, outputs_dir: Path) -> None:
+    def ignore_runtime_files(_directory: str, names: list[str]) -> list[str]:
+        return [name for name in names if name in IGNORED_OUTPUT_NAMES or name.endswith(".pyc")]
+
+    shutil.copytree(work_dir, outputs_dir, ignore=ignore_runtime_files)
+
+
+def read_total_tokens(events_path: Path) -> int | None:
+    total_tokens: int | None = None
+    for line in events_path.read_text().splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        usage = event.get("usage")
+        if not isinstance(usage, dict):
+            continue
+
+        reported_total = usage.get("total_tokens")
+        if isinstance(reported_total, int):
+            total_tokens = reported_total
+            continue
+
+        input_tokens = usage.get("input_tokens")
+        output_tokens = usage.get("output_tokens")
+        if isinstance(input_tokens, int) and isinstance(output_tokens, int):
+            total_tokens = input_tokens + output_tokens
+    return total_tokens
+
+
+def run_codex_trial(
+    codex_path: str,
+    iteration_dir: Path,
+    case: EvalCase,
+    *,
+    with_skill: bool,
+    model: str | None,
+) -> int:
+    mode = "with_skill" if with_skill else "without_skill"
+    run_dir = iteration_dir / f"eval-{case.id}-{case.name}" / mode
+    work_dir = prepare_work_directory(run_dir, case, with_skill)
+    events_path = run_dir / "events.jsonl"
+    stderr_path = run_dir / "stderr.txt"
+    final_path = run_dir / "final.txt"
+
+    prompt = f"Use $pythonic-code. {case.prompt}" if with_skill else case.prompt
+    command = [
+        codex_path,
+        "exec",
+        "--ephemeral",
+        "--ignore-user-config",
+        "--skip-git-repo-check",
+        "--sandbox",
+        "workspace-write",
+        "--json",
+        "-C",
+        str(work_dir),
+        "-o",
+        str(final_path),
+    ]
+    if model:
+        command.extend(["--model", model])
+    command.append(prompt)
+
+    print(f"Running eval {case.id} ({case.name}) [{mode}]", flush=True)
+    started_at = time.perf_counter()
+    with events_path.open("w") as events_file, stderr_path.open("w") as stderr_file:
+        result = subprocess.run(
+            command,
+            stdout=events_file,
+            stderr=stderr_file,
+            text=True,
+            check=False,
+        )
+    duration_ms = round((time.perf_counter() - started_at) * 1000)
+
+    copy_run_outputs(work_dir, run_dir / "outputs")
+    timing = {
+        "total_tokens": read_total_tokens(events_path),
+        "duration_ms": duration_ms,
+        "exit_code": result.returncode,
+    }
+    (run_dir / "timing.json").write_text(json.dumps(timing, indent=2) + "\n")
+    if result.returncode != 0:
+        print(f"Trial failed; see {stderr_path}", file=sys.stderr)
+    return result.returncode
+
+
+def write_case_metadata(iteration_dir: Path, case: EvalCase) -> None:
+    case_dir = iteration_dir / f"eval-{case.id}-{case.name}"
+    case_dir.mkdir(parents=True, exist_ok=True)
+    metadata = {
+        "id": case.id,
+        "eval_name": case.name,
+        "expected_output": case.expected_output,
+        "assertions": case.assertions,
+    }
+    (case_dir / "grading_input.json").write_text(json.dumps(metadata, indent=2) + "\n")
+
+
+def create_iteration_directory(workspace: Path | None) -> Path:
+    timestamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    workspace_root = workspace or Path(tempfile.gettempdir()) / "pythonic-code-evals"
+    iteration_dir = workspace_root.expanduser().resolve() / f"iteration-{timestamp}"
+    iteration_dir.mkdir(parents=True, exist_ok=False)
+    return iteration_dir
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--case", default="all", help="all, a numeric id, or an eval name")
+    parser.add_argument("--workspace", type=Path, help="directory that will contain the iteration")
+    parser.add_argument("--model", default=os.environ.get("CODEX_EVAL_MODEL"))
+    parser.add_argument("--list", action="store_true", help="list cases and exit")
+    parser.add_argument("--validate", action="store_true", help="validate cases and exit")
+    parser.add_argument("--dry-run", action="store_true", help="show selected trials and exit")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        cases = load_eval_cases()
+        selected_cases = select_eval_cases(cases, args.case)
+    except (OSError, ValueError, json.JSONDecodeError, SyntaxError) as error:
+        print(f"Evaluation configuration error: {error}", file=sys.stderr)
+        return 2
+
+    if args.list:
+        for case in cases:
+            files = ", ".join(str(path) for path in case.files)
+            print(f"{case.id}: {case.name} [{files}]")
+        return 0
+    if args.validate:
+        print(f"Validated {len(cases)} pythonic-code eval cases in {EVALS_PATH}")
+        return 0
+    if args.dry_run:
+        for case in selected_cases:
+            print(f"Would run eval {case.id} ({case.name}): with_skill, without_skill")
+        return 0
+
+    codex_path = shutil.which("codex")
+    if codex_path is None:
+        print("codex executable was not found on PATH", file=sys.stderr)
+        return 2
+
+    try:
+        iteration_dir = create_iteration_directory(args.workspace)
+    except OSError as error:
+        print(f"Could not create eval workspace: {error}", file=sys.stderr)
+        return 2
+
+    failures = 0
+    print(f"Eval workspace: {iteration_dir}", flush=True)
+    for case in selected_cases:
+        write_case_metadata(iteration_dir, case)
+        failures += (
+            run_codex_trial(
+                codex_path,
+                iteration_dir,
+                case,
+                with_skill=True,
+                model=args.model,
+            )
+            != 0
+        )
+        failures += (
+            run_codex_trial(
+                codex_path,
+                iteration_dir,
+                case,
+                with_skill=False,
+                model=args.model,
+            )
+            != 0
+        )
+
+    if failures:
+        print(f"Completed with {failures} failed trial(s): {iteration_dir}", file=sys.stderr)
+        return 1
+    print(f"Completed paired eval runs: {iteration_dir}")
+    print("Grade each pair against grading_input.json and record evidence in grading.json.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

PR #1095 introduced the `/pythonic-code` skill, but the skill had no repeatable evaluation surface. Real cleanup issues #1096, #1097, and #1098 provide representative architecture, persistence-invariant, and abstraction-simplification cases without relying on toy Python examples.

## What Changed

- Add three issue-derived eval cases with self-contained fixtures and assertion rubrics.
- Add a skill-local `justfile` for listing, validating, dry-running, and running paired trials.
- Add an isolated runner that executes each case with and without the skill, excludes eval answers from the agent workspace, and records outputs, events, timing, and grading input.
- Add minimal shared workspace instructions and Ruff/pytest configuration so both variants receive realistic repository context.
- Clarify the skill guidance: use `Protocol` for replaceable behavior, not property-only internal result shapes.

## Implementation Details

The runner copies only the selected fixture files into a fresh temporary workspace. Skill-guided trials receive `SKILL.md` but not the eval definitions, assertions, expected outputs, runner, or prior results.

The first fair-context run exposed a concrete weakness: the skill-guided #1098 patch retained two property-only result protocols and scored 3/5 while the baseline scored 5/5. After adding the focused protocol rule, the unchanged #1098 retest scored 5/5; its concurrent baseline scored 4/5 because it introduced an `AcceptedNotePreparer` class instead of direct module-level behavior.

Using the latest result for each unchanged case, the revised skill scored 15/15 versus 14/15 for the baseline. These are directional single-run results; the code-shape difference is the useful signal, while timing and token counts remain stochastic.

## Testing

Passed:

- `cd .agents/skills/pythonic-code && just validate`
- `PYTHONPATH=evals/files uv run pytest -q evals/files/test_accepted_snapshot.py evals/files/test_accepted_preparation.py` — 5 passed
- `uv run python /Users/phernandez/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/pythonic-code`
- `just package-check`
- Paired Codex eval runs for all three cases, plus the focused #1098 retest

## Risks / Follow-ups

- The eval runner invokes Codex and therefore consumes model time and tokens.
- Results are intentionally not treated as deterministic performance benchmarks.
- Assertion grading remains a deliberate manual review of produced code and recommendations.
- This PR does not implement or close #1096, #1097, or #1098; it uses condensed versions as eval inputs.

Related to #1096, #1097, and #1098.
