### PR TITLE
feat(api): add owning-entity external_id to search results

### DIFF
--- a/src/basic_memory/api/v2/utils.py
+++ b/src/basic_memory/api/v2/utils.py
@@ -271,6 +271,10 @@ async def to_search_results(
                         permalink=result.permalink,
                         score=result.score if result.score is not None else 0.0,
                         entity=parent_entity.permalink if parent_entity else None,
+                        # Parent entity UUID, so hosted MCP can deep-link the note this hit
+                        # belongs to. Available for entity, observation, and relation results
+                        # because each row carries its owning entity's id (#1423).
+                        external_id=parent_entity.external_id if parent_entity else None,
                         content=result.content,
                         matched_chunk=result.matched_chunk_text,
                         file_path=_required_str(result.file_path, "file_path"),

--- a/src/basic_memory/schemas/search.py
+++ b/src/basic_memory/schemas/search.py
@@ -121,6 +121,10 @@ class SearchResult(BaseModel):
     type: SearchItemType
     score: float
     entity: Optional[Permalink] = None
+    # External UUID of the note this result belongs to (the parent entity for observation and
+    # relation hits). Stable, API-friendly id the hosted MCP layer uses to build web-app
+    # deep-links to the matching note (#1423).
+    external_id: Optional[str] = None
     permalink: Optional[str]
     content: Optional[str] = None
     matched_chunk: Optional[str] = None

--- a/tests/api/v2/test_search_hydration.py
+++ b/tests/api/v2/test_search_hydration.py
@@ -19,8 +19,12 @@ from basic_memory.repository.search_index_row import SearchIndexRow
 # --- Helpers ---
 
 
-def _make_entity(id: int, permalink: str) -> SimpleNamespace:
-    return SimpleNamespace(id=id, permalink=permalink)
+def _make_entity(id: int, permalink: str, external_id: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=id,
+        permalink=permalink,
+        external_id=external_id if external_id is not None else f"ext-{id}",
+    )
 
 
 def _make_row(*, type: str, id: int, **kwargs: Any) -> SearchIndexRow:
@@ -248,6 +252,48 @@ async def test_mixed_result_types_single_fetch():
     # Relation result
     assert search_results[2].from_entity == "notes/entity-one"
     assert search_results[2].to_entity == "notes/entity-three"
+
+
+# --- Owning-entity external_id (hosted MCP deep-links, #1423) ---
+
+
+@pytest.mark.asyncio
+async def test_external_id_populated_for_all_result_types():
+    """Every result type carries its owning entity's external_id for note deep-links.
+
+    Entity hits map to their own UUID; observation and relation hits map to their parent
+    entity's UUID so the hosted MCP layer can link back to the note the hit belongs to.
+    """
+    service = SpyEntityService(
+        {
+            1: _make_entity(1, "notes/parent", external_id="uuid-parent"),
+            2: _make_entity(2, "notes/source", external_id="uuid-source"),
+            3: _make_entity(3, "notes/target", external_id="uuid-target"),
+        }
+    )
+    results = [
+        _make_row(type="entity", id=1, entity_id=1),
+        _make_row(type="observation", id=10, entity_id=1, category="fact"),
+        _make_row(type="relation", id=20, entity_id=1, from_id=2, to_id=3, relation_type="links"),
+    ]
+
+    search_results = await to_search_results(service, results)
+
+    # Entity hit → its own UUID; observation/relation hits → the parent entity's UUID.
+    assert search_results[0].external_id == "uuid-parent"
+    assert search_results[1].external_id == "uuid-parent"
+    assert search_results[2].external_id == "uuid-parent"
+
+
+@pytest.mark.asyncio
+async def test_external_id_none_when_owning_entity_missing():
+    """A hit whose owning entity isn't found leaves external_id None rather than failing."""
+    service = SpyEntityService({})
+    results = [_make_row(type="entity", id=1)]  # no entity_id → no owning entity resolved
+
+    search_results = await to_search_results(service, results)
+
+    assert search_results[0].external_id is None
 
 
 # --- Graceful handling of missing entities ---

--- a/tests/api/v2/test_utils_telemetry.py
+++ b/tests/api/v2/test_utils_telemetry.py
@@ -34,8 +34,8 @@ async def test_to_search_results_emits_hydration_spans(monkeypatch) -> None:
     class FakeEntityService:
         async def get_entities_by_id(self, ids):
             return [
-                SimpleNamespace(id=1, permalink="notes/root"),
-                SimpleNamespace(id=2, permalink="notes/child"),
+                SimpleNamespace(id=1, permalink="notes/root", external_id="uuid-root"),
+                SimpleNamespace(id=2, permalink="notes/child", external_id="uuid-child"),
             ]
 
     now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Why

External agents calling the hosted Basic Memory Cloud `/mcp` `search_notes` tool have no way to link a search hit back to the note in the web app. Every other content tool already returns web-app links, but search was excluded because `SearchResult` did not expose the entity `external_id` UUID that link-building needs (#1423).

## What

- `SearchResult` gains `external_id: Optional[str]` — the **owning entity's** UUID (the parent entity for observation and relation hits, the note itself for entity hits).
- `to_search_results()` populates it from `parent_entity.external_id`, which is **already batch-fetched** to shape the existing `entity`/`permalink` fields.

Pure plumbing: no search-index column, no reindex.

## How it was tested

- `tests/api/v2/test_search_hydration.py`: `_make_entity` now carries `external_id`; added `test_external_id_populated_for_all_result_types` (entity/observation/relation all resolve to the owning entity's UUID) and `test_external_id_none_when_owning_entity_missing`.
- Fixed the fake entities in `tests/api/v2/test_utils_telemetry.py`.
- `uv run pytest tests/api/v2/test_search_hydration.py tests/api/v2/test_utils_telemetry.py tests/api/v2/test_search_router_telemetry.py tests/schemas/test_search.py` → 22 passed. Lint + pyright clean.

## Companion

The consumer is a basic-memory-cloud PR that builds `/notes?id=cloud|...` deep-links per search result from this field. That PR pins its `basic-memory` git rev to this branch's commit and must be re-pinned to the merged commit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)