### PR TITLE
feat(mcp): emit external_id in search_notes markdown output

### DIFF
--- a/src/basic_memory/mcp/tools/search.py
+++ b/src/basic_memory/mcp/tools/search.py
@@ -332,6 +332,12 @@ def _format_search_markdown(result: SearchResponse, project: str, query: str | N
     for r in result.results:
         parts.append(f"### {r.title}")
         parts.append(f"- permalink: {r.permalink}")
+        # external_id is the note's stable identifier. Emitting it lets the hosted MCP layer
+        # deep-link each hit to the web app from the final (post-merge) result the caller sees,
+        # which matters for all-projects search where the displayed page is decided after the
+        # per-project API calls the gateway would otherwise record (#1423).
+        if r.external_id:
+            parts.append(f"- external_id: {r.external_id}")
         parts.append(f"- score: {r.score:.4f}")
         if r.matched_chunk:
             parts.append(f"- match: {r.matched_chunk[:200]}")

--- a/tests/mcp/test_tool_search.py
+++ b/tests/mcp/test_tool_search.py
@@ -1877,6 +1877,7 @@ def test_format_search_markdown_with_results():
                 type=SearchItemType.ENTITY,
                 score=0.85,
                 permalink="docs/my-note",
+                external_id="46adce12-adfc-42f5-a0f9-83aa65f22619",
                 file_path="docs/My Note.md",
                 matched_chunk="This is a matching snippet",
             ),
@@ -1898,9 +1899,13 @@ def test_format_search_markdown_with_results():
     assert "test-project" in text
     assert "### My Note" in text
     assert "permalink: docs/my-note" in text
+    # external_id is emitted for hits that carry one, so hosted MCP can deep-link them (#1423).
+    assert "external_id: 46adce12-adfc-42f5-a0f9-83aa65f22619" in text
     assert "0.8500" in text
     assert "match: This is a matching snippet" in text
     assert "### Other Note" in text
+    # A hit without an external_id must not render an empty external_id line.
+    assert text.count("external_id:") == 1
     assert "2 results" in text
     assert "page 1" in text
 


### PR DESCRIPTION
## Why

The hosted Basic Memory Cloud MCP layer decorates `search_notes` results with web-app deep-links. For **all-projects** search, the tool fans out one API call per project, then merges/sorts/slices before returning — so links recorded from those per-project API calls don't match the final displayed page (wrong cap, wrong ordering). To decorate from the *final* result the caller actually sees, the cloud layer needs a stable per-result identifier in that output.

`search_notes` text output already prints `permalink`, `score`, and `match`, but not `external_id`. Permalink isn't usable as the key because all-projects search workspace-qualifies it (`workspace/project/...`), while `external_id` is globally unique and unchanged by qualification.

## What

`_format_search_markdown` now emits a `- external_id: {uuid}` line per result that has one — the same pattern `recent_activity` already uses. Hits without an `external_id` render no line.

The `external_id` field itself already exists on `SearchResult` (added in #1101); this only surfaces it in the text output.

## How it was tested

- `tests/mcp/test_tool_search.py::test_format_search_markdown_with_results` — extended: one result carries an `external_id` (asserts the line renders), one does not (asserts exactly one `external_id:` line, no empty line).
- `uv run pytest tests/mcp/test_tool_search.py -k format_search_markdown` → 2 passed. Lint clean.

## Companion

Consumed by basic-memory-cloud #1546, which parses these `external_id`s from the final result to build per-result web-app links that match the displayed page for both single- and multi-project search. That PR pins its `basic-memory` rev to this commit and must be re-pinned to the merged commit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)