### PR TITLE
feat(skills): use Pythonic guidance in GitHub agents

### DIFF
--- a/.claude/skills/basic-machines-review
+++ b/.claude/skills/basic-machines-review
@@ -1,1 +1,1 @@
-../../.agents/skills/basic-machines-review
+../../.agents/skills/code-review

--- a/.claude/skills/pythonic-code
+++ b/.claude/skills/pythonic-code
@@ -1,0 +1,1 @@
+../../.agents/skills/pythonic-code

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,10 +42,15 @@ jobs:
             treat this advisory review as the required merge gate. BM Bossbot owns
             the required `BM Bossbot Approval` status.
 
+            If the PR changes Python, read
+            `.agents/skills/pythonic-code/SKILL.md` in full and apply its Review
+            mode to the changed Python code before reporting findings.
+
             Review the PR against our team checklist:
 
             ## Code Quality & Standards
             - [ ] Follows Basic Memory's coding conventions in CLAUDE.md
+            - [ ] Python changes follow the `pythonic-code` review guidance
             - [ ] Python 3.12+ type annotations and async patterns
             - [ ] SQLAlchemy 2.0 best practices
             - [ ] FastAPI and Typer conventions followed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,11 @@ See [docs/ENGINEERING_STYLE.md](docs/ENGINEERING_STYLE.md) for the fuller house 
 [docs/DOMAIN_MODEL.md](docs/DOMAIN_MODEL.md) for product language, ownership, identity, and
 source-of-truth rules. The short version for agents:
 
+For nontrivial Python writing, refactoring, or review, read and follow
+[`.agents/skills/pythonic-code/SKILL.md`](.agents/skills/pythonic-code/SKILL.md) in full. Use
+the skill's Write, Refactor, or Review mode that matches the task. GitHub coding and review
+agents must apply this skill before changing or evaluating Python code.
+
 - Prefer type-safe, explicit designs over object-heavy indirection. Use Python 3.12 `type`
   aliases, full annotations, and narrow `Protocol`s when a caller only needs a capability.
 - Prefer functions and typed values before classes, and concrete classes before abstract base


### PR DESCRIPTION
## Why

The repository-level `pythonic-code` skill is available to Codex under `.agents/skills`, but the GitHub coding and review agents were not explicitly routed through it. Claude also lacked a project-skill link to the shared source, and its existing Basic Machines review link still targeted the pre-rename skill path.

## What Changed

- require GitHub coding and review agents to apply `pythonic-code` for nontrivial Python writing, refactoring, and review
- expose the canonical skill to Claude through `.claude/skills/pythonic-code`
- make the manual Claude review workflow read and apply the skill Review mode for Python changes
- repair the dangling Claude `basic-machines-review` link after the shared skill was renamed to `code-review`

## Implementation Details

The Codex and Claude entrypoints share the existing `.agents/skills/pythonic-code/SKILL.md` source. Claude uses a symlink rather than a copied skill, so the two agent surfaces cannot drift. The root `CLAUDE.md` already points to `AGENTS.md`, which makes the explicit GitHub-agent rule available to both providers.

## Testing

All passed:

- `just --justfile .agents/skills/pythonic-code/justfile --working-directory .agents/skills/pythonic-code validate`
- `just package-check-codex`
- `just package-check-claude-code`
- `uv run python -c` workflow YAML and shared-skill symlink assertions
- `git diff --check`

## Risks / Follow-ups

Low risk. This changes agent instructions, skill discovery, and review prompting only; it does not change application runtime behavior. No follow-up is currently required.