### PR TITLE
feat(skills): add pull request workflow skills

### DIFF
--- a/.agents/skills/fix-pr-issues/SKILL.md
+++ b/.agents/skills/fix-pr-issues/SKILL.md
@@ -1,29 +1,24 @@
 ---
 name: fix-pr-issues
-description: Use when addressing Basic Memory pull request feedback, failed checks, or BM Bossbot blockers from Codex.
+description: Use when addressing Basic Memory pull request feedback, failed checks, or Codex review blockers, then re-running the latest-head review gate.
 ---
 
 # Fix Basic Memory PR Issues
 
-Resolve PR feedback and failed checks, then wait for BM Bossbot to approve the
-new head SHA. This skill never merges a PR.
+Resolve PR feedback and failed checks, then apply `pr-review-loop` to the new
+head SHA. This skill never merges a PR.
 
 ## Gather
 
-1. Identify the PR:
+1. Identify the live PR and latest head:
    - `gh pr view --json number,url,headRefOid,mergeStateStatus,statusCheckRollup`
-
-2. Collect feedback:
+2. Collect the exact feedback:
    - PR comments and review summaries
    - inline review comments and unresolved review threads
    - failed GitHub Actions jobs and relevant logs
-   - the managed `BM_BOSSBOT_SUMMARY` block in the PR body
-
-3. Build a short issue ledger:
-   - source
-   - concrete problem
-   - expected fix
-   - verification needed
+   - Codex reactions and latest-head review state described by `pr-review-loop`
+3. Build a short issue ledger with the source, concrete problem, expected fix,
+   and verification needed for each item.
 
 ## Fix
 
@@ -31,18 +26,23 @@ new head SHA. This skill never merges a PR.
 2. Read each file in full before editing it.
 3. Keep diffs narrow and preserve unrelated user changes.
 4. Run the smallest meaningful verification first, then widen as needed.
-5. Commit with `git commit -s` when code or docs changed.
+5. Commit changed code or documentation with `git commit -s`.
+
+If a comment is wrong, stale, intentionally out of scope, or not worth the
+tradeoff, reply with concise evidence instead of forcing a code change.
 
 ## Push And Recheck
 
 1. Push the branch.
-2. Watch checks for the new `headRefOid`.
-3. Wait for the required `BM Bossbot Approval` status to pass on that exact SHA.
-4. If BM Bossbot reviews an older SHA, treat the approval as stale and keep
-   waiting for the current one.
+2. Confirm checks are running against the new `headRefOid` and watch them to
+   completion.
+3. Apply `pr-review-loop` in full. A prior Codex approval is stale after a code
+   push; require the current-head approval signal and zero unresolved,
+   non-outdated Codex threads.
+4. If new feedback appears, add it to the ledger and repeat the loop.
 
 ## Reply
 
 For each addressed comment or blocker, reply with the fix commit, verification
-run, and current BM Bossbot status. Do not resolve or dismiss substantive
-feedback without evidence.
+run, and current Codex gate status. Resolve a substantive thread only after the
+fix or rationale is posted with evidence.

--- a/.agents/skills/fix-pr-issues/agents/openai.yaml
+++ b/.agents/skills/fix-pr-issues/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Fix PR Issues"
-  short_description: "Address PR feedback and BM Bossbot blockers"
+  short_description: "Address PR feedback and Codex blockers"
   icon_small: "./assets/icon.svg"
   icon_large: "./assets/icon.svg"
   brand_color: "#2563EB"
-  default_prompt: "Use $fix-pr-issues to address PR feedback and wait for BM Bossbot Approval on the latest head SHA."
+  default_prompt: "Use $fix-pr-issues to address PR feedback and re-run the Codex review gate on the latest head SHA."

--- a/.agents/skills/pr-create/SKILL.md
+++ b/.agents/skills/pr-create/SKILL.md
@@ -1,114 +1,41 @@
 ---
 name: pr-create
-description: Use when creating or updating a Basic Memory pull request from Codex with BM Bossbot merge-gate monitoring.
+description: Use when explicitly creating or updating a Basic Memory pull request. This compatibility entry point delegates the full workflow to pull-request and the latest-head Codex gate to pr-review-loop.
 ---
 
 # Create A Basic Memory PR
 
-Create or update a pull request for the current branch, then wait for BM
-Bossbot to approve the latest head SHA. This skill never merges a PR.
+Create or update a pull request by applying `pull-request` in full. Use
+`pr-description` for the body and enter `pr-review-loop` as soon as the PR is
+open or materially updated. This skill never merges a PR.
 
-## Inputs
+## Compatibility
 
-- Optional `<theme>`: free-form visual direction for the non-gating PR
-  image. Example: `$pr-create "Italian movie poster"`.
-- Treat `<theme>` as style guidance only. It must not affect PR readiness,
-  BM Bossbot review, status checks, or merge behavior.
+`$pr-create` remains available for existing prompts, but its former BM Bossbot
+and automatic PR-infographic workflow has been retired. Do not wait for the
+deleted `BM Bossbot Approval` status or `.github/workflows/bm-bossbot.yml`.
 
-## How To Use
+If a legacy `$pr-create "<theme>"` prompt includes an image theme, do not add
+the retired managed theme or provenance blocks. Explain that the automatic PR
+image path is no longer part of this workflow.
 
-Ask Codex to use the skill from a feature branch:
+## Workflow
 
-```text
-$pr-create
-$pr-create "Italian movie poster"
-$pr-create "80's action movies"
-```
-
-Use the plain form when you only want the PR workflow. Pass a theme when you
-want the non-gating image to lean toward a particular visual direction. The
-theme can be specific ("Rembrandt-inspired approval scene") or broad ("let the
-model choose from BM categories").
-
-## What Happens
-
-1. Codex checks the branch, local verification, GitHub auth, commit sign-offs,
-   and semantic PR title shape.
-2. Codex pushes the branch, creates or reuses the PR, and adds the optional
-   `BM_INFOGRAPHIC_THEME` block when a theme was supplied.
-3. BM Bossbot runs from trusted base code, reviews sanitized PR metadata and
-   diff context, and sets the required `BM Bossbot Approval` status for the
-   exact head SHA.
-4. If approval succeeds, BM Bossbot may publish a non-gating image block and a
-   provenance block:
-
-   ```markdown
-   <!-- BM_INFOGRAPHIC_PROVENANCE:start -->
-   ...
-   <!-- BM_INFOGRAPHIC_PROVENANCE:end -->
-   ```
-
-   The provenance records the image mode, theme source, selected visual
-   direction, and image settings. It is for review/debugging context only.
-5. Codex reports the PR URL, head SHA, checks watched, verification run, and BM
-   Bossbot verdict.
-
-The skill never merges, never enables auto-merge, and never treats the image or
-provenance block as a gate. The only required merge signal is the
-`BM Bossbot Approval` status on the current PR head SHA.
-
-## Preflight
-
-1. Confirm the repo and branch:
-   - `git status --short --branch`
-   - stop if detached or on `main`
-   - keep unrelated user changes intact
-
-2. Confirm GitHub access:
-   - `gh auth status`
-   - `gh repo view --json nameWithOwner,defaultBranchRef,url`
-
-3. Check PR readiness:
-   - commits are signed off with `git commit -s`
-   - title uses the repo semantic format
-   - local verification appropriate to the change has run
-
-## Create Or Reuse
-
-1. Push the branch:
-   - `git push -u origin HEAD`
-
-2. Check for an existing PR:
-   - `gh pr view --json number,url,headRefOid,mergeStateStatus,statusCheckRollup`
-
-3. If no PR exists, create one:
-   - `gh pr create --fill`
-   - adjust the title if it does not satisfy the semantic PR title workflow
-
-4. If `<theme>` is provided, add or update this managed block in the PR body:
-
-```markdown
-<!-- BM_INFOGRAPHIC_THEME:start -->
-<theme>
-<!-- BM_INFOGRAPHIC_THEME:end -->
-```
-
-Keep the rest of the PR body intact. The theme is non-gating image guidance
-only.
-
-5. Do not merge. Do not enable auto-merge.
-
-## Watch The Gate
-
-1. Trigger or wait for `.github/workflows/bm-bossbot.yml`.
-2. Watch the required commit status named `BM Bossbot Approval`.
-3. Treat approval as valid only when it is green for the current `headRefOid`.
-4. If the branch changes after approval, wait for BM Bossbot to review the new
-   head SHA.
-5. If BM Bossbot fails or requests changes, use `$fix-pr-issues`.
+1. Read and follow `pull-request` for branch hygiene, validation, pushing, and
+   PR creation or reuse.
+2. Read and follow `pr-description` when creating or materially updating the
+   PR body.
+3. Confirm commits are signed off, the title follows the repository's semantic
+   PR-title format, and the validation appropriate to the changed surface has
+   passed.
+4. Push the branch and create or reuse the PR. Do not enable auto-merge.
+5. Read and follow `pr-review-loop` on the latest head SHA. Green CI alone is
+   not approval.
+6. If Codex or CI reports a blocker, use `fix-pr-issues`, push the fix, and
+   restart `pr-review-loop` for the new head.
 
 ## Report
 
-Return the PR URL, current head SHA, checks watched, verification run, and the
-BM Bossbot verdict. Include the image `<theme>` if one was supplied. Be
-explicit when any check is still pending.
+Return the PR URL, current head SHA, validation run, check status, and Codex
+gate evidence. Report pending or blocking state explicitly. Do not merge unless
+the user separately requests it and the current-head gate permits it.

--- a/.agents/skills/pr-create/agents/openai.yaml
+++ b/.agents/skills/pr-create/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "PR Create"
-  short_description: "Create PRs and wait for BM Bossbot"
+  short_description: "Create PRs and run the Codex review loop"
   icon_small: "./assets/icon.svg"
   icon_large: "./assets/icon.svg"
   brand_color: "#2563EB"
-  default_prompt: "Use $pr-create to create or update this Basic Memory PR and wait for BM Bossbot Approval."
+  default_prompt: "Use $pr-create to create or update this Basic Memory PR and run the latest-head Codex review loop."

--- a/.agents/skills/pr-description/SKILL.md
+++ b/.agents/skills/pr-description/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pr-description
+description: Use when opening or updating a GitHub PR - writes a detailed PR description that explains what changed, why it changed, how it was implemented, and how it was tested.
+license: MIT
+---
+
+# PR Description Writer
+
+Create and publish high-quality PR descriptions that help reviewers understand intent, implementation details, and verification steps.
+
+## When to Use
+
+- Opening a new PR
+- Refreshing a stale or minimal PR description
+- Capturing implementation rationale for future debugging
+
+## Goals
+
+Every PR body should clearly answer:
+
+1. What changed?
+2. Why did we make this change now?
+3. How was it implemented?
+4. How was it tested?
+5. What risks or follow-ups remain?
+
+## Workflow
+
+1. Discover PR context and changed files.
+2. Extract intent from commit(s) and code changes.
+3. Draft a structured PR body.
+4. Apply the body to the PR.
+5. Re-open the PR view and confirm body/labels.
+
+## Commands
+
+```bash
+# Identify the active PR for current branch
+gh pr view --json number,title,url,baseRefName,headRefName
+
+# Inspect changed files and patch summary
+gh pr diff --name-only
+gh pr diff
+
+# Review commit messages for intent
+git log --oneline --decorate -n 10
+
+# Apply updated body
+gh pr edit <pr-number> --body-file /tmp/pr-body.md
+```
+
+## Body Structure
+
+Use the template in [references/pr-body-template.md](references/pr-body-template.md).
+
+Required sections:
+
+- `## Why`
+- `## What Changed`
+- `## Implementation Details`
+- `## Testing`
+- `## Risks / Follow-ups`
+
+## Quality Bar
+
+- Be specific: name concrete files, routes, scripts, and commands.
+- Explain tradeoffs and constraints, not just mechanics.
+- Testing section must include exact commands run and outcomes.
+- If something is not tested, state it explicitly.
+
+## Optional Enhancements
+
+- Add `## Screenshots` for UI work.
+- Add `## Rollout Notes` when release sequencing matters.
+- Add `## Reviewer Guide` for large diffs.

--- a/.agents/skills/pr-description/references/pr-body-template.md
+++ b/.agents/skills/pr-description/references/pr-body-template.md
@@ -1,0 +1,30 @@
+## Why
+
+- Problem or opportunity this PR addresses.
+- Why this is the right time to do it.
+
+## What Changed
+
+- High-level bullet list of major changes.
+- Mention user-visible behavior changes.
+
+## Implementation Details
+
+- File-level summary of key edits.
+- Notable design decisions and tradeoffs.
+- Constraints that shaped the implementation.
+
+## Testing
+
+### Automated
+
+- `command`: result
+
+### Manual
+
+- Step performed: outcome
+
+## Risks / Follow-ups
+
+- Known risks or edge cases.
+- Explicit follow-up tasks.

--- a/.agents/skills/pr-review-loop/SKILL.md
+++ b/.agents/skills/pr-review-loop/SKILL.md
@@ -57,9 +57,9 @@ invalidate the code-head review unless it changes the scope being reviewed.
 Check the PR body reactions first, and verify the reacting actor:
 
 ```bash
-gh api "repos/<owner>/<repo>/issues/<number>/reactions" \
+gh api "repos/<owner>/<repo>/issues/<number>/reactions" --paginate --slurp \
   -H "Accept: application/vnd.github+json" \
-  | jq '[.[] | select(.user.login == "chatgpt-codex-connector[bot]")
+  | jq '[.[][] | select(.user.login == "chatgpt-codex-connector[bot]")
     | {content, created_at, user: .user.login}]'
 ```
 
@@ -72,8 +72,22 @@ the current head prefix:
 
 ```bash
 gh api "repos/<owner>/<repo>/issues/<number>/comments" --paginate \
-  | jq '[.[] | select(.user.login | test("chatgpt-codex-connector"))
-    | {created_at, html_url, body: .body[0:240], reactions: .reactions}]'
+  --slurp \
+  | jq '[.[][] | select(.user.login | test("chatgpt-codex-connector"))
+    | {id, created_at, html_url, body: .body[0:240]}]'
+```
+
+For a relevant Codex issue comment, verify any approval reaction by actor. The
+aggregate reaction counts on the comment do not identify who reacted:
+
+```bash
+gh api "repos/<owner>/<repo>/issues/comments/<comment-id>/reactions" \
+  --paginate --slurp \
+  -H "Accept: application/vnd.github+json" \
+  | jq '[.[][]
+    | select(.user.login == "chatgpt-codex-connector[bot]"
+      and .content == "+1")
+    | {content, created_at, user: .user.login}]'
 ```
 
 Finally, query GraphQL review threads. GitHub records comment placement SHAs in

--- a/.agents/skills/pr-review-loop/SKILL.md
+++ b/.agents/skills/pr-review-loop/SKILL.md
@@ -54,18 +54,34 @@ Any code push after a prior Codex approval invalidates that approval. A material
 PR-body edit should restart the loop for the description, but it does not
 invalidate the code-head review unless it changes the scope being reviewed.
 
-Check the PR body reactions first, and verify the reacting actor:
+Check the PR body reactions first, and verify both the reacting actor and the
+reaction's freshness for the current head. The status rollup is scoped to the
+current head SHA, so its earliest start time provides a post-push lower bound:
 
 ```bash
+head_started_at="$(
+  gh pr view <number> --json headRefOid,statusCheckRollup \
+    --jq '[.statusCheckRollup[] | .startedAt // empty] | min // empty'
+)"
+if [ -z "$head_started_at" ]; then
+  echo "Cannot prove when current-head activity started; body reaction is not approval."
+  exit 1
+fi
+
 gh api "repos/<owner>/<repo>/issues/<number>/reactions" --paginate --slurp \
   -H "Accept: application/vnd.github+json" \
-  | jq '[.[][] | select(.user.login == "chatgpt-codex-connector[bot]")
+  | jq --arg head_started_at "$head_started_at" \
+    '[.[][]
+    | select(.user.login == "chatgpt-codex-connector[bot]"
+      and .created_at >= $head_started_at)
     | {content, created_at, user: .user.login}]'
 ```
 
 `gh pr view --json reactionGroups` is useful for counts, but it does not show
 which user reacted. Use the REST reactions endpoint above to prove Codex left
-the thumbs-up on the PR body.
+the thumbs-up on the PR body after current-head activity began. If the current
+head has no timestamped status/check activity, require a Codex review or issue
+comment that names the current head instead of trusting a body reaction alone.
 
 Then check Codex issue comments and confirm the latest "Reviewed commit" matches
 the current head prefix:

--- a/.agents/skills/pr-review-loop/SKILL.md
+++ b/.agents/skills/pr-review-loop/SKILL.md
@@ -97,42 +97,51 @@ body_edited_at="$(
     | jq -r '.data.repository.pullRequest.lastEditedAt // empty'
 )"
 
-if [ -z "$head_started_at" ] || [ "$edit_head_sha" != "$head_sha" ]; then
-  echo "Cannot prove current-head freshness; reaction is not approval."
+if [ "$edit_head_sha" != "$head_sha" ]; then
+  echo "Head changed while checking review state; reaction is not approval."
   exit 1
 fi
 
-approval_not_before="$(
-  jq -nr \
-    --arg head_started_at "$head_started_at" \
-    --arg body_edited_at "$body_edited_at" \
-    '[$head_started_at, $body_edited_at]
-    | map(select(length > 0))
-    | max // empty'
-)"
+body_reactions_available=true
+if [ -z "$head_started_at" ]; then
+  body_reactions_available=false
+  approval_not_before="$body_edited_at"
+  echo "No timestamped current-head checks; skipping PR-body reactions."
+else
+  approval_not_before="$(
+    jq -nr \
+      --arg head_started_at "$head_started_at" \
+      --arg body_edited_at "$body_edited_at" \
+      '[$head_started_at, $body_edited_at]
+      | map(select(length > 0))
+      | max // empty'
+  )"
+fi
 
-reactions_json="$(
-  gh api "repos/<owner>/<repo>/issues/<number>/reactions" --paginate --slurp \
-    -H "Accept: application/vnd.github+json"
-)"
+if [ "$body_reactions_available" = true ]; then
+  reactions_json="$(
+    gh api "repos/<owner>/<repo>/issues/<number>/reactions" --paginate --slurp \
+      -H "Accept: application/vnd.github+json"
+  )"
 
-echo "Fresh Codex approvals:"
-printf '%s' "$reactions_json" \
-  | jq --arg approval_not_before "$approval_not_before" \
-    '[.[][]
-    | select(.user.login == "chatgpt-codex-connector[bot]"
-      and .content == "+1"
-      and .created_at >= $approval_not_before)
-    | {content, created_at, user: .user.login}]'
+  echo "Fresh Codex approvals:"
+  printf '%s' "$reactions_json" \
+    | jq --arg approval_not_before "$approval_not_before" \
+      '[.[][]
+      | select(.user.login == "chatgpt-codex-connector[bot]"
+        and .content == "+1"
+        and .created_at >= $approval_not_before)
+      | {content, created_at, user: .user.login}]'
 
-echo "Fresh Codex pending signals:"
-printf '%s' "$reactions_json" \
-  | jq --arg approval_not_before "$approval_not_before" \
-    '[.[][]
-    | select(.user.login == "chatgpt-codex-connector[bot]"
-      and .content == "eyes"
-      and .created_at >= $approval_not_before)
-    | {content, created_at, user: .user.login}]'
+  echo "Fresh Codex pending signals:"
+  printf '%s' "$reactions_json" \
+    | jq --arg approval_not_before "$approval_not_before" \
+      '[.[][]
+      | select(.user.login == "chatgpt-codex-connector[bot]"
+        and .content == "eyes"
+        and .created_at >= $approval_not_before)
+      | {content, created_at, user: .user.login}]'
+fi
 ```
 
 `gh pr view --json reactionGroups` is useful for counts, but it does not show
@@ -140,8 +149,8 @@ which user reacted. Use the REST reactions endpoint above to prove Codex left
 the thumbs-up after both current-head activity began and the PR object was last
 edited. Only a non-empty approval result satisfies the gate; a non-empty pending
 result means keep waiting. If the current head has no timestamped status/check
-activity, require a Codex review or issue comment that names the current head
-instead of trusting a body reaction alone.
+activity, skip PR-body reactions and continue to the review and issue-comment
+checks below instead of exiting the workflow.
 
 Then check Codex issue comments and confirm the latest "Reviewed commit" matches
 the current head prefix:
@@ -152,6 +161,11 @@ gh api "repos/<owner>/<repo>/issues/<number>/comments" --paginate \
   | jq '[.[][] | select(.user.login | test("chatgpt-codex-connector"))
     | {id, created_at, html_url, body: .body[0:240]}]'
 ```
+
+When PR-body reactions were skipped, only use an issue comment that names the
+exact current head and, when `body_edited_at` is non-empty, was created after
+that edit. Its thumbs-up must also pass the actor and `approval_not_before`
+check below.
 
 Top-level pull-request reviews are a separate API surface from issue comments
 and review threads. Fetch every page and inspect Codex reviews submitted for the

--- a/.agents/skills/pr-review-loop/SKILL.md
+++ b/.agents/skills/pr-review-loop/SKILL.md
@@ -34,7 +34,8 @@ but it also does not replace the required thumbs-up.
 - Thumbs-up reaction by `chatgpt-codex-connector[bot]` on the PR body/description: Codex approves/no suggestions. This is the common approval signal.
 - Thumbs-up reaction by `chatgpt-codex-connector[bot]` on a Codex issue comment: also an approval signal, but this is not the only place to look.
 - Codex issue comment saying "Didn't find any major issues": approval-like context, but confirm the PR body/comment thumbs-up or get an explicit user override.
-- Codex top-level review with `CHANGES_REQUESTED` or a substantive review body: blocking feedback even when it has no inline thread.
+- Latest current-head Codex review per actor with `CHANGES_REQUESTED` or a
+  substantive review body: blocking feedback even when it has no inline thread.
 - Codex comment, review body, or review thread containing substantive feedback:
   blocking until addressed, replied to with a clear rationale, or explicitly
   overridden by the user.
@@ -186,14 +187,20 @@ gh api "repos/<owner>/<repo>/pulls/<number>/reviews" --paginate --slurp \
     '[.[][]
     | select((.user.login | test("chatgpt-codex-connector"))
       and .commit_id == $head_sha)
-    | {id, state, submitted_at, html_url, body}]'
+    | {id, user: .user.login, state, submitted_at, html_url, body}]
+    | sort_by(.user, .submitted_at, .id)
+    | group_by(.user)
+    | map(last)'
 ```
 
-A current-head `CHANGES_REQUESTED` review is blocking. Read every non-empty
+Evaluate only the latest current-head review returned for each Codex actor; a
+newer review supersedes that actor's earlier top-level state on the same head.
+A latest `CHANGES_REQUESTED` review is blocking. Read every latest non-empty
 review body and address any substantive finding even when the review has no
 inline thread. A boilerplate-only `COMMENTED` review that merely accompanies
 inline findings is not an additional blocker after those findings are resolved;
-it is also not an approval signal.
+it is also not an approval signal. Review-thread resolution remains a separate
+gate below and is never superseded by top-level review history alone.
 
 For a relevant Codex issue comment, verify any approval reaction by actor. The
 aggregate reaction counts on the comment do not identify who reacted:

--- a/.agents/skills/pr-review-loop/SKILL.md
+++ b/.agents/skills/pr-review-loop/SKILL.md
@@ -56,18 +56,54 @@ PR-body edit should restart the loop for the description, but it does not
 invalidate the code-head review unless it changes the scope being reviewed.
 
 Check the PR body reactions first, and verify both the reacting actor and the
-reaction's freshness for the current head. The status rollup is scoped to the
-current head SHA, so its earliest start time provides a post-push lower bound:
+reaction's freshness for the current head and current PR description. The
+status rollup is scoped to the current head SHA, while GraphQL `lastEditedAt`
+captures later edits to the PR object. Use the later timestamp as the approval
+lower bound:
 
 ```bash
+head_state_json="$(
+  gh pr view <number> --json headRefOid,statusCheckRollup
+)" || exit 1
+head_sha="$(printf '%s' "$head_state_json" | jq -r '.headRefOid')"
 head_started_at="$(
-  gh pr view <number> --json headRefOid,statusCheckRollup \
-    --jq '[.statusCheckRollup[] | .startedAt // empty] | min // empty'
+  printf '%s' "$head_state_json" \
+    | jq -r '[.statusCheckRollup[] | .startedAt // empty] | min // empty'
 )"
-if [ -z "$head_started_at" ]; then
-  echo "Cannot prove when current-head activity started; body reaction is not approval."
+
+edit_state_json="$(
+  gh api graphql \
+    -F owner=<owner> \
+    -F name=<repo> \
+    -F number=<number> \
+    -f query='query($owner:String!,$name:String!,$number:Int!){
+      repository(owner:$owner,name:$name){
+        pullRequest(number:$number){headRefOid lastEditedAt}
+      }
+    }'
+)" || exit 1
+edit_head_sha="$(
+  printf '%s' "$edit_state_json" \
+    | jq -r '.data.repository.pullRequest.headRefOid'
+)"
+body_edited_at="$(
+  printf '%s' "$edit_state_json" \
+    | jq -r '.data.repository.pullRequest.lastEditedAt // empty'
+)"
+
+if [ -z "$head_started_at" ] || [ "$edit_head_sha" != "$head_sha" ]; then
+  echo "Cannot prove current-head freshness; reaction is not approval."
   exit 1
 fi
+
+approval_not_before="$(
+  jq -nr \
+    --arg head_started_at "$head_started_at" \
+    --arg body_edited_at "$body_edited_at" \
+    '[$head_started_at, $body_edited_at]
+    | map(select(length > 0))
+    | max // empty'
+)"
 
 reactions_json="$(
   gh api "repos/<owner>/<repo>/issues/<number>/reactions" --paginate --slurp \
@@ -76,30 +112,30 @@ reactions_json="$(
 
 echo "Fresh Codex approvals:"
 printf '%s' "$reactions_json" \
-  | jq --arg head_started_at "$head_started_at" \
+  | jq --arg approval_not_before "$approval_not_before" \
     '[.[][]
     | select(.user.login == "chatgpt-codex-connector[bot]"
       and .content == "+1"
-      and .created_at >= $head_started_at)
+      and .created_at >= $approval_not_before)
     | {content, created_at, user: .user.login}]'
 
 echo "Fresh Codex pending signals:"
 printf '%s' "$reactions_json" \
-  | jq --arg head_started_at "$head_started_at" \
+  | jq --arg approval_not_before "$approval_not_before" \
     '[.[][]
     | select(.user.login == "chatgpt-codex-connector[bot]"
       and .content == "eyes"
-      and .created_at >= $head_started_at)
+      and .created_at >= $approval_not_before)
     | {content, created_at, user: .user.login}]'
 ```
 
 `gh pr view --json reactionGroups` is useful for counts, but it does not show
 which user reacted. Use the REST reactions endpoint above to prove Codex left
-the thumbs-up on the PR body after current-head activity began. Only a non-empty
-approval result satisfies the gate; a non-empty pending result means keep
-waiting. If the current head has no timestamped status/check activity, require
-a Codex review or issue comment that names the current head instead of trusting
-a body reaction alone.
+the thumbs-up after both current-head activity began and the PR object was last
+edited. Only a non-empty approval result satisfies the gate; a non-empty pending
+result means keep waiting. If the current head has no timestamped status/check
+activity, require a Codex review or issue comment that names the current head
+instead of trusting a body reaction alone.
 
 Then check Codex issue comments and confirm the latest "Reviewed commit" matches
 the current head prefix:
@@ -139,9 +175,11 @@ aggregate reaction counts on the comment do not identify who reacted:
 gh api "repos/<owner>/<repo>/issues/comments/<comment-id>/reactions" \
   --paginate --slurp \
   -H "Accept: application/vnd.github+json" \
-  | jq '[.[][]
+  | jq --arg approval_not_before "$approval_not_before" \
+    '[.[][]
     | select(.user.login == "chatgpt-codex-connector[bot]"
-      and .content == "+1")
+      and .content == "+1"
+      and .created_at >= $approval_not_before)
     | {content, created_at, user: .user.login}]'
 ```
 

--- a/.agents/skills/pr-review-loop/SKILL.md
+++ b/.agents/skills/pr-review-loop/SKILL.md
@@ -29,6 +29,7 @@ If Codex leaves a comment, review comment, or inline thread, the PR is not appro
 - Thumbs-up reaction by `chatgpt-codex-connector[bot]` on the PR body/description: Codex approves/no suggestions. This is the common approval signal.
 - Thumbs-up reaction by `chatgpt-codex-connector[bot]` on a Codex issue comment: also an approval signal, but this is not the only place to look.
 - Codex issue comment saying "Didn't find any major issues": approval-like context, but confirm the PR body/comment thumbs-up or get an explicit user override.
+- Codex top-level review with `CHANGES_REQUESTED` or a substantive review body: blocking feedback even when it has no inline thread.
 - Codex comment or review thread: Codex found feedback. Treat it as blocking until addressed, replied to with a clear rationale, or explicitly overridden by the user.
 - Outdated Codex comments: useful history, but not approval.
 - Empty `reviewDecision`, `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`, and green checks: necessary context, but not Codex approval.
@@ -110,6 +111,27 @@ gh api "repos/<owner>/<repo>/issues/<number>/comments" --paginate \
     | {id, created_at, html_url, body: .body[0:240]}]'
 ```
 
+Top-level pull-request reviews are a separate API surface from issue comments
+and review threads. Fetch every page and inspect Codex reviews submitted for the
+exact current head:
+
+```bash
+head_sha="$(gh pr view <number> --json headRefOid --jq '.headRefOid')"
+
+gh api "repos/<owner>/<repo>/pulls/<number>/reviews" --paginate --slurp \
+  | jq --arg head_sha "$head_sha" \
+    '[.[][]
+    | select((.user.login | test("chatgpt-codex-connector"))
+      and .commit_id == $head_sha)
+    | {id, state, submitted_at, html_url, body}]'
+```
+
+A current-head `CHANGES_REQUESTED` review is blocking. Read every non-empty
+review body and address any substantive finding even when the review has no
+inline thread. A boilerplate-only `COMMENTED` review that merely accompanies
+inline findings is not an additional blocker after those findings are resolved;
+it is also not an approval signal.
+
 For a relevant Codex issue comment, verify any approval reaction by actor. The
 aggregate reaction counts on the comment do not identify who reacted:
 
@@ -178,7 +200,8 @@ comment SHAs as the current resolution state.
 7. The loop is complete only when all of these are true on the same latest head:
 
 - Required tests/checks are passing.
-- Codex has no unaddressed current-head comments.
+- Codex has no unaddressed current-head comments, top-level review findings, or
+  unresolved non-outdated review threads.
 - Codex has left the thumbs-up approval signal, or the user explicitly overrode the gate.
 
 8. Report the gate before merging:

--- a/.agents/skills/pr-review-loop/SKILL.md
+++ b/.agents/skills/pr-review-loop/SKILL.md
@@ -47,7 +47,8 @@ can leave state:
 - PR body/description reactions: the approval thumbs-up may be here.
 - PR issue comments: Codex posts "Codex Review" summaries here, including the reviewed commit.
 - PR reviews and inline review comments: Codex posts actionable findings here.
-- Review threads: unresolved current-head threads remain blocking even when older threads are outdated.
+- Review threads: unresolved, non-outdated Codex threads remain blocking across pushes. Do not
+  infer thread state from the placement commit recorded on individual comments.
 
 Any code push after a prior Codex approval invalidates that approval. A material
 PR-body edit should restart the loop for the description, but it does not
@@ -75,19 +76,39 @@ gh api "repos/<owner>/<repo>/issues/<number>/comments" --paginate \
     | {created_at, html_url, body: .body[0:240], reactions: .reactions}]'
 ```
 
-Finally, check inline review comments on the current head:
+Finally, query GraphQL review threads. GitHub records comment placement SHAs in
+the REST payload, but only the thread exposes whether feedback remains unresolved
+and non-outdated after a follow-up push:
 
 ```bash
-head_sha="$(gh pr view <number> --json headRefOid --jq .headRefOid)"
-gh api "repos/<owner>/<repo>/pulls/<number>/comments" --paginate \
-  | jq --arg head "$head_sha" '
-    [.[] | select((.user.login | test("chatgpt-codex-connector"))
-      and (.commit_id == $head or .original_commit_id == $head))
-      | {path, line, body, html_url}]'
+gh api graphql \
+  -F owner=<owner> \
+  -F name=<repo> \
+  -F number=<number> \
+  -f query='query($owner:String!,$name:String!,$number:Int!){
+    repository(owner:$owner,name:$name){
+      pullRequest(number:$number){
+        reviewThreads(first:100){
+          nodes{
+            id isResolved isOutdated path line
+            comments(first:100){
+              nodes{author{login} body url createdAt commit{oid}}
+            }
+          }
+        }
+      }
+    }
+  }' \
+  | jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+    | select((.isResolved | not) and (.isOutdated | not))
+    | select(any(.comments.nodes[];
+        .author.login | test("chatgpt-codex-connector")))
+    | {id, path, line, comments: .comments.nodes}]'
 ```
 
-If REST inline comments look current but you have replies on them, use GraphQL
-review threads to distinguish unresolved blockers from addressed history.
+An empty result means there are no unresolved, non-outdated Codex threads. Keep
+outdated threads as review history, but do not treat their comment SHAs as the
+current resolution state.
 
 3. If Codex has eyes and no thumbs-up, keep monitoring. Do not infer approval from silence.
 

--- a/.agents/skills/pr-review-loop/SKILL.md
+++ b/.agents/skills/pr-review-loop/SKILL.md
@@ -68,20 +68,37 @@ if [ -z "$head_started_at" ]; then
   exit 1
 fi
 
-gh api "repos/<owner>/<repo>/issues/<number>/reactions" --paginate --slurp \
-  -H "Accept: application/vnd.github+json" \
+reactions_json="$(
+  gh api "repos/<owner>/<repo>/issues/<number>/reactions" --paginate --slurp \
+    -H "Accept: application/vnd.github+json"
+)"
+
+echo "Fresh Codex approvals:"
+printf '%s' "$reactions_json" \
   | jq --arg head_started_at "$head_started_at" \
     '[.[][]
     | select(.user.login == "chatgpt-codex-connector[bot]"
+      and .content == "+1"
+      and .created_at >= $head_started_at)
+    | {content, created_at, user: .user.login}]'
+
+echo "Fresh Codex pending signals:"
+printf '%s' "$reactions_json" \
+  | jq --arg head_started_at "$head_started_at" \
+    '[.[][]
+    | select(.user.login == "chatgpt-codex-connector[bot]"
+      and .content == "eyes"
       and .created_at >= $head_started_at)
     | {content, created_at, user: .user.login}]'
 ```
 
 `gh pr view --json reactionGroups` is useful for counts, but it does not show
 which user reacted. Use the REST reactions endpoint above to prove Codex left
-the thumbs-up on the PR body after current-head activity began. If the current
-head has no timestamped status/check activity, require a Codex review or issue
-comment that names the current head instead of trusting a body reaction alone.
+the thumbs-up on the PR body after current-head activity began. Only a non-empty
+approval result satisfies the gate; a non-empty pending result means keep
+waiting. If the current head has no timestamped status/check activity, require
+a Codex review or issue comment that names the current head instead of trusting
+a body reaction alone.
 
 Then check Codex issue comments and confirm the latest "Reviewed commit" matches
 the current head prefix:

--- a/.agents/skills/pr-review-loop/SKILL.md
+++ b/.agents/skills/pr-review-loop/SKILL.md
@@ -21,7 +21,11 @@ only inspect issue comments.
 If Codex shows an eyes reaction on the PR body or a comment, it is reviewing.
 Wait and keep checking.
 
-If Codex leaves a comment, review comment, or inline thread, the PR is not approved. Use judgement: fix the code when the comment is right; reply with evidence when the comment is wrong or intentionally not worth changing.
+If Codex leaves a comment, review body, or inline thread containing substantive
+feedback, the PR is not approved. Use judgement: fix the code when the comment
+is right; reply with evidence when it is wrong or intentionally not worth
+changing. A no-issue summary or boilerplate-only review body is not a blocker,
+but it also does not replace the required thumbs-up.
 
 ## Signals
 
@@ -30,7 +34,9 @@ If Codex leaves a comment, review comment, or inline thread, the PR is not appro
 - Thumbs-up reaction by `chatgpt-codex-connector[bot]` on a Codex issue comment: also an approval signal, but this is not the only place to look.
 - Codex issue comment saying "Didn't find any major issues": approval-like context, but confirm the PR body/comment thumbs-up or get an explicit user override.
 - Codex top-level review with `CHANGES_REQUESTED` or a substantive review body: blocking feedback even when it has no inline thread.
-- Codex comment or review thread: Codex found feedback. Treat it as blocking until addressed, replied to with a clear rationale, or explicitly overridden by the user.
+- Codex comment, review body, or review thread containing substantive feedback:
+  blocking until addressed, replied to with a clear rationale, or explicitly
+  overridden by the user.
 - Outdated Codex comments: useful history, but not approval.
 - Empty `reviewDecision`, `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`, and green checks: necessary context, but not Codex approval.
 

--- a/.agents/skills/pr-review-loop/SKILL.md
+++ b/.agents/skills/pr-review-loop/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: pr-review-loop
+description: Enforce the Basic Machines GitHub PR review loop before merging. Use whenever Codex is preparing to merge, squash-merge, auto-merge, declare a PR ready, monitor Codex comments, address review feedback, or wait for Codex approval on a GitHub PR, especially when the user says "approved", "merge", "ship", "PR is ready", "monitor Codex comments", or "address Codex feedback".
+---
+
+# PR Review Loop
+
+## Hard Rule
+
+Do not merge a PR merely because CI is green, the branch is mergeable, review threads are outdated, or no current Codex thread is visible.
+
+Merge only when one of these is true:
+
+- Codex has finished reviewing the latest head and left an explicit thumbs-up approval signal.
+- The user explicitly overrides this gate with language like "merge without waiting for Codex approval" or "override Codex gate".
+
+Codex often leaves that thumbs-up as a reaction on the PR description/body itself
+(the GitHub Issue/PR object), not on its "Codex Review" issue comment. Do not
+only inspect issue comments.
+
+If Codex shows an eyes reaction on the PR body or a comment, it is reviewing.
+Wait and keep checking.
+
+If Codex leaves a comment, review comment, or inline thread, the PR is not approved. Use judgement: fix the code when the comment is right; reply with evidence when the comment is wrong or intentionally not worth changing.
+
+## Signals
+
+- Eyes reaction on the PR body or a comment: Codex is looking at the PR. This is pending, not approval.
+- Thumbs-up reaction by `chatgpt-codex-connector[bot]` on the PR body/description: Codex approves/no suggestions. This is the common approval signal.
+- Thumbs-up reaction by `chatgpt-codex-connector[bot]` on a Codex issue comment: also an approval signal, but this is not the only place to look.
+- Codex issue comment saying "Didn't find any major issues": approval-like context, but confirm the PR body/comment thumbs-up or get an explicit user override.
+- Codex comment or review thread: Codex found feedback. Treat it as blocking until addressed, replied to with a clear rationale, or explicitly overridden by the user.
+- Outdated Codex comments: useful history, but not approval.
+- Empty `reviewDecision`, `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`, and green checks: necessary context, but not Codex approval.
+
+## Loop Workflow
+
+1. Resolve the PR and current head SHA.
+
+```bash
+gh pr view <number> --json number,url,headRefOid,headRefName,mergeable,mergeStateStatus,statusCheckRollup
+```
+
+2. Read Codex state on the latest head. Check every GitHub surface where Codex
+can leave state:
+
+- PR body/description reactions: the approval thumbs-up may be here.
+- PR issue comments: Codex posts "Codex Review" summaries here, including the reviewed commit.
+- PR reviews and inline review comments: Codex posts actionable findings here.
+- Review threads: unresolved current-head threads remain blocking even when older threads are outdated.
+
+Any code push after a prior Codex approval invalidates that approval. A material
+PR-body edit should restart the loop for the description, but it does not
+invalidate the code-head review unless it changes the scope being reviewed.
+
+Check the PR body reactions first, and verify the reacting actor:
+
+```bash
+gh api "repos/<owner>/<repo>/issues/<number>/reactions" \
+  -H "Accept: application/vnd.github+json" \
+  | jq '[.[] | select(.user.login == "chatgpt-codex-connector[bot]")
+    | {content, created_at, user: .user.login}]'
+```
+
+`gh pr view --json reactionGroups` is useful for counts, but it does not show
+which user reacted. Use the REST reactions endpoint above to prove Codex left
+the thumbs-up on the PR body.
+
+Then check Codex issue comments and confirm the latest "Reviewed commit" matches
+the current head prefix:
+
+```bash
+gh api "repos/<owner>/<repo>/issues/<number>/comments" --paginate \
+  | jq '[.[] | select(.user.login | test("chatgpt-codex-connector"))
+    | {created_at, html_url, body: .body[0:240], reactions: .reactions}]'
+```
+
+Finally, check inline review comments on the current head:
+
+```bash
+head_sha="$(gh pr view <number> --json headRefOid --jq .headRefOid)"
+gh api "repos/<owner>/<repo>/pulls/<number>/comments" --paginate \
+  | jq --arg head "$head_sha" '
+    [.[] | select((.user.login | test("chatgpt-codex-connector"))
+      and (.commit_id == $head or .original_commit_id == $head))
+      | {path, line, body, html_url}]'
+```
+
+If REST inline comments look current but you have replies on them, use GraphQL
+review threads to distinguish unresolved blockers from addressed history.
+
+3. If Codex has eyes and no thumbs-up, keep monitoring. Do not infer approval from silence.
+
+4. If Codex leaves feedback, start addressing it immediately. Do not wait for all tests to complete before reading and acting on comments; that wastes review-loop time. Tests can keep running in parallel while you inspect the feedback.
+
+5. For each Codex comment, use engineering judgement.
+
+- If the comment identifies a real issue, patch it, run focused validation, push, and restart the loop on the new head.
+- If the comment is wrong, stale, intentionally out of scope, or not worth changing, reply on GitHub with a concise rationale and evidence. You are not forced to make a code change.
+- If the tradeoff is unclear, explain the tradeoff to the user and ask before choosing.
+
+6. After every push, restart from step 1. A new head requires a new Codex response.
+
+7. The loop is complete only when all of these are true on the same latest head:
+
+- Required tests/checks are passing.
+- Codex has no unaddressed current-head comments.
+- Codex has left the thumbs-up approval signal, or the user explicitly overrode the gate.
+
+8. Report the gate before merging:
+
+```text
+Codex gate: approved | waiting | blocking | overridden
+Head: <sha>
+Tests: passing | pending | failing
+Evidence: <thumbs-up reaction, blocking comment URL, reply URL, or explicit user override>
+```
+
+9. Only run `gh pr merge` when the gate is `approved` or `overridden` and tests are passing on that same head.
+
+## Failure Mode This Prevents
+
+PR `basicmachines-co/basic-memory-cloud#1366` was merged after CI went green and existing Codex threads were outdated, but before Codex had left its thumbs-up. Codex then posted a P2 review comment on the merged head. This skill exists to prevent that exact mistake.

--- a/.agents/skills/pr-review-loop/SKILL.md
+++ b/.agents/skills/pr-review-loop/SKILL.md
@@ -81,34 +81,40 @@ the REST payload, but only the thread exposes whether feedback remains unresolve
 and non-outdated after a follow-up push:
 
 ```bash
-gh api graphql \
+gh api graphql --paginate --slurp \
   -F owner=<owner> \
   -F name=<repo> \
   -F number=<number> \
-  -f query='query($owner:String!,$name:String!,$number:Int!){
+  -f query='query(
+    $owner:String!
+    $name:String!
+    $number:Int!
+    $endCursor:String
+  ){
     repository(owner:$owner,name:$name){
       pullRequest(number:$number){
-        reviewThreads(first:100){
+        reviewThreads(first:100,after:$endCursor){
           nodes{
             id isResolved isOutdated path line
             comments(first:100){
               nodes{author{login} body url createdAt commit{oid}}
             }
           }
+          pageInfo{hasNextPage endCursor}
         }
       }
     }
   }' \
-  | jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+  | jq '[.[].data.repository.pullRequest.reviewThreads.nodes[]
     | select((.isResolved | not) and (.isOutdated | not))
     | select(any(.comments.nodes[];
         .author.login | test("chatgpt-codex-connector")))
     | {id, path, line, comments: .comments.nodes}]'
 ```
 
-An empty result means there are no unresolved, non-outdated Codex threads. Keep
-outdated threads as review history, but do not treat their comment SHAs as the
-current resolution state.
+An empty result across every page means there are no unresolved, non-outdated
+Codex threads. Keep outdated threads as review history, but do not treat their
+comment SHAs as the current resolution state.
 
 3. If Codex has eyes and no thumbs-up, keep monitoring. Do not infer approval from silence.
 

--- a/.agents/skills/pr-review-loop/SKILL.md
+++ b/.agents/skills/pr-review-loop/SKILL.md
@@ -18,8 +18,8 @@ Codex often leaves that thumbs-up as a reaction on the PR description/body itsel
 (the GitHub Issue/PR object), not on its "Codex Review" issue comment. Do not
 only inspect issue comments.
 
-If Codex shows an eyes reaction on the PR body or a comment, it is reviewing.
-Wait and keep checking.
+If Codex's newest fresh reaction on the PR body or a relevant comment is eyes,
+it is reviewing. Wait and keep checking.
 
 If Codex leaves a comment, review body, or inline thread containing substantive
 feedback, the PR is not approved. Use judgement: fix the code when the comment
@@ -29,7 +29,8 @@ but it also does not replace the required thumbs-up.
 
 ## Signals
 
-- Eyes reaction on the PR body or a comment: Codex is looking at the PR. This is pending, not approval.
+- Eyes reaction on the PR body or a comment: pending when it is newer than the
+  latest fresh thumbs-up on that same surface.
 - Thumbs-up reaction by `chatgpt-codex-connector[bot]` on the PR body/description: Codex approves/no suggestions. This is the common approval signal.
 - Thumbs-up reaction by `chatgpt-codex-connector[bot]` on a Codex issue comment: also an approval signal, but this is not the only place to look.
 - Codex issue comment saying "Didn't find any major issues": approval-like context, but confirm the PR body/comment thumbs-up or get an explicit user override.
@@ -124,33 +125,39 @@ if [ "$body_reactions_available" = true ]; then
       -H "Accept: application/vnd.github+json"
   )"
 
-  echo "Fresh Codex approvals:"
+  echo "Fresh Codex reaction state:"
   printf '%s' "$reactions_json" \
-    | jq --arg approval_not_before "$approval_not_before" \
-      '[.[][]
-      | select(.user.login == "chatgpt-codex-connector[bot]"
-        and .content == "+1"
-        and .created_at >= $approval_not_before)
-      | {content, created_at, user: .user.login}]'
+    | jq --arg approval_not_before "$approval_not_before" '
+      def latest_reaction($content):
+        [.[][]
+        | select(.user.login == "chatgpt-codex-connector[bot]"
+          and .content == $content
+          and .created_at >= $approval_not_before)
+        | {content, created_at, user: .user.login}]
+        | sort_by(.created_at)
+        | last // null;
 
-  echo "Fresh Codex pending signals:"
-  printf '%s' "$reactions_json" \
-    | jq --arg approval_not_before "$approval_not_before" \
-      '[.[][]
-      | select(.user.login == "chatgpt-codex-connector[bot]"
-        and .content == "eyes"
-        and .created_at >= $approval_not_before)
-      | {content, created_at, user: .user.login}]'
+      {approval: latest_reaction("+1"), pending: latest_reaction("eyes")}
+      | .state = (
+          if .approval != null
+            and (.pending == null
+              or .approval.created_at > .pending.created_at)
+          then "approved"
+          elif .pending != null then "pending"
+          else "none"
+          end
+        )'
 fi
 ```
 
 `gh pr view --json reactionGroups` is useful for counts, but it does not show
 which user reacted. Use the REST reactions endpoint above to prove Codex left
 the thumbs-up after both current-head activity began and the PR object was last
-edited. Only a non-empty approval result satisfies the gate; a non-empty pending
-result means keep waiting. If the current head has no timestamped status/check
-activity, skip PR-body reactions and continue to the review and issue-comment
-checks below instead of exiting the workflow.
+edited. A reaction state of `approved` satisfies the reaction portion of the
+gate. `pending` means the newest fresh signal is eyes, so keep waiting; a newer
+thumbs-up supersedes an older eyes reaction. If the current head has no
+timestamped status/check activity, skip PR-body reactions and continue to the
+review and issue-comment checks below instead of exiting the workflow.
 
 Then check Codex issue comments and confirm the latest "Reviewed commit" matches
 the current head prefix:
@@ -195,12 +202,26 @@ aggregate reaction counts on the comment do not identify who reacted:
 gh api "repos/<owner>/<repo>/issues/comments/<comment-id>/reactions" \
   --paginate --slurp \
   -H "Accept: application/vnd.github+json" \
-  | jq --arg approval_not_before "$approval_not_before" \
-    '[.[][]
-    | select(.user.login == "chatgpt-codex-connector[bot]"
-      and .content == "+1"
-      and .created_at >= $approval_not_before)
-    | {content, created_at, user: .user.login}]'
+  | jq --arg approval_not_before "$approval_not_before" '
+    def latest_reaction($content):
+      [.[][]
+      | select(.user.login == "chatgpt-codex-connector[bot]"
+        and .content == $content
+        and .created_at >= $approval_not_before)
+      | {content, created_at, user: .user.login}]
+      | sort_by(.created_at)
+      | last // null;
+
+    {approval: latest_reaction("+1"), pending: latest_reaction("eyes")}
+    | .state = (
+        if .approval != null
+          and (.pending == null
+            or .approval.created_at > .pending.created_at)
+        then "approved"
+        elif .pending != null then "pending"
+        else "none"
+        end
+      )'
 ```
 
 Finally, query GraphQL review threads. GitHub records comment placement SHAs in
@@ -243,7 +264,8 @@ An empty result across every page means there are no unresolved, non-outdated
 Codex threads. Keep outdated threads as review history, but do not treat their
 comment SHAs as the current resolution state.
 
-3. If Codex has eyes and no thumbs-up, keep monitoring. Do not infer approval from silence.
+3. If the latest fresh reaction state is `pending`, keep monitoring. Do not
+infer approval from silence.
 
 4. If Codex leaves feedback, start addressing it immediately. Do not wait for all tests to complete before reading and acting on comments; that wastes review-loop time. Tests can keep running in parallel while you inspect the feedback.
 

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: pull-request
+description: Drive GitHub pull request work end to end. Use when Codex is asked to open, update, describe, push to, monitor, review, address comments on, declare ready, or merge a PR. Covers branch hygiene, PR descriptions with why/what/testing/risk, CI checks, Codex review-loop monitoring, comment handling, and the final merge gate.
+---
+
+# Pull Request
+
+Use this skill for the whole PR lifecycle, not only the moment of opening or merging.
+
+## Runtime Setup
+
+For Basic Memory Python tooling, use the project environment first:
+
+```bash
+source .venv/bin/activate
+```
+
+After activation, run Python scripts as `python ...`. For one-off commands where activation is awkward, prefer `./.venv/bin/python ...` or the repo's `uv run ...` patterns. Do not fall back to system `python`, `python3`, or global packages just because a command is missing.
+
+## Flow
+
+1. Inspect the live artifact first.
+   - Use `gh pr view`, `gh issue view`, linked review comments, CI status, and current branch state before deciding what to change.
+   - If the user links a specific PR discussion, inspect that exact discussion before broad edits.
+
+2. Keep branch scope clean.
+   - Base product-fix PRs on the intended remote base.
+   - Avoid mixing workflow/skill/doc commits into unrelated product branches.
+   - In `basic-memory`, prefer local branches in the main workspace unless the user asks for a worktree.
+
+3. Implement and validate.
+   - Read files fully before editing.
+   - Make the smallest behaviorally complete change.
+   - Run focused tests for the changed surface.
+   - Run the repo's required gate, such as `just fast-check` for source changes or `just package-check` for agent/package changes, before calling the branch ready.
+
+4. Write or update the PR description.
+   - A PR without a useful description is not done.
+   - Use the existing `pr-description` skill when available.
+   - Make the body explain the change to a reviewer who did not watch the chat.
+
+5. Open or update the PR.
+   - Include linked issues, review comments, or specs.
+   - Include exact validation commands and outcomes.
+   - Mark draft only when the PR is intentionally not ready for review.
+
+6. Enter the review loop immediately.
+   - Use `pr-review-loop` after opening, pushing, updating the PR body in a meaningful way, or when the user asks whether the PR is ready.
+   - Do not treat PR creation as the end of the task when the user expects review follow-through.
+
+## PR Description Standard
+
+Every PR body should include these ideas, using headings that fit the repo's style:
+
+- `Why`: the problem, reviewer comment, issue, incident, user need, or spec requirement that makes the change necessary now.
+- `What Changed`: the concrete behavior or files changed, in reviewer-friendly language.
+- `Implementation Details`: important design choices, constraints, tradeoffs, data-flow changes, or why a simpler-looking alternative was avoided.
+- `Testing`: exact commands run and whether they passed. If something relevant was not tested, say so.
+- `Risks / Follow-ups`: remaining uncertainty, rollout concerns, known deferred work, or why there are none.
+
+Avoid PR bodies that only restate commit messages. Prefer a short but complete explanation over a long changelog.
+
+## Codex Review Loop
+
+Apply `pr-review-loop` as part of normal PR work:
+
+- After opening a ready PR, check Codex state and CI.
+- If Codex shows eyes, keep monitoring; eyes is pending, not approval.
+- If Codex leaves feedback, address it immediately while tests continue when possible.
+- If the feedback is right, patch, run focused validation, push, and restart the loop on the new head.
+- If the feedback is wrong or out of scope, reply with evidence and keep the loop moving.
+- The loop completes only when required checks pass and Codex has approved the latest head with a thumbs-up, unless the user explicitly overrides the gate.
+
+Do not merge, declare merge-ready, or move on as though finished until the loop state is explicit:
+
+```text
+Codex gate: approved | waiting | blocking | overridden
+Head: <sha>
+Tests: passing | pending | failing
+Evidence: <thumbs-up reaction, blocking comment URL, reply URL, or explicit user override>
+```
+
+## Merge Discipline
+
+Before merging:
+
+- Confirm latest head SHA.
+- Confirm required checks are passing on that head.
+- Confirm no current-head Codex comments remain unaddressed.
+- Confirm Codex thumbs-up or explicit user override.
+- Ask or wait for the user's merge instruction unless they already gave it.
+
+Never merge from green CI alone.

--- a/tests/test_codex_plugin_package.py
+++ b/tests/test_codex_plugin_package.py
@@ -111,20 +111,22 @@ def test_infographics_skill_keeps_weekly_contract_and_bm_style_pool() -> None:
     assert "Chosen BM style category" in prompt_blueprint
 
 
-def test_pr_create_skill_documents_optional_infographic_theme_arg() -> None:
+def test_pr_create_skill_delegates_to_current_pr_workflow() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     skill = (repo_root / ".agents/skills/pr-create/SKILL.md").read_text(encoding="utf-8")
     skill_flat = " ".join(skill.split())
 
-    assert "## How To Use" in skill
+    assert "## Compatibility" in skill
+    assert "## Workflow" in skill
     assert "$pr-create" in skill
-    assert "<theme>" in skill
-    assert '$pr-create "Italian movie poster"' in skill
-    assert '$pr-create "80\'s action movies"' in skill
-    assert "<!-- BM_INFOGRAPHIC_THEME:start -->" in skill
-    assert "<!-- BM_INFOGRAPHIC_THEME:end -->" in skill
-    assert "<!-- BM_INFOGRAPHIC_PROVENANCE:start -->" in skill
-    assert "BM Bossbot Approval" in skill
-    assert "selected visual direction" in skill_flat
+    assert "`pull-request`" in skill
+    assert "`pr-description`" in skill
+    assert "`pr-review-loop`" in skill
+    assert "`fix-pr-issues`" in skill
+    assert "automatic PR-infographic workflow has been retired" in skill_flat
+    assert "Do not wait for the deleted `BM Bossbot Approval` status" in skill_flat
+    assert "<!-- BM_INFOGRAPHIC_THEME:start -->" not in skill
+    assert "<!-- BM_INFOGRAPHIC_PROVENANCE:start -->" not in skill
     assert "never merges" in skill
-    assert "non-gating" in skill
+    assert "Do not enable auto-merge" in skill
+    assert "current-head gate" in skill


### PR DESCRIPTION
## Why

- Basic Memory Cloud already carries an end-to-end pull request workflow skill, but this repository did not have the same reusable PR lifecycle guidance.
- Adding the workflow locally keeps branch hygiene, reviewer context, validation evidence, and latest-head Codex review explicit for future runs.
- Existing `$pr-create` and `$fix-pr-issues` entry points still targeted the retired BM Bossbot workflow, so they also needed to be aligned with the new review loop.

## What Changed

- Added the `pull-request` orchestration skill for end-to-end PR work.
- Added the referenced `pr-description` skill and reusable PR body template.
- Added the referenced `pr-review-loop` skill for latest-head Codex approval monitoring.
- Hardened review-state detection across pushes, PR-description edits, GraphQL pages, REST reaction pages, current-head top-level reviews, reaction actors, head freshness, reaction ordering, substantive-vs-boilerplate feedback, and PRs without timestamped checks.
- Converted the existing `pr-create` skill into a compatibility entry point for `pull-request` and refreshed `fix-pr-issues` to restart the same latest-head Codex gate after fixes.
- Updated both compatibility skills' Codex UI metadata so they no longer instruct agents to wait for a deleted Bossbot status.
- Updated the repo's Codex package regression test from the retired infographic-theme contract to the current `$pr-create` delegation contract.

## Implementation Details

- Mirrored the cloud `pr-description` skill and PR body template byte-for-byte.
- Kept the `pull-request` workflow aligned with the cloud source while localizing only the repository name, Python runtime label, and Basic Memory validation examples.
- Started from the cloud `pr-review-loop` workflow, then replaced REST placement-SHA filtering with authoritative GraphQL `isResolved` and `isOutdated` thread state.
- Added cursor pagination with `--paginate --slurp`, `$endCursor`, and `pageInfo` so a blocker cannot be missed after the first 100 review threads.
- Added REST pagination for PR-body reactions and actor-level issue-comment reaction checks so only `chatgpt-codex-connector[bot]` approval is accepted.
- Added a paginated top-level pull-request review query filtered to Codex and the exact current head, with explicit blocking rules for substantive bodies and `CHANGES_REQUESTED`.
- Bound approval reactions to both the exact current head and the current PR description by using the later of the head's earliest status activity and GraphQL `lastEditedAt`; the workflow fails closed if head consistency cannot be proven.
- When a PR has no timestamped status/check activity, the workflow skips only PR-body reactions and continues to exact-head review and issue-comment evidence; relevant issue-comment reactions retain the body-edit freshness bound.
- Classifies the latest fresh Codex reaction by timestamp on both PR-body and issue-comment surfaces: a newer `+1` supersedes an older `eyes`, while a newer `eyes` returns the gate to pending.
- Clarified that substantive Codex comments/review bodies block, while no-issue summaries and boilerplate-only review bodies do not; neither form replaces the required fresh thumbs-up.
- Retained `$pr-create` for explicit legacy invocations while removing its automatic infographic and Bossbot behavior; it now delegates lifecycle work to the imported skills.
- Updated `fix-pr-issues` to gather exact GitHub/Codex evidence, reply with verification, and invalidate prior approval after a new push.
- Requires required checks, resolved current-head feedback across all GitHub review surfaces, and the Codex connector approval signal unless the user explicitly overrides the gate.
- Does not depend on the retired BM Bossbot workflow or status.

## Testing

### Automated

- Structural frontmatter, dependency, reference-link, Codex-gate, GraphQL-state, cursor-pagination, REST-pagination, reaction-actor, head-freshness, PR-edit-freshness, no-check fallback, reaction-type/order, top-level-review, and feedback-classification validators: passed.
- Focused validation of five PR skill frontmatter blocks and seven cross-skill dependencies: passed.
- Cloud source parity and whitespace checks: passed for the unchanged imported artifacts.
- Executed the documented paginated GraphQL query against this PR and confirmed it returned unresolved threads before resolution and an empty result afterward.
- Executed the paginated PR-body, issue-comment, issue-comment-reaction, and current-head pull-request-review REST queries successfully.
- Executed the documented GraphQL `lastEditedAt` query against this PR and confirmed the effective approval lower bound chose the later PR edit time.
- Confirmed with synthetic reactions that an approval after head activity but before the latest PR edit is rejected, while one after the edit is accepted.
- Confirmed the no-check fallback disables PR-body reactions, preserves the PR-edit lower bound, and continues instead of exiting.
- Confirmed with synthetic reaction histories that newer `+1` yields `approved`, newer `eyes` yields `pending`, and pre-bound reactions yield `none`.
- `uv run pytest tests/test_codex_plugin_package.py::test_pr_create_skill_delegates_to_current_pr_workflow -q --no-cov`: passed.
- `uv run pytest tests/test_codex_plugin_package.py -q --no-cov`: 5 passed.
- `uv run ruff check tests/test_codex_plugin_package.py`: passed.
- `just typecheck`: passed with existing Python 3.14 asyncio deprecation warnings only.
- `git diff --check`: passed.
- `just package-check`: passed on the final content, including all consolidated package validators, 257 Hermes tests with 12 expected skips, and 226 OpenClaw tests.

### Manual

- Confirmed the PR contains the four imported skill/reference files, four existing compatibility skill/metadata files updated in response to review, and the matching package regression test update.
- Confirmed all commits include DCO sign-offs.
- Confirmed the current repository no longer has an active BM Bossbot workflow or required status.
- Confirmed the updated `$pr-create` and `$fix-pr-issues` instructions contain no executable dependency on the retired workflow.
- Confirmed top-level Codex reviews for the current head are now inspected separately from issue comments and inline threads.

## Risks / Follow-ups

- Agent-workflow documentation plus its package contract test; no product runtime behavior changes.
- Codex approval is an external review signal; the skill documents an explicit user-override path when necessary.
- The separate infographic-generation skill is outside this PR lifecycle workflow; `$pr-create` no longer routes legacy theme arguments into it.
