### PR TITLE
refactor(api): inject config from composition roots into the DI graph

### DIFF
--- a/src/basic_memory/api/container.py
+++ b/src/basic_memory/api/container.py
@@ -129,6 +129,21 @@ def get_container() -> ApiContainer:
     return _container
 
 
+def resolve_container() -> ApiContainer:
+    """Return the lifespan-installed container, or a fresh one off-lifespan.
+
+    The CLI/MCP local ASGI flow serves requests without running the API
+    lifespan, so no container is installed there. Creating a fresh container
+    keeps the ConfigManager read inside the composition root. The fresh
+    container is deliberately not cached in the module global: ConfigManager
+    already caches config with mtime invalidation, and a cached container here
+    would go stale when the CLI or tests rewrite the config file.
+    """
+    if _container is not None:
+        return _container
+    return ApiContainer.create()
+
+
 def set_container(container: ApiContainer) -> None:
     """Set the API container (called by lifespan)."""
     global _container

--- a/src/basic_memory/deps/config.py
+++ b/src/basic_memory/deps/config.py
@@ -1,26 +1,32 @@
 """Configuration dependency injection for basic-memory.
 
-This module provides configuration-related dependencies.
-Note: Long-term goal is to minimize direct ConfigManager access
-and inject config from composition roots instead.
+Config enters the request DI graph from the composition root: the API lifespan
+stores its container on ``app.state`` and this provider reads it back. Only
+``ApiContainer.create()`` reads ConfigManager.
 """
 
 from typing import Annotated
 
-from fastapi import Depends
+from fastapi import Depends, Request
 
-from basic_memory.config import BasicMemoryConfig, ConfigManager
+from basic_memory.config import BasicMemoryConfig
 
 
-def get_app_config() -> BasicMemoryConfig:  # pragma: no cover
-    """Get the application configuration.
+def get_app_config(request: Request) -> BasicMemoryConfig:
+    """Resolve the application configuration from the composition root.
 
-    Note: This is a transitional dependency. The goal is for composition roots
-    to read ConfigManager and inject config explicitly. During migration,
-    this provides the same behavior as before.
+    API requests read the container the lifespan stored on ``app.state``.
+    Requests served without a lifespan (the CLI/MCP local ASGI flow) fall back
+    to the API composition root, which creates a container on demand.
     """
-    app_config = ConfigManager().config
-    return app_config
+    container = getattr(request.app.state, "container", None)
+    if container is not None:
+        return container.config
+    # Deferred import: importing basic_memory.api at module scope re-enters this
+    # package via api.app -> routers -> deps and fails as a circular import.
+    from basic_memory.api.container import resolve_container
+
+    return resolve_container().config
 
 
 AppConfigDep = Annotated[BasicMemoryConfig, Depends(get_app_config)]

--- a/src/basic_memory/deps/db.py
+++ b/src/basic_memory/deps/db.py
@@ -17,7 +17,6 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from basic_memory import db
-from basic_memory.deps.config import get_app_config
 
 
 async def get_engine_factory(
@@ -36,9 +35,14 @@ async def get_engine_factory(
     ):
         return request.app.state.engine, request.app.state.session_maker
 
-    # Fallback for non-API contexts (CLI)
+    # Fallback for non-API contexts (CLI): config comes from the composition
+    # root rather than a ConfigManager read here.
     logger.debug("Using fallback database connection for non-API context")
-    app_config = get_app_config()
+    # Deferred import: importing basic_memory.api at module scope re-enters this
+    # package via api.app -> routers -> deps and fails as a circular import.
+    from basic_memory.api.container import resolve_container
+
+    app_config = resolve_container().config
     engine, session_maker = await db.get_or_create_db(app_config.database_path)
     return engine, session_maker
 

--- a/src/basic_memory/deps/services.py
+++ b/src/basic_memory/deps/services.py
@@ -191,11 +191,13 @@ async def get_link_resolver_v2_external(
     entity_repository: EntityRepositoryV2ExternalDep,
     search_service: SearchServiceV2ExternalDep,
     session_maker: SessionMakerDep,
+    app_config: AppConfigDep,
 ) -> LinkResolver:
     return LinkResolver(
         entity_repository=entity_repository,
         search_service=search_service,
         session_maker=session_maker,
+        app_config=app_config,
     )
 
 

--- a/src/basic_memory/index/local_dependencies.py
+++ b/src/basic_memory/index/local_dependencies.py
@@ -602,7 +602,7 @@ async def build_local_index_project_dependencies(
         file_service,
         session_maker,
     )
-    link_resolver = LinkResolver(entity_repository, search_service, session_maker)
+    link_resolver = LinkResolver(entity_repository, search_service, session_maker, app_config)
     entity_service = EntityService(
         entity_parser,
         entity_repository,

--- a/src/basic_memory/repository/search_repository.py
+++ b/src/basic_memory/repository/search_repository.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, List, Optional, Protocol
 from sqlalchemy import Result
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from basic_memory.config import BasicMemoryConfig, ConfigManager, DatabaseBackend
+from basic_memory.config import BasicMemoryConfig, DatabaseBackend
 from basic_memory.repository.embedding_provider_factory import create_embedding_provider
 from basic_memory.repository.postgres_search_repository import PostgresSearchRepository
 from basic_memory.repository.search_index_row import SearchIndexRow
@@ -112,7 +112,7 @@ class SearchRepository(Protocol):
 def create_search_repository(
     session_maker: async_sessionmaker[AsyncSession],
     project_id: int,
-    app_config: Optional[BasicMemoryConfig] = None,
+    app_config: BasicMemoryConfig,
     database_backend: Optional[DatabaseBackend] = None,
 ) -> SearchRepository:
     """Factory function to create the appropriate search repository based on database backend.
@@ -120,16 +120,14 @@ def create_search_repository(
     Args:
         session_maker: SQLAlchemy async session maker
         project_id: Project ID for the repository
-        database_backend: Optional explicit backend. If not provided, reads from ConfigManager.
-            Prefer passing explicitly from composition roots.
+        app_config: Application config from the caller's composition root; backend
+            detection and the shared embedding provider both derive from it
+        database_backend: Optional explicit backend override
 
     Returns:
         SearchRepository: Backend-appropriate search repository instance
     """
-    # Resolve config once so backend detection and the shared embedding provider
-    # come from the same source. Prefer the explicit arg; fall back to ConfigManager
-    # for backwards compatibility.
-    config = app_config or ConfigManager().config
+    config = app_config
     if database_backend is None:
         database_backend = config.database_backend
 

--- a/src/basic_memory/services/composition.py
+++ b/src/basic_memory/services/composition.py
@@ -73,7 +73,7 @@ def build_default_project_search_bundle(
     project_id: ProjectId,
     session_maker: async_sessionmaker[AsyncSession],
     file_service: FileService,
-    app_config: BasicMemoryConfig | None = None,
+    app_config: BasicMemoryConfig,
     database_backend: DatabaseBackend | None = None,
 ) -> BasicMemoryProjectSearchBundle:
     """Compose default project-scoped search services without entity/indexing services."""
@@ -132,6 +132,7 @@ def build_default_project_runtime_bundle(
         entity_repository=entity_repository,
         search_service=search_service,
         session_maker=session_maker,
+        app_config=app_config,
     )
 
     if entity_service_factory is None:

--- a/src/basic_memory/services/link_resolver.py
+++ b/src/basic_memory/services/link_resolver.py
@@ -7,7 +7,7 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory import db
-from basic_memory.config import BasicMemoryConfig, ConfigManager
+from basic_memory.config import BasicMemoryConfig
 from basic_memory.models import Entity, Project
 from basic_memory.repository.entity_repository import EntityRepository
 from basic_memory.repository.project_repository import ProjectRepository
@@ -86,13 +86,14 @@ class LinkResolver:
         entity_repository: EntityRepository,
         search_service: SearchService,
         session_maker: async_sessionmaker[AsyncSession],
+        app_config: BasicMemoryConfig,
     ):
-        """Initialize with repositories."""
+        """Initialize with repositories and the caller's composition-root config."""
         self.entity_repository = entity_repository
         self.search_service = search_service
         self.session_maker = session_maker
         self._project_repository = ProjectRepository()
-        self._app_config: BasicMemoryConfig = ConfigManager().config
+        self._app_config: BasicMemoryConfig = app_config
         self._project_permalink: Optional[str] = None
         self._project_cache_by_identifier: Dict[str, Project] = {}
         self._entity_repository_cache: Dict[int, EntityRepository] = {}
@@ -484,7 +485,7 @@ class LinkResolver:
             search_repository = create_search_repository(
                 self.session_maker,
                 project_id=project.id,
-                database_backend=self._app_config.database_backend,
+                app_config=self._app_config,
             )
             search_service = SearchService(
                 search_repository,

--- a/test-int/conftest.py
+++ b/test-int/conftest.py
@@ -492,7 +492,9 @@ async def search_service(engine_factory, test_project, app_config):
     _, session_maker = engine_factory
 
     # Use factory function to create appropriate search repository
-    search_repository = create_search_repository(session_maker, project_id=test_project.id)
+    search_repository = create_search_repository(
+        session_maker, project_id=test_project.id, app_config=app_config
+    )
 
     entity_repository = EntityRepository(project_id=test_project.id)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -528,9 +528,12 @@ def link_resolver(
     entity_repository: EntityRepository,
     search_service: SearchService,
     session_maker: async_sessionmaker[AsyncSession],
+    app_config: BasicMemoryConfig,
 ):
     """Create parser instance."""
-    return LinkResolver(entity_repository, search_service, session_maker=session_maker)
+    return LinkResolver(
+        entity_repository, search_service, session_maker=session_maker, app_config=app_config
+    )
 
 
 @pytest.fixture

--- a/tests/services/test_link_resolver.py
+++ b/tests/services/test_link_resolver.py
@@ -107,13 +107,15 @@ async def test_entities(entity_service, file_service):
 
 
 @pytest_asyncio.fixture
-async def link_resolver(entity_repository, search_service, test_entities, session_maker):
+async def link_resolver(
+    entity_repository, search_service, test_entities, session_maker, app_config
+):
     """Create LinkResolver instance with indexed test data."""
     # Index all test entities
     for entity in test_entities:
         await search_service.index_entity(entity)
 
-    return LinkResolver(entity_repository, search_service, session_maker)
+    return LinkResolver(entity_repository, search_service, session_maker, app_config)
 
 
 @pytest.fixture
@@ -559,7 +561,7 @@ async def test_duplicate_title_handling_in_strict_mode(
 
 @pytest.mark.asyncio
 async def test_cross_project_link_resolution(
-    session_maker, entity_repository, search_service, tmp_path
+    session_maker, entity_repository, search_service, tmp_path, app_config
 ):
     """Test resolving explicit cross-project links."""
     from basic_memory.repository.project_repository import ProjectRepository
@@ -593,7 +595,7 @@ async def test_cross_project_link_resolution(
             ),
         )
 
-    resolver = LinkResolver(entity_repository, search_service, session_maker)
+    resolver = LinkResolver(entity_repository, search_service, session_maker, app_config)
     resolved = await resolver.resolve_link("other-project::Cross Project Note", strict=True)
 
     assert resolved is not None
@@ -745,7 +747,7 @@ async def context_aware_entities(entity_repository, session_maker):
 
 @pytest_asyncio.fixture
 async def context_link_resolver(
-    entity_repository, search_service, context_aware_entities, session_maker
+    entity_repository, search_service, context_aware_entities, session_maker, app_config
 ):
     """Create LinkResolver instance with context-aware test data.
 
@@ -753,7 +755,7 @@ async def context_link_resolver(
     exact title/permalink matching, not fuzzy search. The entities are
     database-only records (no files on disk).
     """
-    return LinkResolver(entity_repository, search_service, session_maker)
+    return LinkResolver(entity_repository, search_service, session_maker, app_config)
 
 
 @pytest.mark.asyncio
@@ -1006,10 +1008,10 @@ async def relative_path_entities(entity_repository, session_maker):
 
 @pytest_asyncio.fixture
 async def relative_path_resolver(
-    entity_repository, search_service, relative_path_entities, session_maker
+    entity_repository, search_service, relative_path_entities, session_maker, app_config
 ):
     """Create LinkResolver instance with relative path test data."""
-    return LinkResolver(entity_repository, search_service, session_maker)
+    return LinkResolver(entity_repository, search_service, session_maker, app_config)
 
 
 @pytest.mark.asyncio

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,11 +1,47 @@
 """Tests for dependency injection functions in the deps package."""
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException, Request
 
-from basic_memory.deps import validate_project_external_id
+from basic_memory.api import container as container_module
+from basic_memory.api.container import ApiContainer, resolve_container
+from basic_memory.deps import get_app_config, validate_project_external_id
 from basic_memory.models.project import Project
 from basic_memory.repository.project_repository import ProjectRepository
+from basic_memory.runtime.mode import resolve_runtime_mode
+
+
+def _request_for(app: FastAPI) -> Request:
+    return Request({"type": "http", "app": app})
+
+
+def test_get_app_config_reads_lifespan_container(app_config):
+    """API requests get the config the lifespan stored on app.state."""
+    app = FastAPI()
+    app.state.container = ApiContainer(
+        config=app_config, mode=resolve_runtime_mode(is_test_env=True)
+    )
+
+    assert get_app_config(_request_for(app)) is app_config
+
+
+def test_get_app_config_falls_back_to_composition_root(app_config, config_manager):
+    """Requests without a lifespan (CLI/MCP local ASGI) resolve via the composition root."""
+    app = FastAPI()
+
+    resolved = get_app_config(_request_for(app))
+
+    # resolve_container() reads the config the config_manager fixture wrote to disk.
+    assert resolved.default_project == app_config.default_project
+    assert resolved.projects == app_config.projects
+
+
+def test_resolve_container_prefers_installed_container(app_config, monkeypatch):
+    """A lifespan-installed container wins over creating a fresh one."""
+    installed = ApiContainer(config=app_config, mode=resolve_runtime_mode(is_test_env=True))
+    monkeypatch.setattr(container_module, "_container", installed)
+
+    assert resolve_container() is installed
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Second half of #1109 (2026-07 architecture review): stop reading `ConfigManager()` below the composition root.

- **`get_app_config`** is now request-aware: API requests read the container the lifespan stored on `app.state` (mirroring `get_engine_factory`'s app-state pattern). Requests served without a lifespan — the CLI/MCP local ASGI flow — resolve through the new `api.container.resolve_container()`, so the only `ConfigManager` read happens inside `ApiContainer.create()`, a composition root. The `# pragma: no cover` is gone; both paths have direct unit tests.
- **`resolve_container()`** intentionally does *not* cache a fresh container in the module global: `ConfigManager` already caches with mtime invalidation, and caching a container here would serve stale config after the CLI or tests rewrite the config file.
- **`get_engine_factory`**'s CLI fallback uses the same composition root.
- **`create_search_repository`** requires `app_config` — the `app_config or ConfigManager().config` fallback is deleted. Every production caller already passed it.
- **`LinkResolver`** takes `app_config` in its constructor instead of an unconditional `ConfigManager().config` read (it was the one *live* below-root read in the API DI graph). Its cross-project search repositories now inherit the injected config instead of triggering a second hidden read.
- **`build_default_project_search_bundle`** requires `app_config` (the runtime bundle already did).

One deferred import (`api.container` inside `deps/config.py`/`deps/db.py` function bodies) is required: a module-scope import re-enters `deps` via `api/__init__ → api.app → routers` and fails as a circular import — commented at both sites.

### Cross-repo note (basic-memory-cloud)

`LinkResolver`, `create_search_repository`, and `build_default_project_search_bundle` now require `app_config`. Cloud call sites needing adaptation on the next rev bump: `services/tigris_notification_processor/storage_adapters.py:76`, `pgq/jobs/deps.py:463,490`, `api/clipper.py:500`, plus two entity-indexer test files. Those sites previously fell back to a **global** `ConfigManager` read in a multi-tenant process — exactly the hazard this issue targets — so requiring the tenant-scoped config there is a correctness win, not just churn.

### Remaining below-root reads (follow-up, noted on #1109)

The concrete search repos' `__init__` fallbacks (`sqlite/postgres`), `services/project_service.py` (mutates config files — needs `ConfigManager` itself, not just values), `schemas/base.py` (Pydantic method), and the background-path reads (`index/local_dependencies.py`, `index/watch_service.py`, `utils.py`, `db.py`) are out of scope here; they're not request-scoped and need config threaded through their own call chains.

## Test plan

- `uv run pytest tests/test_deps.py tests/api/v2 tests/index tests/repository tests/services` — 1145 passed
- `uv run pytest tests/mcp tests/cli` — 1349 passed (exercises the ASGI fallback path)
- `uv run pytest test-int/semantic/test_embedding_provider_reuse.py` + WAL + search benchmark spot-checks — pass
- `just doctor` — end-to-end file↔DB loop through the real CLI/ASGI flow — passed
- `just typecheck` — clean (9 pre-existing uvloop deprecation warnings)

Closes #1109

🤖 Generated with [Claude Code](https://claude.com/claude-code)