### PR TITLE
chore(plugins): rename Codex marketplace to basic-memory

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
-  "name": "basic-memory-local",
+  "name": "basic-memory",
   "interface": {
-    "displayName": "Basic Memory Local"
+    "displayName": "Basic Memory"
   },
   "plugins": [
     {

--- a/plugins/codex/DEVELOPMENT.md
+++ b/plugins/codex/DEVELOPMENT.md
@@ -15,7 +15,7 @@ The repo marketplace lives at:
 It exposes this plugin as:
 
 ```text
-codex@basic-memory-local
+codex@basic-memory
 ```
 
 The marketplace entry points at `./plugins/codex`, resolved relative to the repository root.
@@ -26,7 +26,7 @@ From the repository root:
 
 ```bash
 codex plugin marketplace add "$(git rev-parse --show-toplevel)"
-codex plugin add codex@basic-memory-local
+codex plugin add codex@basic-memory
 ```
 
 Start a new Codex thread after installing. New threads are the reliable boundary for picking up
@@ -49,7 +49,7 @@ Then update the manifest cachebuster and reinstall from the local marketplace:
 ```bash
 python3 "$CODEX_PLUGIN_CREATOR_SCRIPTS/update_plugin_cachebuster.py" \
   "$(git rev-parse --show-toplevel)/plugins/codex"
-codex plugin add codex@basic-memory-local
+codex plugin add codex@basic-memory
 ```
 
 Start a fresh Codex thread to test the updated plugin.

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -62,7 +62,7 @@ Install the plugin once from the Basic Memory repository root:
 
 ```bash
 codex plugin marketplace add "$(git rev-parse --show-toplevel)"
-codex plugin add codex@basic-memory-local
+codex plugin add codex@basic-memory
 ```
 
 Plugin installation is user-level in Codex, so one install makes the plugin

--- a/tests/test_codex_plugin_package.py
+++ b/tests/test_codex_plugin_package.py
@@ -1,3 +1,4 @@
+import json
 import re
 import subprocess
 from pathlib import Path
@@ -46,13 +47,24 @@ def test_codex_plugin_hooks_are_zero_logic_uv_scripts() -> None:
         assert 'HARNESS = "codex"' in text
 
 
+def test_codex_plugin_marketplace_identity() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    marketplace = json.loads(
+        (repo_root / ".agents/plugins/marketplace.json").read_text(encoding="utf-8")
+    )
+
+    assert marketplace["name"] == "basic-memory"
+    assert marketplace["interface"]["displayName"] == "Basic Memory"
+    assert marketplace["plugins"][0]["name"] == "codex"
+
+
 def test_codex_plugin_docs_explain_global_install_and_repo_mapping() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     readme = (repo_root / "plugins/codex/README.md").read_text(encoding="utf-8")
 
     assert "## Install" in readme
     assert 'codex plugin marketplace add "$(git rev-parse --show-toplevel)"' in readme
-    assert "codex plugin add codex@basic-memory-local" in readme
+    assert "codex plugin add codex@basic-memory" in readme
     assert "Plugin installation is user-level in Codex" in readme
     assert "Each repository still needs its own `.codex/basic-memory.json`" in readme
 


### PR DESCRIPTION
## Why

The repo-local Codex marketplace still used the development-specific name
`basic-memory-local`. The marketplace is the standard Basic Memory Codex package now, so its
public identity and installation instructions should use the simpler `basic-memory` name.

## What Changed

- Renamed the Codex marketplace from `basic-memory-local` to `basic-memory`.
- Updated the marketplace display name from `Basic Memory Local` to `Basic Memory`.
- Updated install and development commands to use `codex@basic-memory`.
- Added regression coverage for the marketplace identity and install coordinate.

## Implementation Details

The marketplace identity lives in `.agents/plugins/marketplace.json`; the internal plugin slug
remains `codex`. As a result, the full installation coordinate changes from
`codex@basic-memory-local` to `codex@basic-memory` without changing the plugin package layout,
versioning, MCP configuration, hooks, or skills.

## Testing

### Automated

- `uv run pytest -q tests/test_codex_plugin_package.py`: 6 passed.
- `just fast-check`: passed lint, formatting, and type checking.
- `just package-check-codex`: passed Codex plugin validation.
- `just package-check`: passed all consolidated plugin, skill, and integration package checks.

### Manual

- Searched the repository for `basic-memory-local`: no references remain.
- Verified the commit includes a DCO sign-off.

## Risks / Follow-ups

Existing local installations that reference `codex@basic-memory-local` will need to re-add the
repo marketplace and install `codex@basic-memory`. No product runtime or data migration is
required.
