### PR TITLE
refactor(core): split search query and row hydration

### DIFF
--- a/src/basic_memory/repository/postgres_search_repository.py
+++ b/src/basic_memory/repository/postgres_search_repository.py
@@ -16,10 +16,10 @@ from basic_memory.config import BasicMemoryConfig, ConfigManager
 from basic_memory.repository.embedding_provider import EmbeddingProvider
 from basic_memory.repository.embedding_provider_factory import create_embedding_provider
 from basic_memory.repository.search_index_row import SearchIndexRow
+from basic_memory.repository.search_query import relaxed_query_words
 from basic_memory.repository.search_repository_base import (
     SearchRepositoryBase,
     VectorChunkState,
-    relaxed_query_words,
 )
 from basic_memory.repository.metadata_filters import parse_metadata_filters
 from basic_memory.repository.semantic_errors import SemanticDependenciesMissingError
@@ -1066,31 +1066,7 @@ class PostgresSearchRepository(SearchRepositoryBase):
             logger.error(f"Database error during search: {e}")
             raise
 
-        results = [
-            SearchIndexRow(
-                project_id=self.project_id,
-                id=row.id,
-                title=row.title,
-                permalink=row.permalink,
-                file_path=row.file_path,
-                type=row.type,
-                score=float(row.score) if row.score else 0.0,
-                metadata=(
-                    row.metadata
-                    if isinstance(row.metadata, dict)
-                    else (json.loads(row.metadata) if row.metadata else {})
-                ),
-                from_id=row.from_id,
-                to_id=row.to_id,
-                relation_type=row.relation_type,
-                entity_id=row.entity_id,
-                content_snippet=row.content_snippet,
-                category=row.category,
-                created_at=row.created_at,
-                updated_at=row.updated_at,
-            )
-            for row in rows
-        ]
+        results = [SearchIndexRow.from_mapping(row._asdict()) for row in rows]
 
         logger.trace(f"Found {len(results)} search results")
         for r in results:

--- a/src/basic_memory/repository/search_index_row.py
+++ b/src/basic_memory/repository/search_index_row.py
@@ -1,10 +1,11 @@
 """Search index data structures."""
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
 from pathlib import Path
+from typing import Any, Optional
 
 from basic_memory.schemas.search import SearchItemType
 from basic_memory.utils import ensure_timezone_aware
@@ -44,6 +45,35 @@ class SearchIndexRow:
     matched_chunk_text: Optional[str] = None
 
     CONTENT_DISPLAY_LIMIT = 4000
+
+    @classmethod
+    def from_mapping(cls, row: Mapping[str, Any]) -> "SearchIndexRow":
+        """Hydrate one persisted search row from either supported database backend."""
+        metadata = row.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = json.loads(metadata) if metadata else {}
+
+        raw_score = row.get("score")
+        return cls(
+            project_id=row["project_id"],
+            id=row["id"],
+            title=row.get("title"),
+            permalink=row.get("permalink"),
+            file_path=row["file_path"],
+            type=row["type"],
+            score=float(raw_score) if raw_score is not None else None,
+            metadata=metadata,
+            from_id=row.get("from_id"),
+            to_id=row.get("to_id"),
+            to_name=row.get("to_name"),
+            relation_type=row.get("relation_type"),
+            entity_id=row.get("entity_id"),
+            content_stems=row.get("content_stems"),
+            content_snippet=row.get("content_snippet"),
+            category=row.get("category"),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
 
     def __post_init__(self) -> None:
         """Restore typed, timezone-aware datetimes from raw search query results."""

--- a/src/basic_memory/repository/search_query.py
+++ b/src/basic_memory/repository/search_query.py
@@ -1,0 +1,98 @@
+"""Shared full-text query preparation rules."""
+
+import re
+
+# Interrogative/function words contribute lexical noise when a strict
+# full-text query is relaxed: "when OR did OR a" matches loud wrong documents
+# that displace genuine results from the ranking window.
+RELAXATION_STOPWORDS = frozenset(
+    "a an and are as at be but by did do does for from had has have how i in is it of on "
+    "or our that the their they this to was we were what when where which who whom whose why "
+    "will with you your".split()
+)
+RELAXATION_CJK_PATTERN = re.compile(
+    r"["
+    r"\u1100-\u11ff"  # Hangul Jamo
+    r"\u3040-\u30ff"  # Hiragana and Katakana
+    r"\u3130-\u318f"  # Hangul Compatibility Jamo
+    r"\u31f0-\u31ff"  # Katakana Phonetic Extensions
+    r"\u3400-\u4dbf"  # CJK Unified Ideographs Extension A
+    r"\u4e00-\u9fff"  # CJK Unified Ideographs
+    r"\ua960-\ua97f"  # Hangul Jamo Extended-A
+    r"\uac00-\ud7af"  # Hangul Syllables
+    r"\ud7b0-\ud7ff"  # Hangul Jamo Extended-B
+    r"\uf900-\ufaff"  # CJK Compatibility Ideographs
+    r"\uff65-\uff9f"  # Halfwidth Katakana
+    r"]"
+)
+RELAXATION_ASCII_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9]+")
+RELAXATION_EDGE_PUNCTUATION = "?!.,;:，。！？；：、"
+
+
+def _dedupe_relaxation_words(words: list[str]) -> list[str]:
+    """Preserve first-seen relaxed terms while removing duplicates case-insensitively."""
+    deduped_terms: list[str] = []
+    seen_terms: set[str] = set()
+    for word in words:
+        key = word.lower()
+        if key in seen_terms:
+            continue
+        seen_terms.add(key)
+        deduped_terms.append(word)
+    return deduped_terms
+
+
+def _split_relaxation_words(search_text: str) -> list[str]:
+    """Split whitespace-delimited relaxed terms, preserving CJK words."""
+    words = [word.strip(RELAXATION_EDGE_PUNCTUATION) for word in search_text.split()]
+    return [word for word in words if word]
+
+
+def relaxed_query_words(search_text: str | None) -> list[str] | None:
+    """Return content-bearing words for OR-relaxing a strict full-text query.
+
+    Returns None when relaxation must not apply. These eligibility rules match
+    SearchService._is_relaxed_fts_fallback_eligible so the hybrid FTS branch
+    relaxes exactly the same query shapes as the service-level FTS path:
+
+    - empty / quoted / explicit-boolean queries (user intent is not
+      second-guessed);
+    - fewer than three alphanumeric tokens (short queries like "New Feature"
+      over-broaden under OR — and in hybrid the relaxed FTS-only rows normalize
+      to 1.0 and can outrank the vector result the user wanted);
+    - CJK terms separated by whitespace can relax with two or more terms because
+      the ASCII token gate would otherwise suppress the fallback entirely;
+    - any pure-digit token ("root note 1", "SPEC 16") — identifier-like queries
+      over-broaden and create false positives under OR.
+    """
+    if not search_text:
+        return None
+    stripped = search_text.strip()
+    if '"' in stripped or any(op in f" {stripped} " for op in (" AND ", " OR ", " NOT ")):
+        return None
+
+    # Eligibility checks run on raw alphanumeric tokens (parity with the
+    # service), before stopword filtering.
+    cjk_words = _split_relaxation_words(stripped)
+    has_cjk_term = any(RELAXATION_CJK_PATTERN.search(word) for word in cjk_words)
+
+    if has_cjk_term:
+        if len(cjk_words) < 2 or any(word.isdigit() for word in cjk_words):
+            return None
+        pruned_words = [
+            word
+            for word in cjk_words
+            if word.isalnum() and word.lower() not in RELAXATION_STOPWORDS
+        ]
+        relaxed_words = _dedupe_relaxation_words(pruned_words)
+        # Trigger: punctuation/stopword pruning or deduplication leaves only one term.
+        # Why: the raw whitespace count can make an identifier-like mixed query
+        # appear multi-term even though only one backend-safe CJK prefix remains.
+        # Outcome: preserve the short-query guard after pruning to avoid a broad retry.
+        return relaxed_words if len(relaxed_words) >= 2 else None
+
+    tokens = RELAXATION_ASCII_TOKEN_PATTERN.findall(stripped.lower())
+    if len(tokens) < 3 or any(token.isdigit() for token in tokens):
+        return None
+    pruned_words = [token for token in tokens if token not in RELAXATION_STOPWORDS]
+    return _dedupe_relaxation_words(pruned_words or tokens) or None

--- a/src/basic_memory/repository/search_repository_base.py
+++ b/src/basic_memory/repository/search_repository_base.py
@@ -43,101 +43,6 @@ BULLET_PATTERN = re.compile(r"^[\-\*]\s+")
 OVERSIZED_ENTITY_VECTOR_SHARD_SIZE = 256
 _SQLITE_MAX_PREPARE_WINDOW = 8
 
-# Interrogative/function words contribute lexical noise when a strict
-# full-text query is relaxed: "when OR did OR a" matches loud wrong documents
-# that displace genuine results from the ranking window.
-RELAXATION_STOPWORDS = frozenset(
-    "a an and are as at be but by did do does for from had has have how i in is it of on "
-    "or our that the their they this to was we were what when where which who whom whose why "
-    "will with you your".split()
-)
-RELAXATION_CJK_PATTERN = re.compile(
-    r"["
-    r"\u1100-\u11ff"  # Hangul Jamo
-    r"\u3040-\u30ff"  # Hiragana and Katakana
-    r"\u3130-\u318f"  # Hangul Compatibility Jamo
-    r"\u31f0-\u31ff"  # Katakana Phonetic Extensions
-    r"\u3400-\u4dbf"  # CJK Unified Ideographs Extension A
-    r"\u4e00-\u9fff"  # CJK Unified Ideographs
-    r"\ua960-\ua97f"  # Hangul Jamo Extended-A
-    r"\uac00-\ud7af"  # Hangul Syllables
-    r"\ud7b0-\ud7ff"  # Hangul Jamo Extended-B
-    r"\uf900-\ufaff"  # CJK Compatibility Ideographs
-    r"\uff65-\uff9f"  # Halfwidth Katakana
-    r"]"
-)
-RELAXATION_ASCII_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9]+")
-RELAXATION_EDGE_PUNCTUATION = "?!.,;:，。！？；：、"
-
-
-def _dedupe_relaxation_words(words: list[str]) -> list[str]:
-    """Preserve first-seen relaxed terms while removing duplicates case-insensitively."""
-    deduped_terms: list[str] = []
-    seen_terms: set[str] = set()
-    for word in words:
-        key = word.lower()
-        if key in seen_terms:
-            continue
-        seen_terms.add(key)
-        deduped_terms.append(word)
-    return deduped_terms
-
-
-def _split_relaxation_words(search_text: str) -> list[str]:
-    """Split whitespace-delimited relaxed terms, preserving CJK words."""
-    words = [word.strip(RELAXATION_EDGE_PUNCTUATION) for word in search_text.split()]
-    return [word for word in words if word]
-
-
-def relaxed_query_words(search_text: Optional[str]) -> Optional[list[str]]:
-    """Content-bearing words for OR-relaxing a strict full-text query.
-
-    Returns None when relaxation must not apply. These eligibility rules match
-    SearchService._is_relaxed_fts_fallback_eligible so the hybrid FTS branch
-    relaxes exactly the same query shapes as the service-level FTS path:
-
-    - empty / quoted / explicit-boolean queries (user intent is not
-      second-guessed);
-    - fewer than three alphanumeric tokens (short queries like "New Feature"
-      over-broaden under OR — and in hybrid the relaxed FTS-only rows normalize
-      to 1.0 and can outrank the vector result the user wanted);
-    - CJK terms separated by whitespace can relax with two or more terms because
-      the ASCII token gate would otherwise suppress the fallback entirely;
-    - any pure-digit token ("root note 1", "SPEC 16") — identifier-like queries
-      over-broaden and create false positives under OR.
-    """
-    if not search_text:
-        return None
-    stripped = search_text.strip()
-    if '"' in stripped or any(op in f" {stripped} " for op in (" AND ", " OR ", " NOT ")):
-        return None
-    # Eligibility checks run on raw alphanumeric tokens (parity with the
-    # service), before stopword filtering.
-    cjk_words = _split_relaxation_words(stripped)
-    has_cjk_term = any(RELAXATION_CJK_PATTERN.search(word) for word in cjk_words)
-
-    if has_cjk_term:
-        if len(cjk_words) < 2 or any(word.isdigit() for word in cjk_words):
-            return None
-        pruned_words = [
-            word
-            for word in cjk_words
-            if word.isalnum() and word.lower() not in RELAXATION_STOPWORDS
-        ]
-        relaxed_words = _dedupe_relaxation_words(pruned_words)
-        # Trigger: punctuation/stopword pruning or deduplication leaves only one term.
-        # Why: the raw whitespace count can make an identifier-like mixed query
-        # appear multi-term even though only one backend-safe CJK prefix remains.
-        # Outcome: preserve the short-query guard after pruning to avoid a broad retry.
-        return relaxed_words if len(relaxed_words) >= 2 else None
-
-    tokens = RELAXATION_ASCII_TOKEN_PATTERN.findall(stripped.lower())
-    if len(tokens) < 3 or any(token.isdigit() for token in tokens):
-        return None
-    pruned_words = [token for token in tokens if token not in RELAXATION_STOPWORDS]
-    return _dedupe_relaxation_words(pruned_words or tokens) or None
-
-
 # Entity, observation, and relation rows in search_index carry ids from independent
 # auto-increment sequences, so a bare id is ambiguous across row types. Every map in
 # the vector/hybrid retrieval path must key rows by (type, id) to avoid collisions.
@@ -2162,28 +2067,8 @@ class SearchRepositoryBase(ABC):
         async with db.scoped_session(self.session_maker) as session:
             row_result = await session.execute(text(sql), params)
             for row in row_result.fetchall():
-                result[row.entity_id] = SearchIndexRow(
-                    project_id=self.project_id,
-                    id=row.id,
-                    title=row.title,
-                    permalink=row.permalink,
-                    file_path=row.file_path,
-                    type=row.type,
-                    score=0.0,
-                    metadata=(
-                        row.metadata
-                        if isinstance(row.metadata, dict)
-                        else (json.loads(row.metadata) if row.metadata else {})
-                    ),
-                    from_id=row.from_id,
-                    to_id=row.to_id,
-                    relation_type=row.relation_type,
-                    entity_id=row.entity_id,
-                    content_snippet=row.content_snippet,
-                    category=row.category,
-                    created_at=row.created_at,
-                    updated_at=row.updated_at,
-                )
+                search_row = SearchIndexRow.from_mapping(row._asdict())
+                result[row.entity_id] = search_row
         return result
 
     async def _fetch_search_index_rows_by_ids(
@@ -2214,28 +2099,8 @@ class SearchRepositoryBase(ABC):
         async with db.scoped_session(self.session_maker) as session:
             row_result = await session.execute(text(sql), params)
             for row in row_result.fetchall():
-                result[(row.type, row.id)] = SearchIndexRow(
-                    project_id=self.project_id,
-                    id=row.id,
-                    title=row.title,
-                    permalink=row.permalink,
-                    file_path=row.file_path,
-                    type=row.type,
-                    score=0.0,
-                    metadata=(
-                        row.metadata
-                        if isinstance(row.metadata, dict)
-                        else (json.loads(row.metadata) if row.metadata else {})
-                    ),
-                    from_id=row.from_id,
-                    to_id=row.to_id,
-                    relation_type=row.relation_type,
-                    entity_id=row.entity_id,
-                    content_snippet=row.content_snippet,
-                    category=row.category,
-                    created_at=row.created_at,
-                    updated_at=row.updated_at,
-                )
+                search_row = SearchIndexRow.from_mapping(row._asdict())
+                result[(search_row.type, search_row.id)] = search_row
         return result
 
     # ------------------------------------------------------------------

--- a/src/basic_memory/repository/sqlite_search_repository.py
+++ b/src/basic_memory/repository/sqlite_search_repository.py
@@ -25,10 +25,8 @@ from basic_memory.models.search import (
 from basic_memory.repository.embedding_provider import EmbeddingProvider
 from basic_memory.repository.embedding_provider_factory import create_embedding_provider
 from basic_memory.repository.search_index_row import SearchIndexRow
-from basic_memory.repository.search_repository_base import (
-    SearchRepositoryBase,
-    relaxed_query_words,
-)
+from basic_memory.repository.search_query import relaxed_query_words
+from basic_memory.repository.search_repository_base import SearchRepositoryBase
 from basic_memory.repository.metadata_filters import parse_metadata_filters, build_sqlite_json_path
 from basic_memory.repository.semantic_errors import SemanticDependenciesMissingError
 from basic_memory.schemas.search import SearchItemType, SearchRetrievalMode
@@ -1101,27 +1099,7 @@ class SQLiteSearchRepository(SearchRepositoryBase):
                 logger.error(f"Database error during search: {e}")
                 raise
 
-        results = [
-            SearchIndexRow(
-                project_id=self.project_id,
-                id=row.id,
-                title=row.title,
-                permalink=row.permalink,
-                file_path=row.file_path,
-                type=row.type,
-                score=row.score,
-                metadata=json.loads(row.metadata) if row.metadata else {},
-                from_id=row.from_id,
-                to_id=row.to_id,
-                relation_type=row.relation_type,
-                entity_id=row.entity_id,
-                content_snippet=row.content_snippet,
-                category=row.category,
-                created_at=row.created_at,
-                updated_at=row.updated_at,
-            )
-            for row in rows
-        ]
+        results = [SearchIndexRow.from_mapping(row._asdict()) for row in rows]
 
         logger.trace(f"Found {len(results)} search results")
         for r in results:

--- a/src/basic_memory/services/search_service.py
+++ b/src/basic_memory/services/search_service.py
@@ -23,7 +23,7 @@ from basic_memory.repository.search_repository import (
     SearchRepository,
     VectorSyncBatchResult,
 )
-from basic_memory.repository.search_repository_base import relaxed_query_words
+from basic_memory.repository.search_query import relaxed_query_words
 from basic_memory.schemas.search import SearchQuery, SearchItemType, SearchRetrievalMode
 from basic_memory.services import FileService
 

--- a/tests/repository/test_search_index_row.py
+++ b/tests/repository/test_search_index_row.py
@@ -1,8 +1,33 @@
 """Tests for SearchIndexRow data structure."""
 
 from datetime import datetime
+from decimal import Decimal
 
 from basic_memory.repository.search_index_row import SearchIndexRow
+
+
+def test_from_mapping_normalizes_database_values():
+    """Database rows share one hydration path across SQLite and Postgres."""
+    now = datetime.now()
+    row = SearchIndexRow.from_mapping(
+        {
+            "project_id": 1,
+            "id": 2,
+            "type": "observation",
+            "file_path": "notes/example.md",
+            "created_at": now,
+            "updated_at": now,
+            "metadata": '{"tags": ["example"]}',
+            "score": Decimal("0.25"),
+            "entity_id": 3,
+            "content_snippet": "Shared hydration",
+        }
+    )
+
+    assert row.metadata == {"tags": ["example"]}
+    assert row.score == 0.25
+    assert row.entity_id == 3
+    assert row.content_snippet == "Shared hydration"
 
 
 def test_content_display_limit_is_4000():

--- a/tests/repository/test_search_relaxation.py
+++ b/tests/repository/test_search_relaxation.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from basic_memory.repository.search_repository_base import relaxed_query_words
+from basic_memory.repository.search_query import relaxed_query_words
 
 
 @pytest.mark.parametrize(
@@ -24,6 +24,7 @@ def test_relaxed_query_words_supports_whitespace_separated_cjk_scripts(
 @pytest.mark.parametrize(
     "query",
     [
+        "季度",
         "SPEC-16 设计",
         "foo/bar 季度",
         "季度 季度",


### PR DESCRIPTION
## Why

- Begins #1108 with a reviewable extraction after the naming cleanup from #1121.
- search_repository_base.py mixed backend-neutral lexical query policy and duplicated persisted-row hydration with vector search orchestration.
- The earlier Claude workflow for #1108 was canceled and left no branch or pull request to continue.

## What Changed

- Move relaxed FTS query eligibility and tokenization into repository/search_query.py.
- Add SearchIndexRow.from_mapping() as the explicit persistence boundary used by the base, SQLite, and PostgreSQL repositories.
- Update direct imports and add regression coverage for database value normalization and single-term CJK queries.
- Preserve query SQL, ranking, fallback order, and vector orchestration behavior.

## Implementation Details

- The lexical policy remains a small set of pure functions rather than a new manager or mixin hierarchy.
- Row hydration normalizes SQLite JSON strings, PostgreSQL mappings, and numeric scores in one symmetric counterpart to SearchIndexRow.to_insert().
- Backend-specific syntax, metadata filtering, and savepoint behavior remain in their existing repositories.
- Vector synchronization is intentionally left for a later #1108 slice.

## Testing

### Automated

- just fast-check — passed (existing Python 3.14 asyncio deprecation warnings only)
- BASIC_MEMORY_ENV=test uv run pytest tests/repository/test_search_relaxation.py tests/repository/test_search_index_row.py tests/repository/test_semantic_search_base.py tests/repository/test_search_repository.py tests/repository/test_postgres_search_repository_unit.py tests/services/test_search_service.py --no-cov -q — 164 passed
- just fast-test — 4,580 passed, 41 skipped, 5 failed: one live OpenAI semantic-quality case hit 429 insufficient_quota; four Codex-plugin dependency-floor cases reflected concurrent, unstaged workspace changes outside this PR

### Manual

- git diff --cached --check — passed
- Verified the commit contains only the eight search repository/service/test paths listed in this PR.

## Risks / Follow-ups

- The main risk is SQLite/PostgreSQL row-hydration parity; the impacted repository and service suites cover both paths.
- Continue #1108 with a separate vector-sync extraction rather than expanding this review.
- Concurrent Codex-plugin edits in the shared checkout were explicitly excluded from the commit.
