### PR TITLE
fix(plugins): make Codex hooks and memory notes reliable

### DIFF
--- a/justfile
+++ b/justfile
@@ -575,6 +575,11 @@ migration message:
 set-version version scope="all":
     python3 scripts/update_versions.py "{{version}}" --scope "{{scope}}"
 
+# Pin the Basic Memory Git ref used by both Codex uv hook scripts.
+set-codex-hook-version ref:
+    uv add --script plugins/codex/hooks/session_start.py --raw "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@{{ref}}"
+    uv add --script plugins/codex/hooks/pre_compact.py --raw "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@{{ref}}"
+
 # Preview a version update without writing (scope: all | core | packages)
 set-version-dry-run version scope="all":
     python3 scripts/update_versions.py "{{version}}" --scope "{{scope}}" --dry-run
@@ -639,6 +644,7 @@ release version:
     # Update all package manifests to the one Basic Memory product version.
     echo "📝 Updating consolidated package versions..."
     just set-version "{{version}}"
+    just set-codex-hook-version "$(git rev-parse HEAD)"
 
     # Trigger: main's ruleset rejects direct pushes ("Changes must be made
     # through a pull request").
@@ -656,6 +662,8 @@ release version:
         plugins/claude-code/.claude-plugin/plugin.json \
         plugins/claude-code/.claude-plugin/marketplace.json \
         plugins/codex/.codex-plugin/plugin.json \
+        plugins/codex/hooks/session_start.py \
+        plugins/codex/hooks/pre_compact.py \
         integrations/hermes/plugin.yaml \
         integrations/hermes/__init__.py \
         integrations/openclaw/package.json
@@ -756,6 +764,7 @@ beta version:
     # Update all package manifests to the one Basic Memory product version.
     echo "📝 Updating consolidated package versions..."
     just set-version "{{version}}"
+    just set-codex-hook-version "$(git rev-parse HEAD)"
 
     # Trigger: main's ruleset rejects direct pushes ("Changes must be made
     # through a pull request").
@@ -773,6 +782,8 @@ beta version:
         plugins/claude-code/.claude-plugin/plugin.json \
         plugins/claude-code/.claude-plugin/marketplace.json \
         plugins/codex/.codex-plugin/plugin.json \
+        plugins/codex/hooks/session_start.py \
+        plugins/codex/hooks/pre_compact.py \
         integrations/hermes/plugin.yaml \
         integrations/hermes/__init__.py \
         integrations/openclaw/package.json

--- a/justfile
+++ b/justfile
@@ -644,7 +644,7 @@ release version:
     # Update all package manifests to the one Basic Memory product version.
     echo "📝 Updating consolidated package versions..."
     just set-version "{{version}}"
-    just set-codex-hook-version "$(git rev-parse HEAD)"
+    just set-codex-hook-version "{{version}}"
 
     # Trigger: main's ruleset rejects direct pushes ("Changes must be made
     # through a pull request").
@@ -764,7 +764,7 @@ beta version:
     # Update all package manifests to the one Basic Memory product version.
     echo "📝 Updating consolidated package versions..."
     just set-version "{{version}}"
-    just set-codex-hook-version "$(git rev-parse HEAD)"
+    just set-codex-hook-version "{{version}}"
 
     # Trigger: main's ruleset rejects direct pushes ("Changes must be made
     # through a pull request").

--- a/plugins/codex/DEVELOPMENT.md
+++ b/plugins/codex/DEVELOPMENT.md
@@ -38,6 +38,12 @@ projects on the same machine. Repo-specific memory routing still comes from each
 
 ## Iteration Loop
 
+Pin both hook scripts to the Basic Memory revision under test:
+
+```bash
+just set-codex-hook-version "$(git rev-parse origin/main)"
+```
+
 After changing files in `plugins/codex`, run the local checks:
 
 ```bash

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -17,6 +17,9 @@ verification, decision capture, and resumable checkpoints.
   decisions with rationale, alternatives, and consequences.
 - **Remember lightly.** The `bm-remember` skill saves small facts without turning
   them into a full decision or session note.
+- **Write useful memory.** The `bm-writing` skill provides one user-customizable
+  standard for the voice, narrative quality, observations, and relations used by
+  the plugin's note-writing skills.
 - **Share deliberately.** The `bm-share` skill copies personal notes to configured
   team projects only after confirmation.
 - **Report status.** The `bm-status` skill shows configuration, reachability,
@@ -35,26 +38,22 @@ verification, decision capture, and resumable checkpoints.
 | `schemas/` | Seed schemas for Codex sessions, decisions, and tasks |
 
 The hook scripts carry no logic: the brief, the checkpoint, and opt-in event
-capture all live in the released `basic-memory` package behind `bm hook`. Each
-is a self-contained PEP 723 script whose inline metadata pins the released
-dependency floor uv resolves.
+capture all live in the pinned Basic Memory revision behind `bm hook`. Each is
+a self-contained PEP 723 script pinned to a Basic Memory Git ref. Both refs
+are updated together with `just set-codex-hook-version <sha-or-tag>`.
 
 ## Requirements
 
 - **[uv](https://docs.astral.sh/uv/)** — required: the hooks are PEP 723
-  scripts executed via `uv run --script`. Install per platform:
+  scripts executed via `uv run --script`, which installs their pinned Basic
+  Memory revision. Install per platform:
   - macOS: `brew install uv` (or the curl installer below)
   - Linux/macOS: `curl -LsSf https://astral.sh/uv/install.sh | sh`
   - Windows: `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"`
-- [Basic Memory](https://github.com/basicmachines-co/basic-memory). `uv tool
-  install basic-memory` is recommended (a `basic-memory` binary on PATH keeps the
-  hook version consistent with your MCP server).
 
-Disclosure: uv resolves `basic-memory>=<floor>` from each script's inline
-metadata, fetching from PyPI on first run (pinned minimum version, bumped by
-release tooling); later runs use uv's cache. `BM_BIN` (a binary path or a
-quoted launcher string) overrides the uv-managed environment for development.
-Every failure path exits 0 — the hooks never disrupt a session.
+Disclosure: uv installs the pinned Basic Memory Git ref on first run and reuses
+its cache afterward. Every failure path exits 0 — the hooks never disrupt a
+session.
 
 ## Install
 
@@ -72,6 +71,10 @@ installing so Codex can load the plugin skills, MCP configuration, and hooks.
 Each repository still needs its own `.codex/basic-memory.json` so the plugin
 knows which Basic Memory project and folders to use for that checkout. Run the
 setup skill in each repo, or create the config file shown below.
+
+To customize how Codex writes memory, edit `skills/bm-writing/SKILL.md` in the
+plugin source. `bm-checkpoint`, `bm-decide`, and `bm-remember` all apply that
+shared skill while retaining their own schemas and evidence requirements.
 
 ## Configuration
 

--- a/plugins/codex/hooks/pre_compact.py
+++ b/plugins/codex/hooks/pre_compact.py
@@ -1,28 +1,18 @@
 #!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.12"
-# dependencies = ["basic-memory>=0.22.1"]
+# dependencies = [
+#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@6e9f2fcf5f00f3577d38a3d8b6e2f2baca3079f7",
+# ]
 # ///
-"""PreCompact hook — the entire hook. All logic (config resolution, the
-extractive Codex checkpoint, opt-in envelope capture) lives in the released
-basic-memory package behind `basic-memory hook pre-compact`; this script is
-only the launcher, and uv resolves the dependency floor declared above.
-scripts/update_versions.py bumps that floor at release time.
-
-BM_BIN overrides the uv-managed environment for development: either a path
-to a bm binary, or a POSIX-quoted launcher string like `uvx "basic-memory"`.
+"""PreCompact hook launcher backed by a pinned Basic Memory revision.
 
 Fail-open contract: a hook must never disrupt an agent session, so every
-failure path — unresolvable dependencies, a broken BM_BIN, a crash inside
-the CLI — exits 0. Codex has no project-dir env var; project mapping uses
+failure path exits 0. Codex has no project-dir env var; project mapping uses
 the payload cwd. The hook JSON on stdin passes through untouched.
 """
 
-import os
-import shlex
-import subprocess
 import sys
-from pathlib import Path
 
 VERB = "pre-compact"
 HARNESS = "codex"
@@ -33,15 +23,6 @@ def hook_args() -> list[str]:
 
 
 def main() -> None:
-    bm_bin = os.environ.get("BM_BIN", "").strip()
-    if bm_bin:
-        # An existing path (may contain spaces) stays one word; any other
-        # value is a multi-token launcher, split with shell quoting rules.
-        launcher = [bm_bin] if Path(bm_bin).exists() else shlex.split(bm_bin)
-        subprocess.run([*launcher, *hook_args()], check=False)
-        return
-    # In-process: uv already resolved basic-memory into this script's
-    # environment, so importing the CLI skips a second process spawn.
     from basic_memory.cli.main import app
 
     sys.argv = ["basic-memory", *hook_args()]

--- a/plugins/codex/hooks/session_start.py
+++ b/plugins/codex/hooks/session_start.py
@@ -1,28 +1,18 @@
 #!/usr/bin/env -S uv run --quiet --script
 # /// script
 # requires-python = ">=3.12"
-# dependencies = ["basic-memory>=0.22.1"]
+# dependencies = [
+#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@6e9f2fcf5f00f3577d38a3d8b6e2f2baca3079f7",
+# ]
 # ///
-"""SessionStart hook — the entire hook. All logic (config resolution, the
-Codex memory brief, opt-in envelope capture) lives in the released
-basic-memory package behind `basic-memory hook session-start`; this script is
-only the launcher, and uv resolves the dependency floor declared above.
-scripts/update_versions.py bumps that floor at release time.
-
-BM_BIN overrides the uv-managed environment for development: either a path
-to a bm binary, or a POSIX-quoted launcher string like `uvx "basic-memory"`.
+"""SessionStart hook launcher backed by a pinned Basic Memory revision.
 
 Fail-open contract: a hook must never disrupt an agent session, so every
-failure path — unresolvable dependencies, a broken BM_BIN, a crash inside
-the CLI — exits 0. Codex has no project-dir env var; project mapping uses
+failure path exits 0. Codex has no project-dir env var; project mapping uses
 the payload cwd. The hook JSON on stdin passes through untouched.
 """
 
-import os
-import shlex
-import subprocess
 import sys
-from pathlib import Path
 
 VERB = "session-start"
 HARNESS = "codex"
@@ -33,15 +23,6 @@ def hook_args() -> list[str]:
 
 
 def main() -> None:
-    bm_bin = os.environ.get("BM_BIN", "").strip()
-    if bm_bin:
-        # An existing path (may contain spaces) stays one word; any other
-        # value is a multi-token launcher, split with shell quoting rules.
-        launcher = [bm_bin] if Path(bm_bin).exists() else shlex.split(bm_bin)
-        subprocess.run([*launcher, *hook_args()], check=False)
-        return
-    # In-process: uv already resolved basic-memory into this script's
-    # environment, so importing the CLI skips a second process spawn.
     from basic_memory.cli.main import app
 
     sys.argv = ["basic-memory", *hook_args()]

--- a/plugins/codex/hooks/test_codex_pre_compact.py
+++ b/plugins/codex/hooks/test_codex_pre_compact.py
@@ -1,129 +1,46 @@
-"""Tests for the co-located pre_compact.py uv hook script.
+"""Tests for the Codex PreCompact uv hook script."""
 
-The script is executed via ``sys.executable`` (the PEP 723 metadata is inert
-comments to a plain interpreter), so these tests exercise the real launcher
-logic — BM_BIN resolution, argument plumbing, fail-open — without a network
-resolve. The metadata block itself is pinned against the package version so
-release drift fails here rather than at a user's cold uvx cache.
-"""
-
-import json
 import os
 import re
 import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
-from basic_memory import __version__
 
 SCRIPT = Path(__file__).with_name("pre_compact.py")
-VERB = "pre-compact"
-HARNESS = "codex"
+GIT_DEPENDENCY_RE = re.compile(
+    r'"basic-memory @ git\+https://github\.com/'
+    r'basicmachines-co/basic-memory@([^"]+)"'
+)
 
 
-def run_script(
-    *,
-    stdin: str = "{}",
-    env_overrides: dict[str, str] | None = None,
-) -> subprocess.CompletedProcess[str]:
-    env = {**os.environ, **(env_overrides or {})}
-    # Isolate from the developer's shell: these vars change the script's path.
-    for var in ("BM_BIN", "CLAUDE_PROJECT_DIR"):
-        if var not in (env_overrides or {}):
-            env.pop(var, None)
-    return subprocess.run(
+def test_script_fails_open_with_empty_home(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["USERPROFILE"] = str(tmp_path)
+
+    result = subprocess.run(
         [sys.executable, str(SCRIPT)],
-        input=stdin,
+        input="{}",
         env=env,
         capture_output=True,
         text=True,
         timeout=60,
     )
 
-
-@pytest.fixture
-def recorder(tmp_path: Path) -> tuple[str, Path]:
-    """A BM_BIN launcher that records its argv and stdin to a file."""
-    record_file = tmp_path / "record.json"
-    script = tmp_path / "recorder.py"
-    script.write_text(
-        "import json, os, sys\n"
-        'payload = {"argv": sys.argv[1:], "stdin": sys.stdin.read()}\n'
-        'with open(os.environ["RECORD_FILE"], "w", encoding="utf-8") as fh:\n'
-        "    json.dump(payload, fh)\n",
-        encoding="utf-8",
-    )
-    return f'"{sys.executable}" "{script}"', record_file
-
-
-def test_bm_bin_launcher_receives_verb_and_stdin(
-    recorder: tuple[str, Path],
-) -> None:
-    bm_bin, record_file = recorder
-    hook_json = '{"session_id": "s-1", "cwd": "/tmp/work"}'
-
-    result = run_script(
-        stdin=hook_json,
-        env_overrides={"BM_BIN": bm_bin, "RECORD_FILE": str(record_file)},
-    )
-
-    assert result.returncode == 0
-    recorded = json.loads(record_file.read_text(encoding="utf-8"))
-    assert recorded["argv"] == ["hook", VERB, "--harness", HARNESS]
-    assert recorded["stdin"] == hook_json
-
-
-def test_claude_project_dir_env_is_ignored(recorder: tuple[str, Path]) -> None:
-    # Codex has no project-dir contract; mapping uses the payload cwd. A
-    # CLAUDE_PROJECT_DIR leaking in from a nested environment must not add
-    # arguments meant for the claude harness.
-    bm_bin, record_file = recorder
-
-    result = run_script(
-        env_overrides={
-            "BM_BIN": bm_bin,
-            "RECORD_FILE": str(record_file),
-            "CLAUDE_PROJECT_DIR": "/tmp/should-not-appear",
-        },
-    )
-
-    assert result.returncode == 0
-    recorded = json.loads(record_file.read_text(encoding="utf-8"))
-    assert recorded["argv"] == ["hook", VERB, "--harness", HARNESS]
-
-
-def test_unresolvable_bm_bin_fails_open(tmp_path: Path) -> None:
-    result = run_script(env_overrides={"BM_BIN": str(tmp_path / "missing" / "bm")})
-
     assert result.returncode == 0
 
 
-def test_in_process_cli_fails_open_with_empty_home(tmp_path: Path) -> None:
-    # No BM_BIN: the script imports the CLI from its own environment (in tests,
-    # the dev install). An empty HOME exercises the real fail-open verb path.
-    result = run_script(
-        env_overrides={"HOME": str(tmp_path), "USERPROFILE": str(tmp_path)},
-    )
-
-    assert result.returncode == 0
-
-
-def test_dependency_floor_matches_package_version() -> None:
-    # scripts/update_versions.py bumps this line at release; drift between the
-    # script floor and the package version fails here, before a release lands.
+def test_dependency_is_pinned_to_a_basic_memory_git_ref() -> None:
     text = SCRIPT.read_text(encoding="utf-8")
-    floors = re.findall(r'^# dependencies = \["basic-memory>=([^"]+)"\]$', text, re.MULTILINE)
 
-    assert floors == [__version__]
+    assert len(GIT_DEPENDENCY_RE.findall(text)) == 1
 
 
-def test_metadata_block_shape() -> None:
+def test_metadata_and_command_shape() -> None:
     text = SCRIPT.read_text(encoding="utf-8")
 
     assert text.count("# /// script") == 1
     assert re.search(r'^# requires-python = ">=3\.12"$', text, re.MULTILINE)
-    # The version updater's anchored pattern assumes exactly one basic-memory
-    # spec in the whole file.
-    assert len(re.findall(r"basic-memory>=", text)) == 1
+    assert 'VERB = "pre-compact"' in text
+    assert 'HARNESS = "codex"' in text

--- a/plugins/codex/hooks/test_codex_session_start.py
+++ b/plugins/codex/hooks/test_codex_session_start.py
@@ -1,129 +1,46 @@
-"""Tests for the co-located session_start.py uv hook script.
+"""Tests for the Codex SessionStart uv hook script."""
 
-The script is executed via ``sys.executable`` (the PEP 723 metadata is inert
-comments to a plain interpreter), so these tests exercise the real launcher
-logic — BM_BIN resolution, argument plumbing, fail-open — without a network
-resolve. The metadata block itself is pinned against the package version so
-release drift fails here rather than at a user's cold uvx cache.
-"""
-
-import json
 import os
 import re
 import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
-from basic_memory import __version__
 
 SCRIPT = Path(__file__).with_name("session_start.py")
-VERB = "session-start"
-HARNESS = "codex"
+GIT_DEPENDENCY_RE = re.compile(
+    r'"basic-memory @ git\+https://github\.com/'
+    r'basicmachines-co/basic-memory@([^"]+)"'
+)
 
 
-def run_script(
-    *,
-    stdin: str = "{}",
-    env_overrides: dict[str, str] | None = None,
-) -> subprocess.CompletedProcess[str]:
-    env = {**os.environ, **(env_overrides or {})}
-    # Isolate from the developer's shell: these vars change the script's path.
-    for var in ("BM_BIN", "CLAUDE_PROJECT_DIR"):
-        if var not in (env_overrides or {}):
-            env.pop(var, None)
-    return subprocess.run(
+def test_script_fails_open_with_empty_home(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["USERPROFILE"] = str(tmp_path)
+
+    result = subprocess.run(
         [sys.executable, str(SCRIPT)],
-        input=stdin,
+        input="{}",
         env=env,
         capture_output=True,
         text=True,
         timeout=60,
     )
 
-
-@pytest.fixture
-def recorder(tmp_path: Path) -> tuple[str, Path]:
-    """A BM_BIN launcher that records its argv and stdin to a file."""
-    record_file = tmp_path / "record.json"
-    script = tmp_path / "recorder.py"
-    script.write_text(
-        "import json, os, sys\n"
-        'payload = {"argv": sys.argv[1:], "stdin": sys.stdin.read()}\n'
-        'with open(os.environ["RECORD_FILE"], "w", encoding="utf-8") as fh:\n'
-        "    json.dump(payload, fh)\n",
-        encoding="utf-8",
-    )
-    return f'"{sys.executable}" "{script}"', record_file
-
-
-def test_bm_bin_launcher_receives_verb_and_stdin(
-    recorder: tuple[str, Path],
-) -> None:
-    bm_bin, record_file = recorder
-    hook_json = '{"session_id": "s-1", "cwd": "/tmp/work"}'
-
-    result = run_script(
-        stdin=hook_json,
-        env_overrides={"BM_BIN": bm_bin, "RECORD_FILE": str(record_file)},
-    )
-
-    assert result.returncode == 0
-    recorded = json.loads(record_file.read_text(encoding="utf-8"))
-    assert recorded["argv"] == ["hook", VERB, "--harness", HARNESS]
-    assert recorded["stdin"] == hook_json
-
-
-def test_claude_project_dir_env_is_ignored(recorder: tuple[str, Path]) -> None:
-    # Codex has no project-dir contract; mapping uses the payload cwd. A
-    # CLAUDE_PROJECT_DIR leaking in from a nested environment must not add
-    # arguments meant for the claude harness.
-    bm_bin, record_file = recorder
-
-    result = run_script(
-        env_overrides={
-            "BM_BIN": bm_bin,
-            "RECORD_FILE": str(record_file),
-            "CLAUDE_PROJECT_DIR": "/tmp/should-not-appear",
-        },
-    )
-
-    assert result.returncode == 0
-    recorded = json.loads(record_file.read_text(encoding="utf-8"))
-    assert recorded["argv"] == ["hook", VERB, "--harness", HARNESS]
-
-
-def test_unresolvable_bm_bin_fails_open(tmp_path: Path) -> None:
-    result = run_script(env_overrides={"BM_BIN": str(tmp_path / "missing" / "bm")})
-
     assert result.returncode == 0
 
 
-def test_in_process_cli_fails_open_with_empty_home(tmp_path: Path) -> None:
-    # No BM_BIN: the script imports the CLI from its own environment (in tests,
-    # the dev install). An empty HOME exercises the real fail-open verb path.
-    result = run_script(
-        env_overrides={"HOME": str(tmp_path), "USERPROFILE": str(tmp_path)},
-    )
-
-    assert result.returncode == 0
-
-
-def test_dependency_floor_matches_package_version() -> None:
-    # scripts/update_versions.py bumps this line at release; drift between the
-    # script floor and the package version fails here, before a release lands.
+def test_dependency_is_pinned_to_a_basic_memory_git_ref() -> None:
     text = SCRIPT.read_text(encoding="utf-8")
-    floors = re.findall(r'^# dependencies = \["basic-memory>=([^"]+)"\]$', text, re.MULTILINE)
 
-    assert floors == [__version__]
+    assert len(GIT_DEPENDENCY_RE.findall(text)) == 1
 
 
-def test_metadata_block_shape() -> None:
+def test_metadata_and_command_shape() -> None:
     text = SCRIPT.read_text(encoding="utf-8")
 
     assert text.count("# /// script") == 1
     assert re.search(r'^# requires-python = ">=3\.12"$', text, re.MULTILINE)
-    # The version updater's anchored pattern assumes exactly one basic-memory
-    # spec in the whole file.
-    assert len(re.findall(r"basic-memory>=", text)) == 1
+    assert 'VERB = "session-start"' in text
+    assert 'HARNESS = "codex"' in text

--- a/plugins/codex/schemas/codex-session.md
+++ b/plugins/codex/schemas/codex-session.md
@@ -19,6 +19,8 @@ settings:
     ended?: string, when the session was checkpointed
     status?(enum, lifecycle of the checkpoint): [open, resumed, closed]
     cwd?: string, working directory for the Codex thread
+    username?: string, operating-system user that created the checkpoint
+    hostname?: string, host that created the checkpoint
     codex_session_id?: string, Codex session identifier
     codex_turn_id?: string, Codex turn identifier
     trigger?: string, compaction trigger or deliberate checkpoint source

--- a/plugins/codex/skills/bm-checkpoint/SKILL.md
+++ b/plugins/codex/skills/bm-checkpoint/SKILL.md
@@ -17,8 +17,14 @@ Read `.codex/basic-memory.json` if present:
 - `captureFolder`, default `codex-sessions`
 - `placementConventions`, optional
 
+Apply the `bm-writing` skill before drafting the note.
+
 Gather repo evidence:
 
+- the original problem or goal and why it mattered
+- the approach taken and why it solves the problem
+- the current system state and practical impact
+- tradeoffs, sharp edges, useful simplifications, and intentionally parked work
 - `git status --short`
 - current branch
 - changed files you touched
@@ -27,10 +33,14 @@ Gather repo evidence:
 - decisions made in this thread
 - unresolved blockers
 - next action
+- current username, hostname, and timestamp
 
 Do not claim a test passed unless you ran it or the user supplied the result.
 
 ## Write
+
+A checkpoint is a durable handoff, not a status dump or commit-by-commit
+changelog. Tell the story for a human or agent returning later.
 
 Write a note to Basic Memory:
 
@@ -42,20 +52,40 @@ Write a note to Basic Memory:
   - `status: open`
   - `project: <primaryProject if known>`
   - `cwd: <current cwd>`
+  - `started: <current timestamp>`
+  - `username: <current username>`
+  - `hostname: <current hostname>`
   - `capture: deliberate`
 
-Use sections:
+Begin the body with `# <exact note title>`.
 
-- Summary
-- Changed Files
-- Verification
-- Decisions
-- Blockers
-- Next Action
-- Observations
+Use these sections, omitting optional ones that add no value:
 
-Observations should include at least one `[next_step]` line. Add relations to
-existing tasks, decisions, specs, issues, or PRs when the thread has obvious ones.
+- `## Summary`: one concrete sentence that does not merely repeat the title
+- `## Story`: problem -> approach -> current state and impact in substantive prose
+- `## Changed Files`, when paths are useful for resuming
+- `## Verification`, for checks actually run and their outcomes
+- `## Observations`
+- `## Relations`, when the thread has an obvious graph target
+
+Use observations to distill durable facts for structured recall rather than
+duplicating every narrative sentence:
+
+- `[result]` for concrete outcomes
+- `[decision]` for each decision made or preserved
+- `[blocker]` for each unresolved blocker
+- `[next_step]` for the next concrete action; include at least one
+- `[verification]` or `[changed_file]` only when the item is itself important
+  project memory, not merely supporting detail
+
+Do not create separate Decisions, Blockers, or Next Action sections with plain
+bullets. Omit empty categories instead of writing placeholder text such as
+"None."
+
+Relations are not observations. Put them under `## Relations` using Basic
+Memory relation syntax, for example `- relates_to [[Exact existing note title]]`.
+Never write `[relates_to]` or a bare `memory://` URL as an observation. Only add
+a relation when its target is an existing task, decision, spec, issue, or PR note.
 
 ## Confirm
 

--- a/plugins/codex/skills/bm-decide/SKILL.md
+++ b/plugins/codex/skills/bm-decide/SKILL.md
@@ -15,6 +15,8 @@ choice with rationale and consequences, not a casual preference.
    - follow `placementConventions` for the directory when they are specific
    - otherwise use `decisions`
 
+   Apply the `bm-writing` skill before drafting the note.
+
 2. Clarify only if the choice itself is ambiguous. Do not ask for every field if
    the conversation already contains the rationale.
 

--- a/plugins/codex/skills/bm-remember/SKILL.md
+++ b/plugins/codex/skills/bm-remember/SKILL.md
@@ -14,6 +14,9 @@ a small fact that should survive the current thread.
    - `primaryProject`, default omitted
    - `rememberFolder`, default `codex-remember`
 
+   Apply the `bm-writing` skill before drafting the note. Match its depth to this
+   lightweight capture; do not pad a small fact into an essay.
+
 2. Identify the exact text to save. If the user supplied text, preserve their
    wording. If the user said "remember that" and the referent is unclear, ask one
    short question.

--- a/plugins/codex/skills/bm-writing/SKILL.md
+++ b/plugins/codex/skills/bm-writing/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: bm-writing
+description: Apply the user-customizable writing standard for Basic Memory notes created or substantially revised by Codex. Use with bm-checkpoint, bm-decide, bm-remember, and other Basic Memory note-writing workflows.
+---
+
+# Write Useful Project Memory
+
+Use this shared standard whenever a Codex Basic Memory skill writes or
+substantially revises a note. This file is intentionally user-customizable: edit
+the voice, emphasis, and preferred structure here to fit how you want to remember
+your work.
+
+Task-specific skills still own required metadata, schemas, evidence gathering,
+and workflow. This skill shapes the note; it never overrides factual constraints.
+
+## Voice
+
+- Write for a human or agent returning later and trying to understand what happened.
+- Be clear, direct, warm, and technically honest.
+- Prefer concrete observations over generic praise.
+- Have a point of view when the evidence supports it. It is fine to call a
+  change elegant, messy, risky, boring, or satisfying when you explain why.
+- Keep personality in service of memory, not performance.
+
+## Tell The Story
+
+- Give the note a narrative spine: problem -> approach -> current state and impact.
+- Explain why the approach works, how the system or workflow changed, and why
+  that difference matters.
+- Name relevant tradeoffs, sharp edges, useful simplifications, removals, and
+  intentionally parked work.
+- Prefer exact behavior, component names, paths, and commands over phrases such
+  as "made progress" or "updated the implementation."
+- Use substantive prose for context and reasoning. Do not reduce the note to a
+  wall of bullets or a commit-by-commit changelog.
+- Match depth to the subject. A small remembered fact should remain small.
+
+## Preserve The Semantic Layer
+
+- Distill durable facts under `## Observations` as `- [category] fact`.
+- Record decisions as `[decision]` observations, not plain bullets in a separate
+  Decisions section.
+- Put graph edges under `## Relations` using `- relation_type [[Target Note]]`.
+  Never represent a relation as an observation such as `[relates_to]`.
+- Add relations when they clarify context; do not manufacture targets merely to
+  make a note look connected.
+
+## Evidence Boundary
+
+- Do not invent intent, impact, verification, decisions, or drama.
+- State uncertainty and missing evidence plainly.
+- Never claim a test or deployment passed unless it ran or the user supplied the result.

--- a/plugins/codex/skills/bm-writing/agents/openai.yaml
+++ b/plugins/codex/skills/bm-writing/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Memory Writing"
+  short_description: "Customize how Codex writes project memory"
+  icon_small: "./assets/icon.svg"
+  icon_large: "./assets/icon.svg"
+  brand_color: "#2563EB"
+  default_prompt: "Use $bm-writing to write this Basic Memory note as useful project memory."

--- a/plugins/codex/skills/bm-writing/assets/icon.svg
+++ b/plugins/codex/skills/bm-writing/assets/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 24 24" fill="none" stroke="#111827" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 19.5V5a2 2 0 0 1 2-2h11.5A2.5 2.5 0 0 1 20 5.5v13A2.5 2.5 0 0 1 17.5 21H6a2 2 0 0 1-2-1.5Z"/>
+  <path d="M8 7h8M8 11h8M8 15h5"/>
+</svg>

--- a/scripts/update_versions.py
+++ b/scripts/update_versions.py
@@ -96,14 +96,11 @@ def set_package_version(data: dict[str, Any], version: str) -> None:
     data["version"] = version
 
 
-# Plugin uv hook scripts whose PEP 723 metadata pins a released dependency
-# floor. The floor moves with every release so a cold `uv run --script`
-# resolves a basic-memory that actually ships the `bm hook` verbs.
+# Claude Code uv hook scripts whose released dependency floor moves with each
+# package release. Codex hook refs are managed by `just set-codex-hook-version`.
 HOOK_SCRIPTS = (
     "plugins/claude-code/hooks/session_start.py",
     "plugins/claude-code/hooks/pre_compact.py",
-    "plugins/codex/hooks/session_start.py",
-    "plugins/codex/hooks/pre_compact.py",
 )
 
 

--- a/scripts/validate_codex_plugin.py
+++ b/scripts/validate_codex_plugin.py
@@ -19,6 +19,7 @@ REQUIRED_SKILLS = (
     "bm-checkpoint",
     "bm-decide",
     "bm-remember",
+    "bm-writing",
     "bm-share",
     "bm-status",
 )
@@ -42,6 +43,23 @@ REQUIRED_SKILL_TEXT: dict[str, tuple[str, ...]] = {
         "type=codex_session",
         "type=session",
     ),
+    "bm-checkpoint": (
+        "Apply the `bm-writing` skill",
+        "A checkpoint is a durable handoff, not a status dump",
+        "username: <current username>",
+        "hostname: <current hostname>",
+        "- `[decision]` for each decision made or preserved",
+        "## Relations",
+        "- relates_to [[Exact existing note title]]",
+        "Never write `[relates_to]`",
+    ),
+    "bm-writing": (
+        "intentionally user-customizable",
+        "problem -> approach -> current state and impact",
+        "## Preserve The Semantic Layer",
+        "- relation_type [[Target Note]]",
+        "Do not invent intent, impact, verification, decisions, or drama",
+    ),
 }
 REQUIRED_SCHEMAS = ("codex-session.md", "decision.md", "task.md")
 REQUIRED_HOOK_EVENTS = ("SessionStart", "PreCompact")
@@ -56,6 +74,10 @@ REQUIRED_INTERFACE_ASSETS = {
     "composerIcon": "assets/app-icon.png",
     "logo": "assets/logo.png",
 }
+HOOK_DEPENDENCY_RE = re.compile(
+    r'"basic-memory @ git\+https://github\.com/'
+    r'basicmachines-co/basic-memory@([^"]+)"'
+)
 
 
 def read_json(path: Path) -> dict[str, Any]:
@@ -116,16 +138,19 @@ def validate_plugin(plugin_dir: Path) -> None:
     for event in REQUIRED_HOOK_EVENTS:
         if event not in hooks:
             raise SystemExit(f"hooks/hooks.json: missing {event}")
+    dependency_refs: set[str] = set()
     for rel in REQUIRED_HOOK_SCRIPTS:
         script = plugin_dir / rel
         require_path(script, "hook script")
         if not os.access(script, os.X_OK):
             raise SystemExit(f"Hook script is not executable: {script}")
         text = script.read_text(encoding="utf-8")
-        if "# /// script" not in text or not re.search(
-            r'^# dependencies = \["basic-memory>=[^"]+"\]$', text, re.MULTILINE
-        ):
-            raise SystemExit(f"Hook script missing PEP 723 basic-memory floor: {script}")
+        dependency_match = HOOK_DEPENDENCY_RE.search(text)
+        if "# /// script" not in text or dependency_match is None:
+            raise SystemExit(f"Hook script missing pinned Basic Memory Git dependency: {script}")
+        dependency_refs.add(dependency_match.group(1))
+    if len(dependency_refs) != 1:
+        raise SystemExit("Codex hook scripts must use the same Basic Memory Git ref")
 
     # --- Skills ---
     skills_root = plugin_dir / "skills"

--- a/src/basic_memory/hooks/projector.py
+++ b/src/basic_memory/hooks/projector.py
@@ -137,8 +137,9 @@ def _capture_folder(envelopes: list[Envelope]) -> str:
 def _artifact_username() -> str:
     try:
         return getuser()
-    except OSError:
-        # Trigger: the runtime has no passwd entry for its uid.
+    except (OSError, KeyError):
+        # Trigger: the runtime has no passwd entry for its uid. Python 3.12 may
+        # raise KeyError here; Python 3.13+ normalizes the failure to OSError.
         # Why: optional provenance must never prevent queued notes from flushing.
         # Outcome: use the host-provided identity, or a stable unknown value.
         return os.environ.get("USER") or os.environ.get("USERNAME") or "unknown"

--- a/src/basic_memory/hooks/projector.py
+++ b/src/basic_memory/hooks/projector.py
@@ -18,6 +18,7 @@ Writes go through the same internal write path the CLI's ``write-note`` uses
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import dataclass, field
 from getpass import getuser
@@ -133,6 +134,16 @@ def _capture_folder(envelopes: list[Envelope]) -> str:
     return DEFAULT_CAPTURE_FOLDER
 
 
+def _artifact_username() -> str:
+    try:
+        return getuser()
+    except OSError:
+        # Trigger: the runtime has no passwd entry for its uid.
+        # Why: optional provenance must never prevent queued notes from flushing.
+        # Outcome: use the host-provided identity, or a stable unknown value.
+        return os.environ.get("USER") or os.environ.get("USERNAME") or "unknown"
+
+
 def _artifact_metadata(first: Envelope) -> dict[str, str]:
     """Provenance frontmatter every projected artifact carries.
 
@@ -147,7 +158,7 @@ def _artifact_metadata(first: Envelope) -> dict[str, str]:
     metadata = {
         "created_by": f"{CREATED_BY_PREFIX}/{first.source}",
         "caused_by_event": first.id,
-        "username": getuser(),
+        "username": _artifact_username(),
         "hostname": gethostname(),
     }
     metadata.update(to_frontmatter_fields(first))

--- a/src/basic_memory/hooks/projector.py
+++ b/src/basic_memory/hooks/projector.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
+from getpass import getuser
 from pathlib import Path
+from socket import gethostname
 
 from loguru import logger
 
@@ -145,6 +147,8 @@ def _artifact_metadata(first: Envelope) -> dict[str, str]:
     metadata = {
         "created_by": f"{CREATED_BY_PREFIX}/{first.source}",
         "caused_by_event": first.id,
+        "username": getuser(),
+        "hostname": gethostname(),
     }
     metadata.update(to_frontmatter_fields(first))
     return metadata

--- a/tests/hooks/test_projector.py
+++ b/tests/hooks/test_projector.py
@@ -10,7 +10,7 @@ from basic_memory.hooks.envelope import (
     SESSION_STARTED,
     create_envelope,
 )
-from basic_memory.hooks.projector import flush, split_project_ref
+from basic_memory.hooks.projector import _artifact_username, flush, split_project_ref
 
 WRITE_OK = {"title": "x", "action": "created"}
 
@@ -43,6 +43,22 @@ def test_split_project_ref_routes_uuids_via_project_id() -> None:
         "0198f2b4-77aa-7bbf-9c2d-51e60a92d3c4",
     )
     assert split_project_ref("my-team/notes") == ("my-team/notes", None)
+
+
+def test_artifact_username_falls_back_to_environment() -> None:
+    with (
+        patch("basic_memory.hooks.projector.getuser", side_effect=OSError),
+        patch.dict("os.environ", {"USER": "ci-user"}, clear=True),
+    ):
+        assert _artifact_username() == "ci-user"
+
+
+def test_artifact_username_is_stable_when_unavailable() -> None:
+    with (
+        patch("basic_memory.hooks.projector.getuser", side_effect=OSError),
+        patch.dict("os.environ", {}, clear=True),
+    ):
+        assert _artifact_username() == "unknown"
 
 
 async def test_flush_projects_session_and_ledger(bm_home: Path) -> None:

--- a/tests/hooks/test_projector.py
+++ b/tests/hooks/test_projector.py
@@ -50,7 +50,11 @@ async def test_flush_projects_session_and_ledger(bm_home: Path) -> None:
     _capture(event=COMPACTION_IMMINENT, ts="2026-07-15T10:05:00+00:00")
     mock_write = AsyncMock(return_value=WRITE_OK)
 
-    with patch("basic_memory.mcp.tools.write_note", mock_write):
+    with (
+        patch("basic_memory.mcp.tools.write_note", mock_write),
+        patch("basic_memory.hooks.projector.getuser", return_value="alice"),
+        patch("basic_memory.hooks.projector.gethostname", return_value="devbox"),
+    ):
         result = await flush()
 
     assert result.swept == 2
@@ -73,6 +77,8 @@ async def test_flush_projects_session_and_ledger(bm_home: Path) -> None:
     session_metadata = session_call.kwargs["metadata"]
     assert session_metadata["created_by"] == "bm-hook/claude-code"
     assert session_metadata["caused_by_event"]
+    assert session_metadata["username"] == "alice"
+    assert session_metadata["hostname"] == "devbox"
     assert session_metadata["status"] == "open"
     content = session_call.kwargs["content"]
     assert "- [source] claude-code/s-1" in content
@@ -83,6 +89,8 @@ async def test_flush_projects_session_and_ledger(bm_home: Path) -> None:
     ledger_content = ledger_call.kwargs["content"]
     assert ledger_call.kwargs["note_type"] == "tool_ledger"
     assert ledger_call.kwargs["metadata"]["created_by"] == "bm-hook/claude-code"
+    assert ledger_call.kwargs["metadata"]["username"] == "alice"
+    assert ledger_call.kwargs["metadata"]["hostname"] == "devbox"
     assert "- [event] session_started at" in ledger_content
     assert "- [source] claude-code/s-1" in ledger_content
 

--- a/tests/hooks/test_projector.py
+++ b/tests/hooks/test_projector.py
@@ -55,7 +55,7 @@ def test_artifact_username_falls_back_to_environment() -> None:
 
 def test_artifact_username_is_stable_when_unavailable() -> None:
     with (
-        patch("basic_memory.hooks.projector.getuser", side_effect=OSError),
+        patch("basic_memory.hooks.projector.getuser", side_effect=KeyError),
         patch.dict("os.environ", {}, clear=True),
     ):
         assert _artifact_username() == "unknown"

--- a/tests/test_claude_plugin_hooks.py
+++ b/tests/test_claude_plugin_hooks.py
@@ -1,12 +1,9 @@
 """Manifest-level tests for the plugin uv hook scripts (Claude Code and Codex).
 
 The scripts are the entire plugin hook surface: self-contained PEP 723
-launchers that uv resolves at a released dependency floor, invoking
-``bm hook <event> --harness <name>`` in-process. Script behavior (BM_BIN
-override, argument plumbing, fail-open) is pinned by the co-located tests
-next to each script under plugins/*/hooks/; this suite pins the wiring —
-hooks.json commands, executable bits, and the release-floor cross-check
-against the package version.
+launchers with uv-resolved Basic Memory dependencies. Co-located tests pin
+script behavior; this suite pins manifest wiring, executable bits, and each
+plugin's dependency policy.
 """
 
 import json
@@ -37,6 +34,10 @@ EVENTS = [
     pytest.param("SessionStart", "session_start.py", id="session-start"),
     pytest.param("PreCompact", "pre_compact.py", id="pre-compact"),
 ]
+CODEX_GIT_DEPENDENCY_RE = re.compile(
+    r'"basic-memory @ git\+https://github\.com/'
+    r'basicmachines-co/basic-memory@([^\"]+)"'
+)
 
 
 def _hook_commands(hooks_dir: Path, event: str) -> list[str]:
@@ -74,17 +75,26 @@ def test_hook_scripts_exist_and_are_executable(
     assert first_line == "#!/usr/bin/env -S uv run --quiet --script"
 
 
-@pytest.mark.parametrize(("hooks_dir", "root_var"), PLUGINS)
 @pytest.mark.parametrize(("event", "script_name"), EVENTS)
-def test_script_floor_matches_released_version(
-    hooks_dir: str, root_var: str, event: str, script_name: str
-) -> None:
+def test_claude_script_floor_matches_released_version(event: str, script_name: str) -> None:
     # Release drift between the PEP 723 floor and the package version fails
     # here (and in each script's co-located test) before a release lands.
-    text = (REPO_ROOT / hooks_dir / script_name).read_text(encoding="utf-8")
+    text = (REPO_ROOT / "plugins/claude-code/hooks" / script_name).read_text(encoding="utf-8")
     floors = re.findall(r'^# dependencies = \["basic-memory>=([^"]+)"\]$', text, re.MULTILINE)
 
     assert floors == [CURRENT_VERSION]
+
+
+def test_codex_scripts_share_git_dependency_ref() -> None:
+    refs = {
+        ref
+        for script_name in ("session_start.py", "pre_compact.py")
+        for ref in CODEX_GIT_DEPENDENCY_RE.findall(
+            (REPO_ROOT / "plugins/codex/hooks" / script_name).read_text(encoding="utf-8")
+        )
+    }
+
+    assert len(refs) == 1
 
 
 def test_no_shell_shims_remain() -> None:

--- a/tests/test_codex_plugin_package.py
+++ b/tests/test_codex_plugin_package.py
@@ -34,17 +34,23 @@ def test_codex_plugin_hooks_are_zero_logic_uv_scripts() -> None:
 
     assert not (hooks_dir / "session-start.sh").exists()
     assert not (hooks_dir / "pre-compact.sh").exists()
+    dependency_refs: set[str] = set()
     for script, verb in (
         ("session_start.py", "session-start"),
         ("pre_compact.py", "pre-compact"),
     ):
         text = (hooks_dir / script).read_text(encoding="utf-8")
         assert "# /// script" in text
-        # The PEP 723 floor must pin a released version, declared exactly once
-        # on the anchored line update_versions bumps.
-        assert re.search(r'^# dependencies = \["basic-memory>=\d[^"]*"\]$', text, re.MULTILINE)
+        refs = re.findall(
+            r'"basic-memory @ git\+https://github\.com/'
+            r'basicmachines-co/basic-memory@([^"]+)"',
+            text,
+        )
+        assert len(refs) == 1
+        dependency_refs.add(refs[0])
         assert f'VERB = "{verb}"' in text
         assert 'HARNESS = "codex"' in text
+    assert len(dependency_refs) == 1
 
 
 def test_codex_plugin_marketplace_identity() -> None:
@@ -67,6 +73,35 @@ def test_codex_plugin_docs_explain_global_install_and_repo_mapping() -> None:
     assert "codex plugin add codex@basic-memory" in readme
     assert "Plugin installation is user-level in Codex" in readme
     assert "Each repository still needs its own `.codex/basic-memory.json`" in readme
+
+
+def test_bm_checkpoint_tells_a_story_and_uses_graph_semantics() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    skill = (repo_root / "plugins/codex/skills/bm-checkpoint/SKILL.md").read_text(encoding="utf-8")
+    writing = (repo_root / "plugins/codex/skills/bm-writing/SKILL.md").read_text(encoding="utf-8")
+    decide = (repo_root / "plugins/codex/skills/bm-decide/SKILL.md").read_text(encoding="utf-8")
+    remember = (repo_root / "plugins/codex/skills/bm-remember/SKILL.md").read_text(encoding="utf-8")
+    schema = (repo_root / "plugins/codex/schemas/codex-session.md").read_text(encoding="utf-8")
+
+    assert ".github/basic-memory" not in skill
+    assert "Apply the `bm-writing` skill" in skill
+    assert "Apply the `bm-writing` skill" in decide
+    assert "Apply the `bm-writing` skill" in remember
+    assert "A checkpoint is a durable handoff, not a status dump" in skill
+    assert "Begin the body with `# <exact note title>`" in skill
+    assert "username: <current username>" in skill
+    assert "hostname: <current hostname>" in skill
+    assert "- `[decision]` for each decision made or preserved" in skill
+    assert "- `[next_step]` for the next concrete action" in skill
+    assert "- relates_to [[Exact existing note title]]" in skill
+    assert "Never write `[relates_to]` or a bare `memory://` URL as an observation" in skill
+    assert "\n- Decisions\n" not in skill
+    assert "username?: string" in schema
+    assert "hostname?: string" in schema
+    assert "intentionally user-customizable" in writing
+    assert "problem -> approach -> current state and impact" in writing
+    assert "- relation_type [[Target Note]]" in writing
+    assert "Do not invent intent, impact, verification, decisions, or drama" in writing
 
 
 def test_infographics_skill_keeps_weekly_contract_and_bm_style_pool() -> None:

--- a/tests/test_codex_plugin_package.py
+++ b/tests/test_codex_plugin_package.py
@@ -53,6 +53,13 @@ def test_codex_plugin_hooks_are_zero_logic_uv_scripts() -> None:
     assert len(dependency_refs) == 1
 
 
+def test_release_recipes_pin_codex_hooks_to_the_release_tag() -> None:
+    justfile = (Path(__file__).resolve().parents[1] / "justfile").read_text(encoding="utf-8")
+
+    assert justfile.count('just set-codex-hook-version "{{version}}"') == 2
+    assert 'just set-codex-hook-version "$(git rev-parse HEAD)"' not in justfile
+
+
 def test_codex_plugin_marketplace_identity() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     marketplace = json.loads(


### PR DESCRIPTION
## Why

The Codex hooks had accumulated launcher and version-floor behavior that made a simple question—can the hook run the Basic Memory command it needs?—hard to answer. A fail-open test could also pass while the installed package lacked the hook command entirely.

The notes produced around Codex work had a second problem: checkpoints read like mechanical status dumps, decisions were separated from semantic observations, relations used observation syntax instead of graph syntax, and projected notes did not record which user and host produced them.

## What Changed

- Pin both Codex PEP 723 hook scripts to one Basic Memory Git SHA and invoke the CLI in-process.
- Add `just set-codex-hook-version <ref>` and use it from stable and beta release recipes.
- Add `username` and `hostname` frontmatter to projected hook notes and the Codex session schema.
- Add a plugin-owned, user-customizable `bm-writing` skill shared by checkpoint, decision, and lightweight memory capture.
- Rewrite checkpoint guidance around a useful problem → approach → current-state narrative, typed observations, and real wiki-link relations.
- Strengthen plugin validation and regression tests for shared hook refs, provenance metadata, note structure, and relation syntax.

## Implementation Details

- `plugins/codex/hooks/{session_start,pre_compact}.py` now contain only the pinned uv dependency, the hook verb/harness arguments, and the fail-open in-process Typer invocation. There is no executable discovery, launcher parsing, or separate version parsing.
- `just set-codex-hook-version` delegates dependency editing to `uv add --script`, keeping both scripts on the same ref. Development can pass the current main SHA; stable and beta recipes pass the release tag and stage both scripts.
- `src/basic_memory/hooks/projector.py` records username and hostname in artifact metadata, with an environment fallback so optional username discovery cannot abort a flush.
- `plugins/codex/skills/bm-writing` is the customization point for voice and narrative quality. Task-specific skills still own their schemas and evidence requirements.
- Checkpoint relations now use `- relates_to [[Target Note]]`; decisions, blockers, results, and next steps remain semantic observations.

## Testing

### Automated

- `just fast-check`: passed (ruff, formatting, and type checking).
- `uv run pytest -q tests/test_claude_plugin_hooks.py tests/test_codex_plugin_package.py plugins/codex/hooks/test_codex_session_start.py plugins/codex/hooks/test_codex_pre_compact.py tests/hooks/test_projector.py tests/test_update_versions.py`: 66 passed.
- `just package-check`: passed all consolidated agent package checks.
- `just set-codex-hook-version "$(git rev-parse origin/main)"`: updated both scripts to the same current main SHA.
- `just release-dry-run v0.99.0`: passed.

### Manual

- Ran SessionStart and PreCompact through their uv scripts with Codex hook payloads: both exited successfully and captured their envelopes.
- Flushed the hook inbox and read back the projected session note: the queue emptied and frontmatter included the local username and hostname.

## Risks / Follow-ups

- A cold hook run needs GitHub access to resolve the pinned revision; subsequent runs use uv's cache.
- Existing notes are not rewritten. Provenance and the improved writing contract apply to newly projected or newly written notes.
- The release recipes intentionally move the Codex hook ref; normal package version updates no longer rewrite these two scripts as PyPI version floors.
