### PR TITLE
feat(plugins): add bm-writing skill and coding setup to Claude Code plugin

### DIFF
--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -8,6 +8,16 @@ Memory's durable graph**, rather than a memory layer of its own. See
 
 ### Added
 
+- **`bm-writing` writing standard** (`skills/bm-writing/`) — the user-customizable
+  standard for how Claude writes project memory (voice, narrative spine, git
+  anchors, observations, relations, evidence boundary), ported from the Codex
+  plugin so both hosts share one contract. Applied by `bm-remember` and the
+  output style's capture reflexes; edit the SKILL.md to change how memory is
+  written.
+- **Coding setup** — when the `bm-setup` focus answer is code/dev, the Session
+  schema is seeded with git anchor frontmatter (`repo`, `branch`, `git_sha`,
+  `pr`) so checkpoints pin the repo, branch, and PR the work happened on.
+  Non-coding setups omit those fields.
 - **Team workspace support** (Phase 4). SessionStart now reads **across** the primary
   project plus configured shared/team projects — `secondaryProjects` (read-only recall
   sources) and `teamProjects` (share targets) — querying open decisions from each in

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -14,10 +14,20 @@ Memory's durable graph**, rather than a memory layer of its own. See
   plugin so both hosts share one contract. Applied by `bm-remember` and the
   output style's capture reflexes; edit the SKILL.md to change how memory is
   written.
-- **Coding setup** — when the `bm-setup` focus answer is code/dev, the Session
-  schema is seeded with git anchor frontmatter (`repo`, `branch`, `git_sha`,
-  `pr`) so checkpoints pin the repo, branch, and PR the work happened on.
-  Non-coding setups omit those fields.
+- **`/basic-memory:bm-checkpoint`** (`skills/bm-checkpoint/`) — deliberate,
+  high-signal checkpoints: the story (problem → approach → impact), the durable
+  lesson (`## Project Memory`), verification actually run, decisions, blockers,
+  and the next action, written to the standard. The deliberate counterpart to
+  the automatic PreCompact checkpoint.
+- **Coding setup (`sessionProfile: "coding"`)** — `bm-setup` asks whether the
+  project should capture Git and pull-request context, resolves a stable
+  `repository` identifier (`owner/name`) and confirms it with the user, and
+  seeds a `coding_session` schema whose repository, repo-root, working-directory,
+  branch, and Git SHA frontmatter are **required** — evidence-proven from git
+  itself, never inferred from conversation. Typed pull-request fields are added
+  when a PR exists. Coding checkpoints become queryable by structured filters
+  (`metadata_filters={"repository": ..., "pull_request_number": ...}`) instead
+  of prose search. Mirrors the Codex plugin's coding-session design for parity.
 - **Team workspace support** (Phase 4). SessionStart now reads **across** the primary
   project plus configured shared/team projects — `secondaryProjects` (read-only recall
   sources) and `teamProjects` (share targets) — querying open decisions from each in

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -26,6 +26,10 @@ the session back to it before the context window compacts.
 - **Capture reflexes (output style).** An opt-in output style teaches Claude to
   search the graph before answering recall questions, capture real decisions as
   typed `decision` notes, and cite permalinks.
+- **Writing standard (`bm-writing` skill).** One user-customizable standard for
+  how Claude writes memory — voice, narrative quality, observations, relations,
+  and git anchors (project, branch, PR, sha) — applied by `bm-remember` and the
+  capture reflexes.
 - **Seed schemas.** Picoschema definitions for `session`, `decision`, and `task`
   notes, so the stuff the plugin writes is structured and findable by
   `search_notes` metadata filters — recall is precise, not fuzzy.
@@ -42,6 +46,7 @@ Plugin skills are namespaced under the plugin name:
 | `/basic-memory:bm-remember <text>` | Quick capture — saves the text to the `bm-remember` folder with a `manual-capture` tag. Also fires when you say "remember that…". |
 | `/basic-memory:bm-share <note>` | Promote a personal note to a configured team project, with attribution and confirmation. The deliberate way to write to a shared workspace. |
 | `/basic-memory:bm-status` | Diagnostic — shows the active project, team read-sources and share targets, capture folders, shared local hook inbox/flush health, recent session checkpoints, and active-task count. |
+| `/basic-memory:bm-writing` | The writing standard applied whenever Claude writes or substantially revises a note. Not usually invoked directly — edit `skills/bm-writing/SKILL.md` to change how memory is written. |
 
 ## Requirements
 
@@ -130,10 +135,17 @@ settings (or select it via `/config`).
 | `redactPaths` | `[]` | Additional paths to redact from working-directory and path-bearing capture content |
 
 The plugin seeds schemas for notes the Claude integration writes directly:
-`session`, `decision`, and `task`. Optional flush projection also writes
+`session`, `decision`, and `task`. When the setup interview's focus answer is
+code/dev (a **coding setup**), the Session schema is seeded with git anchor
+fields — `repo`, `branch`, `git_sha`, `pr` — so checkpoints pin exactly where
+the work happened. Optional flush projection also writes
 normalized `session` and `tool_ledger` artifacts. Those projection contracts are
 owned and tested by Basic Memory core rather than copied into separate
 host-plugin schemas.
+
+To customize how Claude writes memory, edit `skills/bm-writing/SKILL.md` in the
+plugin source. `bm-remember` and the output style's capture reflexes apply that
+shared standard while retaining their own schemas and evidence requirements.
 
 See [DESIGN.md](./DESIGN.md) for the complete configuration schema, the
 Claude-Code-project ↔ Basic-Memory-project mapping, and team-workspace behavior.

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -23,6 +23,12 @@ the session back to it before the context window compacts.
   the context window, the plugin writes a `type: session` checkpoint note to the
   graph, so the texture of the session survives and the next one can resume from
   it.
+- **Deliberate checkpoints (`bm-checkpoint` skill).** On request — "checkpoint
+  this", "wrap up", "hand off" — Claude writes a durable handoff note: the story,
+  verification actually run, decisions, blockers, and the next action. In a
+  coding setup these are schema-backed `coding_session` notes with required
+  repository, branch, and SHA context, plus typed pull-request context when a PR
+  exists, queryable by structured filters instead of prose search.
 - **Capture reflexes (output style).** An opt-in output style teaches Claude to
   search the graph before answering recall questions, capture real decisions as
   typed `decision` notes, and cite permalinks.
@@ -31,8 +37,9 @@ the session back to it before the context window compacts.
   and git anchors (project, branch, PR, sha) — applied by `bm-remember` and the
   capture reflexes.
 - **Seed schemas.** Picoschema definitions for `session`, `decision`, and `task`
-  notes, so the stuff the plugin writes is structured and findable by
-  `search_notes` metadata filters — recall is precise, not fuzzy.
+  notes, plus `coding_session` for coding setups, so the stuff the plugin writes
+  is structured and findable by `search_notes` metadata filters — recall is
+  precise, not fuzzy.
 
 The full design and rationale live in [DESIGN.md](./DESIGN.md).
 
@@ -43,6 +50,7 @@ Plugin skills are namespaced under the plugin name:
 | Command | What it does |
 |---------|--------------|
 | `/basic-memory:bm-setup` | One-time guided setup — maps the project to a Basic Memory project, seeds the note schemas, installs the shared `memory-*` skills, optionally learns your conventions, and turns on the capture reflexes. Run this first. |
+| `/basic-memory:bm-checkpoint` | Deliberate checkpoint — writes a durable handoff note (story, verification, decisions, next action). Coding setups get schema-backed `coding_session` notes with required Git identity. Also fires when you say "checkpoint this" or "wrap up". |
 | `/basic-memory:bm-remember <text>` | Quick capture — saves the text to the `bm-remember` folder with a `manual-capture` tag. Also fires when you say "remember that…". |
 | `/basic-memory:bm-share <note>` | Promote a personal note to a configured team project, with attribution and confirmation. The deliberate way to write to a shared workspace. |
 | `/basic-memory:bm-status` | Diagnostic — shows the active project, team read-sources and share targets, capture folders, shared local hook inbox/flush health, recent session checkpoints, and active-task count. |
@@ -130,15 +138,19 @@ settings (or select it via `/config`).
 | `recallTimeframe` | `3d` | Recency window for the session brief |
 | `recallPrompt` | _(built-in)_ | The instruction appended to the brief |
 | `preCompactCapture` | `extractive` | How checkpoints are produced |
+| `sessionProfile` | `general` | `coding` makes deliberate checkpoints schema-backed `coding_session` notes with required Git identity |
+| `repository` | _(none)_ | User-confirmed stable repository identifier (`owner/name`); required for the `coding` profile |
 | `captureEvents` | `false` | Opt-in: record redacted lifecycle-event envelopes to the local inbox (see `basic-memory hook status` / `flush`). Only the JSON boolean `true` enables it. |
 | `redactKeys` | `[]` | Additional payload keys to redact before an event enters the local inbox |
 | `redactPaths` | `[]` | Additional paths to redact from working-directory and path-bearing capture content |
 
 The plugin seeds schemas for notes the Claude integration writes directly:
-`session`, `decision`, and `task`. When the setup interview's focus answer is
-code/dev (a **coding setup**), the Session schema is seeded with git anchor
-fields — `repo`, `branch`, `git_sha`, `pr` — so checkpoints pin exactly where
-the work happened. Optional flush projection also writes
+`session`, `decision`, and `task`. A **coding setup** (the interview's focus
+answer is code/dev, persisted as `sessionProfile: "coding"` with a
+user-confirmed `repository`) also seeds `coding_session`, whose required
+repository, repo-root, working-directory, branch, and Git SHA frontmatter make
+checkpoints queryable by structured filters; typed pull-request fields are
+added when a PR exists. Optional flush projection also writes
 normalized `session` and `tool_ledger` artifacts. Those projection contracts are
 owned and tested by Basic Memory core rather than copied into separate
 host-plugin schemas.

--- a/plugins/claude-code/output-styles/basic-memory.md
+++ b/plugins/claude-code/output-styles/basic-memory.md
@@ -42,6 +42,14 @@ note is invisible to it.
 Don't over-capture. One good note per real decision. Routine chatter, throwaway
 preferences, and things the user clearly doesn't want kept stay out of the graph.
 
+## Write notes to the standard
+When you write or substantially revise a Basic Memory note, apply the
+`basic-memory:bm-writing` skill — the user-customizable writing standard for
+voice, narrative quality, observations, and relations. Anchor repository work
+with its project, branch, and PR (and commit sha when it matters) — in
+frontmatter when the note's schema defines those fields, as observations
+otherwise.
+
 ## Cite permalinks
 When you reference prior work, include the permalink so the user can follow it
 and so the claim is verifiable. Don't paraphrase from memory when you can cite.

--- a/plugins/claude-code/output-styles/basic-memory.md
+++ b/plugins/claude-code/output-styles/basic-memory.md
@@ -50,6 +50,11 @@ with its project, branch, and PR (and commit sha when it matters) — in
 frontmatter when the note's schema defines those fields, as observations
 otherwise.
 
+When the user asks to checkpoint, wrap up, or hand off the current work, run
+the `basic-memory:bm-checkpoint` skill rather than improvising a note — it
+gathers the evidence (git state, verification actually run) and writes the
+durable handoff.
+
 ## Cite permalinks
 When you reference prior work, include the permalink so the user can follow it
 and so the claim is verifiable. Don't paraphrase from memory when you can cite.

--- a/plugins/claude-code/schemas/coding-session.md
+++ b/plugins/claude-code/schemas/coding-session.md
@@ -1,0 +1,54 @@
+---
+title: Coding Session
+type: schema
+entity: CodingSession
+version: 1
+schema:
+  summary?: string, one-paragraph what happened in this coding session
+  changed_file?(array): string, files created, edited, deleted, or inspected
+  verification?(array): string, checks run and their result
+  decision?(array): string, decisions surfaced or created during the session
+  blocker?(array): string, unresolved blockers or failed approaches
+  next_step?(array): string, explicit cursor for the next coding session
+  produced?(array): Entity, notes or artifacts created or updated
+settings:
+  validation: warn
+  frontmatter:
+    project: string, the Basic Memory project this session belongs to
+    started: string, when the session began or checkpoint was created
+    repository: string, stable repository identifier such as owner/name
+    repo_root: string, Git repository root for this checkout
+    cwd: string, working directory for the session
+    branch: string, checked-out Git branch or HEAD when detached
+    git_sha: string, exact Git commit at checkpoint time
+    ended?: string, when the session was checkpointed
+    status?(enum, lifecycle of the checkpoint): [open, resumed, closed]
+    pull_request_number?: integer, current pull request number
+    pull_request_title?: string, current pull request title
+    pull_request_url?: string, canonical pull request URL
+    pull_request_state?(enum, pull request state at checkpoint time): [open, closed, merged]
+    pull_request_base?: string, pull request base branch
+    pull_request_head?: string, pull request head branch
+    username?: string, operating-system user that created the checkpoint
+    hostname?: string, host that created the checkpoint
+    claude_session_id?: string, Claude Code session identifier
+    trigger?: string, compaction trigger or deliberate checkpoint source
+    model?: string, active model slug when known
+    capture?(enum, how this checkpoint was produced): [extractive, deliberate, summarized]
+---
+
+# Coding Session
+
+A **CodingSession** is a resumable engineering checkpoint whose repository
+identity is structured and queryable. Required Git fields make it possible to
+find the exact work cursor without parsing prose.
+
+Examples:
+
+`search_notes(note_types=["coding_session"], metadata_filters={"repository": "owner/repo"})`
+
+`search_notes(note_types=["coding_session"], metadata_filters={"pull_request_number": 123})`
+
+Pull-request fields are optional because valid coding work can precede a pull
+request. When a pull request exists, checkpoint writers populate the complete
+pull-request field set.

--- a/plugins/claude-code/schemas/session.md
+++ b/plugins/claude-code/schemas/session.md
@@ -20,6 +20,10 @@ settings:
     cwd?: string, the working directory the session ran in
     claude_session_id?: string, Claude Code session identifier
     capture?(enum, how this checkpoint was produced): [extractive, summarized]
+    repo?: string, repository or code project the session worked in
+    branch?: string, git branch the session worked on
+    git_sha?: string, commit sha the session ended on
+    pr?: string, pull request or issue reference (e.g. "#1123")
 ---
 
 # Session
@@ -46,3 +50,8 @@ Sessions are found by the SessionStart hook via structured recall:
 `type: session` and `status` are the queryable fields that power recall. `warn`
 validation means a missing field is surfaced, never blocking — the user's flow
 is never gated on schema conformance.
+
+The git anchors (`repo`, `branch`, `git_sha`, `pr`) are the coding-setup fields:
+`/basic-memory:bm-setup` seeds them when the project's focus is code/dev, so a
+checkpoint pins exactly where the work happened and the next session can resume
+on the right branch. Non-coding setups omit them.

--- a/plugins/claude-code/schemas/session.md
+++ b/plugins/claude-code/schemas/session.md
@@ -18,23 +18,26 @@ settings:
     ended?: string, when the session was checkpointed
     status?(enum, lifecycle of the checkpoint): [open, resumed, closed]
     cwd?: string, the working directory the session ran in
+    username?: string, operating-system user that created the checkpoint
+    hostname?: string, host that created the checkpoint
     claude_session_id?: string, Claude Code session identifier
-    capture?(enum, how this checkpoint was produced): [extractive, summarized]
-    repo?: string, repository or code project the session worked in
-    branch?: string, git branch the session worked on
-    git_sha?: string, commit sha the session ended on
-    pr?: string, pull request or issue reference (e.g. "#1123")
+    capture?(enum, how this checkpoint was produced): [extractive, deliberate, summarized]
 ---
 
 # Session
 
-A **SessionNote** is a resume checkpoint written by the Basic Memory plugin's
-PreCompact hook (and, later, the `/basic-memory:bm-handoff` command) right before
-Claude Code compacts the context window. It records what the session was doing
-so the next session can pick up where this one left off.
+A **SessionNote** is a resume checkpoint. The Basic Memory plugin's PreCompact
+hook writes one right before Claude Code compacts the context window, and the
+`/basic-memory:bm-checkpoint` skill writes one deliberately. It records what the
+session was doing so the next session can pick up where this one left off.
 
 Sessions are found by the SessionStart hook via structured recall:
 `search_notes(metadata_filters={"type": "session"}, after_date="3d")`.
+
+In a **coding setup** (`sessionProfile: "coding"`), deliberate checkpoints use
+the Coding Session schema instead — it adds required, queryable Git identity
+(`repository`, `branch`, `git_sha`, pull-request fields). This schema stays the
+general-purpose checkpoint.
 
 ## What goes in a SessionNote
 
@@ -50,8 +53,3 @@ Sessions are found by the SessionStart hook via structured recall:
 `type: session` and `status` are the queryable fields that power recall. `warn`
 validation means a missing field is surfaced, never blocking — the user's flow
 is never gated on schema conformance.
-
-The git anchors (`repo`, `branch`, `git_sha`, `pr`) are the coding-setup fields:
-`/basic-memory:bm-setup` seeds them when the project's focus is code/dev, so a
-checkpoint pins exactly where the work happened and the next session can resume
-on the right branch. Non-coding setups omit them.

--- a/plugins/claude-code/settings.example.json
+++ b/plugins/claude-code/settings.example.json
@@ -8,6 +8,7 @@
     "recallTimeframe": "3d",
     "recallPrompt": "You have Basic Memory available for this project. Before answering recall questions (\"what did we decide\", \"where did we leave off\"), search the graph first — prefer structured filters (search_notes with type/status). When the user makes a material decision, capture it as a note with type: decision. Cite permalinks when referencing prior work.",
     "preCompactCapture": "extractive",
+    "sessionProfile": "general",
     "captureEvents": false,
     "redactKeys": [],
     "redactPaths": [],

--- a/plugins/claude-code/skills/bm-checkpoint/SKILL.md
+++ b/plugins/claude-code/skills/bm-checkpoint/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: bm-checkpoint
+description: Save a deliberate work checkpoint to Basic Memory with the story, changed files, verification, decisions, blockers, and the next action. Use when the user asks to checkpoint, wrap up, hand off, or remember the state of the work.
+argument-hint: (optional short topic for the checkpoint title)
+---
+
+# Checkpoint Claude Work
+
+Create a durable handoff note for the current work. Use this when the user asks
+to checkpoint, wrap up, hand off, remember the state of the work, or before a
+long context transition. This is the deliberate, high-signal counterpart to the
+automatic PreCompact checkpoint.
+
+## Gather
+
+Resolve config: read the `basicMemory` block with the same precedence the hooks
+use — user-level `~/.claude/settings.json` as the base, then the project's
+`.claude/settings.json` and `.claude/settings.local.json` override it per key:
+
+- `primaryProject`, default omitted (Basic Memory's default project)
+- `captureFolder`, default `sessions`
+- `placementConventions`, optional
+- `sessionProfile`, default `general`
+- `repository`, required when `sessionProfile` is `coding`
+
+Apply the `bm-writing` skill before drafting the note.
+
+Gather evidence:
+
+- the original problem or goal and why it mattered
+- the approach taken and why it solves the problem
+- the current system state and practical impact
+- tradeoffs, sharp edges, useful simplifications, and intentionally parked work
+- the durable lesson, if one exists — what future work should know or avoid
+- `git status --short`
+- current branch
+- repository root and current working directory
+- current Git SHA
+- current pull request number, title, URL, state, base, and head when one exists
+- changed files you touched
+- tests or checks actually run
+- failures or skipped checks
+- decisions made in this session
+- unresolved blockers
+- next action
+- current username, hostname, and timestamp
+
+Do not claim a test passed unless you ran it or the user supplied the result.
+
+## Write
+
+A checkpoint is a durable handoff, not a status dump or commit-by-commit
+changelog. Tell the story for a human or agent returning later.
+
+Write the note with `write_note`, routed to `primaryProject` (pass it as
+`project`, or as `project_id` if it's an `external_id` UUID). For the `general`
+profile:
+
+- `title`: `Claude checkpoint - <short topic>`
+- `directory`: configured `captureFolder`
+- `tags`: `["claude", "checkpoint"]`
+- `note_type`: `session`
+- `metadata` (frontmatter):
+  - `status: open`
+  - `project: <primaryProject if known>`
+  - `cwd: <current cwd>`
+  - `started: <current timestamp>`
+  - `username: <current username>`
+  - `hostname: <current hostname>`
+  - `capture: deliberate`
+
+For the `coding` profile, write `note_type: coding_session` (frontmatter
+`type: coding_session`) and use the same common frontmatter plus these
+schema-required fields:
+
+- `repository: <confirmed stable repository identifier>`
+- `repo_root: <git rev-parse --show-toplevel>`
+- `cwd: <current cwd>`
+- `branch: <git rev-parse --abbrev-ref HEAD>`
+- `git_sha: <git rev-parse HEAD>`
+
+When the current branch has a pull request, also add the typed optional fields
+`pull_request_number`, `pull_request_title`, `pull_request_url`, lowercase
+`pull_request_state`, `pull_request_base`, and `pull_request_head`. Resolve the
+pull request with a read-only GitHub query (e.g. `gh pr view --json ...`); omit
+those fields when no PR exists. Never infer or copy repository/PR identity only
+from conversation text. Stop if the required coding fields cannot be proven.
+
+Begin the body with `# <exact note title>`.
+
+Use these sections, omitting optional ones that add no value:
+
+- `## Summary`: one concrete sentence that does not merely repeat the title
+- `## Story`: problem -> approach -> current state and impact in substantive prose
+- `## Project Memory`, when the work surfaced a durable lesson future readers
+  need — the constraint discovered, the boundary made explicit, the shortcut to
+  avoid
+- `## Changed Files`, when paths are useful for resuming
+- `## Verification`, for checks actually run and their outcomes
+- `## Observations`
+- `## Relations`, when the session has an obvious graph target
+
+Use observations to distill durable facts for structured recall rather than
+duplicating every narrative sentence:
+
+- `[result]` for concrete outcomes
+- `[decision]` for each decision made or preserved
+- `[blocker]` for each unresolved blocker
+- `[next_step]` for the next concrete action; include at least one
+- `[verification]` or `[changed_file]` only when the item is itself important
+  project memory, not merely supporting detail
+
+Do not create separate Decisions, Blockers, or Next Action sections with plain
+bullets. Omit empty categories instead of writing placeholder text such as
+"None."
+
+Relations are not observations. Put them under `## Relations` using Basic
+Memory relation syntax, for example `- relates_to [[Exact existing note title]]`.
+Never write `[relates_to]` or a bare `memory://` URL as an observation. Only add
+a relation when its target is an existing task, decision, spec, issue, or PR note.
+
+## Confirm
+
+Reply with the permalink and the one next action the checkpoint preserves.

--- a/plugins/claude-code/skills/bm-remember/SKILL.md
+++ b/plugins/claude-code/skills/bm-remember/SKILL.md
@@ -21,7 +21,9 @@ Capture `$ARGUMENTS` into Basic Memory as a quick note, keeping the user's words
    Both are optional. Use the defaults if the block or a key is missing. Don't fail
    if there's no settings file.
 
-2. **Derive the note.**
+2. **Derive the note.** Apply the `bm-writing` skill before drafting; match its
+   depth to this lightweight capture — keep the user's wording and do not pad a
+   small fact into an essay.
    - **Content** = the text in `$ARGUMENTS`, verbatim. Don't rewrite or pad it.
    - **Title** = the first line of that text, trimmed to ≤ 80 characters (append `…`
      if you truncate). If it's one long line, write a short descriptive title instead.

--- a/plugins/claude-code/skills/bm-setup/SKILL.md
+++ b/plugins/claude-code/skills/bm-setup/SKILL.md
@@ -40,10 +40,16 @@ Ask only what you can't infer. Cover:
    instead of asking, still say the use-case you assumed and the structure it
    implies, and let the user correct it in one word.
 
-   A code/dev answer makes this a **coding setup**: the Session schema is seeded
-   with git anchor fields (`repo`, `branch`, `git_sha`, `pr`) so checkpoints pin
-   exactly where the work happened (see "Seed the schemas"). Tell the user that's
-   part of the deal — it's why the focus question matters.
+   A code/dev answer makes this a **coding setup** (`sessionProfile: "coding"`):
+   verify the directory is inside a Git repository, resolve a stable `repository`
+   identifier such as `owner/name` from the origin remote or GitHub CLI, show it
+   to the user, and ask for confirmation. Do not guess when the remote is missing
+   or ambiguous, and do not infer `coding` merely because the current directory
+   is a Git checkout — for mixed use, ask whether this repository should capture
+   Git and pull-request context. The coding profile seeds the Coding Session
+   schema so deliberate checkpoints carry required, queryable Git identity
+   (repository, branch, SHA, and working directory), plus typed pull-request
+   fields when a PR exists.
 
 2. **Project mapping.** "Do you already have a Basic Memory project for this, or
    should I create one?"
@@ -101,8 +107,9 @@ Ask only what you can't infer. Cover:
    SessionStart brief surfaces it (alongside `captureFolder`), so this is what makes
    your captures land where the user expects — without it, placement is guesswork.
 
-5. **Schemas.** "I'll add schemas for session checkpoints, decisions, and tasks so
-   I can find them precisely later — okay?" (See "Seed the schemas" below.)
+5. **Schemas.** "I'll add schemas for session checkpoints, decisions, and tasks
+   — plus coding sessions for a coding setup — so I can find them precisely
+   later — okay?" (See "Seed the schemas" below.)
 
 6. **Lifecycle-event capture.** "Should I also keep a local, redacted trail of
    SessionStart and PreCompact events for later projection?" Default to **off**.
@@ -161,10 +168,11 @@ For each one:
     round-trips correctly on both local and cloud. After seeding, verify one note
     with `read_note(..., output_format="json", include_frontmatter=true)` —
     `schema`/`settings` must come back as nested objects, not strings.
-- **Coding setup:** the Session seed carries git coding anchor fields in
-  `settings.frontmatter` — `repo`, `branch`, `git_sha`, `pr`. When the focus from
-  step 1 is code/dev, seed them as-is. For a non-coding setup, omit those four
-  keys from the `settings.frontmatter` map; the rest of the schema is unchanged.
+- **Coding setup:** when `sessionProfile` is `coding`, also read and seed
+  `coding-session.md` (title `Coding Session`) the same way. Its Git identity
+  fields (`repository`, `repo_root`, `cwd`, `branch`, `git_sha`) are required by
+  design — required-and-proven fields are what make coding checkpoints queryable
+  — so seed the schema unmodified.
 
 ### 2. Install the shared skills (if the user opted in)
 **First, guard against clobbering a source checkout.** If `./skills` already exists,
@@ -200,6 +208,8 @@ Build the `basicMemory` block from the interview:
     "rememberFolder": "bm-remember",
     "recallTimeframe": "3d",
     "preCompactCapture": "extractive",
+    "sessionProfile": "coding",
+    "repository": "owner/name",
     "captureEvents": false,
     "redactKeys": [],
     "redactPaths": [],
@@ -209,6 +219,12 @@ Build the `basicMemory` block from the interview:
   "outputStyle": "basic-memory"
 }
 ```
+Persist `sessionProfile` explicitly. Persist `repository` only for the `coding`
+profile, after the user confirms it — a coding setup is incomplete without a
+repository identifier because the `coding_session` schema requires queryable
+Git identity fields. Omit both keys' example values for a `general` setup
+(`"sessionProfile": "general"`, no `repository`).
+
 Only include `outputStyle` if the user opted in. Ask whether this is a **team
 default** (write/merge into `.claude/settings.json`, suggest committing it) or
 **personal** (`.claude/settings.local.json`). **Merge** into any existing file —
@@ -226,9 +242,10 @@ missing cloud credentials, or a ref that doesn't route, while the user is still 
 to fix it. Run the same structured query the SessionStart hook runs, via the CLI it
 uses (`basic-memory` / `bm` / `uvx basic-memory`):
 
-- **Primary:** `… tool search-notes --type schema --page-size 5` against
+- **Primary:** `… tool search-notes --type schema --page-size 10` against
   `primaryProject` — use `--project-id <uuid>` for a UUID, `--project <ref>`
-  otherwise. It should return the three schemas you just seeded.
+  otherwise. It should return the schemas you just seeded. For a coding setup,
+  confirm the `Coding Session` schema is present.
 - **One shared project** (only if `secondaryProjects` is non-empty): a
   `--type decision --status open` query against the first ref. It just needs to
   return *cleanly* — `0 results` is fine; an **error** means the ref doesn't route.
@@ -244,8 +261,9 @@ ref before closing — don't let the next session's brief come up empty.
 
 ## Close
 
-Confirm what you did in a few lines: the project mapping, which schemas were seeded
-vs. already present, whether placement was learned or suggested, the smoke-test
+Confirm what you did in a few lines: the project mapping, the session profile
+(and confirmed repository for a coding setup), which schemas were seeded vs.
+already present, whether placement was learned or suggested, the smoke-test
 result, whether lifecycle-event capture is enabled, any extra redaction controls,
 the shared hook inbox/flush state, and whether the output style is on.
 

--- a/plugins/claude-code/skills/bm-setup/SKILL.md
+++ b/plugins/claude-code/skills/bm-setup/SKILL.md
@@ -40,6 +40,11 @@ Ask only what you can't infer. Cover:
    instead of asking, still say the use-case you assumed and the structure it
    implies, and let the user correct it in one word.
 
+   A code/dev answer makes this a **coding setup**: the Session schema is seeded
+   with git anchor fields (`repo`, `branch`, `git_sha`, `pr`) so checkpoints pin
+   exactly where the work happened (see "Seed the schemas"). Tell the user that's
+   part of the deal — it's why the focus question matters.
+
 2. **Project mapping.** "Do you already have a Basic Memory project for this, or
    should I create one?"
    - Existing → show `list_memory_projects()` and let them pick. That name becomes
@@ -156,6 +161,10 @@ For each one:
     round-trips correctly on both local and cloud. After seeding, verify one note
     with `read_note(..., output_format="json", include_frontmatter=true)` —
     `schema`/`settings` must come back as nested objects, not strings.
+- **Coding setup:** the Session seed carries git coding anchor fields in
+  `settings.frontmatter` — `repo`, `branch`, `git_sha`, `pr`. When the focus from
+  step 1 is code/dev, seed them as-is. For a non-coding setup, omit those four
+  keys from the `settings.frontmatter` map; the rest of the schema is unchanged.
 
 ### 2. Install the shared skills (if the user opted in)
 **First, guard against clobbering a source checkout.** If `./skills` already exists,

--- a/plugins/claude-code/skills/bm-status/SKILL.md
+++ b/plugins/claude-code/skills/bm-status/SKILL.md
@@ -23,8 +23,9 @@ This is a quick diagnostic — gather the facts and lay them out; don't over-inv
    - From the `basicMemory` block: `primaryProject` (or note none is pinned — the
      default project is used), `secondaryProjects` (team/shared read sources),
      `teamProjects` (share targets for `/basic-memory:bm-share`), `captureFolder`
-     (default `sessions`), `rememberFolder` (default `bm-remember`), and
-     `preCompactCapture` mode (default `extractive`), `captureEvents` (default
+     (default `sessions`), `rememberFolder` (default `bm-remember`),
+     `preCompactCapture` mode (default `extractive`), `sessionProfile` (default
+     `general`), `repository` (coding profile only), `captureEvents` (default
      `false`), `redactKeys`, and `redactPaths`.
    - From the **root** settings object (not `basicMemory`): whether `outputStyle` is
      `basic-memory` — i.e. whether the capture reflexes are on.
@@ -41,7 +42,10 @@ This is a quick diagnostic — gather the facts and lay them out; don't over-inv
 
 4. **Recent checkpoints.** `search_notes` with
    `metadata_filters={"type": "session"}`, `page_size` 5, scoped to `primaryProject`
-   if one is set. List the most recent session checkpoints by title + permalink.
+   if one is set. When `sessionProfile` is `coding`, also query
+   `metadata_filters={"type": "coding_session", "repository": "<configured repository>"}`,
+   then merge, deduplicate, sort newest first, and keep the newest five. List them
+   by title + permalink.
 
 5. **Active tasks.** `search_notes` with
    `metadata_filters={"type": "task", "status": "active"}` — report just the count.
@@ -65,6 +69,8 @@ you couldn't determine, rather than failing the whole report):
 - Remember folder:   <rememberFolder>
 - Output style:      <enabled | not enabled>
 - PreCompact:        <mode>
+- Session profile:   <general | coding>
+- Repository:        <owner/name or none>
 - Event capture:     <enabled | disabled>
 - Redact keys:       <configured count or none>
 - Redact paths:      <configured count or none>
@@ -73,7 +79,7 @@ you couldn't determine, rather than failing the whole report):
 - Shared processed envelopes: <count or unavailable>
 - Last flush:        <timestamp, never, or unavailable>
 - Hook runtime:      basic-memory <version>; uv <version or missing>
-- Recent checkpoints: <n>
+- Recent checkpoints: <n across session and coding_session>
     - <title> — <permalink>
     ...
 - Active tasks:      <n>

--- a/plugins/claude-code/skills/bm-writing/SKILL.md
+++ b/plugins/claude-code/skills/bm-writing/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: bm-writing
-description: Apply the user-customizable writing standard for Basic Memory notes created or substantially revised by Codex. Use with bm-checkpoint, bm-decide, bm-remember, and other Basic Memory note-writing workflows.
+description: Apply the user-customizable writing standard for Basic Memory notes created or substantially revised by Claude. Use with bm-remember, the basic-memory output style's decision captures, and other Basic Memory note-writing workflows.
 ---
 
 # Write Useful Project Memory
 
-Use this shared standard whenever a Codex Basic Memory skill writes or
-substantially revises a note. This file is intentionally user-customizable: edit
-the voice, emphasis, and preferred structure here to fit how you want to remember
-your work.
+Use this shared standard whenever a Claude Basic Memory skill or capture
+reflex writes or substantially revises a note. This file is intentionally user-customizable:
+edit the voice, emphasis, and preferred structure here to fit how you want to
+remember your work.
 
 Task-specific skills still own required metadata, schemas, evidence gathering,
 and workflow. This skill shapes the note; it never overrides factual constraints.
@@ -40,8 +40,9 @@ and workflow. This skill shapes the note; it never overrides factual constraints
 - When the note records repository work, capture where that work lives: the
   project or repo, the git branch, and the PR or issue — plus the commit sha
   when a specific commit matters.
-- Put anchors the note's schema defines in frontmatter; record the rest as
-  observations, e.g. `- [branch] feat/bm-writing` or `- [pr] #1123`.
+- Put anchors the note's schema defines in frontmatter (session checkpoints
+  from a coding setup define `repo`, `branch`, `git_sha`, and `pr`); record the
+  rest as observations, e.g. `- [branch] feat/bm-writing` or `- [pr] #1123`.
 - Only anchor what is relevant. A remembered fact with no repo context needs no
   git anchors at all.
 

--- a/plugins/claude-code/skills/bm-writing/SKILL.md
+++ b/plugins/claude-code/skills/bm-writing/SKILL.md
@@ -33,6 +33,9 @@ and workflow. This skill shapes the note; it never overrides factual constraints
   as "made progress" or "updated the implementation."
 - Use substantive prose for context and reasoning. Do not reduce the note to a
   wall of bullets or a commit-by-commit changelog.
+- Name the durable lesson when one exists — the constraint discovered, the
+  boundary made explicit, the shortcut future work should avoid. That is the
+  part that turns a status report into project memory.
 - Match depth to the subject. A small remembered fact should remain small.
 
 ## Anchor The Work
@@ -40,9 +43,10 @@ and workflow. This skill shapes the note; it never overrides factual constraints
 - When the note records repository work, capture where that work lives: the
   project or repo, the git branch, and the PR or issue — plus the commit sha
   when a specific commit matters.
-- Put anchors the note's schema defines in frontmatter (session checkpoints
-  from a coding setup define `repo`, `branch`, `git_sha`, and `pr`); record the
-  rest as observations, e.g. `- [branch] feat/bm-writing` or `- [pr] #1123`.
+- Put anchors the note's schema defines in frontmatter (coding-session
+  checkpoints require `repository`, `branch`, and `git_sha`, with typed
+  pull-request fields); record the rest as observations, e.g.
+  `- [branch] feat/bm-writing` or `- [pr] #1123`.
 - Only anchor what is relevant. A remembered fact with no repo context needs no
   git anchors at all.
 

--- a/plugins/codex/skills/bm-writing/SKILL.md
+++ b/plugins/codex/skills/bm-writing/SKILL.md
@@ -33,6 +33,9 @@ and workflow. This skill shapes the note; it never overrides factual constraints
   as "made progress" or "updated the implementation."
 - Use substantive prose for context and reasoning. Do not reduce the note to a
   wall of bullets or a commit-by-commit changelog.
+- Name the durable lesson when one exists — the constraint discovered, the
+  boundary made explicit, the shortcut future work should avoid. That is the
+  part that turns a status report into project memory.
 - Match depth to the subject. A small remembered fact should remain small.
 
 ## Anchor The Work

--- a/scripts/validate_claude_plugin.py
+++ b/scripts/validate_claude_plugin.py
@@ -26,23 +26,46 @@ REQUIRED_HOOK_EVENTS = ("SessionStart", "PreCompact")
 REQUIRED_HOOK_SCRIPTS = ("hooks/session_start.py", "hooks/pre_compact.py")
 # Seed schemas the plugin ships for its note types (copied into the user's
 # project at bootstrap). Each must be a parseable schema note.
-REQUIRED_SCHEMAS = ("session.md", "decision.md", "task.md")
+REQUIRED_SCHEMAS = ("session.md", "coding-session.md", "decision.md", "task.md")
 # Skills the plugin ships as namespaced slash commands (/basic-memory:<name>).
-REQUIRED_SKILLS = ("bm-setup", "bm-remember", "bm-status", "bm-share", "bm-writing")
+REQUIRED_SKILLS = (
+    "bm-setup",
+    "bm-checkpoint",
+    "bm-remember",
+    "bm-status",
+    "bm-share",
+    "bm-writing",
+)
 REQUIRED_SKILL_TEXT: dict[str, tuple[str, ...]] = {
     "bm-setup": (
         "captureEvents",
         "redactKeys",
         "redactPaths",
+        "sessionProfile",
+        "coding-session.md",
         "hook status --harness claude",
-        "coding setup",
-        "`repo`, `branch`, `git_sha`, `pr`",
     ),
     "bm-status": (
         "hook status --harness claude",
         "pending envelopes",
         "processed envelopes",
         "last flush",
+        '"type": "session"',
+        '"type": "coding_session"',
+    ),
+    # Mirrors the Codex validator's bm-checkpoint contract, adapted to the
+    # Claude harness (settings-based config, session/coding_session types).
+    "bm-checkpoint": (
+        "Apply the `bm-writing` skill",
+        "A checkpoint is a durable handoff, not a status dump",
+        "username: <current username>",
+        "hostname: <current hostname>",
+        "type: coding_session",
+        "pull_request_number",
+        "- `[decision]` for each decision made or preserved",
+        "## Relations",
+        "- relates_to [[Exact existing note title]]",
+        "Never write `[relates_to]`",
     ),
     "bm-remember": ("Apply the `bm-writing` skill",),
     # Mirrors the Codex validator's bm-writing contract so the shared writing

--- a/scripts/validate_claude_plugin.py
+++ b/scripts/validate_claude_plugin.py
@@ -28,19 +28,32 @@ REQUIRED_HOOK_SCRIPTS = ("hooks/session_start.py", "hooks/pre_compact.py")
 # project at bootstrap). Each must be a parseable schema note.
 REQUIRED_SCHEMAS = ("session.md", "decision.md", "task.md")
 # Skills the plugin ships as namespaced slash commands (/basic-memory:<name>).
-REQUIRED_SKILLS = ("bm-setup", "bm-remember", "bm-status", "bm-share")
+REQUIRED_SKILLS = ("bm-setup", "bm-remember", "bm-status", "bm-share", "bm-writing")
 REQUIRED_SKILL_TEXT: dict[str, tuple[str, ...]] = {
     "bm-setup": (
         "captureEvents",
         "redactKeys",
         "redactPaths",
         "hook status --harness claude",
+        "coding setup",
+        "`repo`, `branch`, `git_sha`, `pr`",
     ),
     "bm-status": (
         "hook status --harness claude",
         "pending envelopes",
         "processed envelopes",
         "last flush",
+    ),
+    "bm-remember": ("Apply the `bm-writing` skill",),
+    # Mirrors the Codex validator's bm-writing contract so the shared writing
+    # standard stays in sync across host plugins.
+    "bm-writing": (
+        "intentionally user-customizable",
+        "problem -> approach -> current state and impact",
+        "## Anchor The Work",
+        "## Preserve The Semantic Layer",
+        "- relation_type [[Target Note]]",
+        "Do not invent intent, impact, verification, decisions, or drama",
     ),
 }
 

--- a/scripts/validate_codex_plugin.py
+++ b/scripts/validate_codex_plugin.py
@@ -56,6 +56,7 @@ REQUIRED_SKILL_TEXT: dict[str, tuple[str, ...]] = {
     "bm-writing": (
         "intentionally user-customizable",
         "problem -> approach -> current state and impact",
+        "## Anchor The Work",
         "## Preserve The Semantic Layer",
         "- relation_type [[Target Note]]",
         "Do not invent intent, impact, verification, decisions, or drama",


### PR DESCRIPTION
## Why

Claude Code needs the same durable writing standard as Codex, and coding checkpoints need structured repository identity so they can be recalled by repository and pull request instead of fuzzy prose search.

## What Changed

- Port the shared `bm-writing` standard to the Claude Code plugin and apply it to Claude note-writing surfaces.
- Add `/basic-memory:bm-checkpoint` for deliberate, high-signal handoffs.
- Add a dedicated `coding_session` schema for coding setups while keeping `session` general-purpose.
- Teach `bm-setup` to persist `sessionProfile`, confirm a stable `repository`, and seed only the schemas relevant to that profile.
- Teach `bm-status` to query repository-filtered coding checkpoints alongside general sessions.
- Update plugin documentation, examples, and validation contracts.

## Implementation Details

Coding checkpoints require evidence-proven `repository`, `repo_root`, `cwd`, `branch`, and `git_sha` frontmatter. When the current branch has a pull request, the checkpoint adds the complete typed PR field set and normalizes `pull_request_state` to the schema's lowercase enum. If required Git identity cannot be proven, the checkpoint stops instead of guessing.

The existing `session` schema remains the contract for general work. Coding work uses `coding_session`, allowing structured queries such as `metadata_filters={"type": "coding_session", "repository": "owner/name"}` without adding irrelevant fields to non-coding notes.

This PR provides deliberate coding checkpoints and the Claude setup/schema contract. Profile-aware automatic PreCompact capture is completed by stacked PR #1125; after both merge, a follow-up updates the bundled hook dependency SHA to the durable merged core revision.

## Testing

- `git diff --check`
- `just fast-check`
- `just package-check`
  - 257 Python package tests passed; 12 integration tests skipped by their opt-in flag
  - 226 OpenClaw tests passed
  - Claude Code, Codex, shared-skills, and Hermes validators passed
- `just package-check-claude-code`
- `just package-check-codex`

## Risks

- Automatic PreCompact capture remains on the general session contract until #1125 merges and the plugin hook dependency SHA is updated.
- Existing user-customized schemas are never overwritten by setup; users must adopt the new coding schema deliberately.

Generated with Claude Code and Codex.
