### PR TITLE
feat(plugins): add bm-decide and bm-orient skills to Claude Code plugin

### DIFF
--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -8,6 +8,16 @@ Memory's durable graph**, rather than a memory layer of its own. See
 
 ### Added
 
+- **`/basic-memory:bm-orient`** (`skills/bm-orient/`) — deliberate mid-session
+  orientation: reads active tasks, open decisions, and recent checkpoints
+  (repository-scoped `coding_session` recall for coding setups — never an
+  unscoped query) and presents an evidence-backed summary with permalinks.
+  Ported from the Codex plugin for parity.
+- **`/basic-memory:bm-decide`** (`skills/bm-decide/`) — deliberate decision
+  capture: rationale, alternatives, consequences, and affected work as a
+  `type: decision` note, written to the `bm-writing` standard. Works whether or
+  not the output style's inline capture reflex is enabled. Ported from the
+  Codex plugin for parity.
 - **`bm-writing` writing standard** (`skills/bm-writing/`) — the user-customizable
   standard for how Claude writes project memory (voice, narrative spine, git
   anchors, observations, relations, evidence boundary), ported from the Codex

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -29,6 +29,14 @@ the session back to it before the context window compacts.
   coding setup these are schema-backed `coding_session` notes with required
   repository, branch, and SHA context, plus typed pull-request context when a PR
   exists, queryable by structured filters instead of prose search.
+- **Orient from memory (`bm-orient` skill).** A deliberate mid-session "where do
+  things stand" — reads active tasks, open decisions, and recent checkpoints
+  (repository-scoped for coding setups) and presents an evidence-backed
+  orientation with permalinks.
+- **Capture decisions (`bm-decide` skill).** Records a durable choice with
+  rationale, alternatives, consequences, and affected work — the deliberate
+  version of the output style's inline decision capture, available whether or
+  not that style is enabled.
 - **Capture reflexes (output style).** An opt-in output style teaches Claude to
   search the graph before answering recall questions, capture real decisions as
   typed `decision` notes, and cite permalinks.
@@ -50,7 +58,9 @@ Plugin skills are namespaced under the plugin name:
 | Command | What it does |
 |---------|--------------|
 | `/basic-memory:bm-setup` | One-time guided setup — maps the project to a Basic Memory project, seeds the note schemas, installs the shared `memory-*` skills, optionally learns your conventions, and turns on the capture reflexes. Run this first. |
+| `/basic-memory:bm-orient` | Deliberate orientation — reads active tasks, open decisions, and recent checkpoints from the graph and summarizes where things stand, with permalinks. The mid-session counterpart to the SessionStart brief. |
 | `/basic-memory:bm-checkpoint` | Deliberate checkpoint — writes a durable handoff note (story, verification, decisions, next action). Coding setups get schema-backed `coding_session` notes with required Git identity. Also fires when you say "checkpoint this" or "wrap up". |
+| `/basic-memory:bm-decide` | Capture a durable decision — rationale, alternatives, consequences, affected work — as a `type: decision` note findable by structured recall. Also fires when you say "record this decision". |
 | `/basic-memory:bm-remember <text>` | Quick capture — saves the text to the `bm-remember` folder with a `manual-capture` tag. Also fires when you say "remember that…". |
 | `/basic-memory:bm-share <note>` | Promote a personal note to a configured team project, with attribution and confirmation. The deliberate way to write to a shared workspace. |
 | `/basic-memory:bm-status` | Diagnostic — shows the active project, team read-sources and share targets, capture folders, shared local hook inbox/flush health, recent session checkpoints, and active-task count. |

--- a/plugins/claude-code/output-styles/basic-memory.md
+++ b/plugins/claude-code/output-styles/basic-memory.md
@@ -41,6 +41,8 @@ note is invisible to it.
 
 Don't over-capture. One good note per real decision. Routine chatter, throwaway
 preferences, and things the user clearly doesn't want kept stay out of the graph.
+When the user explicitly asks to record a decision, run the
+`basic-memory:bm-decide` skill — the deliberate version of this reflex.
 
 ## Write notes to the standard
 When you write or substantially revise a Basic Memory note, apply the

--- a/plugins/claude-code/skills/bm-decide/SKILL.md
+++ b/plugins/claude-code/skills/bm-decide/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: bm-decide
+description: Capture a durable engineering decision in Basic Memory with rationale, alternatives, consequences, and affected work. Use when the user makes or asks to record a real choice — "let's go with X", "record this decision", or runs /basic-memory:bm-decide.
+argument-hint: (optional short statement of the decision)
+---
+
+# Capture A Decision
+
+Use this when the user makes or asks to record a durable choice. A decision is a
+choice with rationale and consequences, not a casual preference. This is the
+deliberate version of the basic-memory output style's decision-capture reflex —
+it works whether or not that style is enabled.
+
+## Steps
+
+1. Resolve config: read the `basicMemory` block with the same precedence the
+   hooks use — user-level `~/.claude/settings.json` as the base, then the
+   project's `.claude/settings.json` and `.claude/settings.local.json` override
+   it per key:
+   - write to `primaryProject` when set (pass it as `project`, or as
+     `project_id` if it's an `external_id` UUID)
+   - follow `placementConventions` for the directory when they are specific
+   - otherwise use `decisions`
+
+   Apply the `bm-writing` skill before drafting the note.
+
+2. Clarify only if the choice itself is ambiguous. Do not ask for every field if
+   the conversation already contains the rationale.
+
+3. Write a `type: decision` note (`note_type: decision`):
+   - `status: open` unless the user says it is accepted, superseded, or rejected
+   - `decided: <ISO timestamp when known>`
+   - `project: <primaryProject if known>`
+
+4. Include:
+   - the decision
+   - context
+   - rationale
+   - alternatives considered
+   - consequences
+   - affected files, specs, issues, PRs, or notes
+
+5. Confirm with the permalink. If this supersedes an older decision, update the old
+   note or link it as `supersedes`.

--- a/plugins/claude-code/skills/bm-orient/SKILL.md
+++ b/plugins/claude-code/skills/bm-orient/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: bm-orient
+description: Orient Claude from Basic Memory before substantial repo work by reading active tasks, open decisions, recent checkpoints, and repo conventions. Use when resuming old work or when the user asks where things stand.
+argument-hint: (no arguments — reads the graph and summarizes)
+---
+
+# Orient From Basic Memory
+
+Use this before substantial work in a repo, before resuming an old thread, or when
+the user asks where things stand. The SessionStart hook already briefs the start
+of a session; this is the deliberate mid-session version with deeper reads.
+
+## Steps
+
+1. Resolve config: read the `basicMemory` block with the same precedence the
+   hooks use — user-level `~/.claude/settings.json` as the base, then the
+   project's `.claude/settings.json` and `.claude/settings.local.json` override
+   it per key. Use `primaryProject`, `secondaryProjects`, `recallTimeframe`,
+   `sessionProfile`, `repository`, and `placementConventions`. If no config is
+   present, continue against the default Basic Memory project and mention that
+   setup has not been run. Scope queries to `primaryProject` by passing it as
+   `project`, or as `project_id` if it's an `external_id` UUID.
+
+2. Query the primary project with `search_notes`:
+   - active tasks: `metadata_filters={"type": "task", "status": "active"}`
+   - open decisions: `metadata_filters={"type": "decision", "status": "open"}`
+   - recent sessions: `metadata_filters={"type": "session"}`, after
+     `recallTimeframe`
+   - recent coding sessions: `metadata_filters={"type": "coding_session",
+     "repository": "<configured repository>"}`, after `recallTimeframe`, when
+     `sessionProfile` is `coding`
+
+   Always query `"type": "session"`; include `"type": "coding_session"` for a
+   coding profile only with the configured `repository` metadata filter.
+   Never run an unscoped coding-session query; if the repository is missing,
+   report that setup is incomplete. Merge and deduplicate the results, sort them
+   newest first, and prefer the highest-signal checkpoint regardless of which
+   producer wrote it. `coding_session` carries schema-required, queryable Git
+   context; `session` covers general checkpoints, PreCompact captures, and
+   normalized `bm hook flush` projections.
+
+3. Query configured `secondaryProjects` read-only for open decisions. Do not write
+   to shared projects during orientation.
+
+4. Read the highest-signal hits before summarizing. Prefer notes that match the
+   current repository, branch, Git SHA, pull request, named route, issue, or file
+   path. For coding sessions, use structured metadata filters before text search.
+
+5. Present a compact orientation:
+   - active work
+   - decisions that constrain the next move
+   - recent checkpoint cursor
+   - likely next action
+   - any missing setup or ambiguous project mapping
+
+Keep the summary evidence-backed. Include permalinks for notes you rely on.

--- a/plugins/claude-code/skills/bm-remember/SKILL.md
+++ b/plugins/claude-code/skills/bm-remember/SKILL.md
@@ -48,8 +48,8 @@ Capture `$ARGUMENTS` into Basic Memory as a quick note, keeping the user's words
 
 - This is a *quick* capture. Keep the user's wording; don't add observations,
   relations, or structure unless they ask.
-- For a decision with rationale and alternatives, write a `type: decision` note
-  instead (the basic-memory output style covers this). Wrapping up a work session is
-  the PreCompact checkpoint's job, not this skill's.
+- For a decision with rationale and alternatives, use the `bm-decide` skill
+  instead (the basic-memory output style also captures these inline). Wrapping up
+  a work session is `bm-checkpoint`'s job, not this skill's.
 - Use whichever Basic Memory MCP server is connected — don't assume a specific tool
   name prefix.

--- a/scripts/validate_claude_plugin.py
+++ b/scripts/validate_claude_plugin.py
@@ -30,7 +30,9 @@ REQUIRED_SCHEMAS = ("session.md", "coding-session.md", "decision.md", "task.md")
 # Skills the plugin ships as namespaced slash commands (/basic-memory:<name>).
 REQUIRED_SKILLS = (
     "bm-setup",
+    "bm-orient",
     "bm-checkpoint",
+    "bm-decide",
     "bm-remember",
     "bm-status",
     "bm-share",
@@ -68,6 +70,14 @@ REQUIRED_SKILL_TEXT: dict[str, tuple[str, ...]] = {
         "Never write `[relates_to]`",
     ),
     "bm-remember": ("Apply the `bm-writing` skill",),
+    "bm-decide": ("Apply the `bm-writing` skill",),
+    # Coding-session recall must stay repository-scoped — an unscoped query
+    # crosses repos and pollutes orientation.
+    "bm-orient": (
+        'Always query `"type": "session"`',
+        '"type": "coding_session"',
+        "Never run an unscoped coding-session query",
+    ),
     # Mirrors the Codex validator's bm-writing contract so the shared writing
     # standard stays in sync across host plugins.
     "bm-writing": (


### PR DESCRIPTION
## Why

#1124/#1125 brought the Claude Code plugin up to the Codex plugin's coding-session design (shared `bm-writing` standard, `bm-checkpoint`, `coding_session` schema, `sessionProfile`/`repository` config, core hook support). Two deliberate gestures remained Codex-only: decision capture and mid-session orientation. This closes that gap so the two plugins have skill parity.

## What Changed

- **`skills/bm-decide/`** — deliberate decision capture: rationale, alternatives, consequences, affected work, as a `type: decision` note written to the `bm-writing` standard. The deliberate version of the output style's inline reflex — works even when that style is off (previously the only path). `bm-remember` and the output style now point to it.
- **`skills/bm-orient/`** — deliberate mid-session orientation: active tasks, open decisions, recent `session` checkpoints, plus `coding_session` recall for coding profiles — **always scoped to the configured `repository`**; an unscoped coding-session query is forbidden, matching the Codex contract. Presents an evidence-backed summary with permalinks. The mid-session counterpart to the SessionStart brief.
- **`scripts/validate_claude_plugin.py`** — requires both skills and pins their contracts (`Apply the \`bm-writing\` skill` for bm-decide; the scoped-query rules for bm-orient), mirroring the Codex validator.
- README (bullets + command rows) and plugin CHANGELOG entries.

## Verification

- `python3 scripts/validate_claude_plugin.py` ✓ (now requires 8 skills)
- `python3 scripts/validate_codex_plugin.py` ✓
- `claude plugin validate plugins/claude-code --strict` ✓
- `uv run pytest tests/test_codex_plugin_package.py tests/cli/test_coding_session_context.py` — 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2bgrGfWiL4izcjj66u9R8