### PR TITLE
fix(core): normalize coding-session paths to POSIX form

### DIFF
--- a/src/basic_memory/cli/commands/hook.py
+++ b/src/basic_memory/cli/commands/hook.py
@@ -773,7 +773,9 @@ def _coding_context(cfg: dict, directory: str) -> CodingContext:
         raise RuntimeError("coding session profile requires basicMemory.repository; rerun bm-setup")
     return CodingContext(
         repository=repository.strip(),
-        repo_root=_required_git_value(directory, "rev-parse", "--show-toplevel"),
+        # as_posix keeps repo_root in the forward-slash form git already emits on
+        # every platform, so stored path identity is queryable cross-platform.
+        repo_root=Path(_required_git_value(directory, "rev-parse", "--show-toplevel")).as_posix(),
         branch=_required_git_value(directory, "rev-parse", "--abbrev-ref", "HEAD"),
         git_sha=_required_git_value(directory, "rev-parse", "HEAD"),
         pull_request=_pull_request_context(directory),
@@ -849,6 +851,13 @@ def _checkpoint_note(
 
     safe_coding_context: dict[str, str] | None = None
     if coding_context is not None:
+        # Trigger: coding sessions require repo_root == cwd to be comparable identity.
+        # Why: git emits repo_root with forward slashes on every platform, while the
+        # event cwd arrives in native form — on Windows that's C:\Users vs C:/Users.
+        # Outcome: store the coding note's cwd in the same POSIX form as repo_root.
+        # (Redaction ran first; the [redacted-path] sentinel has no separators and
+        # passes through as_posix unchanged.)
+        metadata["cwd"] = Path(safe_cwd).as_posix()
         safe_coding_context = {
             "repository": redactor.redact_text(coding_context.repository),
             "repo_root": redactor.redact_text(coding_context.repo_root),


### PR DESCRIPTION
## Why

`tests/cli/test_coding_session_context.py::test_coding_profile_writes_required_git_and_pull_request_frontmatter` fails on the Windows matrix: `repo_root` comes from `git rev-parse --show-toplevel` (forward slashes on every platform) while the checkpoint `cwd` comes from the hook event in native form (`C:\Users\...`), so the coding-session identity invariant `repo_root == cwd` breaks.

Main never surfaced this: the #1125 push run was **cancelled** (superseded by the follow-up merge push) and the follow-up run skipped the Python matrix (plugins-only change), so the first full Windows runs happened on PR branches rebased onto main (#1090, #1088) — both red through no fault of their own.

## What Changed

- `_coding_context` stores `repo_root` via `Path(...).as_posix()` (no-op on POSIX; pins the canonical form).
- The coding checkpoint's `cwd` frontmatter is stored in the same POSIX form, after redaction (the `[redacted-path]` sentinel has no separators and passes through unchanged).

Path identity for `coding_session` notes is now comparable and queryable cross-platform. General (non-coding) session notes keep native `cwd` — unchanged behavior.

## Verification

- `uv run pytest tests/cli/test_coding_session_context.py tests/cli/test_hook_command.py` — 100 passed (POSIX; the conversion no-ops here — the Windows matrix on this PR is the real proof)
- `ruff format --check` / `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2bgrGfWiL4izcjj66u9R8