### PR TITLE
refactor(core): extract semantic chunk planning

### DIFF
--- a/src/basic_memory/repository/postgres_search_repository.py
+++ b/src/basic_memory/repository/postgres_search_repository.py
@@ -17,6 +17,7 @@ from basic_memory.repository.embedding_provider import EmbeddingProvider
 from basic_memory.repository.embedding_provider_factory import create_embedding_provider
 from basic_memory.repository.search_index_row import SearchIndexRow
 from basic_memory.repository.search_query import relaxed_query_words
+from basic_memory.repository.semantic_chunking import VectorChunkRecord
 from basic_memory.repository.search_repository_base import (
     SearchRepositoryBase,
     VectorChunkState,
@@ -480,7 +481,7 @@ class PostgresSearchRepository(SearchRepositoryBase):
         session: AsyncSession,
         *,
         entity_id: int,
-        scheduled_records: list[dict[str, str]],
+        scheduled_records: list[VectorChunkRecord],
         existing_by_key: dict[str, VectorChunkState],
         entity_fingerprint: str,
         embedding_model: str,

--- a/src/basic_memory/repository/search_repository_base.py
+++ b/src/basic_memory/repository/search_repository_base.py
@@ -1,12 +1,10 @@
 """Abstract base class for search repository implementations."""
 
 import asyncio
-import hashlib
-import json
 import math
-import re
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field, replace
 from datetime import datetime
@@ -23,6 +21,14 @@ from basic_memory.repository.embedding_provider import (
     embedding_provider_identity,
 )
 from basic_memory.repository.search_index_row import SearchIndexRow
+from basic_memory.repository.semantic_chunking import (
+    SemanticSourceRow,
+    VectorChunkRecord,
+    build_entity_fingerprint,
+    build_vector_chunk_records,
+    compose_row_source_text,
+    split_text_into_chunks,
+)
 from basic_memory.repository.semantic_errors import (
     SemanticDependenciesMissingError,
     SemanticSearchDisabledError,
@@ -34,12 +40,8 @@ from basic_memory.schemas.search import SearchItemType, SearchRetrievalMode
 VECTOR_FILTER_SCAN_LIMIT = 50000
 FUSION_BONUS = 0.3
 FTS_GATE_THRESHOLD = 0.0
-MAX_VECTOR_CHUNK_CHARS = 900
-VECTOR_CHUNK_OVERLAP_CHARS = 120
 TOP_CHUNKS_PER_RESULT = 5
 SMALL_NOTE_CONTENT_LIMIT = 2000
-HEADER_LINE_PATTERN = re.compile(r"^\s*#{1,6}\s+")
-BULLET_PATTERN = re.compile(r"^[\-\*]\s+")
 OVERSIZED_ENTITY_VECTOR_SHARD_SIZE = 256
 _SQLITE_MAX_PREPARE_WINDOW = 8
 
@@ -512,89 +514,29 @@ class SearchRepositoryBase(ABC):
                 "and set semantic_search_enabled=true."
             )
 
-    def _compose_row_source_text(self, row) -> str:
+    def _compose_row_source_text(self, row: SemanticSourceRow) -> str:
         """Build the text blob that will be chunked and embedded for one search_index row.
 
         For entity rows we use title, permalink, and content_snippet (the actual
         human-readable content).  content_stems is an FTS-optimised variant that
         includes word-boundary expansions and would dilute embedding quality.
         """
-        if row.type == SearchItemType.ENTITY.value:
-            row_parts = [
-                row.title or "",
-                row.permalink or "",
-                row.content_snippet or "",
-            ]
-            return "\n\n".join(part for part in row_parts if part)
+        return compose_row_source_text(row)
 
-        if row.type == SearchItemType.OBSERVATION.value:
-            row_parts = [
-                row.title or "",
-                row.permalink or "",
-                row.category or "",
-                row.content_snippet or "",
-            ]
-            return "\n\n".join(part for part in row_parts if part)
-
-        row_parts = [
-            row.title or "",
-            row.permalink or "",
-            row.relation_type or "",
-            row.content_snippet or "",
-        ]
-        return "\n\n".join(part for part in row_parts if part)
-
-    def _build_chunk_records(self, rows) -> list[dict[str, str]]:
-        records_by_key: dict[str, dict[str, str]] = {}
-        duplicate_chunk_keys = 0
-        for row in rows:
-            source_text = self._compose_row_source_text(row)
-            chunks = self._split_text_into_chunks(source_text)
-            for chunk_index, chunk_text in enumerate(chunks):
-                chunk_key = f"{row.type}:{row.id}:{chunk_index}"
-                source_hash = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
-                # Trigger: SQLite FTS5 can accumulate duplicate logical rows for the
-                # same search_index id because it does not enforce relational uniqueness.
-                # Why: duplicate chunk keys would schedule duplicate writes for the same
-                # chunk row and eventually trip UNIQUE(rowid) in search_vector_embeddings.
-                # Outcome: collapse chunk work to one deterministic record per chunk key.
-                if chunk_key in records_by_key:
-                    duplicate_chunk_keys += 1
-                records_by_key[chunk_key] = {
-                    "chunk_key": chunk_key,
-                    "chunk_text": chunk_text,
-                    "source_hash": source_hash,
-                }
-
-        if duplicate_chunk_keys:
+    def _build_chunk_records(self, rows: Iterable[SemanticSourceRow]) -> list[VectorChunkRecord]:
+        chunk_build = build_vector_chunk_records(rows)
+        if chunk_build.duplicate_chunk_keys:
             logger.warning(
                 "Collapsed duplicate vector chunk keys before embedding sync: "
                 "project_id={project_id} duplicate_chunk_keys={duplicate_chunk_keys}",
                 project_id=self.project_id,
-                duplicate_chunk_keys=duplicate_chunk_keys,
+                duplicate_chunk_keys=chunk_build.duplicate_chunk_keys,
             )
 
-        return list(records_by_key.values())
+        return chunk_build.records
 
-    def _build_entity_fingerprint(self, chunk_records: list[dict[str, str]]) -> str:
-        """Hash the semantic chunk inputs for one entity.
-
-        Trigger: vector sync eligibility depends on the chunk records derived
-        from search_index rows, not raw file bytes.
-        Why: title/permalink/observation metadata can change vector inputs even
-        when unrelated file bytes do not, and vice versa.
-        Outcome: one deterministic fingerprint invalidates the entity-level skip
-        whenever the embeddable chunk set changes.
-        """
-        canonical_records = [
-            {
-                "chunk_key": record["chunk_key"],
-                "source_hash": record["source_hash"],
-            }
-            for record in sorted(chunk_records, key=lambda record: record["chunk_key"])
-        ]
-        payload = json.dumps(canonical_records, separators=(",", ":"), sort_keys=True)
-        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    def _build_entity_fingerprint(self, chunk_records: list[VectorChunkRecord]) -> str:
+        return build_entity_fingerprint(chunk_records)
 
     def _embedding_model_key(self) -> str:
         """Build a stable model identity for vector invalidation checks."""
@@ -610,7 +552,7 @@ class SearchRepositoryBase(ABC):
 
     def _plan_entity_vector_shard(
         self,
-        pending_records: list[dict[str, str]],
+        pending_records: list[VectorChunkRecord],
     ) -> _EntityVectorShardPlan:
         """Select the bounded shard to process for one entity sync invocation."""
         pending_jobs_total = len(pending_records)
@@ -666,138 +608,7 @@ class SearchRepositoryBase(ABC):
     # --- Text splitting ---
 
     def _split_text_into_chunks(self, text_value: str) -> list[str]:
-        normalized = (text_value or "").strip()
-        if not normalized:
-            return []
-
-        # Split on markdown headers AND bullet boundaries to ensure each
-        # discrete fact gets its own embedding vector for granular retrieval.
-        lines = normalized.splitlines()
-        sections: list[str] = []
-        current_section: list[str] = []
-        for line in lines:
-            if HEADER_LINE_PATTERN.match(line) and current_section:
-                sections.append("\n".join(current_section).strip())
-                current_section = [line]
-            elif BULLET_PATTERN.match(line) and current_section:
-                sections.append("\n".join(current_section).strip())
-                current_section = [line]
-            else:
-                current_section.append(line)
-        if current_section:
-            sections.append("\n".join(current_section).strip())
-
-        chunked_sections: list[str] = []
-        current_chunk = ""
-
-        for section in sections:
-            is_bullet = bool(BULLET_PATTERN.match(section))
-
-            if len(section) > MAX_VECTOR_CHUNK_CHARS:
-                if current_chunk:
-                    chunked_sections.append(current_chunk)
-                    current_chunk = ""
-                long_chunks = self._split_long_section(section)
-                if long_chunks:
-                    chunked_sections.extend(long_chunks[:-1])
-                    current_chunk = long_chunks[-1]
-                continue
-
-            # Keep bullets as individual chunks for granular fact retrieval.
-            # Non-bullet sections (headers, prose) merge up to MAX_VECTOR_CHUNK_CHARS.
-            if is_bullet:
-                if current_chunk:
-                    chunked_sections.append(current_chunk)
-                    current_chunk = ""
-                chunked_sections.append(section)
-                continue
-
-            candidate = section if not current_chunk else f"{current_chunk}\n\n{section}"
-            if len(candidate) <= MAX_VECTOR_CHUNK_CHARS:
-                current_chunk = candidate
-                continue
-
-            chunked_sections.append(current_chunk)
-            current_chunk = section
-
-        if current_chunk:
-            chunked_sections.append(current_chunk)
-
-        return [chunk for chunk in chunked_sections if chunk.strip()]
-
-    @staticmethod
-    def _split_into_paragraphs(section_text: str) -> list[str]:
-        """Split section into paragraphs, treating bullet lists as separate items.
-
-        Double newlines always split. Within a single-newline block, bullet
-        boundaries (lines starting with - or *) also create splits so that
-        individual facts in a list become separate embeddable chunks.
-        """
-        raw_paragraphs = [p.strip() for p in section_text.split("\n\n") if p.strip()]
-        result: list[str] = []
-        for para in raw_paragraphs:
-            lines = para.split("\n")
-            # Check if this paragraph contains bullet items
-            has_bullets = any(BULLET_PATTERN.match(line) for line in lines)
-            if not has_bullets:
-                result.append(para)
-                continue
-            # Split on bullet boundaries: group consecutive non-bullet lines
-            # with their preceding bullet
-            current_item: list[str] = []
-            for line in lines:
-                if BULLET_PATTERN.match(line) and current_item:
-                    result.append("\n".join(current_item).strip())
-                    current_item = [line]
-                else:
-                    current_item.append(line)
-            if current_item:
-                result.append("\n".join(current_item).strip())
-        return [p for p in result if p]
-
-    def _split_long_section(self, section_text: str) -> list[str]:
-        paragraphs = self._split_into_paragraphs(section_text)
-        if not paragraphs:
-            return []
-
-        chunks: list[str] = []
-        current = ""
-        for paragraph in paragraphs:
-            if len(paragraph) > MAX_VECTOR_CHUNK_CHARS:
-                if current:
-                    chunks.append(current)
-                    current = ""
-                chunks.extend(self._split_by_char_window(paragraph))
-                continue
-
-            candidate = paragraph if not current else f"{current}\n\n{paragraph}"
-            if len(candidate) <= MAX_VECTOR_CHUNK_CHARS:
-                current = candidate
-            else:
-                if current:
-                    chunks.append(current)
-                current = paragraph
-
-        if current:
-            chunks.append(current)
-        return chunks
-
-    def _split_by_char_window(self, paragraph: str) -> list[str]:
-        text_value = paragraph.strip()
-        if not text_value:
-            return []
-
-        chunks: list[str] = []
-        start = 0
-        while start < len(text_value):
-            end = min(len(text_value), start + MAX_VECTOR_CHUNK_CHARS)
-            chunk = text_value[start:end].strip()
-            if chunk:
-                chunks.append(chunk)
-            if end >= len(text_value):
-                break
-            start = max(0, end - VECTOR_CHUNK_OVERLAP_CHARS)
-        return chunks
+        return split_text_into_chunks(text_value)
 
     # ------------------------------------------------------------------
     # Shared semantic search: sync_entity_vectors orchestration
@@ -1389,7 +1200,7 @@ class SearchRepositoryBase(ABC):
 
         timestamp_expr = self._timestamp_now_expr()
         metadata_update_ids: list[int] = []
-        pending_records: list[dict[str, str]] = []
+        pending_records: list[VectorChunkRecord] = []
         skipped_chunks_count = 0
         for record in chunk_records:
             current = existing_by_key.get(record["chunk_key"])
@@ -1485,7 +1296,7 @@ class SearchRepositoryBase(ABC):
         session: AsyncSession,
         *,
         entity_id: int,
-        scheduled_records: list[dict[str, str]],
+        scheduled_records: list[VectorChunkRecord],
         existing_by_key: dict[str, VectorChunkState],
         entity_fingerprint: str,
         embedding_model: str,

--- a/src/basic_memory/repository/semantic_chunking.py
+++ b/src/basic_memory/repository/semantic_chunking.py
@@ -1,0 +1,248 @@
+"""Pure semantic chunk planning for vector indexing."""
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Protocol, TypedDict
+
+from basic_memory.schemas.search import SearchItemType
+
+MAX_VECTOR_CHUNK_CHARS = 900
+VECTOR_CHUNK_OVERLAP_CHARS = 120
+
+_HEADER_LINE_PATTERN = re.compile(r"^\s*#{1,6}\s+")
+_BULLET_PATTERN = re.compile(r"^[\-\*]\s+")
+
+
+class SemanticSourceRow(Protocol):
+    """Search row fields needed to build semantic chunks."""
+
+    id: int
+    type: str
+    title: str | None
+    permalink: str | None
+    content_snippet: str | None
+    category: str | None
+    relation_type: str | None
+
+
+class VectorChunkRecord(TypedDict):
+    """One deterministic chunk input for vector synchronization."""
+
+    chunk_key: str
+    chunk_text: str
+    source_hash: str
+
+
+@dataclass(frozen=True, slots=True)
+class VectorChunkBuildResult:
+    """Chunk records plus duplicate-source diagnostics for the caller."""
+
+    records: list[VectorChunkRecord]
+    duplicate_chunk_keys: int
+
+
+def compose_row_source_text(row: SemanticSourceRow) -> str:
+    """Build the human-readable text embedded for one search row."""
+    if row.type == SearchItemType.ENTITY.value:
+        row_parts = [
+            row.title or "",
+            row.permalink or "",
+            row.content_snippet or "",
+        ]
+        return "\n\n".join(part for part in row_parts if part)
+
+    if row.type == SearchItemType.OBSERVATION.value:
+        row_parts = [
+            row.title or "",
+            row.permalink or "",
+            row.category or "",
+            row.content_snippet or "",
+        ]
+        return "\n\n".join(part for part in row_parts if part)
+
+    row_parts = [
+        row.title or "",
+        row.permalink or "",
+        row.relation_type or "",
+        row.content_snippet or "",
+    ]
+    return "\n\n".join(part for part in row_parts if part)
+
+
+def build_vector_chunk_records(rows: Iterable[SemanticSourceRow]) -> VectorChunkBuildResult:
+    """Build one deterministic chunk record per logical search-row chunk."""
+    records_by_key: dict[str, VectorChunkRecord] = {}
+    duplicate_chunk_keys = 0
+
+    for row in rows:
+        source_text = compose_row_source_text(row)
+        chunks = split_text_into_chunks(source_text)
+        for chunk_index, chunk_text in enumerate(chunks):
+            chunk_key = f"{row.type}:{row.id}:{chunk_index}"
+            source_hash = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+            # SQLite FTS5 can return duplicate logical rows because it does not
+            # enforce relational uniqueness. Collapse them before the vector
+            # writer encounters duplicate chunk keys.
+            if chunk_key in records_by_key:
+                duplicate_chunk_keys += 1
+            records_by_key[chunk_key] = {
+                "chunk_key": chunk_key,
+                "chunk_text": chunk_text,
+                "source_hash": source_hash,
+            }
+
+    return VectorChunkBuildResult(
+        records=list(records_by_key.values()),
+        duplicate_chunk_keys=duplicate_chunk_keys,
+    )
+
+
+def build_entity_fingerprint(chunk_records: Iterable[VectorChunkRecord]) -> str:
+    """Hash the semantic chunk inputs for one entity.
+
+    Vector eligibility follows the derived search rows rather than raw file
+    bytes. Title, permalink, or observation changes therefore invalidate the
+    entity fingerprint even when unrelated file bytes do not.
+    """
+    canonical_records = [
+        {
+            "chunk_key": record["chunk_key"],
+            "source_hash": record["source_hash"],
+        }
+        for record in sorted(chunk_records, key=lambda record: record["chunk_key"])
+    ]
+    payload = json.dumps(canonical_records, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def split_text_into_chunks(text_value: str) -> list[str]:
+    """Split semantic source text at Markdown-aware boundaries."""
+    normalized = (text_value or "").strip()
+    if not normalized:
+        return []
+
+    # Headers and bullets represent natural semantic boundaries. In particular,
+    # keeping bullets separate gives individual facts their own retrieval vector.
+    lines = normalized.splitlines()
+    sections: list[str] = []
+    current_section: list[str] = []
+    for line in lines:
+        if _HEADER_LINE_PATTERN.match(line) and current_section:
+            sections.append("\n".join(current_section).strip())
+            current_section = [line]
+        elif _BULLET_PATTERN.match(line) and current_section:
+            sections.append("\n".join(current_section).strip())
+            current_section = [line]
+        else:
+            current_section.append(line)
+    if current_section:
+        sections.append("\n".join(current_section).strip())
+
+    chunked_sections: list[str] = []
+    current_chunk = ""
+
+    for section in sections:
+        is_bullet = bool(_BULLET_PATTERN.match(section))
+
+        if len(section) > MAX_VECTOR_CHUNK_CHARS:
+            if current_chunk:
+                chunked_sections.append(current_chunk)
+                current_chunk = ""
+            long_chunks = _split_long_section(section)
+            if long_chunks:
+                chunked_sections.extend(long_chunks[:-1])
+                current_chunk = long_chunks[-1]
+            continue
+
+        if is_bullet:
+            if current_chunk:
+                chunked_sections.append(current_chunk)
+                current_chunk = ""
+            chunked_sections.append(section)
+            continue
+
+        candidate = section if not current_chunk else f"{current_chunk}\n\n{section}"
+        if len(candidate) <= MAX_VECTOR_CHUNK_CHARS:
+            current_chunk = candidate
+            continue
+
+        chunked_sections.append(current_chunk)
+        current_chunk = section
+
+    if current_chunk:
+        chunked_sections.append(current_chunk)
+
+    return [chunk for chunk in chunked_sections if chunk.strip()]
+
+
+def _split_into_paragraphs(section_text: str) -> list[str]:
+    """Split prose and bullet-list sections into semantic paragraphs."""
+    raw_paragraphs = [paragraph.strip() for paragraph in section_text.split("\n\n")]
+    result: list[str] = []
+    for paragraph in raw_paragraphs:
+        if not paragraph:
+            continue
+        lines = paragraph.split("\n")
+        if not any(_BULLET_PATTERN.match(line) for line in lines):
+            result.append(paragraph)
+            continue
+
+        current_item: list[str] = []
+        for line in lines:
+            if _BULLET_PATTERN.match(line) and current_item:
+                result.append("\n".join(current_item).strip())
+                current_item = [line]
+            else:
+                current_item.append(line)
+        if current_item:
+            result.append("\n".join(current_item).strip())
+    return [paragraph for paragraph in result if paragraph]
+
+
+def _split_long_section(section_text: str) -> list[str]:
+    paragraphs = _split_into_paragraphs(section_text)
+    if not paragraphs:
+        return []
+
+    chunks: list[str] = []
+    current = ""
+    for paragraph in paragraphs:
+        if len(paragraph) > MAX_VECTOR_CHUNK_CHARS:
+            if current:
+                chunks.append(current)
+                current = ""
+            chunks.extend(_split_by_char_window(paragraph))
+            continue
+
+        candidate = paragraph if not current else f"{current}\n\n{paragraph}"
+        if len(candidate) <= MAX_VECTOR_CHUNK_CHARS:
+            current = candidate
+        else:
+            if current:
+                chunks.append(current)
+            current = paragraph
+
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _split_by_char_window(paragraph: str) -> list[str]:
+    text_value = paragraph.strip()
+    if not text_value:
+        return []
+
+    chunks: list[str] = []
+    start = 0
+    while start < len(text_value):
+        end = min(len(text_value), start + MAX_VECTOR_CHUNK_CHARS)
+        chunk = text_value[start:end].strip()
+        if chunk:
+            chunks.append(chunk)
+        if end >= len(text_value):
+            break
+        start = max(0, end - VECTOR_CHUNK_OVERLAP_CHARS)
+    return chunks

--- a/tests/repository/test_semantic_chunking.py
+++ b/tests/repository/test_semantic_chunking.py
@@ -1,0 +1,275 @@
+"""Tests for pure semantic chunk planning."""
+
+from types import SimpleNamespace
+
+from basic_memory.repository import semantic_chunking
+from basic_memory.repository.semantic_chunking import (
+    MAX_VECTOR_CHUNK_CHARS,
+    VectorChunkRecord,
+    build_entity_fingerprint,
+    build_vector_chunk_records,
+    compose_row_source_text,
+    split_text_into_chunks,
+)
+from basic_memory.schemas.search import SearchItemType
+
+
+def _make_row(
+    *,
+    row_type: str,
+    title: str = "Test Title",
+    permalink: str = "test/permalink",
+    content_stems: str = "",
+    content_snippet: str = "",
+    category: str = "",
+    relation_type: str = "",
+    row_id: int = 1,
+):
+    """Create a SimpleNamespace matching the semantic source-row contract."""
+    return SimpleNamespace(
+        id=row_id,
+        type=row_type,
+        title=title,
+        permalink=permalink,
+        content_stems=content_stems,
+        content_snippet=content_snippet,
+        category=category,
+        relation_type=relation_type,
+    )
+
+
+class TestComposeRowSourceText:
+    """Verify source text uses the human-readable fields for each row type."""
+
+    def test_entity_row_uses_content_snippet_not_content_stems(self):
+        row = _make_row(
+            row_type=SearchItemType.ENTITY.value,
+            title="Auth Design",
+            permalink="specs/auth-design",
+            content_stems="auth login token session stems expanded variants",
+            content_snippet="JWT authentication with session management",
+        )
+
+        result = compose_row_source_text(row)
+
+        assert "Auth Design" in result
+        assert "specs/auth-design" in result
+        assert "JWT authentication with session management" in result
+        assert "stems expanded variants" not in result
+
+    def test_observation_row_includes_category(self):
+        row = _make_row(
+            row_type=SearchItemType.OBSERVATION.value,
+            title="Coffee Notes",
+            permalink="notes/coffee",
+            category="technique",
+            content_snippet="Pour over produces cleaner cups",
+        )
+
+        result = compose_row_source_text(row)
+
+        assert "Coffee Notes" in result
+        assert "technique" in result
+        assert "Pour over produces cleaner cups" in result
+
+    def test_relation_row_includes_relation_type(self):
+        row = _make_row(
+            row_type=SearchItemType.RELATION.value,
+            title="Brewing",
+            permalink="notes/brewing",
+            relation_type="relates_to",
+            content_snippet="Coffee brewing method",
+        )
+
+        result = compose_row_source_text(row)
+
+        assert "Brewing" in result
+        assert "relates_to" in result
+        assert "Coffee brewing method" in result
+
+    def test_entity_row_with_none_fields(self):
+        row = _make_row(
+            row_type=SearchItemType.ENTITY.value,
+            title="Minimal",
+            permalink="",
+            content_snippet="",
+        )
+        row.permalink = None
+        row.content_snippet = None
+
+        assert compose_row_source_text(row) == "Minimal"
+
+
+class TestSplitTextIntoChunks:
+    """Verify Markdown-aware text splitting."""
+
+    def test_short_text_returns_single_chunk(self):
+        assert split_text_into_chunks("Short text") == ["Short text"]
+
+    def test_empty_text_returns_empty(self):
+        assert split_text_into_chunks("") == []
+        assert split_text_into_chunks("   ") == []
+
+    def test_splits_on_headers(self):
+        long_section_a = "## Section A\n" + ("A content. " * 100)
+        long_section_b = "## Section B\n" + ("B content. " * 100)
+        long_text = f"Intro paragraph\n\n{long_section_a}\n\n{long_section_b}"
+
+        result = split_text_into_chunks(long_text)
+
+        assert len(result) >= 2
+
+    def test_paragraph_merging_within_limit(self):
+        para1 = "First paragraph."
+        para2 = "Second paragraph."
+        text = f"# Header\n\n{para1}\n\n{para2}"
+
+        result = split_text_into_chunks(text)
+
+        assert len(result) == 1
+        assert para1 in result[0]
+        assert para2 in result[0]
+
+    def test_long_paragraph_uses_char_window(self):
+        long_paragraph = "x" * (MAX_VECTOR_CHUNK_CHARS * 3)
+
+        result = split_text_into_chunks(long_paragraph)
+
+        assert len(result) >= 3
+        assert all(len(chunk) <= MAX_VECTOR_CHUNK_CHARS for chunk in result)
+
+    def test_bullets_are_independent_chunks(self):
+        text = "Intro\n- First fact\n  supporting detail\n- Second fact"
+
+        result = split_text_into_chunks(text)
+
+        assert result == [
+            "Intro",
+            "- First fact\n  supporting detail",
+            "- Second fact",
+        ]
+
+    def test_sections_that_exceed_combined_limit_remain_separate(self):
+        first_section = "a" * 500
+        second_section = f"# Second\n{'b' * 500}"
+
+        result = split_text_into_chunks(f"{first_section}\n{second_section}")
+
+        assert result == [first_section, second_section]
+
+    def test_long_section_flushes_prose_before_windowed_paragraph(self):
+        long_paragraph = "x" * (MAX_VECTOR_CHUNK_CHARS + 100)
+
+        result = split_text_into_chunks(f"Short introduction.\n\n{long_paragraph}")
+
+        assert result[0] == "Short introduction."
+        assert "".join(result[1:]).startswith("x" * MAX_VECTOR_CHUNK_CHARS)
+
+    def test_long_section_splits_medium_paragraphs_at_chunk_limit(self):
+        first_paragraph = "a" * 500
+        second_paragraph = "b" * 500
+
+        result = split_text_into_chunks(f"{first_paragraph}\n\n{second_paragraph}")
+
+        assert result == [first_paragraph, second_paragraph]
+
+
+class TestSemanticChunkHelpers:
+    """Cover helper preconditions and Markdown list grouping directly."""
+
+    def test_split_into_paragraphs_groups_bullet_continuations(self):
+        result = semantic_chunking._split_into_paragraphs(
+            "\n\n- First fact\ncontinuation\n- Second fact"
+        )
+
+        assert result == ["- First fact\ncontinuation", "- Second fact"]
+
+    def test_empty_helper_inputs_return_no_chunks(self):
+        assert semantic_chunking._split_long_section("") == []
+        assert semantic_chunking._split_by_char_window("   ") == []
+
+
+class TestBuildVectorChunkRecords:
+    def test_produces_records_with_correct_keys(self):
+        rows = [
+            _make_row(
+                row_type=SearchItemType.ENTITY.value,
+                title="Test",
+                permalink="test",
+                content_snippet="content",
+                row_id=42,
+            )
+        ]
+
+        result = build_vector_chunk_records(rows)
+
+        assert result.records
+        for record in result.records:
+            assert set(record) == {"chunk_key", "chunk_text", "source_hash"}
+            assert record["chunk_key"].startswith("entity:")
+
+    def test_chunk_key_includes_row_id(self):
+        rows = [
+            _make_row(
+                row_type=SearchItemType.OBSERVATION.value,
+                content_snippet="obs content",
+                row_id=99,
+            )
+        ]
+
+        result = build_vector_chunk_records(rows)
+
+        assert any("99" in record["chunk_key"] for record in result.records)
+
+    def test_duplicate_rows_collapse_to_unique_chunk_keys(self):
+        rows = [
+            _make_row(
+                row_type=SearchItemType.ENTITY.value,
+                title="Spec",
+                permalink="spec",
+                content_snippet="shared content",
+                row_id=77,
+            ),
+            _make_row(
+                row_type=SearchItemType.ENTITY.value,
+                title="Spec",
+                permalink="spec",
+                content_snippet="shared content",
+                row_id=77,
+            ),
+        ]
+
+        result = build_vector_chunk_records(rows)
+
+        assert result.duplicate_chunk_keys == 1
+        assert len(result.records) == 1
+        assert result.records[0]["chunk_key"] == "entity:77:0"
+
+
+class TestBuildEntityFingerprint:
+    def test_fingerprint_is_stable_across_record_order(self):
+        first_record: VectorChunkRecord = {
+            "chunk_key": "entity:1:0",
+            "chunk_text": "First chunk",
+            "source_hash": "first-hash",
+        }
+        second_record: VectorChunkRecord = {
+            "chunk_key": "entity:1:1",
+            "chunk_text": "Second chunk",
+            "source_hash": "second-hash",
+        }
+
+        forward = build_entity_fingerprint([first_record, second_record])
+        reversed_order = build_entity_fingerprint([second_record, first_record])
+
+        assert forward == reversed_order
+
+    def test_fingerprint_changes_with_source_hash(self):
+        original: VectorChunkRecord = {
+            "chunk_key": "entity:1:0",
+            "chunk_text": "Same chunk",
+            "source_hash": "first-hash",
+        }
+        changed: VectorChunkRecord = {**original, "source_hash": "second-hash"}
+
+        assert build_entity_fingerprint([original]) != build_entity_fingerprint([changed])

--- a/tests/repository/test_semantic_search_base.py
+++ b/tests/repository/test_semantic_search_base.py
@@ -1,8 +1,4 @@
-"""Tests for shared semantic search logic in SearchRepositoryBase.
-
-Covers: _compose_row_source_text, _split_text_into_chunks, _build_chunk_records,
-_search_hybrid entity_id fusion key, and SemanticSearchDisabledError in SQLite.
-"""
+"""Tests for semantic search orchestration in SearchRepositoryBase."""
 
 import asyncio
 from contextlib import asynccontextmanager
@@ -17,7 +13,6 @@ import basic_memory.repository.search_repository_base as search_repository_base_
 from basic_memory.repository.fastembed_provider import FastEmbedEmbeddingProvider
 from basic_memory.repository.search_index_row import SearchIndexRow
 from basic_memory.repository.search_repository_base import (
-    MAX_VECTOR_CHUNK_CHARS,
     SearchRepositoryBase,
     _PreparedEntityVectorSync,
 )
@@ -27,30 +22,6 @@ from basic_memory.schemas.search import SearchItemType, SearchRetrievalMode
 
 
 # --- Helpers ---
-
-
-def _make_row(
-    *,
-    row_type: str,
-    title: str = "Test Title",
-    permalink: str = "test/permalink",
-    content_stems: str = "",
-    content_snippet: str = "",
-    category: str = "",
-    relation_type: str = "",
-    row_id: int = 1,
-):
-    """Create a SimpleNamespace mimicking a search_index DB row."""
-    return SimpleNamespace(
-        id=row_id,
-        type=row_type,
-        title=title,
-        permalink=permalink,
-        content_stems=content_stems,
-        content_snippet=content_snippet,
-        category=category,
-        relation_type=relation_type,
-    )
 
 
 class _ConcreteRepo(SearchRepositoryBase):
@@ -113,176 +84,6 @@ class _ConcreteRepo(SearchRepositoryBase):
 
     def _distance_to_similarity(self, distance: float) -> float:
         return 1.0 / (1.0 + max(distance, 0.0))
-
-
-# --- _compose_row_source_text ---
-
-
-class TestComposeRowSourceText:
-    """Verify _compose_row_source_text produces correct text for all row types."""
-
-    def setup_method(self):
-        self.repo = _ConcreteRepo()
-
-    def test_entity_row_uses_content_snippet_not_content_stems(self):
-        """Entity rows should use content_snippet (human-readable) instead of content_stems."""
-        row = _make_row(
-            row_type=SearchItemType.ENTITY.value,
-            title="Auth Design",
-            permalink="specs/auth-design",
-            content_stems="auth login token session stems expanded variants",
-            content_snippet="JWT authentication with session management",
-        )
-        result = self.repo._compose_row_source_text(row)
-        assert "Auth Design" in result
-        assert "specs/auth-design" in result
-        assert "JWT authentication with session management" in result
-        # content_stems should NOT appear
-        assert "stems expanded variants" not in result
-
-    def test_observation_row_includes_category(self):
-        row = _make_row(
-            row_type=SearchItemType.OBSERVATION.value,
-            title="Coffee Notes",
-            permalink="notes/coffee",
-            category="technique",
-            content_snippet="Pour over produces cleaner cups",
-        )
-        result = self.repo._compose_row_source_text(row)
-        assert "Coffee Notes" in result
-        assert "technique" in result
-        assert "Pour over produces cleaner cups" in result
-
-    def test_relation_row_includes_relation_type(self):
-        row = _make_row(
-            row_type=SearchItemType.RELATION.value,
-            title="Brewing",
-            permalink="notes/brewing",
-            relation_type="relates_to",
-            content_snippet="Coffee brewing method",
-        )
-        result = self.repo._compose_row_source_text(row)
-        assert "Brewing" in result
-        assert "relates_to" in result
-        assert "Coffee brewing method" in result
-
-    def test_entity_row_with_none_fields(self):
-        """Null fields should be skipped, not included as empty strings."""
-        row = _make_row(
-            row_type=SearchItemType.ENTITY.value,
-            title="Minimal",
-            permalink="",
-            content_snippet="",
-        )
-        row.permalink = None
-        row.content_snippet = None
-        result = self.repo._compose_row_source_text(row)
-        assert result == "Minimal"
-
-
-# --- _split_text_into_chunks ---
-
-
-class TestSplitTextIntoChunks:
-    """Verify markdown-aware text splitting."""
-
-    def setup_method(self):
-        self.repo = _ConcreteRepo()
-
-    def test_short_text_returns_single_chunk(self):
-        result = self.repo._split_text_into_chunks("Short text")
-        assert result == ["Short text"]
-
-    def test_empty_text_returns_empty(self):
-        assert self.repo._split_text_into_chunks("") == []
-        assert self.repo._split_text_into_chunks("   ") == []
-
-    def test_splits_on_headers(self):
-        # Make it long enough to actually split
-        long_section_a = "## Section A\n" + ("A content. " * 100)
-        long_section_b = "## Section B\n" + ("B content. " * 100)
-        long_text = f"Intro paragraph\n\n{long_section_a}\n\n{long_section_b}"
-        result = self.repo._split_text_into_chunks(long_text)
-        assert len(result) >= 2
-
-    def test_paragraph_merging_within_limit(self):
-        """Paragraphs shorter than limit should be merged."""
-        para1 = "First paragraph."
-        para2 = "Second paragraph."
-        text = f"# Header\n\n{para1}\n\n{para2}"
-        result = self.repo._split_text_into_chunks(text)
-        # Both paragraphs fit in one chunk
-        assert len(result) == 1
-        assert para1 in result[0]
-        assert para2 in result[0]
-
-    def test_long_paragraph_uses_char_window(self):
-        """A single paragraph longer than MAX_VECTOR_CHUNK_CHARS uses sliding window."""
-        long_para = "x" * (MAX_VECTOR_CHUNK_CHARS * 3)
-        result = self.repo._split_text_into_chunks(long_para)
-        assert len(result) >= 3
-        for chunk in result:
-            assert len(chunk) <= MAX_VECTOR_CHUNK_CHARS
-
-
-# --- _build_chunk_records ---
-
-
-class TestBuildChunkRecords:
-    def setup_method(self):
-        self.repo = _ConcreteRepo()
-
-    def test_produces_records_with_correct_keys(self):
-        rows = [
-            _make_row(
-                row_type=SearchItemType.ENTITY.value,
-                title="Test",
-                permalink="test",
-                content_snippet="content",
-                row_id=42,
-            )
-        ]
-        records = self.repo._build_chunk_records(rows)
-        assert len(records) >= 1
-        for record in records:
-            assert "chunk_key" in record
-            assert "chunk_text" in record
-            assert "source_hash" in record
-            assert record["chunk_key"].startswith("entity:")
-
-    def test_chunk_key_includes_row_id(self):
-        rows = [
-            _make_row(
-                row_type=SearchItemType.OBSERVATION.value,
-                content_snippet="obs content",
-                row_id=99,
-            )
-        ]
-        records = self.repo._build_chunk_records(rows)
-        assert any("99" in r["chunk_key"] for r in records)
-
-    def test_duplicate_rows_collapse_to_unique_chunk_keys(self):
-        rows = [
-            _make_row(
-                row_type=SearchItemType.ENTITY.value,
-                title="Spec",
-                permalink="spec",
-                content_snippet="shared content",
-                row_id=77,
-            ),
-            _make_row(
-                row_type=SearchItemType.ENTITY.value,
-                title="Spec",
-                permalink="spec",
-                content_snippet="shared content",
-                row_id=77,
-            ),
-        ]
-
-        records = self.repo._build_chunk_records(rows)
-
-        assert len(records) == 1
-        assert records[0]["chunk_key"] == "entity:77:0"
 
 
 # --- SQLite SemanticSearchDisabledError ---


### PR DESCRIPTION
## Why

- Continue #1108 with the next bounded `SearchRepositoryBase` extraction after #1122 split query and row-hydration concerns.
- Semantic source composition, Markdown-aware chunking, deterministic chunk records, and entity fingerprints are pure planning work. Keeping them inside the async repository base mixed deterministic transformations with database and embedding orchestration.

## What Changed

- Added `repository/semantic_chunking.py` as the typed, side-effect-free home for semantic chunk planning.
- Kept thin compatibility delegates on `SearchRepositoryBase` while removing the planning implementation from the repository class.
- Preserved project-aware duplicate chunk logging in the repository orchestration layer.
- Updated the Postgres vector scheduling hook to use the shared `VectorChunkRecord` type.
- Moved pure chunk-planning tests to the new module boundary and expanded edge-case and fingerprint coverage.
- No user-visible semantic search behavior changes are intended.

## Implementation Details

- `SemanticSourceRow` defines the narrow search-row input contract.
- `VectorChunkRecord` names the deterministic writer input, and `VectorChunkBuildResult` returns records with duplicate-key diagnostics.
- Source composition, chunk splitting, record hashing, and entity fingerprinting are ordinary module functions with no repository or database dependencies.
- `SearchRepositoryBase` still owns backend coordination, embedding calls, state inspection, logging, and persistence hooks.

## Testing

### Automated

- `just fast-check`: passed (Ruff formatting/lint and `ty` type checking).
- `BASIC_MEMORY_ENV=test uv run pytest tests/repository/test_semantic_chunking.py tests/repository/test_semantic_search_base.py tests/repository/test_sqlite_vector_search_repository.py tests/repository/test_postgres_search_repository.py test-int/semantic/test_search_diagnostics.py --no-cov -q`: 51 passed, 23 skipped after rebasing onto current `main`.
- `just fast-test`: 4,594 passed, 41 skipped.
- `BASIC_MEMORY_ENV=test uv run pytest tests/repository/test_semantic_chunking.py tests/repository/test_semantic_search_base.py --cov=basic_memory.repository.semantic_chunking --cov-report=term-missing:skip-covered --cov-fail-under=0 -q`: 33 passed; `semantic_chunking.py` reached 141/141 statements (100%).
- `git diff --check`: passed.

### Manual

- `just doctor`: passed the local configuration, database, file/index/search, and FastEmbed vector-sync health checks.

## Risks / Follow-ups

- This is a behavior-preserving refactor; the primary risk is accidental drift in chunk boundaries or hashes. Existing backend tests, the full suite, and direct 100% module coverage guard those contracts.
- This PR is part of #1108 and intentionally does not close it. Vector-sync orchestration and the other tracker-listed core files remain follow-up slices.
