### PR TITLE
perf(core): batch relation resolution writes

### DIFF
--- a/src/basic_memory/index/local_dependencies.py
+++ b/src/basic_memory/index/local_dependencies.py
@@ -45,6 +45,8 @@ from basic_memory.indexing.models import (
 )
 from basic_memory.indexing.orphan_cleanup import OrphanEntityRepository, OrphanSearchIndex
 from basic_memory.indexing.relation_resolution import (
+    BatchRelationResolutionEntityIndexer,
+    BatchRelationResolutionEntityRepository,
     RelationResolutionEntityIndexer,
     RelationResolutionEntityRepository,
     RelationResolutionLinkResolver,
@@ -110,6 +112,7 @@ class LocalIndexEntityRepository(
     IndexedFileChecksumRepository,
     CurrentMaterializedNoteEntityRepository,
     OrphanEntityRepository[Entity],
+    BatchRelationResolutionEntityRepository,
     RelationResolutionEntityRepository,
     Protocol,
 ):
@@ -163,6 +166,7 @@ class LocalIndexEntityRepository(
 
 class LocalIndexSearchService(
     OrphanSearchIndex[Entity],
+    BatchRelationResolutionEntityIndexer,
     RelationResolutionEntityIndexer,
     Protocol,
 ):

--- a/src/basic_memory/indexing/relation_resolution.py
+++ b/src/basic_memory/indexing/relation_resolution.py
@@ -9,12 +9,15 @@ from typing import Protocol
 
 import logfire
 from loguru import logger
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory import db
 from basic_memory.indexing.models import IndexFileJobStatus
-from basic_memory.models import Entity, Relation
+from basic_memory.models import Entity
+from basic_memory.repository.relation_repository import (
+    ResolvedRelationWrite,
+    ResolvedRelationWriteResult,
+)
 
 type EntityId = int
 type AffectedEntityIds = set[EntityId]
@@ -63,21 +66,12 @@ class RelationResolutionRelationRepository(Protocol):
     ) -> Sequence[UnresolvedRelation]:
         """Return unresolved relations for one source entity."""
 
-    # Positional-only parameters: the concrete implementation is the generic
-    # model repository, whose parameters are named for entities. `/` lets this
-    # contract name the relation id honestly without renaming the shared
-    # repository method.
-    async def update(
+    async def apply_resolved_targets(
         self,
         session: AsyncSession,
-        relation_id: int,
-        resolved_target_fields: dict[str, int | str],
-        /,
-    ) -> Relation | None:
-        """Apply resolved target fields (to_id, to_name) to one relation row."""
-
-    async def delete(self, session: AsyncSession, relation_id: int, /) -> bool:
-        """Delete one redundant unresolved relation row."""
+        writes: Sequence[ResolvedRelationWrite],
+    ) -> ResolvedRelationWriteResult:
+        """Apply canonical targets and remove duplicate edges as one batch."""
 
 
 class RelationResolutionEntityRepository(Protocol):
@@ -85,6 +79,17 @@ class RelationResolutionEntityRepository(Protocol):
 
     async def find_by_id(self, session: AsyncSession, entity_id: EntityId) -> Entity | None:
         """Return one source entity by database id."""
+
+
+class BatchRelationResolutionEntityRepository(Protocol):
+    """Repository capability for loading an affected source-entity batch."""
+
+    async def find_by_ids(
+        self,
+        session: AsyncSession,
+        ids: list[EntityId],
+    ) -> Sequence[Entity]:
+        """Return source entities by database id."""
 
 
 class RelationResolutionLinkResolver(Protocol):
@@ -107,15 +112,22 @@ class RelationResolutionEntityIndexer(Protocol):
         """Refresh derived index rows for one entity."""
 
 
+class BatchRelationResolutionEntityIndexer(Protocol):
+    """Capability for refreshing a batch of derived entity search rows."""
+
+    async def index_entities(self, entities: Sequence[Entity]) -> None:
+        """Refresh derived index rows for a group of entities."""
+
+
 @dataclass(frozen=True, slots=True)
 class RepositoryRelationResolutionRuntime:
     """Resolve forward references with project-scoped repositories and services."""
 
     session_maker: async_sessionmaker[AsyncSession]
     relation_repository: RelationResolutionRelationRepository
-    entity_repository: RelationResolutionEntityRepository
+    entity_repository: BatchRelationResolutionEntityRepository
     link_resolver: RelationResolutionLinkResolver
-    entity_indexer: RelationResolutionEntityIndexer
+    entity_indexer: BatchRelationResolutionEntityIndexer
 
     async def count_unresolved_relations(self) -> int:
         """Return the current unresolved relation count for this project."""
@@ -127,6 +139,7 @@ class RepositoryRelationResolutionRuntime:
         entity_id: EntityId | None = None,
     ) -> AffectedEntityIds:
         """Resolve visible forward references and refresh affected entities."""
+        resolved_targets_by_link_text: dict[str, ResolvedRelationTarget | None] = {}
         async with db.scoped_session(self.session_maker) as session:
             if entity_id is None:
                 unresolved_relations = await self.relation_repository.find_unresolved_relations(
@@ -145,64 +158,66 @@ class RepositoryRelationResolutionRuntime:
                     count=len(unresolved_relations),
                 )
 
-        affected_entity_ids: AffectedEntityIds = set()
-
-        for relation in unresolved_relations:
-            logger.trace(
-                "Attempting to resolve relation "
-                f"relation_id={relation.id} "
-                f"from_id={relation.from_id} "
-                f"to_name={relation.to_name}"
-            )
-            async with db.scoped_session(self.session_maker) as session:
-                resolved_entity = await self.link_resolver.resolve_link(
-                    relation.to_name,
-                    strict=True,
-                    session=session,
+            writes: list[ResolvedRelationWrite] = []
+            for relation in unresolved_relations:
+                logger.trace(
+                    "Attempting to resolve relation "
+                    f"relation_id={relation.id} "
+                    f"from_id={relation.from_id} "
+                    f"to_name={relation.to_name}"
                 )
-
-            if resolved_entity is None or resolved_entity.id == relation.from_id:
-                continue
-
-            logger.debug(
-                "Resolved forward reference "
-                f"relation_id={relation.id} "
-                f"from_id={relation.from_id} "
-                f"to_name={relation.to_name} "
-                f"resolved_id={resolved_entity.id} "
-                f"resolved_title={resolved_entity.title}",
-            )
-            try:
-                async with db.scoped_session(self.session_maker) as session:
-                    await self.relation_repository.update(
-                        session,
-                        relation.id,
-                        {
-                            "to_id": resolved_entity.id,
-                            "to_name": resolved_entity.title,
-                        },
+                if relation.to_name not in resolved_targets_by_link_text:
+                    resolved_targets_by_link_text[
+                        relation.to_name
+                    ] = await self.link_resolver.resolve_link(
+                        relation.to_name,
+                        strict=True,
+                        session=session,
                     )
-            except IntegrityError:
-                with logfire.span(
-                    "indexing.relation.resolve_conflict",
-                    relation_id=relation.id,
-                    relation_type=relation.relation_type,
-                ):
-                    # Another resolved row already represents this edge. Remove
-                    # the redundant unresolved row so future passes do not keep
-                    # retrying the same conflict.
-                    async with db.scoped_session(self.session_maker) as session:
-                        await self.relation_repository.delete(session, relation.id)
-            affected_entity_ids.add(relation.from_id)
+                resolved_entity = resolved_targets_by_link_text[relation.to_name]
+                if resolved_entity is None or resolved_entity.id == relation.from_id:
+                    continue
 
-        for affected_entity_id in sorted(affected_entity_ids):
-            async with db.scoped_session(self.session_maker) as session:
-                source_entity = await self.entity_repository.find_by_id(
-                    session,
-                    affected_entity_id,
+                logger.debug(
+                    "Resolved forward reference "
+                    f"relation_id={relation.id} "
+                    f"from_id={relation.from_id} "
+                    f"to_name={relation.to_name} "
+                    f"resolved_id={resolved_entity.id} "
+                    f"resolved_title={resolved_entity.title}",
                 )
-            if source_entity is not None:
-                await self.entity_indexer.index_entity(source_entity)
+                writes.append(
+                    ResolvedRelationWrite(
+                        relation_id=relation.id,
+                        from_id=relation.from_id,
+                        target_id=resolved_entity.id,
+                        target_name=resolved_entity.title,
+                        relation_type=relation.relation_type,
+                    )
+                )
+            write_result = await self.relation_repository.apply_resolved_targets(session, writes)
+
+        affected_entity_ids: AffectedEntityIds = set(write_result.affected_entity_ids)
+        if write_result.duplicate_relation_ids:
+            with logfire.span(
+                "indexing.relation.resolve_conflicts",
+                relation_ids=write_result.duplicate_relation_ids,
+                conflict_count=len(write_result.duplicate_relation_ids),
+            ):
+                logger.debug(
+                    "Removed redundant unresolved relations",
+                    relation_ids=write_result.duplicate_relation_ids,
+                )
+
+        if affected_entity_ids:
+            async with db.scoped_session(self.session_maker) as session:
+                source_entities = await self.entity_repository.find_by_ids(
+                    session,
+                    sorted(affected_entity_ids),
+                )
+            await self.entity_indexer.index_entities(
+                sorted(source_entities, key=lambda entity: entity.id)
+            )
 
         return affected_entity_ids
 

--- a/src/basic_memory/repository/relation_repository.py
+++ b/src/basic_memory/repository/relation_repository.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import Sequence, List, Optional, Any, cast
 
-from sqlalchemy import and_, delete, select
+from sqlalchemy import and_, case, delete, select, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
@@ -29,6 +29,25 @@ class AcceptedRelationWrite:
     target_name: str
     context: str | None
     target_id: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedRelationWrite:
+    """One unresolved relation with its canonical resolved target."""
+
+    relation_id: int
+    from_id: int
+    target_id: int
+    target_name: str
+    relation_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedRelationWriteResult:
+    """Outcome of applying one set of resolved relation targets."""
+
+    affected_entity_ids: frozenset[int]
+    duplicate_relation_ids: tuple[int, ...]
 
 
 class RelationRepository(Repository[Relation]):
@@ -114,6 +133,120 @@ class RelationRepository(Repository[Relation]):
         query = self.select().filter(Relation.from_id == entity_id, Relation.to_id.is_(None))
         result = await self.execute_query(session, query)
         return result.scalars().all()
+
+    async def apply_resolved_targets(
+        self,
+        session: AsyncSession,
+        writes: Sequence[ResolvedRelationWrite],
+    ) -> ResolvedRelationWriteResult:
+        """Resolve relation targets in one transaction without duplicate edges.
+
+        Both relation uniqueness constraints can collide when aliases resolve to
+        the same canonical entity. The old row-at-a-time path handled that by
+        deleting the later unresolved row after an ``IntegrityError``. Planning
+        the accepted and redundant rows up front preserves that behavior while
+        allowing the mutations to run as set-based statements.
+        """
+        if not writes:
+            return ResolvedRelationWriteResult(frozenset(), ())
+
+        ordered_writes = sorted(writes, key=lambda write: write.relation_id)
+        relation_ids = {write.relation_id for write in ordered_writes}
+        source_entity_ids = {write.from_id for write in ordered_writes}
+        result = await session.execute(
+            select(
+                Relation.id,
+                Relation.from_id,
+                Relation.to_id,
+                Relation.to_name,
+                Relation.relation_type,
+            ).where(
+                Relation.project_id == self.project_id,
+                Relation.from_id.in_(source_entity_ids),
+            )
+        )
+        existing_relations = result.tuples().all()
+
+        occupied_target_keys: set[tuple[int, int, str]] = set()
+        occupied_name_keys: set[tuple[int, str, str]] = set()
+        all_name_keys: set[tuple[int, str, str]] = set()
+        for relation_id, from_id, to_id, to_name, relation_type in existing_relations:
+            name_key = (from_id, to_name, relation_type)
+            all_name_keys.add(name_key)
+            if relation_id in relation_ids:
+                continue
+            occupied_name_keys.add(name_key)
+            if to_id is not None:
+                occupied_target_keys.add((from_id, to_id, relation_type))
+
+        accepted_writes: list[ResolvedRelationWrite] = []
+        duplicate_relation_ids: list[int] = []
+        for write in ordered_writes:
+            target_key = (write.from_id, write.target_id, write.relation_type)
+            name_key = (write.from_id, write.target_name, write.relation_type)
+            if target_key in occupied_target_keys or name_key in occupied_name_keys:
+                duplicate_relation_ids.append(write.relation_id)
+                continue
+            accepted_writes.append(write)
+            occupied_target_keys.add(target_key)
+            occupied_name_keys.add(name_key)
+
+        if duplicate_relation_ids:
+            await session.execute(
+                delete(Relation).where(
+                    Relation.project_id == self.project_id,
+                    Relation.id.in_(duplicate_relation_ids),
+                )
+            )
+
+        if accepted_writes:
+            accepted_relation_ids = [write.relation_id for write in accepted_writes]
+            temporary_names_by_relation_id: dict[int, str] = {}
+            for write in accepted_writes:
+                temporary_name = f"__basic_memory_resolving_relation_{write.relation_id}__"
+                while (write.from_id, temporary_name, write.relation_type) in all_name_keys:
+                    temporary_name += "_"
+                temporary_names_by_relation_id[write.relation_id] = temporary_name
+                all_name_keys.add((write.from_id, temporary_name, write.relation_type))
+
+            # Clear both unique keys before assigning canonical targets. This
+            # makes alias swaps safe on databases that check uniqueness row by
+            # row inside a multi-row UPDATE.
+            await session.execute(
+                update(Relation)
+                .where(
+                    Relation.project_id == self.project_id,
+                    Relation.id.in_(accepted_relation_ids),
+                )
+                .values(
+                    to_id=None,
+                    to_name=case(temporary_names_by_relation_id, value=Relation.id),
+                )
+                .execution_options(synchronize_session=False)
+            )
+            await session.execute(
+                update(Relation)
+                .where(
+                    Relation.project_id == self.project_id,
+                    Relation.id.in_(accepted_relation_ids),
+                )
+                .values(
+                    to_id=case(
+                        {write.relation_id: write.target_id for write in accepted_writes},
+                        value=Relation.id,
+                    ),
+                    to_name=case(
+                        {write.relation_id: write.target_name for write in accepted_writes},
+                        value=Relation.id,
+                    ),
+                )
+                .execution_options(synchronize_session=False)
+            )
+
+        return ResolvedRelationWriteResult(
+            affected_entity_ids=frozenset(source_entity_ids),
+            duplicate_relation_ids=tuple(duplicate_relation_ids),
+        )
 
     async def add_all_ignore_duplicates(
         self, session: AsyncSession, relations: List[Relation]

--- a/src/basic_memory/services/search_service.py
+++ b/src/basic_memory/services/search_service.py
@@ -3,6 +3,7 @@
 import asyncio
 import ast
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, List, Optional, Set, Dict
@@ -406,6 +407,16 @@ class SearchService:
             background_tasks.add_task(self.index_entity_data, entity, content)
         else:
             await self.index_entity_data(entity, content)
+
+    async def index_entities(self, entities: Sequence[Entity]) -> None:
+        """Refresh a group of entity search rows through one batch entry point.
+
+        Index writes stay sequential because local SQLite connections cannot
+        safely run these mutations concurrently. Callers still avoid reopening
+        repository sessions and dispatching one indexing API call per entity.
+        """
+        for entity in entities:
+            await self.index_entity_data(entity)
 
     async def index_entity_data(
         self,

--- a/tests/index/test_local_project_index.py
+++ b/tests/index/test_local_project_index.py
@@ -61,6 +61,10 @@ from basic_memory.indexing.relation_resolution import (
 from basic_memory.models import Entity, Project, Relation
 from basic_memory.repository import EntityRepository
 from basic_memory.repository.note_content_repository import NoteContentRepository
+from basic_memory.repository.relation_repository import (
+    ResolvedRelationWrite,
+    ResolvedRelationWriteResult,
+)
 from basic_memory.runtime.jobs import (
     RuntimeIndexFileBatchJobRequest,
     RuntimeObservedIndexFile,
@@ -2445,6 +2449,9 @@ class RuntimeFactorySearchIndex:
     async def index_entity(self, entity: Entity) -> None:
         return None
 
+    async def index_entities(self, entities: Sequence[Entity]) -> None:
+        return None
+
     async def sync_entity_vectors_batch(
         self,
         entity_ids: list[int],
@@ -2485,6 +2492,16 @@ class RuntimeFactoryRelationRepository:
 
     async def delete(self, session: AsyncSession, relation_id: int, /) -> bool:
         return False
+
+    async def apply_resolved_targets(
+        self,
+        session: AsyncSession,
+        writes: Sequence[ResolvedRelationWrite],
+    ) -> ResolvedRelationWriteResult:
+        return ResolvedRelationWriteResult(
+            affected_entity_ids=frozenset(write.from_id for write in writes),
+            duplicate_relation_ids=(),
+        )
 
 
 class RuntimeFactoryLinkResolver:

--- a/tests/indexing/test_relation_resolution.py
+++ b/tests/indexing/test_relation_resolution.py
@@ -1,11 +1,11 @@
 """Tests for portable relation resolution orchestration."""
 
+from collections.abc import Sequence
 from dataclasses import FrozenInstanceError, dataclass
 from datetime import timedelta
 from typing import cast
 
 import pytest
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory.indexing.relation_resolution import (
@@ -21,7 +21,11 @@ from basic_memory.indexing.relation_resolution import (
     resolve_project_relations,
 )
 from basic_memory.indexing.models import IndexFileJobStatus
-from basic_memory.models import Entity, Relation
+from basic_memory.models import Entity
+from basic_memory.repository.relation_repository import (
+    ResolvedRelationWrite,
+    ResolvedRelationWriteResult,
+)
 
 
 class StubRelationResolutionRuntime:
@@ -45,6 +49,11 @@ class StubRelationResolutionRuntime:
 
 
 class FakeSession:
+    created_count = 0
+
+    def __init__(self) -> None:
+        type(self).created_count += 1
+
     def get_bind(self) -> object:
         return type("Bind", (), {"dialect": type("Dialect", (), {"name": "postgresql"})()})()
 
@@ -80,14 +89,10 @@ class StubRelationRepository:
     def __init__(
         self,
         unresolved_per_call: list[list[FakeRelation]],
-        *,
-        fail_update_ids: set[int] | None = None,
     ) -> None:
         self._unresolved_per_call = unresolved_per_call
-        self._fail_update_ids = fail_update_ids or set()
         self.calls = 0
-        self.updates: list[tuple[int, dict[str, int | str]]] = []
-        self.deletes: list[int] = []
+        self.write_batches: list[tuple[ResolvedRelationWrite, ...]] = []
 
     async def find_unresolved_relations(
         self,
@@ -110,23 +115,17 @@ class StubRelationRepository:
             if relation.from_id == entity_id
         ]
 
-    async def update(
+    async def apply_resolved_targets(
         self,
         session: AsyncSession,
-        relation_id: int,
-        resolved_target_fields: dict[str, int | str],
-        /,
-    ) -> Relation | None:
+        writes: Sequence[ResolvedRelationWrite],
+    ) -> ResolvedRelationWriteResult:
         assert isinstance(session, FakeSession)
-        if relation_id in self._fail_update_ids:
-            raise IntegrityError("update relation", {}, Exception("duplicate relation"))
-        self.updates.append((relation_id, resolved_target_fields))
-        return None
-
-    async def delete(self, session: AsyncSession, relation_id: int, /) -> bool:
-        assert isinstance(session, FakeSession)
-        self.deletes.append(relation_id)
-        return True
+        self.write_batches.append(tuple(writes))
+        return ResolvedRelationWriteResult(
+            affected_entity_ids=frozenset(write.from_id for write in writes),
+            duplicate_relation_ids=(),
+        )
 
 
 class StubEntityRepository:
@@ -143,6 +142,14 @@ class StubEntityRepository:
     ) -> Entity | None:
         assert isinstance(session, FakeSession)
         return self.entities.get(entity_id)
+
+    async def find_by_ids(
+        self,
+        session: AsyncSession,
+        ids: list[int],
+    ) -> list[Entity]:
+        assert isinstance(session, FakeSession)
+        return [self.entities[entity_id] for entity_id in ids if entity_id in self.entities]
 
 
 class StubLinkResolver:
@@ -165,9 +172,14 @@ class StubLinkResolver:
 class StubEntityIndexer:
     def __init__(self) -> None:
         self.indexed_entities: list[Entity] = []
+        self.indexed_batches: list[tuple[Entity, ...]] = []
 
     async def index_entity(self, entity: Entity) -> None:
         self.indexed_entities.append(entity)
+
+    async def index_entities(self, entities: Sequence[Entity]) -> None:
+        self.indexed_batches.append(tuple(entities))
+        self.indexed_entities.extend(entities)
 
 
 def build_repository_runtime(
@@ -364,7 +376,7 @@ async def test_project_relation_resolution_uses_repository_runtime_and_counts_re
                 "Target B": FakeResolvedEntity(id=21, title="Target B"),
             }
         ),
-        entity_indexer,
+        entity_indexer=entity_indexer,
     )
 
     result = await resolve_project_relations(runtime)
@@ -376,13 +388,30 @@ async def test_project_relation_resolution_uses_repository_runtime_and_counts_re
         affected_entities=2,
     )
     assert result.resolved == 2
-    assert repo.updates == [
-        (1, {"to_id": 20, "to_name": "Target A"}),
-        (2, {"to_id": 21, "to_name": "Target B"}),
+    assert repo.write_batches == [
+        (
+            ResolvedRelationWrite(
+                relation_id=1,
+                from_id=10,
+                target_id=20,
+                target_name="Target A",
+                relation_type="related_to",
+            ),
+            ResolvedRelationWrite(
+                relation_id=2,
+                from_id=11,
+                target_id=21,
+                target_name="Target B",
+                relation_type="related_to",
+            ),
+        ),
+        (),
     ]
-    assert entity_indexer.indexed_entities == [
-        FakeResolvedEntity(id=10, title="Source A"),
-        FakeResolvedEntity(id=11, title="Source B"),
+    assert entity_indexer.indexed_batches == [
+        (
+            FakeResolvedEntity(id=10, title="Source A"),
+            FakeResolvedEntity(id=11, title="Source B"),
+        ),
     ]
 
 
@@ -403,7 +432,7 @@ async def test_project_relation_resolution_stops_when_nothing_resolves() -> None
     assert result.passes == 1
     assert result.resolved == 0
     assert result.remaining == 1
-    assert repo.updates == []
+    assert repo.write_batches == [()]
     assert entity_indexer.indexed_entities == []
 
 
@@ -431,23 +460,38 @@ async def test_project_relation_resolution_respects_pass_limit() -> None:
     result = await resolve_project_relations(runtime, max_passes=3)
 
     assert result.passes == 3
-    assert len(repo.updates) == 3
+    assert len(repo.write_batches) == 3
     assert result.remaining == 0
 
 
 @pytest.mark.asyncio
-async def test_repository_runtime_deletes_duplicate_unresolved_relation() -> None:
-    relation = FakeRelation(id=1, from_id=10, to_name="Target A")
-    repo = StubRelationRepository([[relation]], fail_update_ids={1})
+async def test_repository_runtime_batches_resolution_and_entity_refresh_sessions() -> None:
+    FakeSession.created_count = 0
+    relations = [
+        FakeRelation(id=1, from_id=10, to_name="Target A"),
+        FakeRelation(id=2, from_id=11, to_name="Target B"),
+    ]
+    repo = StubRelationRepository([relations])
     entity_indexer = StubEntityIndexer()
     runtime = build_repository_runtime(
-        repo,
-        StubLinkResolver({"Target A": FakeResolvedEntity(id=20, title="Target A")}),
-        entity_indexer,
+        relation_repository=repo,
+        link_resolver=StubLinkResolver(
+            {
+                "Target A": FakeResolvedEntity(id=20, title="Target A"),
+                "Target B": FakeResolvedEntity(id=21, title="Target B"),
+            }
+        ),
+        entity_indexer=entity_indexer,
     )
 
     affected = await runtime.resolve_relations()
 
-    assert affected == {10}
-    assert repo.deletes == [1]
-    assert entity_indexer.indexed_entities == [FakeResolvedEntity(id=10, title="Source A")]
+    assert affected == {10, 11}
+    assert len(repo.write_batches) == 1
+    assert entity_indexer.indexed_batches == [
+        (
+            FakeResolvedEntity(id=10, title="Source A"),
+            FakeResolvedEntity(id=11, title="Source B"),
+        )
+    ]
+    assert FakeSession.created_count == 2

--- a/tests/repository/test_relation_repository.py
+++ b/tests/repository/test_relation_repository.py
@@ -11,6 +11,8 @@ from basic_memory.models import Entity, Project, Relation
 from basic_memory.repository.relation_repository import (
     AcceptedRelationWrite,
     RelationRepository,
+    ResolvedRelationWrite,
+    ResolvedRelationWriteResult,
 )
 
 
@@ -701,3 +703,99 @@ async def test_replace_accepted_outgoing_relations_clears_when_empty(
         )
 
     assert remaining == []
+
+
+@pytest.mark.asyncio
+async def test_apply_resolved_targets_batches_updates_and_duplicate_cleanup(
+    relation_repository: RelationRepository,
+    source_entity: Entity,
+    target_entity: Entity,
+    related_entity: Entity,
+    test_project: Project,
+    session_maker,
+):
+    """Canonical targets update together while redundant resolved edges are removed."""
+    accepted_target = Relation(
+        project_id=test_project.id,
+        from_id=source_entity.id,
+        to_id=None,
+        to_name="Target Alias",
+        relation_type="documents",
+    )
+    accepted_related = Relation(
+        project_id=test_project.id,
+        from_id=source_entity.id,
+        to_id=None,
+        to_name="Related Alias",
+        relation_type="references",
+    )
+    existing_edge = Relation(
+        project_id=test_project.id,
+        from_id=source_entity.id,
+        to_id=target_entity.id,
+        to_name=target_entity.title,
+        relation_type="links_to",
+    )
+    redundant_unresolved = Relation(
+        project_id=test_project.id,
+        from_id=source_entity.id,
+        to_id=None,
+        to_name="Duplicate Target Alias",
+        relation_type="links_to",
+    )
+    async with db.scoped_session(session_maker) as session:
+        session.add_all([accepted_target, accepted_related, existing_edge, redundant_unresolved])
+        await session.flush()
+        accepted_target_id = accepted_target.id
+        accepted_related_id = accepted_related.id
+        redundant_unresolved_id = redundant_unresolved.id
+
+    async with db.scoped_session(session_maker) as session:
+        result = await relation_repository.apply_resolved_targets(
+            session,
+            [
+                ResolvedRelationWrite(
+                    relation_id=accepted_related_id,
+                    from_id=source_entity.id,
+                    target_id=related_entity.id,
+                    target_name=related_entity.title,
+                    relation_type="references",
+                ),
+                ResolvedRelationWrite(
+                    relation_id=redundant_unresolved_id,
+                    from_id=source_entity.id,
+                    target_id=target_entity.id,
+                    target_name=target_entity.title,
+                    relation_type="links_to",
+                ),
+                ResolvedRelationWrite(
+                    relation_id=accepted_target_id,
+                    from_id=source_entity.id,
+                    target_id=target_entity.id,
+                    target_name=target_entity.title,
+                    relation_type="documents",
+                ),
+            ],
+        )
+
+    assert result == ResolvedRelationWriteResult(
+        affected_entity_ids=frozenset({source_entity.id}),
+        duplicate_relation_ids=(redundant_unresolved_id,),
+    )
+
+    async with db.scoped_session(session_maker) as session:
+        documents = await relation_repository.find_by_type(session, "documents")
+        references = await relation_repository.find_by_type(session, "references")
+        links = await relation_repository.find_by_type(session, "links_to")
+        redundant = await relation_repository.find_by_id(session, redundant_unresolved_id)
+
+    assert [(relation.to_id, relation.to_name) for relation in documents] == [
+        (target_entity.id, target_entity.title)
+    ]
+    assert [(relation.to_id, relation.to_name) for relation in references] == [
+        (related_entity.id, related_entity.title)
+    ]
+    assert [(relation.to_id, relation.to_name) for relation in links] == [
+        (target_entity.id, target_entity.title)
+    ]
+    assert redundant is None


### PR DESCRIPTION
## Summary

- resolve relation targets with one shared session and one set-based repository write
- load and refresh affected source entities as one deterministic batch
- preserve duplicate-edge cleanup across SQLite and PostgreSQL while avoiding per-relation transactions

## Testing

- `just fast-check`
- focused relation/local-index tests: 78 passed
- `just fast-test`: 163 passed, 1 skipped
- targeted PostgreSQL relation tests: 40 passed
- `just package-check`
- `git diff --check`

Part of #1110