### PR TITLE
feat(plugins): share Codex hook defaults

### DIFF
--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -71,8 +71,10 @@ installing so Codex can load the plugin skills, MCP configuration, and hooks.
 
 Configuration can live at user level in `~/.codex/basic-memory.json` or at
 project level in `.codex/basic-memory.json`. User-level settings are the base;
-the nearest project file overrides only the keys it declares. The setup skill
-asks which scope to use and recommends user-level configuration by default.
+the nearest project file overrides only the keys it declares. `redactKeys` and
+`redactPaths` are the privacy exception: their user and project lists accumulate.
+The setup skill asks which scope to use and recommends user-level configuration
+by default.
 
 To customize how Codex writes memory, edit `skills/bm-writing/SKILL.md` in the
 plugin source. `bm-checkpoint`, `bm-decide`, and `bm-remember` all apply that

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -91,7 +91,6 @@ Run the setup skill, or create `~/.codex/basic-memory.json` for shared defaults:
     "secondaryProjects": [],
     "teamProjects": {},
     "focus": "code/dev",
-    "sessionProfile": "coding",
     "rememberFolder": "codex-remember",
     "recallTimeframe": "7d",
     "captureEvents": true,
@@ -111,12 +110,13 @@ lifecycle-event envelopes land in a local inbox under your Basic Memory home
 When `captureFolder` is omitted, Codex resolves the Git top-level directory and
 writes to `codex/<repo-dir>`. An explicit folder still wins.
 
-For a coding profile, keep the checkout-specific repository identifier in the
-project file without duplicating the shared settings:
+For a coding profile, keep both the profile and checkout-specific repository
+identifier in the project file without duplicating the shared settings:
 
 ```json
 {
   "basicMemory": {
+    "sessionProfile": "coding",
     "repository": "owner/repo"
   }
 }

--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -38,7 +38,7 @@ verification, decision capture, and resumable checkpoints.
 | `skills/` | Codex-native Basic Memory workflows |
 | `schemas/` | Seed schemas for Codex sessions, decisions, and tasks |
 
-The hook scripts carry no logic: the brief, the checkpoint, and opt-in event
+The hook scripts carry no logic: the brief, the checkpoint, and lifecycle-event
 capture all live in the pinned Basic Memory revision behind `bm hook`. Each is
 a self-contained PEP 723 script pinned to a Basic Memory Git ref. Both refs
 are updated together with `just set-codex-hook-version <sha-or-tag>`.
@@ -69,9 +69,10 @@ Plugin installation is user-level in Codex, so one install makes the plugin
 available across projects on the same machine. Start a new Codex thread after
 installing so Codex can load the plugin skills, MCP configuration, and hooks.
 
-Each repository still needs its own `.codex/basic-memory.json` so the plugin
-knows which Basic Memory project and folders to use for that checkout. Run the
-setup skill in each repo, or create the config file shown below.
+Configuration can live at user level in `~/.codex/basic-memory.json` or at
+project level in `.codex/basic-memory.json`. User-level settings are the base;
+the nearest project file overrides only the keys it declares. The setup skill
+asks which scope to use and recommends user-level configuration by default.
 
 To customize how Codex writes memory, edit `skills/bm-writing/SKILL.md` in the
 plugin source. `bm-checkpoint`, `bm-decide`, and `bm-remember` all apply that
@@ -79,7 +80,7 @@ shared skill while retaining their own schemas and evidence requirements.
 
 ## Configuration
 
-Run the setup skill, or create `.codex/basic-memory.json` in a repo:
+Run the setup skill, or create `~/.codex/basic-memory.json` for shared defaults:
 
 ```json
 {
@@ -89,23 +90,35 @@ Run the setup skill, or create `.codex/basic-memory.json` in a repo:
     "teamProjects": {},
     "focus": "code/dev",
     "sessionProfile": "coding",
-    "repository": "owner/repo",
-    "captureFolder": "codex",
     "rememberFolder": "codex-remember",
     "recallTimeframe": "7d",
-    "captureEvents": false,
+    "captureEvents": true,
     "redactKeys": [],
     "redactPaths": [],
-    "placementConventions": "Put decisions in decisions/ and work checkpoints in codex/."
+    "placementConventions": "Put decisions in decisions/ and work checkpoints in codex/<repo-dir>/."
   }
 }
 ```
 
-`captureEvents` is opt-in and off by default: only the JSON boolean `true`
-enables recording of redacted lifecycle-event envelopes to a local inbox under
-your Basic Memory home (`basic-memory hook status` / `basic-memory hook flush`).
-Add `redactKeys` and `redactPaths` arrays to extend the built-in redaction floor
-for repository-specific payload fields and paths.
+Codex event capture is on by default. Set the JSON boolean `false` at user or
+project level to opt out; malformed values fail closed. Captured, redacted
+lifecycle-event envelopes land in a local inbox under your Basic Memory home
+(`basic-memory hook status` / `basic-memory hook flush`). Add `redactKeys` and
+`redactPaths` arrays to extend the built-in redaction floor.
+
+When `captureFolder` is omitted, Codex resolves the Git top-level directory and
+writes to `codex/<repo-dir>`. An explicit folder still wins.
+
+For a coding profile, keep the checkout-specific repository identifier in the
+project file without duplicating the shared settings:
+
+```json
+{
+  "basicMemory": {
+    "repository": "owner/repo"
+  }
+}
+```
 
 The plugin's seed schemas cover notes Codex writes directly: `codex_session`,
 `coding_session`, `decision`, and `task`. Coding sessions require structured

--- a/plugins/codex/hooks/pre_compact.py
+++ b/plugins/codex/hooks/pre_compact.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@8f3b8800dadef94ee78115b1c3cb9d826e84a53a",
+#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@bd5d145d5be3bab3c73291ae2a698f8e5a1e54cb",
 # ]
 # ///
 """PreCompact hook launcher backed by a pinned Basic Memory revision.

--- a/plugins/codex/hooks/pre_compact.py
+++ b/plugins/codex/hooks/pre_compact.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@4fa5934d5339f55d69f26e2bb0d2dfb8e15cfa80",
+#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@8f3b8800dadef94ee78115b1c3cb9d826e84a53a",
 # ]
 # ///
 """PreCompact hook launcher backed by a pinned Basic Memory revision.

--- a/plugins/codex/hooks/pre_compact.py
+++ b/plugins/codex/hooks/pre_compact.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@9a7c14075fd2005ba97f10948ead32a8571aeb36",
+#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@4fa5934d5339f55d69f26e2bb0d2dfb8e15cfa80",
 # ]
 # ///
 """PreCompact hook launcher backed by a pinned Basic Memory revision.

--- a/plugins/codex/hooks/pre_compact.py
+++ b/plugins/codex/hooks/pre_compact.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@6e9f2fcf5f00f3577d38a3d8b6e2f2baca3079f7",
+#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@9a7c14075fd2005ba97f10948ead32a8571aeb36",
 # ]
 # ///
 """PreCompact hook launcher backed by a pinned Basic Memory revision.

--- a/plugins/codex/hooks/session_start.py
+++ b/plugins/codex/hooks/session_start.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@4fa5934d5339f55d69f26e2bb0d2dfb8e15cfa80",
+#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@8f3b8800dadef94ee78115b1c3cb9d826e84a53a",
 # ]
 # ///
 """SessionStart hook launcher backed by a pinned Basic Memory revision.

--- a/plugins/codex/hooks/session_start.py
+++ b/plugins/codex/hooks/session_start.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@8f3b8800dadef94ee78115b1c3cb9d826e84a53a",
+#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@bd5d145d5be3bab3c73291ae2a698f8e5a1e54cb",
 # ]
 # ///
 """SessionStart hook launcher backed by a pinned Basic Memory revision.

--- a/plugins/codex/hooks/session_start.py
+++ b/plugins/codex/hooks/session_start.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@6e9f2fcf5f00f3577d38a3d8b6e2f2baca3079f7",
+#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@9a7c14075fd2005ba97f10948ead32a8571aeb36",
 # ]
 # ///
 """SessionStart hook launcher backed by a pinned Basic Memory revision.

--- a/plugins/codex/hooks/session_start.py
+++ b/plugins/codex/hooks/session_start.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@9a7c14075fd2005ba97f10948ead32a8571aeb36",
+#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@4fa5934d5339f55d69f26e2bb0d2dfb8e15cfa80",
 # ]
 # ///
 """SessionStart hook launcher backed by a pinned Basic Memory revision.

--- a/plugins/codex/skills/bm-checkpoint/SKILL.md
+++ b/plugins/codex/skills/bm-checkpoint/SKILL.md
@@ -11,10 +11,11 @@ context transition.
 
 ## Gather
 
-Read `.codex/basic-memory.json` if present:
+Read `~/.codex/basic-memory.json`, then the nearest project
+`.codex/basic-memory.json`; project keys override user keys:
 
 - `primaryProject`, default omitted
-- `captureFolder`, default `codex`
+- `captureFolder`, default `codex/<git top-level directory name>`
 - `placementConventions`, optional
 - `sessionProfile`, default `general`
 - `repository`, required when `sessionProfile` is `coding`

--- a/plugins/codex/skills/bm-decide/SKILL.md
+++ b/plugins/codex/skills/bm-decide/SKILL.md
@@ -10,7 +10,8 @@ choice with rationale and consequences, not a casual preference.
 
 ## Steps
 
-1. Resolve `.codex/basic-memory.json`:
+1. Resolve `~/.codex/basic-memory.json`, then the nearest project
+   `.codex/basic-memory.json`; project keys override user keys:
    - write to `primaryProject` when set
    - follow `placementConventions` for the directory when they are specific
    - otherwise use `decisions`

--- a/plugins/codex/skills/bm-orient/SKILL.md
+++ b/plugins/codex/skills/bm-orient/SKILL.md
@@ -10,7 +10,8 @@ the user asks where things stand.
 
 ## Steps
 
-1. Read `.codex/basic-memory.json` if present. Use `primaryProject`, `secondaryProjects`,
+1. Read `~/.codex/basic-memory.json`, then the nearest project
+   `.codex/basic-memory.json`; project keys override user keys. Use `primaryProject`, `secondaryProjects`,
    `recallTimeframe`, `sessionProfile`, `repository`, and `placementConventions`.
    If the file is missing, continue
    against the default Basic Memory project and mention that setup has not been run.

--- a/plugins/codex/skills/bm-remember/SKILL.md
+++ b/plugins/codex/skills/bm-remember/SKILL.md
@@ -10,7 +10,8 @@ a small fact that should survive the current thread.
 
 ## Steps
 
-1. Read `.codex/basic-memory.json` if present:
+1. Read `~/.codex/basic-memory.json`, then the nearest project
+   `.codex/basic-memory.json`; project keys override user keys:
    - `primaryProject`, default omitted
    - `rememberFolder`, default `codex-remember`
 

--- a/plugins/codex/skills/bm-setup/SKILL.md
+++ b/plugins/codex/skills/bm-setup/SKILL.md
@@ -27,7 +27,8 @@ repo, default project, current directory, or previous local state.
 
 - config level: user-level `~/.codex/basic-memory.json` or project-level
   `.codex/basic-memory.json`. Ask explicitly and recommend user level by default.
-  Project settings override user settings key by key.
+  Project settings override user settings key by key, except `redactKeys` and
+  `redactPaths`, which accumulate so project config cannot weaken user privacy.
 - storage mode: cloud, local, or mixed. Prefer the user's stated mode over any
   CLI default.
 - `focus`: code/dev, research, writing, planning, or mixed.
@@ -99,8 +100,9 @@ override. Preserve unrelated keys if the chosen file already exists. Include
 `captureEvents` as a JSON boolean. Empty `redactKeys` and `redactPaths` lists may
 be omitted; when present, they must be JSON arrays of strings. `redactKeys`
 extends payload-key redaction, while `redactPaths` also protects
-working-directory and path-bearing checkpoint content. These files are
-intentionally Codex-specific; do not write `.claude/settings.json`.
+working-directory and path-bearing checkpoint content. User and project
+redaction lists accumulate. These files are intentionally Codex-specific; do
+not write `.claude/settings.json`.
 
 When common settings live at user level but a coding repository identifier is
 checkout-specific, keep only `repository` in the project file. The project key

--- a/plugins/codex/skills/bm-setup/SKILL.md
+++ b/plugins/codex/skills/bm-setup/SKILL.md
@@ -72,7 +72,8 @@ summarizing the real convention.
 
 ## Apply
 
-After confirming the plan, write the chosen user-level or project-level file:
+After confirming the plan, write the shared settings to the chosen user-level or
+project-level file:
 
 ```json
 {
@@ -83,7 +84,6 @@ After confirming the plan, write the chosen user-level or project-level file:
     "teamProjects": {},
     "focus": "<focus>",
     "sessionProfile": "coding",
-    "repository": "owner/name",
     "rememberFolder": "codex-remember",
     "recallTimeframe": "7d",
     "captureEvents": true,
@@ -104,10 +104,19 @@ working-directory and path-bearing checkpoint content. User and project
 redaction lists accumulate. These files are intentionally Codex-specific; do
 not write `.claude/settings.json`.
 
-When common settings live at user level but a coding repository identifier is
-checkout-specific, keep only `repository` in the project file. The project key
-overrides the shared user-level value without duplicating the rest of the
-configuration.
+For a user-level coding setup, always keep the confirmed repository identifier in
+the project file so it cannot affect other repositories:
+
+```json
+{
+  "basicMemory": {
+    "repository": "owner/name"
+  }
+}
+```
+
+For a project-level setup, add `repository` to the shared settings in that same
+project file.
 
 Persist `sessionProfile` explicitly. Persist `repository` only for the `coding`
 profile, after the user confirms it. A coding setup is incomplete without a

--- a/plugins/codex/skills/bm-setup/SKILL.md
+++ b/plugins/codex/skills/bm-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bm-setup
-description: Set up Basic Memory for Codex in the current repo by mapping a Basic Memory project, seeding schemas, and writing .codex/basic-memory.json.
+description: Set up Basic Memory for Codex at user or project level by mapping a Basic Memory project and seeding schemas.
 ---
 
 # Basic Memory for Codex Setup
@@ -25,6 +25,9 @@ Confirm Basic Memory is reachable before changing files:
 Ask the user to choose the project mapping. Do not infer write targets from the
 repo, default project, current directory, or previous local state.
 
+- config level: user-level `~/.codex/basic-memory.json` or project-level
+  `.codex/basic-memory.json`. Ask explicitly and recommend user level by default.
+  Project settings override user settings key by key.
 - storage mode: cloud, local, or mixed. Prefer the user's stated mode over any
   CLI default.
 - `focus`: code/dev, research, writing, planning, or mixed.
@@ -35,13 +38,13 @@ repo, default project, current directory, or previous local state.
 - `primaryProject`: an existing Basic Memory project or a new one to create.
 - `secondaryProjects`: optional read-only projects for session-start context.
 - `teamProjects`: optional share targets for `bm-share`.
-- `captureFolder`: default `codex`.
+- `captureFolder`: default `codex/<repo-dir>`, derived from the Git top-level
+  directory. Ask only when the user wants an explicit override.
 - `rememberFolder`: default `codex-remember`.
 - `placementConventions`: a short note about where decisions, tasks, and research
   notes should land.
 - `captureEvents`: whether to record redacted lifecycle-event envelopes in the
-  local hook inbox. Default to `false`; SessionStart briefs and PreCompact
-  checkpoints work without it.
+  local hook inbox. Default to `true`; an explicit JSON boolean `false` opts out.
 - `redactKeys` and `redactPaths`: optional additions to the built-in redaction
   floor. Ask for these only when event capture is enabled or the user has
   repo-specific privacy requirements.
@@ -55,7 +58,8 @@ and optional pull-request metadata in Basic Memory.
 
 Explain the capture tradeoff before asking: enabled capture adds a local,
 redacted event trail that stays queued until `bm hook flush` projects it. It does
-not write to team projects, and only the JSON boolean `true` enables it.
+not write to team projects. The default is enabled; an explicit JSON boolean
+`false` disables it, and malformed values fail closed.
 
 If there are duplicate names, show qualified names and ask the user which one to
 use. Prefer qualified project names or project ids for cloud projects. Never pick
@@ -67,7 +71,7 @@ summarizing the real convention.
 
 ## Apply
 
-After confirming the plan, write `.codex/basic-memory.json` in the repo:
+After confirming the plan, write the chosen user-level or project-level file:
 
 ```json
 {
@@ -79,10 +83,9 @@ After confirming the plan, write `.codex/basic-memory.json` in the repo:
     "focus": "<focus>",
     "sessionProfile": "coding",
     "repository": "owner/name",
-    "captureFolder": "codex",
     "rememberFolder": "codex-remember",
     "recallTimeframe": "7d",
-    "captureEvents": false,
+    "captureEvents": true,
     "redactKeys": [],
     "redactPaths": [],
     "placementConventions": "<short convention>"
@@ -90,13 +93,19 @@ After confirming the plan, write `.codex/basic-memory.json` in the repo:
 }
 ```
 
-Preserve unrelated keys if the file already exists. Include `projectMode` when
-the user chose cloud, local, or mixed routing. Always persist `captureEvents` as
-a JSON boolean. Empty `redactKeys` and `redactPaths` lists may be omitted; when
-present, they must be JSON arrays of strings. `redactKeys` extends payload-key
-redaction, while `redactPaths` also protects working-directory and path-bearing
-checkpoint content. This file is intentionally Codex-specific; do not write
-`.claude/settings.json`.
+Omit `captureFolder` to use `codex/<repo-dir>`; persist it only for an explicit
+override. Preserve unrelated keys if the chosen file already exists. Include
+`projectMode` when the user chose cloud, local, or mixed routing. Always persist
+`captureEvents` as a JSON boolean. Empty `redactKeys` and `redactPaths` lists may
+be omitted; when present, they must be JSON arrays of strings. `redactKeys`
+extends payload-key redaction, while `redactPaths` also protects
+working-directory and path-bearing checkpoint content. These files are
+intentionally Codex-specific; do not write `.claude/settings.json`.
+
+When common settings live at user level but a coding repository identifier is
+checkout-specific, keep only `repository` in the project file. The project key
+overrides the shared user-level value without duplicating the rest of the
+configuration.
 
 Persist `sessionProfile` explicitly. Persist `repository` only for the `coding`
 profile, after the user confirms it. A coding setup is incomplete without a

--- a/plugins/codex/skills/bm-setup/SKILL.md
+++ b/plugins/codex/skills/bm-setup/SKILL.md
@@ -83,7 +83,7 @@ project-level file:
     "projectMode": "cloud",
     "teamProjects": {},
     "focus": "<focus>",
-    "sessionProfile": "coding",
+    "sessionProfile": "<general-or-coding>",
     "rememberFolder": "codex-remember",
     "recallTimeframe": "7d",
     "captureEvents": true,
@@ -104,12 +104,14 @@ working-directory and path-bearing checkpoint content. User and project
 redaction lists accumulate. These files are intentionally Codex-specific; do
 not write `.claude/settings.json`.
 
-For a user-level coding setup, always keep the confirmed repository identifier in
-the project file so it cannot affect other repositories:
+For a user-level coding setup, omit `sessionProfile` from the shared user file and
+keep both the coding profile and confirmed repository identifier in the project
+file so neither can affect other repositories:
 
 ```json
 {
   "basicMemory": {
+    "sessionProfile": "coding",
     "repository": "owner/name"
   }
 }
@@ -118,10 +120,11 @@ the project file so it cannot affect other repositories:
 For a project-level setup, add `repository` to the shared settings in that same
 project file.
 
-Persist `sessionProfile` explicitly. Persist `repository` only for the `coding`
-profile, after the user confirms it. A coding setup is incomplete without a
-repository identifier because the `coding_session` schema requires queryable Git
-identity fields.
+Persist `sessionProfile` explicitly in the chosen file, except for a user-level
+coding setup where it belongs in the project file alongside `repository`. Persist
+`repository` only for the `coding` profile, after the user confirms it. A coding
+setup is incomplete without a repository identifier because the `coding_session`
+schema requires queryable Git identity fields.
 
 ## Seed Schemas
 

--- a/plugins/codex/skills/bm-share/SKILL.md
+++ b/plugins/codex/skills/bm-share/SKILL.md
@@ -11,7 +11,8 @@ stay personal.
 
 ## Steps
 
-1. Read `.codex/basic-memory.json` and resolve:
+1. Read `~/.codex/basic-memory.json`, then the nearest project
+   `.codex/basic-memory.json`; project keys override user keys. Resolve:
    - `primaryProject`
    - `teamProjects`, a map of project ref to settings
 

--- a/plugins/codex/skills/bm-status/SKILL.md
+++ b/plugins/codex/skills/bm-status/SKILL.md
@@ -19,8 +19,9 @@ Gather a concise diagnostic. Do not over-investigate.
    claiming the hooks cannot work.
 
 2. Plugin config:
-   - read `.codex/basic-memory.json`
-   - report `primaryProject`, `secondaryProjects`, `teamProjects`,
+   - read `~/.codex/basic-memory.json`, then the nearest project
+     `.codex/basic-memory.json`; project keys override user keys
+   - report the resolved `primaryProject`, `secondaryProjects`, `teamProjects`,
      `captureFolder`, `rememberFolder`, `recallTimeframe`, `focus`,
      `sessionProfile`, `repository`, `captureEvents`, `redactKeys`, and
      `redactPaths`

--- a/plugins/codex/skills/bm-status/SKILL.md
+++ b/plugins/codex/skills/bm-status/SKILL.md
@@ -20,7 +20,8 @@ Gather a concise diagnostic. Do not over-investigate.
 
 2. Plugin config:
    - read `~/.codex/basic-memory.json`, then the nearest project
-     `.codex/basic-memory.json`; project keys override user keys
+     `.codex/basic-memory.json`; project keys override user keys, while
+     `redactKeys` and `redactPaths` accumulate
    - report the resolved `primaryProject`, `secondaryProjects`, `teamProjects`,
      `captureFolder`, `rememberFolder`, `recallTimeframe`, `focus`,
      `sessionProfile`, `repository`, `captureEvents`, `redactKeys`, and

--- a/scripts/validate_codex_plugin.py
+++ b/scripts/validate_codex_plugin.py
@@ -26,6 +26,9 @@ REQUIRED_SKILLS = (
 REQUIRED_SKILL_TEXT: dict[str, tuple[str, ...]] = {
     "bm-setup": (
         "captureEvents",
+        "user-level",
+        "project-level",
+        "codex/<repo-dir>",
         "redactKeys",
         "redactPaths",
         "sessionProfile",
@@ -33,6 +36,7 @@ REQUIRED_SKILL_TEXT: dict[str, tuple[str, ...]] = {
         "hook status --harness codex",
     ),
     "bm-status": (
+        "~/.codex/basic-memory.json",
         "hook status --harness codex",
         "pending envelopes",
         "processed envelopes",

--- a/src/basic_memory/cli/commands/hook.py
+++ b/src/basic_memory/cli/commands/hook.py
@@ -3,14 +3,14 @@
 Harness plugins reduce to manifests plus one-line shims that exec
 ``bm hook <event> --harness claude|codex`` with the hook JSON on stdin. All
 logic lives here: per-harness stdin adapters, the session-start context brief,
-the pre-compact checkpoint note, opt-in envelope capture into the inbox WAL,
+the pre-compact checkpoint note, lifecycle-event capture into the inbox WAL,
 and the flush/status operator surface.
 
 Contracts:
   - Harness verbs (session-start, pre-compact) are fail-open: any error logs
     to stderr and exits 0 — a hook must never disrupt an agent session.
-  - The capture gate is fail-closed: ``captureEvents`` must be the JSON
-    boolean ``true``; strings never enable recording.
+  - Codex event capture defaults on. An explicit JSON boolean ``false`` turns
+    it off, while malformed values and malformed config fail closed.
   - Graph-derived brief content is fenced and labeled as reference data, not
     instructions — the prompt-injection boundary.
 
@@ -18,8 +18,9 @@ Settings sources are the same files the original plugin hook scripts read
 (ported here; the plugin hooks are now zero-logic shims that exec these
 verbs): the ``basicMemory`` block of ``.claude/settings.json`` /
 ``.claude/settings.local.json`` (nearest ancestor, over the user-level
-``~/.claude/settings.json``) for Claude, and ``.codex/basic-memory.json`` for
-Codex. ``install`` / ``remove`` wire the same verbs into the user-level
+``~/.claude/settings.json``) for Claude, and the nearest project
+``.codex/basic-memory.json`` over ``~/.codex/basic-memory.json`` for Codex.
+``install`` / ``remove`` wire the same verbs into the user-level
 harness config for standalone (non-marketplace) users, ownership-tagged so
 removal is surgical.
 """
@@ -71,6 +72,7 @@ QUERY_TIMEOUT_SECONDS = 10.0
 # Cap how many shared projects we read per session — bounds latency and output.
 MAX_SHARED = 6
 CODING_SESSION_PROFILE = "coding"
+CODEX_DEFAULT_CAPTURE_EVENTS = True
 
 
 @dataclass(frozen=True)
@@ -227,23 +229,91 @@ def load_claude_settings(directory: Path) -> tuple[dict, bool]:
     return merged, found
 
 
-def load_codex_settings(directory: Path) -> tuple[dict, bool]:
-    """Read the Codex config file, mirroring the codex hook scripts.
-
-    A present-but-broken file still counts as configured (found=True) so the
-    user sees the status hint instead of the first-run nudge.
-    """
-    path = directory / ".codex" / "basic-memory.json"
+def _read_codex_block(path: Path) -> tuple[dict | None, bool]:
+    """Read one Codex settings block and preserve malformed-file presence."""
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
-        return {}, False
+        return None, False
     except (OSError, json.JSONDecodeError):
-        return {}, True
+        return None, True
     if not isinstance(data, dict):
-        return {}, True
+        return None, True
     block = data.get("basicMemory", data)
-    return (block if isinstance(block, dict) else {}), True
+    return (block if isinstance(block, dict) else None), True
+
+
+def _codex_project_dir(directory: Path) -> Path:
+    """Nearest ancestor with a project Codex config, excluding user fallback."""
+    current = directory.resolve()
+    while True:
+        if (current / ".codex" / "basic-memory.json").is_file():
+            return current
+        if current.parent == current:
+            return directory.resolve()
+        current = current.parent
+
+
+def _git_value(directory: Path, *args: str) -> str | None:
+    """Read one optional Git value without turning config defaults into failures."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=directory,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    value = result.stdout.strip()
+    return value if result.returncode == 0 and value else None
+
+
+def _codex_default_capture_folder(directory: Path) -> str:
+    """Namespace the default checkpoint folder by the current repository directory."""
+    repo_root = _git_value(directory, "rev-parse", "--show-toplevel")
+    if repo_root is None:
+        return PROFILES[Harness.codex].default_capture_folder
+    repo_dir = Path(repo_root).name.strip()
+    if not repo_dir:
+        return PROFILES[Harness.codex].default_capture_folder
+    return f"codex/{repo_dir}"
+
+
+def load_codex_settings(directory: Path) -> tuple[dict, bool]:
+    """Merge user and project Codex settings, then resolve checkout defaults.
+
+    Precedence (lowest to highest): ``~/.codex/basic-memory.json``, then the
+    nearest project ``.codex/basic-memory.json``. Codex capture is enabled when
+    omitted, and its default folder is namespaced by the Git repository
+    directory. A malformed source counts as configured but disables capture;
+    a later valid source can explicitly re-enable it.
+    """
+    merged: dict = {
+        "captureEvents": CODEX_DEFAULT_CAPTURE_EVENTS,
+        "captureFolder": _codex_default_capture_folder(directory),
+    }
+    found = False
+    home = Path.home()
+    sources = [home / ".codex" / "basic-memory.json"]
+    project = _codex_project_dir(directory)
+    project_path = project / ".codex" / "basic-memory.json"
+    if project_path != sources[0]:
+        sources.append(project_path)
+
+    for path in sources:
+        block, present = _read_codex_block(path)
+        if not present:
+            continue
+        found = True
+        if block is None:
+            # An unreadable privacy setting must never silently enable capture.
+            merged["captureEvents"] = False
+            continue
+        merged.update(block)
+
+    return merged, found
 
 
 def load_harness_settings(harness: Harness, directory: Path) -> tuple[dict, bool]:

--- a/src/basic_memory/cli/commands/hook.py
+++ b/src/basic_memory/cli/commands/hook.py
@@ -288,9 +288,9 @@ def load_codex_settings(directory: Path) -> tuple[dict, bool]:
     nearest project ``.codex/basic-memory.json``. Redaction lists accumulate so
     a project cannot weaken user-level privacy rules. Codex capture is enabled
     when omitted, and its default folder is namespaced by the Git repository
-    directory. A malformed source counts as configured, invalidates all
-    lower-precedence settings, and disables capture; a later valid source can
-    explicitly rebuild the settings and re-enable it.
+    directory. Any malformed source counts as configured and fails closed for
+    the whole evaluation so a later source cannot rebuild routing without the
+    missing redaction policy.
     """
     defaults: dict = {
         "captureEvents": CODEX_DEFAULT_CAPTURE_EVENTS,
@@ -311,13 +311,11 @@ def load_codex_settings(directory: Path) -> tuple[dict, bool]:
             continue
         found = True
         if block is None:
-            # Trigger: a higher-precedence config exists but cannot be trusted.
-            # Why: falling back to earlier routing or redaction settings could
-            # persist repository data while silently skipping intended overrides.
-            # Outcome: discard the fallback route and disable event capture; a
-            # later valid source may explicitly rebuild the effective settings.
-            merged = {**defaults, "captureEvents": False}
-            continue
+            # Trigger: any configured source exists but cannot be trusted.
+            # Why: continuing could combine a later checkpoint route with a
+            # missing earlier redaction policy and persist unredacted data.
+            # Outcome: discard every route and disable capture for this event.
+            return {**defaults, "captureEvents": False}, True
         cumulative_redactions: dict[str, list[str]] = {}
         for key in ("redactKeys", "redactPaths"):
             values = [*_string_list(merged.get(key)), *_string_list(block.get(key))]

--- a/src/basic_memory/cli/commands/hook.py
+++ b/src/basic_memory/cli/commands/hook.py
@@ -285,10 +285,11 @@ def load_codex_settings(directory: Path) -> tuple[dict, bool]:
     """Merge user and project Codex settings, then resolve checkout defaults.
 
     Precedence (lowest to highest): ``~/.codex/basic-memory.json``, then the
-    nearest project ``.codex/basic-memory.json``. Codex capture is enabled when
-    omitted, and its default folder is namespaced by the Git repository
-    directory. A malformed source counts as configured but disables capture;
-    a later valid source can explicitly re-enable it.
+    nearest project ``.codex/basic-memory.json``. Redaction lists accumulate so
+    a project cannot weaken user-level privacy rules. Codex capture is enabled
+    when omitted, and its default folder is namespaced by the Git repository
+    directory. A malformed source counts as configured but disables capture; a
+    later valid source can explicitly re-enable it.
     """
     merged: dict = {
         "captureEvents": CODEX_DEFAULT_CAPTURE_EVENTS,
@@ -311,7 +312,13 @@ def load_codex_settings(directory: Path) -> tuple[dict, bool]:
             # An unreadable privacy setting must never silently enable capture.
             merged["captureEvents"] = False
             continue
+        cumulative_redactions: dict[str, list[str]] = {}
+        for key in ("redactKeys", "redactPaths"):
+            values = [*_string_list(merged.get(key)), *_string_list(block.get(key))]
+            if values:
+                cumulative_redactions[key] = list(dict.fromkeys(values))
         merged.update(block)
+        merged.update(cumulative_redactions)
 
     return merged, found
 

--- a/src/basic_memory/cli/commands/hook.py
+++ b/src/basic_memory/cli/commands/hook.py
@@ -288,13 +288,15 @@ def load_codex_settings(directory: Path) -> tuple[dict, bool]:
     nearest project ``.codex/basic-memory.json``. Redaction lists accumulate so
     a project cannot weaken user-level privacy rules. Codex capture is enabled
     when omitted, and its default folder is namespaced by the Git repository
-    directory. A malformed source counts as configured but disables capture; a
-    later valid source can explicitly re-enable it.
+    directory. A malformed source counts as configured, invalidates all
+    lower-precedence settings, and disables capture; a later valid source can
+    explicitly rebuild the settings and re-enable it.
     """
-    merged: dict = {
+    defaults: dict = {
         "captureEvents": CODEX_DEFAULT_CAPTURE_EVENTS,
         "captureFolder": _codex_default_capture_folder(directory),
     }
+    merged = dict(defaults)
     found = False
     home = Path.home()
     sources = [home / ".codex" / "basic-memory.json"]
@@ -309,8 +311,12 @@ def load_codex_settings(directory: Path) -> tuple[dict, bool]:
             continue
         found = True
         if block is None:
-            # An unreadable privacy setting must never silently enable capture.
-            merged["captureEvents"] = False
+            # Trigger: a higher-precedence config exists but cannot be trusted.
+            # Why: falling back to earlier routing or redaction settings could
+            # persist repository data while silently skipping intended overrides.
+            # Outcome: discard the fallback route and disable event capture; a
+            # later valid source may explicitly rebuild the effective settings.
+            merged = {**defaults, "captureEvents": False}
             continue
         cumulative_redactions: dict[str, list[str]] = {}
         for key in ("redactKeys", "redactPaths"):

--- a/tests/cli/test_hook_command.py
+++ b/tests/cli/test_hook_command.py
@@ -1706,6 +1706,8 @@ def test_codex_settings_merge_user_then_project_with_checkout_folder(tmp_path: P
                     "primaryProject": "user-wide",
                     "recallTimeframe": "9d",
                     "captureEvents": True,
+                    "redactKeys": ["token", "shared-secret"],
+                    "redactPaths": ["/shared/private"],
                 }
             }
         ),
@@ -1715,7 +1717,16 @@ def test_codex_settings_merge_user_then_project_with_checkout_folder(tmp_path: P
     (project / ".codex").mkdir(parents=True)
     _init_git_repo(project)
     (project / ".codex" / "basic-memory.json").write_text(
-        json.dumps({"basicMemory": {"primaryProject": "project-level"}}), encoding="utf-8"
+        json.dumps(
+            {
+                "basicMemory": {
+                    "primaryProject": "project-level",
+                    "redactKeys": ["token", "repo-secret"],
+                    "redactPaths": [],
+                }
+            }
+        ),
+        encoding="utf-8",
     )
 
     merged, found = hook_module.load_codex_settings(project)
@@ -1725,6 +1736,8 @@ def test_codex_settings_merge_user_then_project_with_checkout_folder(tmp_path: P
     assert merged["recallTimeframe"] == "9d"
     assert merged["captureEvents"] is True
     assert merged["captureFolder"] == "codex/widgets"
+    assert merged["redactKeys"] == ["token", "shared-secret", "repo-secret"]
+    assert merged["redactPaths"] == ["/shared/private"]
 
 
 def test_codex_project_settings_override_user_capture_defaults(tmp_path: Path) -> None:

--- a/tests/cli/test_hook_command.py
+++ b/tests/cli/test_hook_command.py
@@ -882,6 +882,41 @@ def test_pre_compact_codex_malformed_project_does_not_use_user_checkpoint_route(
     mock_write.assert_not_awaited()
 
 
+def test_pre_compact_codex_malformed_user_blocks_project_checkpoint_route(
+    bm_home: Path, tmp_path: Path
+) -> None:
+    home = Path.home()
+    (home / ".codex").mkdir(parents=True, exist_ok=True)
+    (home / ".codex" / "basic-memory.json").write_text("{broken", encoding="utf-8")
+    project = tmp_path / "codex-proj"
+    (project / ".codex").mkdir(parents=True)
+    (project / ".codex" / "basic-memory.json").write_text(
+        json.dumps(
+            {
+                "basicMemory": {
+                    "primaryProject": "project-level",
+                    "captureEvents": True,
+                    "redactPaths": ["/project/private"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    transcript = _transcript(tmp_path)
+    mock_write = AsyncMock()
+
+    with patch("basic_memory.mcp.tools.write_note", mock_write):
+        result = runner.invoke(
+            cli_app,
+            ["hook", "pre-compact", "--harness", "codex", "--project-dir", str(project)],
+            input=_payload(project, transcript_path=str(transcript), trigger="auto"),
+        )
+
+    assert result.exit_code == 0
+    assert not (bm_home / "inbox").exists()
+    mock_write.assert_not_awaited()
+
+
 # --- Fail-open contract ---
 
 
@@ -1715,6 +1750,31 @@ def test_codex_settings_malformed_project_invalidates_user_fallback(tmp_path: Pa
     project = tmp_path / "proj"
     (project / ".codex").mkdir(parents=True)
     (project / ".codex" / "basic-memory.json").write_text("{broken", encoding="utf-8")
+
+    merged, found = hook_module.load_codex_settings(project)
+
+    assert merged == {"captureEvents": False, "captureFolder": "codex"}
+    assert found is True
+
+
+def test_codex_settings_malformed_user_blocks_project_fallback(tmp_path: Path) -> None:
+    home = Path.home()
+    (home / ".codex").mkdir(parents=True, exist_ok=True)
+    (home / ".codex" / "basic-memory.json").write_text("{broken", encoding="utf-8")
+    project = tmp_path / "proj"
+    (project / ".codex").mkdir(parents=True)
+    (project / ".codex" / "basic-memory.json").write_text(
+        json.dumps(
+            {
+                "basicMemory": {
+                    "primaryProject": "project-level",
+                    "captureEvents": True,
+                    "redactPaths": ["/project/private"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
 
     merged, found = hook_module.load_codex_settings(project)
 

--- a/tests/cli/test_hook_command.py
+++ b/tests/cli/test_hook_command.py
@@ -89,6 +89,10 @@ def _transcript(tmp_path: Path) -> Path:
     return path
 
 
+def _init_git_repo(project: Path) -> None:
+    subprocess.run(["git", "init"], cwd=project, check=True, capture_output=True)
+
+
 def _inbox_envelopes(bm_home: Path) -> list[dict]:
     inbox_dir = bm_home / "inbox"
     return [
@@ -461,6 +465,28 @@ def test_capture_events_true_boolean_writes_envelope(bm_home: Path, claude_proje
     assert envelope["payload"]["capture_folder"] == "sessions"
 
 
+def test_codex_capture_events_defaults_on(bm_home: Path, tmp_path: Path) -> None:
+    project = tmp_path / "codex-proj"
+    (project / ".codex").mkdir(parents=True)
+    (project / ".codex" / "basic-memory.json").write_text(
+        json.dumps({"basicMemory": {"primaryProject": "demo"}}), encoding="utf-8"
+    )
+    with patch(
+        "basic_memory.mcp.tools.search_notes", new_callable=AsyncMock, return_value=SEARCH_EMPTY
+    ):
+        result = runner.invoke(
+            cli_app,
+            ["hook", "session-start", "--harness", "codex", "--project-dir", str(project)],
+            input=_payload(project, source="startup"),
+        )
+
+    assert result.exit_code == 0
+    envelopes = _inbox_envelopes(bm_home)
+    assert len(envelopes) == 1
+    assert envelopes[0]["source"] == "codex"
+    assert envelopes[0]["payload"]["capture_folder"] == "codex"
+
+
 @pytest.mark.parametrize("gate_value", ["true", "false", 1, "yes", {"on": True}])
 def test_capture_events_fails_closed_on_non_boolean(
     bm_home: Path, claude_project: Path, gate_value
@@ -716,6 +742,7 @@ def test_pre_compact_surfaces_write_error_on_stderr(
 def test_pre_compact_codex_includes_workspace_sections(bm_home: Path, tmp_path: Path) -> None:
     project = tmp_path / "codex-proj"
     (project / ".codex").mkdir(parents=True)
+    _init_git_repo(project)
     (project / ".codex" / "basic-memory.json").write_text(
         json.dumps({"primaryProject": "demo"}),
         encoding="utf-8",  # flat form, no basicMemory key
@@ -741,7 +768,7 @@ def test_pre_compact_codex_includes_workspace_sections(bm_home: Path, tmp_path: 
     assert result.exit_code == 0
     assert mock_write.await_args is not None
     kwargs = mock_write.await_args.kwargs
-    assert kwargs["directory"] == "codex"
+    assert kwargs["directory"] == "codex/codex-proj"
     assert kwargs["tags"] == ["codex", "auto-capture"]
     assert kwargs["title"].startswith("Codex session ")
     assert kwargs["note_type"] == "codex_session"
@@ -1631,7 +1658,7 @@ def test_codex_settings_broken_file_counts_as_configured(tmp_path: Path) -> None
 
     merged, found = hook_module.load_codex_settings(project)
 
-    assert merged == {}
+    assert merged == {"captureEvents": False, "captureFolder": "codex"}
     assert found is True
 
 
@@ -1640,7 +1667,10 @@ def test_codex_settings_non_dict_document(tmp_path: Path) -> None:
     (project / ".codex").mkdir(parents=True)
     (project / ".codex" / "basic-memory.json").write_text("[1]", encoding="utf-8")
 
-    assert hook_module.load_codex_settings(project) == ({}, True)
+    assert hook_module.load_codex_settings(project) == (
+        {"captureEvents": False, "captureFolder": "codex"},
+        True,
+    )
 
 
 def test_codex_settings_non_dict_basic_memory_block(tmp_path: Path) -> None:
@@ -1650,7 +1680,78 @@ def test_codex_settings_non_dict_basic_memory_block(tmp_path: Path) -> None:
         json.dumps({"basicMemory": 42}), encoding="utf-8"
     )
 
-    assert hook_module.load_codex_settings(project) == ({}, True)
+    assert hook_module.load_codex_settings(project) == (
+        {"captureEvents": False, "captureFolder": "codex"},
+        True,
+    )
+
+
+def test_codex_settings_default_on_without_config(tmp_path: Path) -> None:
+    project = tmp_path / "bare"
+    project.mkdir()
+
+    assert hook_module.load_codex_settings(project) == (
+        {"captureEvents": True, "captureFolder": "codex"},
+        False,
+    )
+
+
+def test_codex_settings_merge_user_then_project_with_checkout_folder(tmp_path: Path) -> None:
+    home = Path.home()
+    (home / ".codex").mkdir(parents=True, exist_ok=True)
+    (home / ".codex" / "basic-memory.json").write_text(
+        json.dumps(
+            {
+                "basicMemory": {
+                    "primaryProject": "user-wide",
+                    "recallTimeframe": "9d",
+                    "captureEvents": True,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    project = tmp_path / "widgets"
+    (project / ".codex").mkdir(parents=True)
+    _init_git_repo(project)
+    (project / ".codex" / "basic-memory.json").write_text(
+        json.dumps({"basicMemory": {"primaryProject": "project-level"}}), encoding="utf-8"
+    )
+
+    merged, found = hook_module.load_codex_settings(project)
+
+    assert found is True
+    assert merged["primaryProject"] == "project-level"
+    assert merged["recallTimeframe"] == "9d"
+    assert merged["captureEvents"] is True
+    assert merged["captureFolder"] == "codex/widgets"
+
+
+def test_codex_project_settings_override_user_capture_defaults(tmp_path: Path) -> None:
+    home = Path.home()
+    (home / ".codex").mkdir(parents=True, exist_ok=True)
+    (home / ".codex" / "basic-memory.json").write_text(
+        json.dumps({"basicMemory": {"captureEvents": True}}), encoding="utf-8"
+    )
+    project = tmp_path / "proj"
+    (project / ".codex").mkdir(parents=True)
+    (project / ".codex" / "basic-memory.json").write_text(
+        json.dumps(
+            {
+                "basicMemory": {
+                    "captureEvents": False,
+                    "captureFolder": "private/checkpoints",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    merged, found = hook_module.load_codex_settings(project)
+
+    assert found is True
+    assert merged["captureEvents"] is False
+    assert merged["captureFolder"] == "private/checkpoints"
 
 
 def test_string_list_guards_config_types() -> None:

--- a/tests/cli/test_hook_command.py
+++ b/tests/cli/test_hook_command.py
@@ -847,6 +847,41 @@ def test_pre_compact_codex_skips_working_tree_when_workspace_denied(
     assert kwargs["metadata"]["cwd"] == "[REDACTED_PATH]"
 
 
+def test_pre_compact_codex_malformed_project_does_not_use_user_checkpoint_route(
+    bm_home: Path, tmp_path: Path
+) -> None:
+    home = Path.home()
+    (home / ".codex").mkdir(parents=True, exist_ok=True)
+    (home / ".codex" / "basic-memory.json").write_text(
+        json.dumps(
+            {
+                "basicMemory": {
+                    "primaryProject": "user-wide",
+                    "captureEvents": True,
+                    "redactPaths": ["/shared/private"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    project = tmp_path / "codex-proj"
+    (project / ".codex").mkdir(parents=True)
+    (project / ".codex" / "basic-memory.json").write_text("{broken", encoding="utf-8")
+    transcript = _transcript(tmp_path)
+    mock_write = AsyncMock()
+
+    with patch("basic_memory.mcp.tools.write_note", mock_write):
+        result = runner.invoke(
+            cli_app,
+            ["hook", "pre-compact", "--harness", "codex", "--project-dir", str(project)],
+            input=_payload(project, transcript_path=str(transcript), trigger="auto"),
+        )
+
+    assert result.exit_code == 0
+    assert not (bm_home / "inbox").exists()
+    mock_write.assert_not_awaited()
+
+
 # --- Fail-open contract ---
 
 
@@ -1652,6 +1687,31 @@ def test_claude_settings_non_dict_block_is_ignored(tmp_path: Path) -> None:
 
 
 def test_codex_settings_broken_file_counts_as_configured(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    (project / ".codex").mkdir(parents=True)
+    (project / ".codex" / "basic-memory.json").write_text("{broken", encoding="utf-8")
+
+    merged, found = hook_module.load_codex_settings(project)
+
+    assert merged == {"captureEvents": False, "captureFolder": "codex"}
+    assert found is True
+
+
+def test_codex_settings_malformed_project_invalidates_user_fallback(tmp_path: Path) -> None:
+    home = Path.home()
+    (home / ".codex").mkdir(parents=True, exist_ok=True)
+    (home / ".codex" / "basic-memory.json").write_text(
+        json.dumps(
+            {
+                "basicMemory": {
+                    "primaryProject": "user-wide",
+                    "captureEvents": True,
+                    "redactPaths": ["/shared/private"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
     project = tmp_path / "proj"
     (project / ".codex").mkdir(parents=True)
     (project / ".codex" / "basic-memory.json").write_text("{broken", encoding="utf-8")

--- a/tests/test_codex_plugin_package.py
+++ b/tests/test_codex_plugin_package.py
@@ -79,7 +79,9 @@ def test_codex_plugin_docs_explain_global_install_and_repo_mapping() -> None:
     assert 'codex plugin marketplace add "$(git rev-parse --show-toplevel)"' in readme
     assert "codex plugin add codex@basic-memory" in readme
     assert "Plugin installation is user-level in Codex" in readme
-    assert "Each repository still needs its own `.codex/basic-memory.json`" in readme
+    assert "Configuration can live at user level in `~/.codex/basic-memory.json`" in readme
+    assert "the nearest project file overrides only the keys it declares" in readme
+    assert "keep the checkout-specific repository identifier in the" in readme
 
 
 def test_coding_session_schema_is_shared_across_host_plugins() -> None:

--- a/tests/test_codex_plugin_package.py
+++ b/tests/test_codex_plugin_package.py
@@ -81,7 +81,25 @@ def test_codex_plugin_docs_explain_global_install_and_repo_mapping() -> None:
     assert "Plugin installation is user-level in Codex" in readme
     assert "Configuration can live at user level in `~/.codex/basic-memory.json`" in readme
     assert "the nearest project file overrides only the keys it declares" in readme
-    assert "keep the checkout-specific repository identifier in the" in readme
+    assert "keep both the profile and checkout-specific repository" in readme
+
+
+def test_user_level_coding_profile_stays_with_repository_override() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    readme = (repo_root / "plugins/codex/README.md").read_text(encoding="utf-8")
+    setup = (repo_root / "plugins/codex/skills/bm-setup/SKILL.md").read_text(encoding="utf-8")
+
+    readme_blocks = re.findall(r"```json\n(.*?)\n```", readme, flags=re.DOTALL)
+    shared_settings = json.loads(readme_blocks[0])["basicMemory"]
+    project_settings = json.loads(readme_blocks[1])["basicMemory"]
+
+    assert "sessionProfile" not in shared_settings
+    assert project_settings == {
+        "sessionProfile": "coding",
+        "repository": "owner/repo",
+    }
+    assert "omit `sessionProfile` from the shared user file" in setup
+    assert '"sessionProfile": "coding",\n    "repository": "owner/name"' in setup
 
 
 def test_coding_session_schema_is_shared_across_host_plugins() -> None:


### PR DESCRIPTION
## Why

Codex lifecycle capture was opt-in and repository-scoped, which made it easy for sessions to run without producing any capture envelopes. Repeating the same defaults in every checkout also made shared Codex configuration awkward and allowed repositories to write into the same checkpoint folder.

## What Changed

- Merge `~/.codex/basic-memory.json` with the nearest project `.codex/basic-memory.json`, with project keys taking precedence.
- Accumulate user and project `redactKeys`/`redactPaths` so project config cannot weaken global privacy rules.
- Enable Codex lifecycle-event capture by default while preserving an explicit boolean `false` opt-out and fail-closed malformed settings.
- Treat any malformed user or project config as a sticky failure for the event, preventing later settings from restoring capture or checkpoint routing without the missing redaction policy.
- Default checkpoint placement to `codex/<repo-dir>` using the Git top-level directory name.
- Keep `sessionProfile: "coding"` and the confirmed repository identity together in the project file when shared defaults are user-scoped.
- Update the Codex setup and companion skills to explain the two configuration levels and recommend user-level setup.
- Extend hook and plugin validation coverage for precedence, opt-out behavior, malformed settings, repository-specific folders, cumulative redaction, and repository-scoped coding profiles.
- Advance both packaged Codex hook launchers to the tested core implementation commit.

## Implementation Details

The hook command owns the merge and default resolution so marketplace hook shims remain logic-free. Defaults are applied before the user and project blocks are merged; an explicit setting at either level wins. Redaction lists are the deliberate exception: valid string entries are deduplicated in user-then-project order and cannot be cleared by an empty project value. If either configured source is malformed, evaluation returns the capture-disabled defaults immediately, so neither envelope capture nor PreCompact checkpoint routing can combine a later route with a missing earlier redaction policy. For user-level setups, repository-scoped coding mode and identity stay together in the project file, while the user file carries only defaults that are safe to share across repositories.

The PEP 723 launchers pin `bd5d145d`, the implementation commit containing the final hook behavior and tests. The later pin-only commit keeps that revision reachable as an ancestor; release automation will replace it with the release tag.

## Testing

### Automated

- `uv run pytest tests/test_codex_plugin_package.py tests/cli/test_hook_command.py -q`: 109 passed.
- `just fast-check`: passed lint, format, and type checks.
- `just package-check`: passed all consolidated package validation suites.

### Manual

- Ran `uv run basic-memory hook status --harness codex --project-dir /Users/phernandez/dev/basicmachines/basic-memory-cloud` with a user-level `captureEvents: true` setting and no repository capture override: reported `capture events: on` and `capture folder: codex/basic-memory-cloud` while retaining the project-specific mapping.

## Risks / Follow-ups

- Existing installations must refresh the plugin after this lands to pick up the new skills and pinned hook launchers.
