### PR TITLE
fix(plugins): pin Codex hooks to merged runtime

### DIFF
--- a/plugins/codex/hooks/pre_compact.py
+++ b/plugins/codex/hooks/pre_compact.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@1cb7a541fbb43c5a4f1b552c0123a1c55beb8dfb",
+#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@c28159d2077158c4f596fb62f351e6e9012b95a5",
 # ]
 # ///
 """PreCompact hook launcher backed by a pinned Basic Memory revision.

--- a/plugins/codex/hooks/session_start.py
+++ b/plugins/codex/hooks/session_start.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@1cb7a541fbb43c5a4f1b552c0123a1c55beb8dfb",
+#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@c28159d2077158c4f596fb62f351e6e9012b95a5",
 # ]
 # ///
 """SessionStart hook launcher backed by a pinned Basic Memory revision.

--- a/plugins/codex/hooks/stop.py
+++ b/plugins/codex/hooks/stop.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@1cb7a541fbb43c5a4f1b552c0123a1c55beb8dfb",
+#     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@c28159d2077158c4f596fb62f351e6e9012b95a5",
 # ]
 # ///
 """Stop hook launcher backed by a pinned Basic Memory revision.


### PR DESCRIPTION
## Why

PR #1138 merged the Codex checkpoint runtime as commit `c28159d2`, but the Codex hook launchers still referenced the intermediate feature commit `1cb7a541`. Aligning the hook launchers with the durable merged revision keeps plugin execution and operator CLI usage on the same source.

## What Changed

- Repinned the SessionStart, PreCompact, and Stop hook launchers to merged commit `c28159d2077158c4f596fb62f351e6e9012b95a5`.
- Preserved the existing self-contained `uv run --script` execution model.
- Made no hook behavior, configuration, or capture-policy changes.

## Implementation Details

The PEP 723 dependency declarations continue to use an immutable commit SHA rather than the moving `main` ref. The plugin therefore remains reproducible and does not depend on a separately installed `basic-memory` executable being present on `PATH`.

## Testing

### Automated

- `git diff --check`
- `uv run pytest -q --no-cov plugins/codex/hooks tests/test_codex_plugin_package.py` — 21 passed
- `just package-check` — passed the Claude Code, Codex, shared skills, Hermes, and OpenClaw package gates

### Manual

Not required for this dependency-metadata-only repin; the hook package tests exercise the launchers and the full package gate validates all bundled agent packages.

## Risks / Follow-ups

Risk is low because runtime logic is unchanged. Existing installed marketplace caches will continue using the previous immutable revision until the updated plugin is released and reinstalled.
