### PR TITLE
fix(core): reject stale file reconciliation

### DIFF
--- a/src/basic_memory/index/local_dependencies.py
+++ b/src/basic_memory/index/local_dependencies.py
@@ -287,6 +287,11 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
             )
         operation = FileIndexOperation.created if existing is None else FileIndexOperation.updated
 
+        anchor = (
+            await self.note_content_reconciler.capture_anchor(existing.id)
+            if existing is not None
+            else None
+        )
         synced = await self.index_current_markdown_file(
             file_path,
             new=existing is None,
@@ -299,6 +304,7 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
             markdown_content=synced.markdown_content,
             observed_at=synced.updated_at,
             source=source,
+            anchor=anchor,
         )
 
         logger.info(

--- a/src/basic_memory/index/local_dependencies.py
+++ b/src/basic_memory/index/local_dependencies.py
@@ -23,8 +23,10 @@ from basic_memory.indexing.file_index_checking import (
     IndexedFileChecksumRow,
 )
 from basic_memory.indexing.file_indexer import (
+    MAX_NOTE_CONTENT_INDEX_ATTEMPTS,
     IndexMarkdownEntityRepository,
     IndexMarkdownNoteContentReconciler,
+    NoteContentChangedDuringIndexError,
 )
 from basic_memory.indexing.index_batch_runtime import (
     IndexBatchRuntime,
@@ -287,25 +289,45 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
             )
         operation = FileIndexOperation.created if existing is None else FileIndexOperation.updated
 
-        anchor = (
-            await self.note_content_reconciler.capture_anchor(existing.id)
-            if existing is not None
-            else None
-        )
-        synced = await self.index_current_markdown_file(
-            file_path,
-            new=existing is None,
-            index_search=True,
-            resolve_relations=True,
-            refresh_unchanged_derived_state=existing is not None,
-        )
-        await self.note_content_reconciler.reconcile(
-            entity=synced.entity,
-            markdown_content=synced.markdown_content,
-            observed_at=synced.updated_at,
-            source=source,
-            anchor=anchor,
-        )
+        for attempt in range(MAX_NOTE_CONTENT_INDEX_ATTEMPTS):
+            if attempt > 0:
+                async with db.scoped_session(self.session_maker) as session:
+                    existing = await self.entity_repository.get_by_file_path(
+                        session,
+                        file_path,
+                        load_relations=False,
+                    )
+
+            anchor = await self.note_content_reconciler.capture_anchor(
+                existing.id if existing is not None else None
+            )
+            synced = await self.index_current_markdown_file(
+                file_path,
+                new=existing is None,
+                index_search=True,
+                resolve_relations=True,
+                refresh_unchanged_derived_state=existing is not None,
+            )
+            outcome = await self.note_content_reconciler.reconcile(
+                entity=synced.entity,
+                markdown_content=synced.markdown_content,
+                observed_at=synced.updated_at,
+                source=source,
+                anchor=anchor,
+            )
+            if outcome == "current":
+                break
+
+            logger.info(
+                "Retrying markdown index after concurrent accepted note write: {}",
+                file_path,
+                entity_id=synced.entity.id,
+                attempt=attempt + 1,
+            )
+        else:
+            raise NoteContentChangedDuringIndexError(
+                f"Note content changed repeatedly while indexing {file_path}"
+            )
 
         logger.info(
             f"Indexed markdown file: {file_path}",

--- a/src/basic_memory/indexing/file_indexer.py
+++ b/src/basic_memory/indexing/file_indexer.py
@@ -12,7 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory.indexing.file_index_checking import IndexedFileChecksumRow
 from basic_memory import db
-from basic_memory.indexing.note_content_reconciliation import NoteContentReconciliationAnchor
+from basic_memory.indexing.note_content_reconciliation import (
+    NoteContentReconciliationAnchor,
+    NoteContentReconciliationOutcome,
+)
 from basic_memory.indexing.models import (
     FileIndexOperation,
     FileIndexResult,
@@ -96,7 +99,7 @@ class IndexCurrentMarkdownFileIndexer(Protocol):
 class IndexMarkdownNoteContentReconciler(Protocol):
     """Note-content capability needed after canonical markdown sync succeeds."""
 
-    async def capture_anchor(self, entity_id: int) -> NoteContentReconciliationAnchor:
+    async def capture_anchor(self, entity_id: int | None) -> NoteContentReconciliationAnchor:
         """Capture accepted state before the file observation is indexed."""
 
     async def reconcile(
@@ -107,7 +110,14 @@ class IndexMarkdownNoteContentReconciler(Protocol):
         observed_at: datetime | None,
         source: str,
         anchor: NoteContentReconciliationAnchor | None = None,
-    ) -> None: ...
+    ) -> NoteContentReconciliationOutcome: ...
+
+
+class NoteContentChangedDuringIndexError(RuntimeError):
+    """Raised when repeated concurrent writes prevent a current derived-state index."""
+
+
+MAX_NOTE_CONTENT_INDEX_ATTEMPTS = 2
 
 
 class FileIndexer:
@@ -160,26 +170,46 @@ class FileIndexer:
             )
         operation = FileIndexOperation.created if existing is None else FileIndexOperation.updated
 
-        anchor = (
-            await self.note_content_reconciler.capture_anchor(existing.id)
-            if existing is not None
-            else None
-        )
-        synced = await self.markdown_indexer.index_current_markdown_file(
-            file_path,
-            new=existing is None,
-            index_search=True,
-            resolve_relations=False,
-            refresh_unchanged_derived_state=existing is not None,
-        )
+        for attempt in range(MAX_NOTE_CONTENT_INDEX_ATTEMPTS):
+            if attempt > 0:
+                async with db.scoped_session(self.markdown_indexer.session_maker) as session:
+                    existing = await self.markdown_indexer.entity_repository.get_by_file_path(
+                        session,
+                        file_path,
+                        load_relations=False,
+                    )
 
-        await self.note_content_reconciler.reconcile(
-            entity=synced.entity,
-            markdown_content=synced.markdown_content,
-            observed_at=synced.updated_at,
-            source=source,
-            anchor=anchor,
-        )
+            anchor = await self.note_content_reconciler.capture_anchor(
+                existing.id if existing is not None else None
+            )
+            synced = await self.markdown_indexer.index_current_markdown_file(
+                file_path,
+                new=existing is None,
+                index_search=True,
+                resolve_relations=False,
+                refresh_unchanged_derived_state=existing is not None,
+            )
+
+            outcome = await self.note_content_reconciler.reconcile(
+                entity=synced.entity,
+                markdown_content=synced.markdown_content,
+                observed_at=synced.updated_at,
+                source=source,
+                anchor=anchor,
+            )
+            if outcome == "current":
+                break
+
+            log.info(
+                "Retrying markdown index after concurrent accepted note write: {}",
+                file_path,
+                entity_id=synced.entity.id,
+                attempt=attempt + 1,
+            )
+        else:
+            raise NoteContentChangedDuringIndexError(
+                f"Note content changed repeatedly while indexing {file_path}"
+            )
 
         log.info(
             f"Indexed markdown file: {file_path}",

--- a/src/basic_memory/indexing/file_indexer.py
+++ b/src/basic_memory/indexing/file_indexer.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory.indexing.file_index_checking import IndexedFileChecksumRow
 from basic_memory import db
+from basic_memory.indexing.note_content_reconciliation import NoteContentReconciliationAnchor
 from basic_memory.indexing.models import (
     FileIndexOperation,
     FileIndexResult,
@@ -95,6 +96,9 @@ class IndexCurrentMarkdownFileIndexer(Protocol):
 class IndexMarkdownNoteContentReconciler(Protocol):
     """Note-content capability needed after canonical markdown sync succeeds."""
 
+    async def capture_anchor(self, entity_id: int) -> NoteContentReconciliationAnchor:
+        """Capture accepted state before the file observation is indexed."""
+
     async def reconcile(
         self,
         *,
@@ -102,6 +106,7 @@ class IndexMarkdownNoteContentReconciler(Protocol):
         markdown_content: str,
         observed_at: datetime | None,
         source: str,
+        anchor: NoteContentReconciliationAnchor | None = None,
     ) -> None: ...
 
 
@@ -155,6 +160,11 @@ class FileIndexer:
             )
         operation = FileIndexOperation.created if existing is None else FileIndexOperation.updated
 
+        anchor = (
+            await self.note_content_reconciler.capture_anchor(existing.id)
+            if existing is not None
+            else None
+        )
         synced = await self.markdown_indexer.index_current_markdown_file(
             file_path,
             new=existing is None,
@@ -168,6 +178,7 @@ class FileIndexer:
             markdown_content=synced.markdown_content,
             observed_at=synced.updated_at,
             source=source,
+            anchor=anchor,
         )
 
         log.info(

--- a/src/basic_memory/indexing/note_content_batch_reconciliation.py
+++ b/src/basic_memory/indexing/note_content_batch_reconciliation.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from basic_memory import db
 from basic_memory.indexing.file_index_planning import FileIndexPath
 from basic_memory.indexing.models import IndexedEntity
+from basic_memory.indexing.note_content_reconciliation import NoteContentReconciliationOutcome
 from basic_memory.indexing.note_content_reconciler import NoteContentReconcileFileReader
 
 
@@ -71,7 +72,7 @@ class IndexedNoteContentReconciler(Protocol[EntityT]):
         markdown_content: str,
         observed_at: datetime | None,
         source: str,
-    ) -> None:
+    ) -> NoteContentReconciliationOutcome | None:
         """Apply the note_content state change for one markdown entity."""
 
 

--- a/src/basic_memory/indexing/note_content_reconciler.py
+++ b/src/basic_memory/indexing/note_content_reconciler.py
@@ -20,8 +20,11 @@ from basic_memory.indexing.note_content_reconciliation import (
     NoteContentMaterializedCurrent,
     NoteContentMaterializedStale,
     NoteContentPromoted,
+    NoteContentReconciliationAnchor,
+    NoteContentReconciliationDeferred,
     NoteContentState,
     NoteContentSource,
+    NoteContentWriteStatus,
     ObservedNoteContent,
     plan_note_content_reconciliation,
 )
@@ -152,6 +155,15 @@ class RepositoryNoteMaterializationFailureMarker:
                 )
 
 
+def note_content_write_status(value: str) -> NoteContentWriteStatus:
+    """Validate the persisted write status before using it in pure planning."""
+    match value:
+        case "pending" | "writing" | "synced" | "failed" | "external_change_detected":
+            return value
+        case _:
+            raise ValueError(f"Unsupported note_content file_write_status: {value}")
+
+
 def note_content_state_from_model(note_content: NoteContent) -> NoteContentState:
     """Map the ORM row into the portable reconciliation state."""
     return NoteContentState(
@@ -163,6 +175,7 @@ def note_content_state_from_model(note_content: NoteContent) -> NoteContentState
         file_checksum=str(note_content.file_checksum)
         if note_content.file_checksum is not None
         else None,
+        file_write_status=note_content_write_status(note_content.file_write_status),
     )
 
 
@@ -280,6 +293,18 @@ class NoteContentReconciler:
         self._note_content_repository = note_content_repository
         self._session_maker = session_maker
 
+    async def capture_anchor(self, entity_id: int) -> NoteContentReconciliationAnchor:
+        """Capture the accepted state before storage bytes enter the index pipeline."""
+        async with db.scoped_session(self._session_maker) as session:
+            note_content = await self._note_content_repository.get_by_entity_id(
+                session,
+                entity_id,
+            )
+        return NoteContentReconciliationAnchor(
+            entity_id=entity_id,
+            state=note_content_state_from_model(note_content) if note_content else None,
+        )
+
     async def reconcile(
         self,
         *,
@@ -287,6 +312,7 @@ class NoteContentReconciler:
         markdown_content: str,
         observed_at: datetime | None,
         source: NoteContentSource,
+        anchor: NoteContentReconciliationAnchor | None = None,
     ) -> None:
         """Apply the shared file-vs-DB rule for one markdown entity."""
         observed_checksum = await file_utils.compute_checksum(markdown_content)
@@ -302,6 +328,22 @@ class NoteContentReconciler:
                 session,
                 entity.id,
             )
+
+            current_state = (
+                note_content_state_from_model(note_content) if note_content is not None else None
+            )
+            if anchor is not None:
+                if anchor.entity_id != entity.id:
+                    raise ValueError(
+                        "Note-content reconciliation anchor belongs to another entity."
+                    )
+                if anchor.state != current_state:
+                    logger.debug(
+                        "Skipped stale note_content observation for entity {}: "
+                        "accepted state changed during indexing",
+                        entity.id,
+                    )
+                    return
 
             if note_content is None:
                 plan = plan_note_content_reconciliation(None, observed)
@@ -330,12 +372,23 @@ class NoteContentReconciler:
             # that db_version so a concurrent accepted API mutation that advanced
             # the row between our read and write is not silently reverted.
             expected_db_version = int(note_content.db_version)
+            current_state = note_content_state_from_model(note_content)
             plan = plan_note_content_reconciliation(
-                note_content_state_from_model(note_content),
+                current_state,
                 observed,
             )
             if isinstance(plan, NoteContentBootstrap):
                 raise RuntimeError("Existing note_content cannot bootstrap reconciliation")
+            if isinstance(plan, NoteContentReconciliationDeferred):
+                logger.debug(
+                    "Deferred note_content file promotion for entity {}: "
+                    "db_version={}, file_version={}, file_write_status={}",
+                    entity.id,
+                    current_state.db_version,
+                    current_state.file_version,
+                    current_state.file_write_status,
+                )
+                return
 
             applied = await apply_note_content_update_plan(
                 self._note_content_repository,

--- a/src/basic_memory/indexing/note_content_reconciler.py
+++ b/src/basic_memory/indexing/note_content_reconciler.py
@@ -22,6 +22,7 @@ from basic_memory.indexing.note_content_reconciliation import (
     NoteContentPromoted,
     NoteContentReconciliationAnchor,
     NoteContentReconciliationDeferred,
+    NoteContentReconciliationOutcome,
     NoteContentState,
     NoteContentSource,
     NoteContentWriteStatus,
@@ -293,8 +294,11 @@ class NoteContentReconciler:
         self._note_content_repository = note_content_repository
         self._session_maker = session_maker
 
-    async def capture_anchor(self, entity_id: int) -> NoteContentReconciliationAnchor:
+    async def capture_anchor(self, entity_id: int | None) -> NoteContentReconciliationAnchor:
         """Capture the accepted state before storage bytes enter the index pipeline."""
+        if entity_id is None:
+            return NoteContentReconciliationAnchor(entity_id=None, state=None)
+
         async with db.scoped_session(self._session_maker) as session:
             note_content = await self._note_content_repository.get_by_entity_id(
                 session,
@@ -313,7 +317,7 @@ class NoteContentReconciler:
         observed_at: datetime | None,
         source: NoteContentSource,
         anchor: NoteContentReconciliationAnchor | None = None,
-    ) -> None:
+    ) -> NoteContentReconciliationOutcome:
         """Apply the shared file-vs-DB rule for one markdown entity."""
         observed_checksum = await file_utils.compute_checksum(markdown_content)
         observed_timestamp = observed_at or datetime.now(tz=UTC)
@@ -333,7 +337,7 @@ class NoteContentReconciler:
                 note_content_state_from_model(note_content) if note_content is not None else None
             )
             if anchor is not None:
-                if anchor.entity_id != entity.id:
+                if anchor.entity_id is not None and anchor.entity_id != entity.id:
                     raise ValueError(
                         "Note-content reconciliation anchor belongs to another entity."
                     )
@@ -343,7 +347,7 @@ class NoteContentReconciler:
                         "accepted state changed during indexing",
                         entity.id,
                     )
-                    return
+                    return "stale"
 
             if note_content is None:
                 plan = plan_note_content_reconciliation(None, observed)
@@ -355,7 +359,7 @@ class NoteContentReconciler:
                         session,
                         note_content_from_bootstrap(entity.id, plan),
                     )
-                    return
+                    return "current"
                 except IntegrityError:
                     # Concurrent repair/index workers can both observe a missing row before
                     # one wins the insert. Reload the winner and let normal reconciliation
@@ -367,6 +371,15 @@ class NoteContentReconciler:
                     )
                     if note_content is None:
                         raise
+                    if anchor is not None and anchor.state != note_content_state_from_model(
+                        note_content
+                    ):
+                        logger.debug(
+                            "Skipped stale note_content bootstrap for entity {}: "
+                            "accepted state was created during indexing",
+                            entity.id,
+                        )
+                        return "stale"
 
             # The plan is computed from the row read above; guard the write on
             # that db_version so a concurrent accepted API mutation that advanced
@@ -388,7 +401,7 @@ class NoteContentReconciler:
                     current_state.file_version,
                     current_state.file_write_status,
                 )
-                return
+                return "current"
 
             applied = await apply_note_content_update_plan(
                 self._note_content_repository,
@@ -404,6 +417,9 @@ class NoteContentReconciler:
                     expected_db_version,
                     entity.id,
                 )
+                return "stale"
+
+            return "current"
 
 
 async def reconcile_note_content_for_entity(

--- a/src/basic_memory/indexing/note_content_reconciliation.py
+++ b/src/basic_memory/indexing/note_content_reconciliation.py
@@ -35,6 +35,15 @@ class NoteContentState:
     db_checksum: NoteContentChecksum
     file_version: int | None = None
     file_checksum: NoteContentChecksum | None = None
+    file_write_status: NoteContentWriteStatus = "synced"
+
+
+@dataclass(frozen=True, slots=True)
+class NoteContentReconciliationAnchor:
+    """note_content state captured before an observed file is indexed."""
+
+    entity_id: int
+    state: NoteContentState | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -130,6 +139,11 @@ class NoteContentMaterializationStatusUpdate:
 
 
 @dataclass(frozen=True, slots=True)
+class NoteContentReconciliationDeferred:
+    """No-op when an observed file did not start from stable canonical state."""
+
+
+@dataclass(frozen=True, slots=True)
 class NoteContentPromoted:
     """Update when an external file change becomes the newest accepted content."""
 
@@ -147,7 +161,11 @@ class NoteContentPromoted:
 
 
 type NoteContentReconciliationPlan = (
-    NoteContentBootstrap | NoteContentFileSynced | NoteContentFileObserved | NoteContentPromoted
+    NoteContentBootstrap
+    | NoteContentFileSynced
+    | NoteContentFileObserved
+    | NoteContentReconciliationDeferred
+    | NoteContentPromoted
 )
 type NoteContentMaterializationPublishPlan = (
     NoteContentMaterializedCurrent | NoteContentMaterializedStale
@@ -172,7 +190,8 @@ def plan_note_content_reconciliation(
     The same rule must apply everywhere:
     - observed checksum == DB checksum: the file now matches accepted DB content
     - observed checksum == previous file checksum while versions differ: DB stays ahead
-    - otherwise: the observed file wins the next DB/file version
+    - an unrelated observation can advance DB only from fully synchronized state
+    - otherwise: defer until the accepted DB/file lineage is stable
     """
     if current is None:
         return NoteContentBootstrap(
@@ -211,6 +230,14 @@ def plan_note_content_reconciliation(
             file_checksum=current.file_checksum,
             file_updated_at=observed.observed_at,
         )
+
+    file_state_is_stable = (
+        current.file_write_status == "synced"
+        and current.file_version == current.db_version
+        and current.file_checksum == current.db_checksum
+    )
+    if not file_state_is_stable:
+        return NoteContentReconciliationDeferred()
 
     next_version = max(current.db_version, current.file_version or 0) + 1
     return NoteContentPromoted(

--- a/src/basic_memory/indexing/note_content_reconciliation.py
+++ b/src/basic_memory/indexing/note_content_reconciliation.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 type NoteContentChecksum = str
 type NoteContentSource = str
+type NoteContentReconciliationOutcome = Literal["current", "stale"]
 type NoteContentWriteStatus = Literal[
     "pending",
     "writing",
@@ -42,7 +43,7 @@ class NoteContentState:
 class NoteContentReconciliationAnchor:
     """note_content state captured before an observed file is indexed."""
 
-    entity_id: int
+    entity_id: int | None
     state: NoteContentState | None
 
 

--- a/tests/indexing/test_file_indexer.py
+++ b/tests/indexing/test_file_indexer.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from basic_memory.indexing.file_indexer import (
     FileIndexer,
     IndexCurrentMarkdownFileIndexer,
+    NoteContentChangedDuringIndexError,
     build_default_file_indexer,
 )
 from basic_memory.indexing.models import FileIndexOperation, FileIndexResult, SyncedMarkdownFile
@@ -55,11 +56,15 @@ def _entity(*, entity_id: int = 42, checksum: str = "old-checksum") -> Mock:
     return entity
 
 
-def _synced_file(*, entity: Mock | None = None) -> SyncedMarkdownFile:
+def _synced_file(
+    *,
+    entity: Mock | None = None,
+    checksum: str = CHECKSUM,
+) -> SyncedMarkdownFile:
     """Create the canonical markdown index result consumed by FileIndexer."""
     return SyncedMarkdownFile(
         entity=entity or _entity(),
-        checksum=CHECKSUM,
+        checksum=checksum,
         markdown_content=CANONICAL_MARKDOWN,
         file_path="notes/note.md",
         content_type="text/markdown",
@@ -95,10 +100,10 @@ def _file_indexer(
     )
 
     note_content_reconciler = Mock()
-    note_content_reconciler.reconcile = AsyncMock()
+    note_content_reconciler.reconcile = AsyncMock(return_value="current")
     note_content_reconciler.capture_anchor = AsyncMock(
         return_value=NoteContentReconciliationAnchor(
-            entity_id=existing_entity.id if existing_entity is not None else 42,
+            entity_id=existing_entity.id if existing_entity is not None else None,
             state=NoteContentState(
                 db_version=3,
                 db_checksum="old-checksum",
@@ -176,13 +181,13 @@ async def test_file_indexer_indexes_new_markdown_file() -> None:
         resolve_relations=False,
         refresh_unchanged_derived_state=False,
     )
-    note_content_reconciler.capture_anchor.assert_not_awaited()
+    note_content_reconciler.capture_anchor.assert_awaited_once_with(None)
     note_content_reconciler.reconcile.assert_awaited_once_with(
         entity=synced_file.entity,
         markdown_content=CANONICAL_MARKDOWN,
         observed_at=OBSERVED_AT,
         source="s3_webhook",
-        anchor=None,
+        anchor=note_content_reconciler.capture_anchor.return_value,
     )
     assert result.file_path == "notes/note.md"
     assert result.entity_id == 42
@@ -222,6 +227,86 @@ async def test_file_indexer_indexes_existing_markdown_file() -> None:
         anchor=note_content_reconciler.capture_anchor.return_value,
     )
     assert result.operation == FileIndexOperation.updated
+
+
+@pytest.mark.asyncio
+async def test_file_indexer_reindexes_current_file_after_anchor_becomes_stale() -> None:
+    """A stale pass must repair derived state from the current file before succeeding."""
+    existing_entity = _entity(entity_id=7, checksum="older-checksum")
+    current_entity = _entity(entity_id=7, checksum="current-checksum")
+    stale_file = _synced_file(entity=existing_entity)
+    current_file = _synced_file(entity=current_entity, checksum="current-checksum")
+
+    file_indexer, markdown_indexer, note_content_reconciler = _file_indexer(
+        existing_entity=existing_entity,
+        synced_file=stale_file,
+    )
+    markdown_indexer.entity_repository.get_by_file_path.side_effect = [
+        existing_entity,
+        current_entity,
+    ]
+    markdown_indexer.index_current_markdown_file.side_effect = [
+        stale_file,
+        current_file,
+    ]
+    note_content_reconciler.reconcile.side_effect = ["stale", "current"]
+
+    result = await file_indexer.index_markdown_file("notes/note.md")
+
+    assert markdown_indexer.index_current_markdown_file.await_count == 2
+    assert note_content_reconciler.capture_anchor.await_args_list[0].args == (7,)
+    assert note_content_reconciler.capture_anchor.await_args_list[1].args == (7,)
+    assert result.checksum == "current-checksum"
+
+
+@pytest.mark.asyncio
+async def test_file_indexer_reloads_entity_after_initial_absence_becomes_stale() -> None:
+    """An entity created concurrently after an absent lookup must anchor the retry by id."""
+    created_entity = _entity(entity_id=42, checksum="current-checksum")
+    stale_file = _synced_file()
+    current_file = _synced_file(entity=created_entity, checksum="current-checksum")
+
+    file_indexer, markdown_indexer, note_content_reconciler = _file_indexer(
+        synced_file=stale_file,
+    )
+    markdown_indexer.entity_repository.get_by_file_path.side_effect = [
+        None,
+        created_entity,
+    ]
+    markdown_indexer.index_current_markdown_file.side_effect = [
+        stale_file,
+        current_file,
+    ]
+    note_content_reconciler.reconcile.side_effect = ["stale", "current"]
+
+    result = await file_indexer.index_markdown_file("notes/note.md")
+
+    assert note_content_reconciler.capture_anchor.await_args_list[0].args == (None,)
+    assert note_content_reconciler.capture_anchor.await_args_list[1].args == (42,)
+    assert result.checksum == "current-checksum"
+    assert result.operation == FileIndexOperation.created
+
+
+@pytest.mark.asyncio
+async def test_file_indexer_fails_for_retry_after_repeated_stale_indexes() -> None:
+    """Repeated concurrent writes must fail the job instead of reporting stale derived state."""
+    existing_entity = _entity(entity_id=7)
+    file_indexer, markdown_indexer, note_content_reconciler = _file_indexer(
+        existing_entity=existing_entity,
+    )
+    markdown_indexer.entity_repository.get_by_file_path.side_effect = [
+        existing_entity,
+        existing_entity,
+    ]
+    note_content_reconciler.reconcile.side_effect = ["stale", "stale"]
+
+    with pytest.raises(
+        NoteContentChangedDuringIndexError,
+        match="changed repeatedly",
+    ):
+        await file_indexer.index_markdown_file("notes/note.md")
+
+    assert markdown_indexer.index_current_markdown_file.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_file_indexer.py
+++ b/tests/indexing/test_file_indexer.py
@@ -15,6 +15,10 @@ from basic_memory.indexing.file_indexer import (
     build_default_file_indexer,
 )
 from basic_memory.indexing.models import FileIndexOperation, FileIndexResult, SyncedMarkdownFile
+from basic_memory.indexing.note_content_reconciliation import (
+    NoteContentReconciliationAnchor,
+    NoteContentState,
+)
 from basic_memory.indexing.note_content_reconciler import NoteContentReconciler
 
 CHECKSUM = "abc123"
@@ -92,6 +96,18 @@ def _file_indexer(
 
     note_content_reconciler = Mock()
     note_content_reconciler.reconcile = AsyncMock()
+    note_content_reconciler.capture_anchor = AsyncMock(
+        return_value=NoteContentReconciliationAnchor(
+            entity_id=existing_entity.id if existing_entity is not None else 42,
+            state=NoteContentState(
+                db_version=3,
+                db_checksum="old-checksum",
+                file_version=3,
+                file_checksum="old-checksum",
+                file_write_status="synced",
+            ),
+        )
+    )
 
     return (
         FileIndexer(
@@ -160,11 +176,13 @@ async def test_file_indexer_indexes_new_markdown_file() -> None:
         resolve_relations=False,
         refresh_unchanged_derived_state=False,
     )
+    note_content_reconciler.capture_anchor.assert_not_awaited()
     note_content_reconciler.reconcile.assert_awaited_once_with(
         entity=synced_file.entity,
         markdown_content=CANONICAL_MARKDOWN,
         observed_at=OBSERVED_AT,
         source="s3_webhook",
+        anchor=None,
     )
     assert result.file_path == "notes/note.md"
     assert result.entity_id == 42
@@ -179,18 +197,29 @@ async def test_file_indexer_indexes_existing_markdown_file() -> None:
     When the per-file indexer processes that file
     Then it asks the markdown indexer to persist it as an update.
     """
-    file_indexer, markdown_indexer, _note_content_reconciler = _file_indexer(
-        existing_entity=_entity(entity_id=7),
+    existing_entity = _entity(entity_id=7)
+    synced_file = _synced_file(entity=existing_entity)
+    file_indexer, markdown_indexer, note_content_reconciler = _file_indexer(
+        existing_entity=existing_entity,
+        synced_file=synced_file,
     )
 
     result = await file_indexer.index_markdown_file("notes/note.md")
 
+    note_content_reconciler.capture_anchor.assert_awaited_once_with(7)
     markdown_indexer.index_current_markdown_file.assert_awaited_once_with(
         "notes/note.md",
         new=False,
         index_search=True,
         resolve_relations=False,
         refresh_unchanged_derived_state=True,
+    )
+    note_content_reconciler.reconcile.assert_awaited_once_with(
+        entity=synced_file.entity,
+        markdown_content=CANONICAL_MARKDOWN,
+        observed_at=OBSERVED_AT,
+        source="index",
+        anchor=note_content_reconciler.capture_anchor.return_value,
     )
     assert result.operation == FileIndexOperation.updated
 

--- a/tests/indexing/test_note_content_reconciler.py
+++ b/tests/indexing/test_note_content_reconciler.py
@@ -15,6 +15,8 @@ from basic_memory import file_utils
 from basic_memory.indexing.note_content_reconciliation import (
     NoteContentMaterializationStatusUpdate,
     NoteContentMaterializedCurrent,
+    NoteContentReconciliationAnchor,
+    NoteContentState,
 )
 from basic_memory.indexing.note_content_reconciler import (
     NoteContentReconciler,
@@ -64,9 +66,10 @@ async def test_reconciler_converges_after_concurrent_create_conflict() -> None:
     observed_checksum = await file_utils.compute_checksum(markdown_content)
     existing_note_content = SimpleNamespace(
         db_version=1,
-        db_checksum="previous-db-checksum",
+        db_checksum="previous-file-checksum",
         file_version=1,
         file_checksum="previous-file-checksum",
+        file_write_status="synced",
     )
     repository = SimpleNamespace(
         get_by_entity_id=AsyncMock(side_effect=[None, existing_note_content]),
@@ -133,6 +136,7 @@ async def test_reconciler_skips_stale_plan_when_version_guard_loses() -> None:
         db_checksum=stale_checksum,
         file_version=3,
         file_checksum=stale_checksum,
+        file_write_status="synced",
     )
     repository = SimpleNamespace(
         get_by_entity_id=AsyncMock(return_value=existing_note_content),
@@ -167,6 +171,103 @@ async def test_reconciler_skips_stale_plan_when_version_guard_loses() -> None:
     assert repository.update_state_fields.await_count == 1
     _, kwargs = repository.update_state_fields.await_args
     assert kwargs["expected_db_version"] == 3
+
+
+@pytest.mark.asyncio
+async def test_reconciler_skips_observation_when_anchor_changed_during_indexing() -> None:
+    """A file read against version N cannot promote after an accepted write advances to N+1."""
+    observed_at = datetime(2026, 4, 13, 15, 0, tzinfo=UTC)
+    accepted_checksum = await file_utils.compute_checksum("# MCP winner\n")
+    repository = SimpleNamespace(
+        get_by_entity_id=AsyncMock(
+            return_value=SimpleNamespace(
+                db_version=4,
+                db_checksum=accepted_checksum,
+                file_version=3,
+                file_checksum="old-file-checksum",
+                file_write_status="pending",
+            )
+        ),
+        create=AsyncMock(),
+        update_state_fields=AsyncMock(),
+    )
+    entity = cast(Entity, SimpleNamespace(id=42))
+
+    @asynccontextmanager
+    async def fake_scoped_session(_session_maker: object):
+        yield FakeSession()
+
+    anchor = NoteContentReconciliationAnchor(
+        entity_id=42,
+        state=NoteContentState(
+            db_version=3,
+            db_checksum="old-file-checksum",
+            file_version=3,
+            file_checksum="old-file-checksum",
+            file_write_status="synced",
+        ),
+    )
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_content_reconciler.db.scoped_session",
+            fake_scoped_session,
+        )
+        await NoteContentReconciler(
+            note_content_repository=cast(Any, repository),
+            session_maker=cast(Any, object()),
+        ).reconcile(
+            entity=entity,
+            markdown_content="# Stale file snapshot\n",
+            observed_at=observed_at,
+            source="file_indexer",
+            anchor=anchor,
+        )
+
+    repository.create.assert_not_awaited()
+    repository.update_state_fields.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconciler_defers_unrelated_file_while_materialization_is_pending() -> None:
+    """An unanchored repair cannot turn a third checksum into a revision while DB is ahead."""
+    observed_at = datetime(2026, 4, 13, 15, 0, tzinfo=UTC)
+    accepted_checksum = await file_utils.compute_checksum("# MCP winner\n")
+    repository = SimpleNamespace(
+        get_by_entity_id=AsyncMock(
+            return_value=SimpleNamespace(
+                db_version=4,
+                db_checksum=accepted_checksum,
+                file_version=3,
+                file_checksum="old-file-checksum",
+                file_write_status="pending",
+            )
+        ),
+        create=AsyncMock(),
+        update_state_fields=AsyncMock(),
+    )
+    entity = cast(Entity, SimpleNamespace(id=42))
+
+    @asynccontextmanager
+    async def fake_scoped_session(_session_maker: object):
+        yield FakeSession()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_content_reconciler.db.scoped_session",
+            fake_scoped_session,
+        )
+        await NoteContentReconciler(
+            note_content_repository=cast(Any, repository),
+            session_maker=cast(Any, object()),
+        ).reconcile(
+            entity=entity,
+            markdown_content="# Unrelated file snapshot\n",
+            observed_at=observed_at,
+            source="read_repair",
+        )
+
+    repository.create.assert_not_awaited()
+    repository.update_state_fields.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_note_content_reconciler.py
+++ b/tests/indexing/test_note_content_reconciler.py
@@ -94,7 +94,7 @@ async def test_reconciler_converges_after_concurrent_create_conflict() -> None:
             "basic_memory.indexing.note_content_reconciler.db.scoped_session",
             fake_scoped_session,
         )
-        await NoteContentReconciler(
+        outcome = await NoteContentReconciler(
             note_content_repository=cast(Any, repository),
             session_maker=cast(Any, object()),
         ).reconcile(
@@ -105,6 +105,7 @@ async def test_reconciler_converges_after_concurrent_create_conflict() -> None:
         )
 
     repository.create.assert_awaited_once()
+    assert outcome == "current"
     assert session.rollback_count == 1
     assert repository.get_by_entity_id.await_count == 2
     repository.update_state_fields.assert_awaited_once_with(
@@ -157,7 +158,7 @@ async def test_reconciler_skips_stale_plan_when_version_guard_loses() -> None:
             fake_scoped_session,
         )
         # Must not raise even though the guarded write was skipped.
-        await NoteContentReconciler(
+        outcome = await NoteContentReconciler(
             note_content_repository=cast(Any, repository),
             session_maker=cast(Any, object()),
         ).reconcile(
@@ -168,6 +169,7 @@ async def test_reconciler_skips_stale_plan_when_version_guard_loses() -> None:
         )
 
     repository.create.assert_not_awaited()
+    assert outcome == "stale"
     assert repository.update_state_fields.await_count == 1
     _, kwargs = repository.update_state_fields.await_args
     assert kwargs["expected_db_version"] == 3
@@ -212,7 +214,7 @@ async def test_reconciler_skips_observation_when_anchor_changed_during_indexing(
             "basic_memory.indexing.note_content_reconciler.db.scoped_session",
             fake_scoped_session,
         )
-        await NoteContentReconciler(
+        outcome = await NoteContentReconciler(
             note_content_repository=cast(Any, repository),
             session_maker=cast(Any, object()),
         ).reconcile(
@@ -223,6 +225,51 @@ async def test_reconciler_skips_observation_when_anchor_changed_during_indexing(
             anchor=anchor,
         )
 
+    repository.create.assert_not_awaited()
+    repository.update_state_fields.assert_not_awaited()
+    assert outcome == "stale"
+
+
+@pytest.mark.asyncio
+async def test_reconciler_treats_initial_absence_as_stale_when_content_appears() -> None:
+    """An accepted write that creates note_content during indexing must win."""
+    accepted_checksum = await file_utils.compute_checksum("# Accepted write\n")
+    repository = SimpleNamespace(
+        get_by_entity_id=AsyncMock(
+            return_value=SimpleNamespace(
+                db_version=1,
+                db_checksum=accepted_checksum,
+                file_version=1,
+                file_checksum=accepted_checksum,
+                file_write_status="synced",
+            )
+        ),
+        create=AsyncMock(),
+        update_state_fields=AsyncMock(),
+    )
+    entity = cast(Entity, SimpleNamespace(id=42))
+
+    @asynccontextmanager
+    async def fake_scoped_session(_session_maker: object):
+        yield FakeSession()
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_content_reconciler.db.scoped_session",
+            fake_scoped_session,
+        )
+        outcome = await NoteContentReconciler(
+            note_content_repository=cast(Any, repository),
+            session_maker=cast(Any, object()),
+        ).reconcile(
+            entity=entity,
+            markdown_content="# Stale initial file\n",
+            observed_at=datetime(2026, 4, 13, 15, 0, tzinfo=UTC),
+            source="file_indexer",
+            anchor=NoteContentReconciliationAnchor(entity_id=None, state=None),
+        )
+
+    assert outcome == "stale"
     repository.create.assert_not_awaited()
     repository.update_state_fields.assert_not_awaited()
 
@@ -256,7 +303,7 @@ async def test_reconciler_defers_unrelated_file_while_materialization_is_pending
             "basic_memory.indexing.note_content_reconciler.db.scoped_session",
             fake_scoped_session,
         )
-        await NoteContentReconciler(
+        outcome = await NoteContentReconciler(
             note_content_repository=cast(Any, repository),
             session_maker=cast(Any, object()),
         ).reconcile(
@@ -268,6 +315,7 @@ async def test_reconciler_defers_unrelated_file_while_materialization_is_pending
 
     repository.create.assert_not_awaited()
     repository.update_state_fields.assert_not_awaited()
+    assert outcome == "current"
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_note_content_reconciliation.py
+++ b/tests/indexing/test_note_content_reconciliation.py
@@ -12,6 +12,7 @@ from basic_memory.indexing.note_content_reconciliation import (
     NoteContentMaterializedStale,
     NoteContentMaterializationStatusUpdate,
     NoteContentPromoted,
+    NoteContentReconciliationDeferred,
     NoteContentState,
     ObservedNoteContent,
     plan_note_content_materialization_publish,
@@ -87,13 +88,29 @@ def test_plan_refreshes_file_observation_when_db_is_ahead() -> None:
     )
 
 
-def test_plan_promotes_external_file_change_after_latest_known_version() -> None:
+def test_plan_defers_external_file_change_while_file_state_is_not_synced() -> None:
     plan = plan_note_content_reconciliation(
         NoteContentState(
             db_version=3,
             db_checksum="db-checksum",
             file_version=5,
             file_checksum="materialized-file-checksum",
+            file_write_status="pending",
+        ),
+        _observed("external-change-checksum"),
+    )
+
+    assert plan == NoteContentReconciliationDeferred()
+
+
+def test_plan_promotes_external_file_change_from_synced_state() -> None:
+    plan = plan_note_content_reconciliation(
+        NoteContentState(
+            db_version=5,
+            db_checksum="db-checksum",
+            file_version=5,
+            file_checksum="db-checksum",
+            file_write_status="synced",
         ),
         _observed("external-change-checksum"),
     )


### PR DESCRIPTION
## Why

A note write accepted through MCP or the browser can race with file indexing that
started from an older Tigris object. Before this change, the stale indexing pass
could reconcile its older Markdown back into `note_content`, effectively making
an accepted write disappear from the canonical database state and file history.

This is the Core half of the single-editor persistence work tracked in
https://github.com/basicmachines-co/basic-memory-cloud/issues/1589.

## What Changed

- Capture the canonical `note_content` reconciliation state before indexing an
  existing Markdown file.
- Reconcile the indexed file only when the canonical state still matches that
  captured anchor.
- Keep legitimate external file changes: an unrelated file checksum may still
  advance canonical state when the prior file write was fully synchronized and
  its file/database versions and checksums agreed.
- Defer reconciliation explicitly when a concurrent accepted write changed the
  canonical state while indexing was in flight.
- Treat initial `note_content` absence as an anchor rather than disabling the
  optimistic check for newly indexed entities.
- Re-read and re-index the current file when a stale pass is detected so entity,
  observation, relation, and search projections cannot finish on old Markdown.
- Fail for normal job retry if a second concurrent write also makes the bounded
  immediate retry stale.
- Cover stale races, stable external changes, and dependency wiring with focused
  regression tests.

## Implementation Details

`NoteContentReconciliationAnchor` records the pre-index canonical version,
checksums, and file-write status. `FileIndexer` captures that anchor before
parsing an existing Markdown file and passes it to the reconciler after the
entity update.

The reconciler treats the anchor as an optimistic concurrency boundary:

- If current canonical state differs from the anchor, the index pass is stale
  and cannot promote its file content.
- If current state still matches, equal checksums remain a no-op.
- A different file checksum can be promoted only from a fully synchronized
  baseline (`file_write_status == "synced"`, equal file/database versions, and
  equal file/database checksums).

Reconciliation returns an explicit `current` or `stale` outcome. A stale
outcome makes the per-file indexer run one fresh pass from current storage,
repairing every derived projection. A second stale outcome raises rather than
reporting a false success, allowing the existing indexing job retry policy to
converge later.

This preserves first-writer CAS behavior without adding locks or a second
version authority.

## Testing

- `uv run pytest -q tests/indexing/test_note_content_reconciliation.py tests/indexing/test_note_content_reconciler.py tests/indexing/test_file_indexer.py tests/indexing/test_index_batch_runtime.py tests/indexing/test_note_content_batch_reconciliation.py`
  - 44 passed
- `just fast-check`
  - Ruff and formatting passed
  - type checking passed
  - only pre-existing Python 3.14 asyncio deprecation diagnostics remain
- `git diff --check`

## Risks / Follow-ups

- This PR changes only Core reconciliation. The Cloud follow-up will pin the
  merged Core SHA and publish the File History conflict-resolution UI already
  verified locally.
- The full development browser conflict matrix will be rerun after Cloud is
  pinned to this Core change.
- No production deployment is included.
