### PR TITLE
fix(core): gate move-orphan skip on a durable move-vacate marker

### DIFF
--- a/src/basic_memory/alembic/versions/o8j9k0l1m2n3_add_note_file_vacate_table.py
+++ b/src/basic_memory/alembic/versions/o8j9k0l1m2n3_add_note_file_vacate_table.py
@@ -30,12 +30,12 @@ def upgrade() -> None:
         "note_file_vacate",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("project_id", sa.Integer(), nullable=False),
-        sa.Column("entity_id", sa.Integer(), nullable=False),
+        sa.Column("entity_id", sa.Integer(), nullable=True),
         sa.Column("file_path", sa.String(), nullable=False),
         sa.Column("file_checksum", sa.String(), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(["project_id"], ["project.id"], ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"], ondelete="SET NULL"),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "project_id", "file_path", name="uix_note_file_vacate_project_file_path"

--- a/src/basic_memory/alembic/versions/o8j9k0l1m2n3_add_note_file_vacate_table.py
+++ b/src/basic_memory/alembic/versions/o8j9k0l1m2n3_add_note_file_vacate_table.py
@@ -1,0 +1,52 @@
+"""Add note_file_vacate table
+
+Revision ID: o8j9k0l1m2n3
+Revises: n7i8j9k0l1m2
+Create Date: 2026-07-26 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "o8j9k0l1m2n3"
+down_revision: Union[str, None] = "n7i8j9k0l1m2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create note_file_vacate: durable proof a source path was vacated by a move.
+
+    The indexer keys on (project_id, file_path) to tell a move's lingering source object (skip
+    re-import) from a legitimate byte-identical copy (index as new) — see
+    basic-memory-cloud#1601.
+    """
+    op.create_table(
+        "note_file_vacate",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("project_id", sa.Integer(), nullable=False),
+        sa.Column("entity_id", sa.Integer(), nullable=False),
+        sa.Column("file_path", sa.String(), nullable=False),
+        sa.Column("file_checksum", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["project.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "project_id", "file_path", name="uix_note_file_vacate_project_file_path"
+        ),
+    )
+    op.create_index(
+        "ix_note_file_vacate_project_id", "note_file_vacate", ["project_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    """Drop note_file_vacate and its supporting index."""
+    op.drop_index("ix_note_file_vacate_project_id", table_name="note_file_vacate")
+    op.drop_table("note_file_vacate")

--- a/src/basic_memory/index/local_notes.py
+++ b/src/basic_memory/index/local_notes.py
@@ -76,7 +76,7 @@ class LocalAcceptedNotePreparerFactory:
         project: Project,
         file_path: RuntimeFilePath,
     ) -> RuntimeFileChecksum | None:
-        """Return the source checksum observed while accepting an ambiguous move."""
+        """Return the source checksum observed while accepting a path change."""
         _, file_service = self._create_file_service(project)
         if not await file_service.exists(file_path):
             return None

--- a/src/basic_memory/index/local_notes.py
+++ b/src/basic_memory/index/local_notes.py
@@ -46,14 +46,20 @@ class LocalAcceptedNotePreparerFactory:
     session_maker: async_sessionmaker[AsyncSession]
     app_config: BasicMemoryConfig
 
-    def create_note_preparer(self, project: Project) -> AcceptedNoteMutationPreparer:
+    def _create_file_service(self, project: Project) -> tuple[EntityParser, FileService]:
         entity_parser = EntityParser(Path(project.path))
         markdown_processor = MarkdownProcessor(entity_parser, app_config=self.app_config)
-        file_service = FileService(
-            Path(project.path),
-            markdown_processor,
-            app_config=self.app_config,
+        return (
+            entity_parser,
+            FileService(
+                Path(project.path),
+                markdown_processor,
+                app_config=self.app_config,
+            ),
         )
+
+    def create_note_preparer(self, project: Project) -> AcceptedNoteMutationPreparer:
+        entity_parser, file_service = self._create_file_service(project)
         entity_repository = EntityRepository(project_id=project.id)
         return NotePreparation(
             NotePreparationDependencies(
@@ -64,6 +70,17 @@ class LocalAcceptedNotePreparerFactory:
                 app_config=self.app_config,
             )
         )
+
+    async def load_current_file_checksum(
+        self,
+        project: Project,
+        file_path: RuntimeFilePath,
+    ) -> RuntimeFileChecksum | None:
+        """Return the source checksum observed while accepting an ambiguous move."""
+        _, file_service = self._create_file_service(project)
+        if not await file_service.exists(file_path):
+            return None
+        return await file_service.compute_checksum(file_path)
 
 
 LocalAcceptedNoteRepositories = AcceptedNoteRepositories

--- a/src/basic_memory/index/local_project.py
+++ b/src/basic_memory/index/local_project.py
@@ -45,8 +45,11 @@ from basic_memory.indexing.file_batch_runner import (
 from basic_memory.indexing.file_index_checking import (
     FileIndexChecker,
     RepositoryIndexedFileChecksumSource,
+    RepositoryMovedEntitySource,
+    RepositoryMoveVacateSource,
     StorageCurrentFileChecksumSource,
 )
+from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
 from basic_memory.indexing.models import (
     IndexFileBatchJobResult,
     IndexFileJobResult,
@@ -587,6 +590,14 @@ class LocalProjectIndexRuntimeFactory:
             ),
             current_checksum_source=StorageCurrentFileChecksumSource(
                 metadata_source=metadata_source,
+            ),
+            moved_entity_source=RepositoryMovedEntitySource(
+                session_maker=dependencies.session_maker,
+                entity_repository=dependencies.entity_repository,
+            ),
+            move_vacate_source=RepositoryMoveVacateSource(
+                session_maker=dependencies.session_maker,
+                vacate_repository=NoteFileVacateRepository(dependencies.project_id),
             ),
         )
         maintenance_store = RepositoryProjectIndexMaintenanceStore(

--- a/src/basic_memory/index/local_runtime.py
+++ b/src/basic_memory/index/local_runtime.py
@@ -30,8 +30,11 @@ from basic_memory.indexing.external_file_delete_runner import ExternalFileDelete
 from basic_memory.indexing.file_index_checking import (
     FileIndexChecker,
     RepositoryIndexedFileChecksumSource,
+    RepositoryMovedEntitySource,
+    RepositoryMoveVacateSource,
     StorageCurrentFileChecksumSource,
 )
+from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
 from basic_memory.indexing.index_file_runner import (
     IndexFileObjectMetadata,
     RepositoryCurrentMaterializedNoteSource,
@@ -260,6 +263,14 @@ class LocalWatchEventIndexRuntimeFactory:
             ),
             current_checksum_source=StorageCurrentFileChecksumSource(
                 metadata_source=metadata_source,
+            ),
+            moved_entity_source=RepositoryMovedEntitySource(
+                session_maker=dependencies.session_maker,
+                entity_repository=dependencies.entity_repository,
+            ),
+            move_vacate_source=RepositoryMoveVacateSource(
+                session_maker=dependencies.session_maker,
+                vacate_repository=NoteFileVacateRepository(dependencies.project_id),
             ),
         )
         maintenance_store = RepositoryProjectIndexMaintenanceStore(

--- a/src/basic_memory/index/note_content_materialization.py
+++ b/src/basic_memory/index/note_content_materialization.py
@@ -431,6 +431,14 @@ class InlineNoteFileDeleteEnqueuer:
                 file_path=request.file_path,
                 live_file_path=request.live_file_path,
             )
+            # No separate source object exists: the old path aliases the live destination, so the
+            # move is already physically complete and its suppression marker must not outlive it.
+            if self.vacate_clearer is not None:
+                await self.vacate_clearer.clear_move_vacate(
+                    project_id=request.project_id,
+                    file_path=request.file_path,
+                    file_checksum=request.file_checksum,
+                )
             return
         await run_note_file_delete(
             request, storage=self.storage, vacate_clearer=self.vacate_clearer

--- a/src/basic_memory/index/note_content_materialization.py
+++ b/src/basic_memory/index/note_content_materialization.py
@@ -287,6 +287,26 @@ async def _recover_deleted_destination_vacate(
     )
 
 
+@dataclass(frozen=True, slots=True)
+class SessionMoveVacateClearer:
+    """Retire a recovery marker in the transaction that locked its current state."""
+
+    session: AsyncSession
+
+    async def clear_move_vacate(
+        self,
+        *,
+        project_id: int,
+        file_path: RuntimeFilePath,
+        file_checksum: RuntimeFileChecksum | None,
+    ) -> None:
+        await NoteFileVacateRepository(project_id).clear_vacate(
+            self.session,
+            file_path=str(file_path),
+            file_checksum=file_checksum,
+        )
+
+
 async def recover_move_vacates(
     *,
     session_maker: async_sessionmaker[AsyncSession],
@@ -312,42 +332,51 @@ async def recover_move_vacates(
         vacate_count=len(vacates),
     )
     storage = LocalNoteContentStorage(file_service)
-    vacate_clearer = RepositoryMoveVacateClearer(session_maker=session_maker)
-    cleanup_enqueuer = InlineNoteFileDeleteEnqueuer(
-        storage,
-        vacate_clearer=vacate_clearer,
-    )
+    vacate_repository = NoteFileVacateRepository(project_id)
     recovered = 0
-    for vacate in vacates:
+    for candidate in vacates:
         try:
-            if vacate.entity_id is None:
-                # The destination entity no longer exists, so the queue-neutral
-                # cleanup request has no valid entity identity. The durable
-                # marker still carries the checksum needed for the same guarded
-                # storage delete and marker retirement.
-                await _recover_deleted_destination_vacate(
-                    vacate,
-                    project_id=project_id,
-                    storage=storage,
-                    vacate_clearer=vacate_clearer,
+            async with db.scoped_session(session_maker) as session:
+                vacate = await vacate_repository.lock_recoverable_vacate(
+                    session,
+                    file_path=candidate.file_path,
+                    file_checksum=candidate.file_checksum,
                 )
-            else:
-                await cleanup_enqueuer.enqueue_note_file_delete(
-                    RuntimeNoteFileDeleteJobRequest(
+                if vacate is None:
+                    continue
+
+                vacate_clearer = SessionMoveVacateClearer(session)
+                if vacate.entity_id is None:
+                    # The destination entity no longer exists, so the queue-neutral
+                    # cleanup request has no valid entity identity. The durable
+                    # marker still carries the checksum needed for the same guarded
+                    # storage delete and marker retirement.
+                    await _recover_deleted_destination_vacate(
+                        vacate,
                         project_id=project_id,
-                        entity_id=vacate.entity_id,
-                        file_path=vacate.file_path,
-                        file_checksum=vacate.file_checksum,
-                        live_file_path=vacate.live_file_path,
+                        storage=storage,
+                        vacate_clearer=vacate_clearer,
                     )
-                )
+                else:
+                    await InlineNoteFileDeleteEnqueuer(
+                        storage,
+                        vacate_clearer=vacate_clearer,
+                    ).enqueue_note_file_delete(
+                        RuntimeNoteFileDeleteJobRequest(
+                            project_id=project_id,
+                            entity_id=vacate.entity_id,
+                            file_path=vacate.file_path,
+                            file_checksum=vacate.file_checksum,
+                            live_file_path=vacate.live_file_path,
+                        )
+                    )
         except Exception:  # pragma: no cover - defensive startup guard
             # A failed marker stays durable and can be retried on the next startup;
             # one unavailable path must not block cleanup for the rest of the project.
             logger.exception(
                 "Failed to recover move-vacate source cleanup",
                 project_id=project_id,
-                file_path=vacate.file_path,
+                file_path=candidate.file_path,
             )
             continue
         recovered += 1

--- a/src/basic_memory/index/note_content_materialization.py
+++ b/src/basic_memory/index/note_content_materialization.py
@@ -13,7 +13,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory import db, file_utils
 from basic_memory.indexing.index_file_runner import IndexFileExecutor
-from basic_memory.indexing.note_file_delete_runner import run_note_file_delete
+from basic_memory.indexing.note_file_delete_runner import (
+    MoveVacateClearer,
+    RepositoryMoveVacateClearer,
+    run_note_file_delete,
+)
 from basic_memory.indexing.note_materialization_runner import (
     ContentStoreNoteMaterializationFileWriter,
     RepositoryNoteMaterializationPreflight,
@@ -192,7 +196,10 @@ async def run_recovery_materialization(
         writer=ContentStoreNoteMaterializationFileWriter(storage),
         publisher=RepositoryNoteMaterializationPublisher(session_maker=session_maker),
         status_publisher=RepositoryNoteMaterializationStatusPublisher(session_maker=session_maker),
-        cleanup_enqueuer=InlineNoteFileDeleteEnqueuer(storage),
+        cleanup_enqueuer=InlineNoteFileDeleteEnqueuer(
+            storage,
+            vacate_clearer=RepositoryMoveVacateClearer(session_maker=session_maker),
+        ),
     )
 
 
@@ -401,6 +408,8 @@ class InlineNoteFileDeleteEnqueuer:
     """Execute note-file cleanup immediately in the local runtime."""
 
     storage: LocalNoteContentStorage
+    # Clears the move-vacate marker once a moved note's source object is actually deleted (#1601).
+    vacate_clearer: MoveVacateClearer | None = None
 
     async def enqueue_note_file_delete(self, request: RuntimeNoteFileDeleteJobRequest) -> None:
         # Trigger: a move scheduled old-path cleanup whose old and new paths differ
@@ -423,7 +432,9 @@ class InlineNoteFileDeleteEnqueuer:
                 live_file_path=request.live_file_path,
             )
             return
-        await run_note_file_delete(request, storage=self.storage)
+        await run_note_file_delete(
+            request, storage=self.storage, vacate_clearer=self.vacate_clearer
+        )
 
 
 class RelationResolutionScheduling(Protocol):
@@ -494,7 +505,10 @@ class LocalNoteContentMaterializationProvider:
         if accepted.materialization is None:  # pragma: no cover - guarded by caller
             return accepted
         storage = LocalNoteContentStorage(self.file_service)
-        cleanup_enqueuer = InlineNoteFileDeleteEnqueuer(storage)
+        cleanup_enqueuer = InlineNoteFileDeleteEnqueuer(
+            storage,
+            vacate_clearer=RepositoryMoveVacateClearer(session_maker=self.session_maker),
+        )
         result = await run_note_materialization(
             plan_note_materialization_job_request(accepted.materialization),
             preflight=RepositoryNoteMaterializationPreflight(
@@ -554,7 +568,10 @@ class LocalNoteContentMaterializationProvider:
             return accepted
 
         storage = LocalNoteContentStorage(self.file_service)
-        await InlineNoteFileDeleteEnqueuer(storage).enqueue_note_file_delete(
+        await InlineNoteFileDeleteEnqueuer(
+            storage,
+            vacate_clearer=RepositoryMoveVacateClearer(session_maker=self.session_maker),
+        ).enqueue_note_file_delete(
             plan_note_file_delete_job_request(accepted.file_delete)
         )
         return accepted

--- a/src/basic_memory/index/note_content_materialization.py
+++ b/src/basic_memory/index/note_content_materialization.py
@@ -571,7 +571,5 @@ class LocalNoteContentMaterializationProvider:
         await InlineNoteFileDeleteEnqueuer(
             storage,
             vacate_clearer=RepositoryMoveVacateClearer(session_maker=self.session_maker),
-        ).enqueue_note_file_delete(
-            plan_note_file_delete_job_request(accepted.file_delete)
-        )
+        ).enqueue_note_file_delete(plan_note_file_delete_job_request(accepted.file_delete))
         return accepted

--- a/src/basic_memory/index/note_content_materialization.py
+++ b/src/basic_memory/index/note_content_materialization.py
@@ -40,11 +40,16 @@ from basic_memory.runtime.note_content import (
     RuntimePendingNoteMaterialization,
     plan_accepted_note_response,
     plan_note_materialization_job_request,
+    read_runtime_file_checksum,
 )
 from basic_memory.runtime.note_materialization import RuntimeFileMetadataSource
 from basic_memory.runtime.storage import RuntimeFileChecksum, RuntimeFilePath
 from basic_memory.models import Entity
 from basic_memory.repository import EntityRepository, NoteContentRepository
+from basic_memory.repository.note_file_vacate_repository import (
+    NoteFileVacateRepository,
+    RecoverableVacate,
+)
 from basic_memory.schemas.response import ObservationResponse, RelationResponse
 from basic_memory.services.file_service import FileService
 
@@ -261,6 +266,91 @@ async def recover_stuck_materializations(
             continue
         if result.status is RuntimeNoteMaterializationStatus.written:
             recovered += 1
+    return recovered
+
+
+async def _recover_deleted_destination_vacate(
+    vacate: RecoverableVacate,
+    *,
+    project_id: int,
+    storage: "LocalNoteContentStorage",
+    vacate_clearer: MoveVacateClearer,
+) -> None:
+    """Resolve one guarded vacate after its destination entity was deleted."""
+    actual_checksum = await read_runtime_file_checksum(storage, vacate.file_path)
+    if actual_checksum == vacate.file_checksum:
+        await storage.delete_file(vacate.file_path)
+    await vacate_clearer.clear_move_vacate(
+        project_id=project_id,
+        file_path=vacate.file_path,
+        file_checksum=vacate.file_checksum,
+    )
+
+
+async def recover_move_vacates(
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+    file_service: FileService,
+    project_id: int,
+) -> int:
+    """Retry durable move-source cleanup work that an in-process enqueue lost.
+
+    Only checksum-guarded markers with a synchronized or deleted destination are
+    eligible. This keeps the old source intact while destination publication is
+    still pending or failed, then converges it on a later startup after recovery
+    reaches ``synced``.
+    """
+    async with db.scoped_session(session_maker) as session:
+        vacates = await NoteFileVacateRepository(project_id).list_recoverable_vacates(session)
+
+    if not vacates:
+        return 0
+
+    logger.info(
+        "Recovering move-vacate source cleanup",
+        project_id=project_id,
+        vacate_count=len(vacates),
+    )
+    storage = LocalNoteContentStorage(file_service)
+    vacate_clearer = RepositoryMoveVacateClearer(session_maker=session_maker)
+    cleanup_enqueuer = InlineNoteFileDeleteEnqueuer(
+        storage,
+        vacate_clearer=vacate_clearer,
+    )
+    recovered = 0
+    for vacate in vacates:
+        try:
+            if vacate.entity_id is None:
+                # The destination entity no longer exists, so the queue-neutral
+                # cleanup request has no valid entity identity. The durable
+                # marker still carries the checksum needed for the same guarded
+                # storage delete and marker retirement.
+                await _recover_deleted_destination_vacate(
+                    vacate,
+                    project_id=project_id,
+                    storage=storage,
+                    vacate_clearer=vacate_clearer,
+                )
+            else:
+                await cleanup_enqueuer.enqueue_note_file_delete(
+                    RuntimeNoteFileDeleteJobRequest(
+                        project_id=project_id,
+                        entity_id=vacate.entity_id,
+                        file_path=vacate.file_path,
+                        file_checksum=vacate.file_checksum,
+                        live_file_path=vacate.live_file_path,
+                    )
+                )
+        except Exception:  # pragma: no cover - defensive startup guard
+            # A failed marker stays durable and can be retried on the next startup;
+            # one unavailable path must not block cleanup for the rest of the project.
+            logger.exception(
+                "Failed to recover move-vacate source cleanup",
+                project_id=project_id,
+                file_path=vacate.file_path,
+            )
+            continue
+        recovered += 1
     return recovered
 
 

--- a/src/basic_memory/index/watch_coordinator.py
+++ b/src/basic_memory/index/watch_coordinator.py
@@ -64,9 +64,15 @@ class WatchCoordinator:
             # depends on basic_memory.index, whose __init__ imports this module.
             from basic_memory.services.initialization import initialize_file_indexing
 
+            recovery_complete = asyncio.Event()
+
             async def _watch_runner() -> None:  # pragma: no cover
                 try:
-                    await initialize_file_indexing(self.config, quiet=self.quiet)
+                    await initialize_file_indexing(
+                        self.config,
+                        quiet=self.quiet,
+                        recovery_complete=recovery_complete,
+                    )
                 except asyncio.CancelledError:
                     logger.debug("Local event-index watcher cancelled")
                     raise
@@ -74,8 +80,15 @@ class WatchCoordinator:
                     logger.error(f"Error in local event-index watcher: {exc}")
                     self._status = WatchStatus.ERROR
                     raise
+                finally:
+                    # A startup failure must unblock start() so it can propagate
+                    # the watcher exception instead of waiting indefinitely.
+                    recovery_complete.set()
 
             self._watch_task = asyncio.create_task(_watch_runner())
+            await recovery_complete.wait()
+            if self._status is WatchStatus.ERROR or self._watch_task.done():
+                await self._watch_task
             self._status = WatchStatus.RUNNING
             logger.info("Watch coordinator started successfully")
 

--- a/src/basic_memory/indexing/accepted_note_mutation_runner.py
+++ b/src/basic_memory/indexing/accepted_note_mutation_runner.py
@@ -40,6 +40,7 @@ from basic_memory.runtime.note_content import (
     accepted_note_file_path_conflicts,
     classify_accepted_note_write_conflict,
     plan_accepted_note_write_change,
+    select_accepted_note_source_checksum,
 )
 from basic_memory.runtime.note_move import normalize_note_move_destination_path
 from basic_memory.runtime.note_object_metadata import NOTE_SOURCE_COLLABORATION_RELAY
@@ -603,9 +604,7 @@ async def _run_accepted_note_update(
         # cleanup cannot let a later project index recreate the old path as a ghost.
         vacated_source = (
             entity.file_path,
-            current_note_content.file_checksum
-            if current_note_content.file_checksum is not None
-            else current_note_content.db_checksum,
+            select_accepted_note_source_checksum(current_note_content),
         )
         # Optimistic-concurrency precondition: the caller sent the db_checksum it
         # last synced; if the accepted row has advanced to a different write,
@@ -772,11 +771,7 @@ async def _run_accepted_note_move(
     # Capture the source checksum before persisting the move mutates note_content to the
     # destination version. When materialization has not published a file checksum yet, the
     # accepted DB checksum still identifies the exact Markdown bytes the source write produced.
-    vacated_source_checksum = (
-        current_note_content.file_checksum
-        if current_note_content.file_checksum is not None
-        else current_note_content.db_checksum
-    )
+    vacated_source_checksum = select_accepted_note_source_checksum(current_note_content)
     # Same-path moves fail fast everywhere by decision (2026-07-14): cloud's
     # pre-unification route returned a 200 no-op, local rejected — the unified
     # runner keeps the rejection so a mistaken identity move surfaces instead

--- a/src/basic_memory/indexing/accepted_note_mutation_runner.py
+++ b/src/basic_memory/indexing/accepted_note_mutation_runner.py
@@ -31,6 +31,7 @@ from basic_memory.indexing.accepted_note_write_runner import (
 )
 from basic_memory.models import Entity, NoteContent, Project
 from basic_memory.repository import NoteContentVersionConflict
+from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
 from basic_memory.services.exceptions import EntityAlreadyExistsError
 from basic_memory.runtime.note_content import (
     RuntimeAcceptedNoteChange,
@@ -805,6 +806,20 @@ async def _run_accepted_note_move(
         current_note_content=current_note_content,
         existing_file_path=existing_file_path,
         repositories=dependencies.write_repositories,
+    )
+    # Record that this move vacated the source path, atomically with the move. A later index of the
+    # still-present source object then recognizes it as this move's leftover rather than a new note
+    # and skips it (basic-memory-cloud#1601). Recorded even when the source checksum is unknown (so
+    # no physical cleanup is scheduled) — the marker's existence is what the gate needs, and the
+    # checksum guard only affects clearing. The repository is pure per-tenant DB logic, identical
+    # for local and cloud, so it is built inline on the move's own session rather than injected.
+    await NoteFileVacateRepository(project.id).record_vacate(
+        session,
+        entity_id=entity.id,
+        file_path=existing_file_path,
+        file_checksum=(
+            current_note_content.file_checksum if current_note_content is not None else None
+        ),
     )
     return plan_accepted_note_write_change(
         status_code=200,

--- a/src/basic_memory/indexing/accepted_note_mutation_runner.py
+++ b/src/basic_memory/indexing/accepted_note_mutation_runner.py
@@ -48,6 +48,7 @@ from basic_memory.runtime.storage import (
     NoteExternalId,
     ProjectExternalId,
     ProjectId,
+    RuntimeFileChecksum,
     RuntimeFilePath,
     RuntimeNoteActorKind,
     RuntimeNoteActorName,
@@ -264,6 +265,12 @@ class AcceptedNoteMutationPreparerFactory(Protocol):
 
     def create_note_preparer(self, project: Project) -> AcceptedNoteMutationPreparer: ...
 
+    async def load_current_file_checksum(
+        self,
+        project: Project,
+        file_path: RuntimeFilePath,
+    ) -> RuntimeFileChecksum | None: ...
+
 
 class AcceptedNoteMutationRepositories(Protocol):
     """Repository lookup capability set for accepted-note mutation orchestration."""
@@ -341,6 +348,26 @@ def reject_stale_base_checksum(current_db_checksum: str | None) -> NoReturn:
             kind=AcceptedNoteMutationRejectKind.conflict,
             detail=AcceptedNoteBaseChecksumConflict(db_checksum=current_db_checksum),
         )
+    )
+
+
+async def resolve_accepted_note_source_checksum(
+    *,
+    project: Project,
+    file_path: RuntimeFilePath,
+    current_note_content: NoteContent,
+    preparer_factory: AcceptedNoteMutationPreparerFactory,
+) -> RuntimeFileChecksum:
+    """Resolve the exact source bytes when an in-flight publication is ambiguous."""
+    observed_file_checksum = None
+    if current_note_content.file_write_status in {"pending", "writing"}:
+        observed_file_checksum = await preparer_factory.load_current_file_checksum(
+            project,
+            file_path,
+        )
+    return select_accepted_note_source_checksum(
+        current_note_content,
+        observed_file_checksum=observed_file_checksum,
     )
 
 
@@ -599,13 +626,19 @@ async def _run_accepted_note_update(
             dependencies=dependencies,
             missing_kind=AcceptedNoteMutationRejectKind.conflict,
         )
-        # A PUT replacement may also rename the note. Capture the accepted source bytes before
+        # A PUT replacement may also rename the note. Capture the exact source bytes before
         # persistence mutates the entity and note_content to the destination version so delayed
         # cleanup cannot let a later project index recreate the old path as a ghost.
-        vacated_source = (
-            entity.file_path,
-            select_accepted_note_source_checksum(current_note_content),
-        )
+        if request.data.file_path != entity.file_path:
+            vacated_source = (
+                entity.file_path,
+                await resolve_accepted_note_source_checksum(
+                    project=project,
+                    file_path=entity.file_path,
+                    current_note_content=current_note_content,
+                    preparer_factory=dependencies.preparer_factory,
+                ),
+            )
         # Optimistic-concurrency precondition: the caller sent the db_checksum it
         # last synced; if the accepted row has advanced to a different write,
         # reject with the current checksum so the client rebases instead of
@@ -666,6 +699,7 @@ async def _run_accepted_note_update(
         current_note_content=current_note_content,
         existing_file_path=existing_file_path,
         accepted_file_path=entity.file_path,
+        source_file_checksum=vacated_source[1] if vacated_source is not None else None,
         repositories=dependencies.write_repositories,
     )
     if vacated_source is not None and entity.file_path != vacated_source[0]:
@@ -768,10 +802,6 @@ async def _run_accepted_note_move(
         dependencies=dependencies,
     )
     existing_file_path = entity.file_path
-    # Capture the source checksum before persisting the move mutates note_content to the
-    # destination version. When materialization has not published a file checksum yet, the
-    # accepted DB checksum still identifies the exact Markdown bytes the source write produced.
-    vacated_source_checksum = select_accepted_note_source_checksum(current_note_content)
     # Same-path moves fail fast everywhere by decision (2026-07-14): cloud's
     # pre-unification route returned a 200 no-op, local rejected — the unified
     # runner keeps the rejection so a mistaken identity move surfaces instead
@@ -781,6 +811,16 @@ async def _run_accepted_note_move(
             AcceptedNoteMutationRejectKind.bad_request,
             "Source and destination paths are the same.",
         )
+
+    # Capture the source checksum before persisting the move mutates note_content to the
+    # destination version. For an in-flight publication, observe storage once to distinguish the
+    # last published bytes from accepted bytes written before their result was recorded.
+    vacated_source_checksum = await resolve_accepted_note_source_checksum(
+        project=project,
+        file_path=existing_file_path,
+        current_note_content=current_note_content,
+        preparer_factory=dependencies.preparer_factory,
+    )
 
     await reject_conflicting_accepted_note_file_path(
         session,
@@ -823,14 +863,15 @@ async def _run_accepted_note_move(
         updated_at=now,
         current_note_content=current_note_content,
         existing_file_path=existing_file_path,
+        source_file_checksum=vacated_source_checksum,
         repositories=dependencies.write_repositories,
     )
     # Record that this move vacated the source path, atomically with the move. A later index of the
     # still-present source object then recognizes it as this move's leftover rather than a new note
-    # and skips it (basic-memory-cloud#1601). The accepted DB checksum closes the window where the
-    # source write reached storage but its file checksum did not reach note_content. The repository
-    # is pure per-tenant DB logic, identical for local and cloud, so it is built inline on the
-    # move's own session rather than injected.
+    # and skips it (basic-memory-cloud#1601). In-flight publication states use one observed source
+    # checksum, closing both sides of the before-write/written-before-publish ambiguity. The
+    # repository is pure per-tenant DB logic, identical for local and cloud, so it is built inline
+    # on the move's own session rather than injected.
     await NoteFileVacateRepository(project.id).record_vacate(
         session,
         entity_id=entity.id,

--- a/src/basic_memory/indexing/accepted_note_mutation_runner.py
+++ b/src/basic_memory/indexing/accepted_note_mutation_runner.py
@@ -632,9 +632,7 @@ async def _run_accepted_note_update(
                 or current_head_in_storage
             )
             if not relay_supersede:
-                reject_stale_base_checksum(
-                    current_db_checksum=current_note_content.db_checksum
-                )
+                reject_stale_base_checksum(current_db_checksum=current_note_content.db_checksum)
         try:
             prepared_write = await prepare_accepted_note_replace(
                 preparer,
@@ -754,6 +752,14 @@ async def _run_accepted_note_move(
         dependencies=dependencies,
     )
     existing_file_path = entity.file_path
+    # Capture the source checksum before persisting the move mutates note_content to the
+    # destination version. When materialization has not published a file checksum yet, the
+    # accepted DB checksum still identifies the exact Markdown bytes the source write produced.
+    vacated_source_checksum = (
+        current_note_content.file_checksum
+        if current_note_content.file_checksum is not None
+        else current_note_content.db_checksum
+    )
     # Same-path moves fail fast everywhere by decision (2026-07-14): cloud's
     # pre-unification route returned a 200 no-op, local rejected — the unified
     # runner keeps the rejection so a mistaken identity move surfaces instead
@@ -809,17 +815,15 @@ async def _run_accepted_note_move(
     )
     # Record that this move vacated the source path, atomically with the move. A later index of the
     # still-present source object then recognizes it as this move's leftover rather than a new note
-    # and skips it (basic-memory-cloud#1601). Recorded even when the source checksum is unknown (so
-    # no physical cleanup is scheduled) — the marker's existence is what the gate needs, and the
-    # checksum guard only affects clearing. The repository is pure per-tenant DB logic, identical
-    # for local and cloud, so it is built inline on the move's own session rather than injected.
+    # and skips it (basic-memory-cloud#1601). The accepted DB checksum closes the window where the
+    # source write reached storage but its file checksum did not reach note_content. The repository
+    # is pure per-tenant DB logic, identical for local and cloud, so it is built inline on the
+    # move's own session rather than injected.
     await NoteFileVacateRepository(project.id).record_vacate(
         session,
         entity_id=entity.id,
         file_path=existing_file_path,
-        file_checksum=(
-            current_note_content.file_checksum if current_note_content is not None else None
-        ),
+        file_checksum=vacated_source_checksum,
     )
     return plan_accepted_note_write_change(
         status_code=200,

--- a/src/basic_memory/indexing/accepted_note_mutation_runner.py
+++ b/src/basic_memory/indexing/accepted_note_mutation_runner.py
@@ -357,8 +357,8 @@ async def resolve_accepted_note_source_checksum(
     file_path: RuntimeFilePath,
     current_note_content: NoteContent,
     preparer_factory: AcceptedNoteMutationPreparerFactory,
-) -> RuntimeFileChecksum:
-    """Resolve the exact source bytes when an in-flight publication is ambiguous."""
+) -> RuntimeFileChecksum | None:
+    """Resolve source bytes only when storage or synchronized state proves ownership."""
     observed_file_checksum = None
     if current_note_content.file_write_status in {"pending", "writing", "failed"}:
         observed_file_checksum = await preparer_factory.load_current_file_checksum(
@@ -562,7 +562,7 @@ async def _run_accepted_note_update(
     )
     created = entity is None
     existing_file_path = entity.file_path if entity is not None else None
-    vacated_source: tuple[RuntimeFilePath, str] | None = None
+    vacated_source: tuple[RuntimeFilePath, RuntimeFileChecksum | None] | None = None
 
     await reject_conflicting_accepted_note_file_path(
         session,
@@ -702,7 +702,11 @@ async def _run_accepted_note_update(
         source_file_checksum=vacated_source[1] if vacated_source is not None else None,
         repositories=dependencies.write_repositories,
     )
-    if vacated_source is not None and entity.file_path != vacated_source[0]:
+    if (
+        vacated_source is not None
+        and vacated_source[1] is not None
+        and entity.file_path != vacated_source[0]
+    ):
         await NoteFileVacateRepository(project.id).record_vacate(
             session,
             entity_id=entity.id,
@@ -866,18 +870,17 @@ async def _run_accepted_note_move(
         source_file_checksum=vacated_source_checksum,
         repositories=dependencies.write_repositories,
     )
-    # Record that this move vacated the source path, atomically with the move. A later index of the
-    # still-present source object then recognizes it as this move's leftover rather than a new note
-    # and skips it (basic-memory-cloud#1601). In-flight publication states use one observed source
-    # checksum, closing both sides of the before-write/written-before-publish ambiguity. The
-    # repository is pure per-tenant DB logic, identical for local and cloud, so it is built inline
-    # on the move's own session rather than injected.
-    await NoteFileVacateRepository(project.id).record_vacate(
-        session,
-        entity_id=entity.id,
-        file_path=existing_file_path,
-        file_checksum=vacated_source_checksum,
-    )
+    # Trigger: storage confirms which source bytes this move vacated.
+    # Why: an absent source is not evidence that the accepted DB checksum owns that path; recording
+    # it could let delayed cleanup delete a legitimate byte-identical file created there later.
+    # Outcome: only confirmed source objects receive the durable orphan gate and guarded cleanup.
+    if vacated_source_checksum is not None:
+        await NoteFileVacateRepository(project.id).record_vacate(
+            session,
+            entity_id=entity.id,
+            file_path=existing_file_path,
+            file_checksum=vacated_source_checksum,
+        )
     return plan_accepted_note_write_change(
         status_code=200,
         entity=entity,

--- a/src/basic_memory/indexing/accepted_note_mutation_runner.py
+++ b/src/basic_memory/indexing/accepted_note_mutation_runner.py
@@ -360,7 +360,7 @@ async def resolve_accepted_note_source_checksum(
 ) -> RuntimeFileChecksum:
     """Resolve the exact source bytes when an in-flight publication is ambiguous."""
     observed_file_checksum = None
-    if current_note_content.file_write_status in {"pending", "writing"}:
+    if current_note_content.file_write_status in {"pending", "writing", "failed"}:
         observed_file_checksum = await preparer_factory.load_current_file_checksum(
             project,
             file_path,

--- a/src/basic_memory/indexing/accepted_note_mutation_runner.py
+++ b/src/basic_memory/indexing/accepted_note_mutation_runner.py
@@ -534,6 +534,7 @@ async def _run_accepted_note_update(
     )
     created = entity is None
     existing_file_path = entity.file_path if entity is not None else None
+    vacated_source: tuple[RuntimeFilePath, str] | None = None
 
     await reject_conflicting_accepted_note_file_path(
         session,
@@ -597,6 +598,15 @@ async def _run_accepted_note_update(
             dependencies=dependencies,
             missing_kind=AcceptedNoteMutationRejectKind.conflict,
         )
+        # A PUT replacement may also rename the note. Capture the accepted source bytes before
+        # persistence mutates the entity and note_content to the destination version so delayed
+        # cleanup cannot let a later project index recreate the old path as a ghost.
+        vacated_source = (
+            entity.file_path,
+            current_note_content.file_checksum
+            if current_note_content.file_checksum is not None
+            else current_note_content.db_checksum,
+        )
         # Optimistic-concurrency precondition: the caller sent the db_checksum it
         # last synced; if the accepted row has advanced to a different write,
         # reject with the current checksum so the client rebases instead of
@@ -659,6 +669,13 @@ async def _run_accepted_note_update(
         accepted_file_path=entity.file_path,
         repositories=dependencies.write_repositories,
     )
+    if vacated_source is not None and entity.file_path != vacated_source[0]:
+        await NoteFileVacateRepository(project.id).record_vacate(
+            session,
+            entity_id=entity.id,
+            file_path=vacated_source[0],
+            file_checksum=vacated_source[1],
+        )
     return plan_accepted_note_write_change(
         status_code=201 if created else 200,
         entity=entity,

--- a/src/basic_memory/indexing/accepted_note_mutation_runner.py
+++ b/src/basic_memory/indexing/accepted_note_mutation_runner.py
@@ -360,7 +360,12 @@ async def resolve_accepted_note_source_checksum(
 ) -> RuntimeFileChecksum | None:
     """Resolve source bytes only when storage or synchronized state proves ownership."""
     observed_file_checksum = None
-    if current_note_content.file_write_status in {"pending", "writing", "failed"}:
+    if current_note_content.file_write_status in {
+        "pending",
+        "writing",
+        "failed",
+        "external_change_detected",
+    }:
         observed_file_checksum = await preparer_factory.load_current_file_checksum(
             project,
             file_path,
@@ -817,8 +822,8 @@ async def _run_accepted_note_move(
         )
 
     # Capture the source checksum before persisting the move mutates note_content to the
-    # destination version. For an in-flight publication, observe storage once to distinguish the
-    # last published bytes from accepted bytes written before their result was recorded.
+    # destination version. For ambiguous publication state, observe storage once to distinguish
+    # known source bytes from an unrelated external file.
     vacated_source_checksum = await resolve_accepted_note_source_checksum(
         project=project,
         file_path=existing_file_path,

--- a/src/basic_memory/indexing/accepted_note_mutation_runner.py
+++ b/src/basic_memory/indexing/accepted_note_mutation_runner.py
@@ -358,18 +358,11 @@ async def resolve_accepted_note_source_checksum(
     current_note_content: NoteContent,
     preparer_factory: AcceptedNoteMutationPreparerFactory,
 ) -> RuntimeFileChecksum | None:
-    """Resolve source bytes only when storage or synchronized state proves ownership."""
-    observed_file_checksum = None
-    if current_note_content.file_write_status in {
-        "pending",
-        "writing",
-        "failed",
-        "external_change_detected",
-    }:
-        observed_file_checksum = await preparer_factory.load_current_file_checksum(
-            project,
-            file_path,
-        )
+    """Resolve source bytes only when current storage proves ownership."""
+    observed_file_checksum = await preparer_factory.load_current_file_checksum(
+        project,
+        file_path,
+    )
     return select_accepted_note_source_checksum(
         current_note_content,
         observed_file_checksum=observed_file_checksum,
@@ -822,8 +815,9 @@ async def _run_accepted_note_move(
         )
 
     # Capture the source checksum before persisting the move mutates note_content to the
-    # destination version. For ambiguous publication state, observe storage once to distinguish
-    # known source bytes from an unrelated external file.
+    # destination version. Observe storage for every publication state: even a synchronized DB
+    # row can outlive a locally deleted source, and stale DB state must not authorize cleanup of a
+    # byte-identical file recreated at that path later.
     vacated_source_checksum = await resolve_accepted_note_source_checksum(
         project=project,
         file_path=existing_file_path,

--- a/src/basic_memory/indexing/accepted_note_write_runner.py
+++ b/src/basic_memory/indexing/accepted_note_write_runner.py
@@ -34,6 +34,7 @@ from basic_memory.runtime.note_content import (
 from basic_memory.runtime.storage import (
     ProjectId,
     RuntimeEntityId,
+    RuntimeFileChecksum,
     RuntimeFilePath,
     RuntimeNoteChangeSource,
     RuntimeNoteContentChecksum,
@@ -559,6 +560,7 @@ async def _persist_accepted_note_content_and_search(
     current_note_content: RuntimeAcceptedNoteContentWriteSource | None = None,
     existing_file_path: RuntimeFilePath | None = None,
     accepted_file_path: RuntimeFilePath | None = None,
+    source_file_checksum: RuntimeFileChecksum | None = None,
     repositories: AcceptedNoteWriteRepositories,
 ) -> AcceptedPersistedNoteWrite:
     """Internal content/search phase shared by complete snapshots and moves."""
@@ -568,6 +570,7 @@ async def _persist_accepted_note_content_and_search(
         existing_file_path=existing_file_path,
         accepted_file_path=accepted_file_path or entity.file_path,
         current_note_content=current_note_content,
+        source_file_checksum=source_file_checksum,
     )
     note_content = await accept_note_content_write(
         session,
@@ -661,6 +664,7 @@ async def persist_accepted_note_snapshot(
     current_note_content: RuntimeAcceptedNoteContentWriteSource | None = None,
     existing_file_path: RuntimeFilePath | None = None,
     accepted_file_path: RuntimeFilePath | None = None,
+    source_file_checksum: RuntimeFileChecksum | None = None,
     repositories: AcceptedNoteWriteRepositories,
 ) -> AcceptedPersistedNoteWrite:
     """Persist one complete accepted Markdown snapshot in the caller's transaction."""
@@ -675,6 +679,7 @@ async def persist_accepted_note_snapshot(
         current_note_content=current_note_content,
         existing_file_path=existing_file_path,
         accepted_file_path=accepted_file_path,
+        source_file_checksum=source_file_checksum,
         repositories=repositories,
     )
     await _replace_accepted_note_graph(
@@ -696,6 +701,7 @@ async def persist_accepted_note_move(
     updated_at: datetime,
     current_note_content: RuntimeAcceptedNoteContentWriteSource,
     existing_file_path: RuntimeFilePath,
+    source_file_checksum: RuntimeFileChecksum | None = None,
     repositories: AcceptedNoteWriteRepositories,
 ) -> AcceptedPersistedNoteWrite:
     """Persist the explicitly narrower content/search state for an accepted move."""
@@ -710,6 +716,7 @@ async def persist_accepted_note_move(
         current_note_content=current_note_content,
         existing_file_path=existing_file_path,
         accepted_file_path=prepared.file_path,
+        source_file_checksum=source_file_checksum,
         repositories=repositories,
     )
 

--- a/src/basic_memory/indexing/file_index_checking.py
+++ b/src/basic_memory/indexing/file_index_checking.py
@@ -197,8 +197,15 @@ class StorageCurrentFileChecksumSource:
         """Return the current storage checksum for one file."""
         try:
             current_metadata = await self.metadata_source.load_current_file_metadata(file_path)
-        except (FileError, FileOperationError):
-            return None
+        except (FileError, FileOperationError) as exc:
+            # A local checksum read wraps the race where a file vanishes after exists() as
+            # FileError. Only that concrete disappearance is a missing target; permission and
+            # transient I/O failures must fail the indexing job instead of silently leaving stale
+            # database/search state.
+            cause = exc.__cause__ if exc.__cause__ is not None else exc.__context__
+            if isinstance(cause, FileNotFoundError):
+                return None
+            raise
         return current_metadata.checksum if current_metadata is not None else None
 
 
@@ -287,6 +294,15 @@ class FileIndexChecker:
         indexed_checksum_by_path = await self.indexed_checksum_source.load_indexed_file_checksums(
             tuple(target.path for target in targets)
         )
+        legacy_markers: Mapping[FileIndexPath, MoveVacateMarker] | None = None
+        if legacy_targets:
+            # Forced-full reads every non-orphan target regardless of freshness. Query the cheap
+            # marker table first, then hash only DB-absent paths that could actually be move
+            # orphans; the later content reader remains the single checksum pass for all others.
+            assert self.move_vacate_source is not None
+            legacy_markers = await self.move_vacate_source.load_vacate_markers(
+                [target.path for target in targets if target.path not in indexed_checksum_by_path]
+            )
         inspected: list[_InspectedTarget] = []
         for target in targets:
             if not legacy_targets:
@@ -302,8 +318,10 @@ class FileIndexChecker:
                     status=FileIndexDecisionStatus.read,
                     reason=f"legacy target requires indexing: {target.path}",
                 )
-                current_checksum = await self.current_checksum_source.load_current_file_checksum(
-                    target.path
+                current_checksum = (
+                    await self.current_checksum_source.load_current_file_checksum(target.path)
+                    if legacy_markers is not None and target.path in legacy_markers
+                    else None
                 )
             inspected.append(
                 _InspectedTarget(
@@ -316,7 +334,10 @@ class FileIndexChecker:
                 )
             )
 
-        decisions = await self._apply_move_orphan_gate(inspected)
+        decisions = await self._apply_move_orphan_gate(
+            inspected,
+            prefetched_markers=legacy_markers,
+        )
         return build_file_index_plan(decisions)
 
     async def inspect_target(
@@ -346,6 +367,8 @@ class FileIndexChecker:
     async def _apply_move_orphan_gate(
         self,
         inspected: Sequence[_InspectedTarget],
+        *,
+        prefetched_markers: Mapping[FileIndexPath, MoveVacateMarker] | None = None,
     ) -> list[FileIndexDecision]:
         """Downgrade a move's leftover source object to `current` in one batch (#1601).
 
@@ -371,8 +394,12 @@ class FileIndexChecker:
         if not candidates:
             return decisions
 
-        markers = await self.move_vacate_source.load_vacate_markers(
-            [item.target.path for _, item in candidates]
+        markers = (
+            prefetched_markers
+            if prefetched_markers is not None
+            else await self.move_vacate_source.load_vacate_markers(
+                [item.target.path for _, item in candidates]
+            )
         )
         marked_entity_ids = [
             marker.entity_id for marker in markers.values() if marker.entity_id is not None

--- a/src/basic_memory/indexing/file_index_checking.py
+++ b/src/basic_memory/indexing/file_index_checking.py
@@ -279,7 +279,8 @@ class FileIndexChecker:
         if not targets:
             return FileIndexPlan(paths_to_read=(), decisions=())
 
-        if not any(target.observed_checksum is not None for target in targets):
+        legacy_targets = not any(target.observed_checksum is not None for target in targets)
+        if legacy_targets and (self.moved_entity_source is None or self.move_vacate_source is None):
             return plan_legacy_file_index_targets(targets)
 
         indexed_checksum_by_path = await self.indexed_checksum_source.load_indexed_file_checksums(
@@ -287,10 +288,22 @@ class FileIndexChecker:
         )
         inspected: list[_InspectedTarget] = []
         for target in targets:
-            decision, current_checksum = await self.inspect_target(
-                target,
-                indexed_checksum=indexed_checksum_by_path.get(target.path),
-            )
+            if not legacy_targets:
+                decision, current_checksum = await self.inspect_target(
+                    target,
+                    indexed_checksum=indexed_checksum_by_path.get(target.path),
+                )
+            else:
+                # Forced-full and legacy batches still read every non-orphan target. Load current
+                # metadata only so the move-orphan safety gate can recognize a lingering source.
+                decision = FileIndexDecision(
+                    path=target.path,
+                    status=FileIndexDecisionStatus.read,
+                    reason=f"legacy target requires indexing: {target.path}",
+                )
+                current_checksum = await self.current_checksum_source.load_current_file_checksum(
+                    target.path
+                )
             inspected.append(
                 _InspectedTarget(
                     target=target,

--- a/src/basic_memory/indexing/file_index_checking.py
+++ b/src/basic_memory/indexing/file_index_checking.py
@@ -93,7 +93,7 @@ class MovedEntityFacts:
 class MoveVacateMarker:
     """The moved entity and source content checksum recorded for a vacated path."""
 
-    entity_id: int
+    entity_id: int | None
     checksum: str | None
 
 
@@ -148,7 +148,7 @@ class MoveVacateMarkerRow(Protocol):
     """Marker fields the repository yields for a vacated path."""
 
     @property
-    def entity_id(self) -> int:
+    def entity_id(self) -> int | None:
         """Return the moved entity id recorded on the marker."""
 
     @property
@@ -374,12 +374,29 @@ class FileIndexChecker:
         markers = await self.move_vacate_source.load_vacate_markers(
             [item.target.path for _, item in candidates]
         )
-        entity_facts = await self.moved_entity_source.load_entity_facts_by_id(
-            [marker.entity_id for marker in markers.values()]
+        marked_entity_ids = [
+            marker.entity_id for marker in markers.values() if marker.entity_id is not None
+        ]
+        entity_facts = (
+            await self.moved_entity_source.load_entity_facts_by_id(marked_entity_ids)
+            if marked_entity_ids
+            else {}
         )
         for index, item in candidates:
             marker = markers.get(item.target.path)
             if marker is None:
+                continue
+            if marker.entity_id is None:
+                # The destination entity was deleted before source cleanup. A checksum-backed
+                # tombstone still proves these exact source bytes were vacated; keep suppressing
+                # resurrection until guarded cleanup clears the marker. A legacy null-checksum
+                # tombstone cannot prove identity, so it remains a normal create candidate.
+                if marker.checksum is None or marker.checksum != item.current_checksum:
+                    continue
+                decisions[index] = move_orphan_file_index_decision(
+                    item.target.path,
+                    indexed_at=None,
+                )
                 continue
             moved_entity = entity_facts.get(marker.entity_id)
             if moved_entity is None or moved_entity.file_path == item.target.path:

--- a/src/basic_memory/indexing/file_index_checking.py
+++ b/src/basic_memory/indexing/file_index_checking.py
@@ -135,13 +135,20 @@ class MovedEntitySource(Protocol):
 
 
 class MoveVacateSource(Protocol):
-    """Capability that reports the move-vacate marker recorded for each path."""
+    """Capability that reports and retires move-vacate markers."""
 
     async def load_vacate_markers(
         self,
         file_paths: Sequence[FileIndexPath],
     ) -> Mapping[FileIndexPath, MoveVacateMarker]:
         """Return the vacate marker for each of ``file_paths`` that carries one."""
+
+    async def clear_vacate_marker(
+        self,
+        file_path: FileIndexPath,
+        file_checksum: FileIndexChecksum,
+    ) -> None:
+        """Retire the marker only if it still describes ``file_checksum``."""
 
 
 class MoveVacateMarkerRow(Protocol):
@@ -165,6 +172,15 @@ class MoveVacateRepository(Protocol):
         file_paths: Sequence[str],
     ) -> Mapping[str, MoveVacateMarkerRow]:
         """Return the marker (moved entity id + source checksum) for each marked path."""
+
+    async def clear_vacate(
+        self,
+        session: AsyncSession,
+        *,
+        file_path: str,
+        file_checksum: str | None,
+    ) -> None:
+        """Retire the marker only if its source checksum still matches."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -237,7 +253,7 @@ class RepositoryMovedEntitySource:
 
 @dataclass(frozen=True, slots=True)
 class RepositoryMoveVacateSource:
-    """Resolve outstanding move-vacate markers via one batched repository lookup."""
+    """Resolve and retire outstanding move-vacate markers."""
 
     session_maker: async_sessionmaker[AsyncSession]
     vacate_repository: MoveVacateRepository
@@ -256,6 +272,19 @@ class RepositoryMoveVacateSource:
             path: MoveVacateMarker(entity_id=row.entity_id, checksum=row.file_checksum)
             for path, row in rows.items()
         }
+
+    async def clear_vacate_marker(
+        self,
+        file_path: FileIndexPath,
+        file_checksum: FileIndexChecksum,
+    ) -> None:
+        """Retire one marker in its own committed transaction."""
+        async with self.session_maker.begin() as session:
+            await self.vacate_repository.clear_vacate(
+                session,
+                file_path=file_path,
+                file_checksum=file_checksum,
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -376,10 +405,10 @@ class FileIndexChecker:
         current checksum. Such a candidate is a move orphan only when its path carries a vacate
         marker AND the object is still the moved note's content: the current checksum equals the
         marker's recorded source checksum, and either the marker's entity now holds that same
-        content at a *different* path or that destination entity has been deleted. Anything else —
-        an edit, a genuine new file, a copy that has no marker, or a path overwritten with a
-        different note's bytes (checksum no longer matches the marker) — indexes normally, so a
-        legitimate replacement is never suppressed.
+        content at a *different* path or that destination entity has been deleted. A path
+        overwritten with different bytes indexes normally and retires the old checksum-backed
+        marker, because observing a different source object proves the moved bytes no longer need
+        cleanup. A genuine new file or copy without a marker also indexes normally.
         """
         decisions = [item.decision for item in inspected]
         if self.moved_entity_source is None or self.move_vacate_source is None:
@@ -402,18 +431,33 @@ class FileIndexChecker:
                 [item.target.path for _, item in candidates]
             )
         )
+        gated_candidates: list[tuple[int, _InspectedTarget, MoveVacateMarker]] = []
+        for index, item in candidates:
+            marker = markers.get(item.target.path)
+            if marker is None:
+                continue
+            if marker.checksum is not None and marker.checksum != item.current_checksum:
+                # Trigger: a different source object now occupies the vacated path.
+                # Why: even if the process died before cleanup was enqueued, the moved bytes are
+                # gone and their marker must not suppress a later legitimate reuse of those bytes.
+                # Outcome: conditionally retire only the checksum we observed, preserving any
+                # concurrent move that refreshed the marker after this read.
+                await self.move_vacate_source.clear_vacate_marker(
+                    item.target.path,
+                    marker.checksum,
+                )
+                continue
+            gated_candidates.append((index, item, marker))
+
         marked_entity_ids = [
-            marker.entity_id for marker in markers.values() if marker.entity_id is not None
+            marker.entity_id for _, _, marker in gated_candidates if marker.entity_id is not None
         ]
         entity_facts = (
             await self.moved_entity_source.load_entity_facts_by_id(marked_entity_ids)
             if marked_entity_ids
             else {}
         )
-        for index, item in candidates:
-            marker = markers.get(item.target.path)
-            if marker is None:
-                continue
+        for index, item, marker in gated_candidates:
             moved_entity = (
                 entity_facts.get(marker.entity_id) if marker.entity_id is not None else None
             )
@@ -434,12 +478,7 @@ class FileIndexChecker:
                 # The recorded entity never actually moved off this path, so a stale/spurious
                 # marker must not lose content.
                 continue
-            if marker.checksum is not None:
-                # Source checksum recorded at move time: the leftover still holds that content, so
-                # a path overwritten with different bytes (checksum changed) is not gated.
-                if marker.checksum != item.current_checksum:
-                    continue
-            elif moved_entity.checksum != item.current_checksum:
+            if marker.checksum is None and moved_entity.checksum != item.current_checksum:
                 # Source checksum was unknown at move time (gap (a)): fall back to confirming the
                 # object is the moved entity's current content before treating it as the leftover.
                 continue

--- a/src/basic_memory/indexing/file_index_checking.py
+++ b/src/basic_memory/indexing/file_index_checking.py
@@ -375,10 +375,11 @@ class FileIndexChecker:
         A create is a candidate only when it would read, no DB row owns the path, and it has a
         current checksum. Such a candidate is a move orphan only when its path carries a vacate
         marker AND the object is still the moved note's content: the current checksum equals the
-        marker's recorded source checksum, and the marker's entity now holds that same content at a
-        *different* path. Anything else — an edit, a genuine new file, a copy that has no marker, or
-        a path overwritten with a different note's bytes (checksum no longer matches the marker) —
-        indexes normally, so a legitimate replacement is never suppressed.
+        marker's recorded source checksum, and either the marker's entity now holds that same
+        content at a *different* path or that destination entity has been deleted. Anything else —
+        an edit, a genuine new file, a copy that has no marker, or a path overwritten with a
+        different note's bytes (checksum no longer matches the marker) — indexes normally, so a
+        legitimate replacement is never suppressed.
         """
         decisions = [item.decision for item in inspected]
         if self.moved_entity_source is None or self.move_vacate_source is None:
@@ -413,11 +414,15 @@ class FileIndexChecker:
             marker = markers.get(item.target.path)
             if marker is None:
                 continue
-            if marker.entity_id is None:
-                # The destination entity was deleted before source cleanup. A checksum-backed
-                # tombstone still proves these exact source bytes were vacated; keep suppressing
-                # resurrection until guarded cleanup clears the marker. A legacy null-checksum
-                # tombstone cannot prove identity, so it remains a normal create candidate.
+            moved_entity = (
+                entity_facts.get(marker.entity_id) if marker.entity_id is not None else None
+            )
+            if moved_entity is None:
+                # SQLite variants do not always apply ON DELETE SET NULL consistently, so a
+                # deleted destination can leave either a null or dangling entity ID. The
+                # transactionally recorded source checksum proves both forms are tombstones for
+                # these exact bytes; keep suppressing resurrection until guarded cleanup clears
+                # the marker. Without that checksum proof, the file remains a normal create.
                 if marker.checksum is None or marker.checksum != item.current_checksum:
                     continue
                 decisions[index] = move_orphan_file_index_decision(
@@ -425,10 +430,9 @@ class FileIndexChecker:
                     indexed_at=None,
                 )
                 continue
-            moved_entity = entity_facts.get(marker.entity_id)
-            if moved_entity is None or moved_entity.file_path == item.target.path:
-                # The recorded entity is gone, or never actually moved off this path — don't drop
-                # the object (a stale/spurious marker must not lose content).
+            if moved_entity.file_path == item.target.path:
+                # The recorded entity never actually moved off this path, so a stale/spurious
+                # marker must not lose content.
                 continue
             if marker.checksum is not None:
                 # Source checksum recorded at move time: the leftover still holds that content, so

--- a/src/basic_memory/indexing/file_index_checking.py
+++ b/src/basic_memory/indexing/file_index_checking.py
@@ -8,6 +8,7 @@ from typing import Protocol
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from basic_memory.file_utils import FileError
 from basic_memory.indexing.file_index_planning import (
     FileIndexChecksum,
     FileIndexDecision,
@@ -196,7 +197,7 @@ class StorageCurrentFileChecksumSource:
         """Return the current storage checksum for one file."""
         try:
             current_metadata = await self.metadata_source.load_current_file_metadata(file_path)
-        except FileOperationError:
+        except (FileError, FileOperationError):
             return None
         return current_metadata.checksum if current_metadata is not None else None
 

--- a/src/basic_memory/indexing/file_index_checking.py
+++ b/src/basic_memory/indexing/file_index_checking.py
@@ -11,10 +11,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from basic_memory.indexing.file_index_planning import (
     FileIndexChecksum,
     FileIndexDecision,
+    FileIndexDecisionStatus,
     FileIndexPath,
     FileIndexPlan,
     FileIndexTarget,
     build_file_index_plan,
+    move_orphan_file_index_decision,
     plan_file_index_target_from_current,
     plan_file_index_target_from_observed,
     plan_legacy_file_index_targets,
@@ -79,6 +81,92 @@ class CurrentFileMetadataSource(Protocol):
 
 
 @dataclass(frozen=True, slots=True)
+class MovedEntityFacts:
+    """The current path and content checksum of a candidate moved entity."""
+
+    file_path: str
+    checksum: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class MoveVacateMarker:
+    """The moved entity and source content checksum recorded for a vacated path."""
+
+    entity_id: int
+    checksum: str | None
+
+
+class MoveDetectionEntity(Protocol):
+    """Minimal entity shape needed to confirm a move orphan by id."""
+
+    @property
+    def id(self) -> int:
+        """Return the entity's database id."""
+
+    @property
+    def file_path(self) -> str:
+        """Return the entity's current stored file path."""
+
+    @property
+    def checksum(self) -> str | None:
+        """Return the entity's stored content checksum."""
+
+
+class MoveDetectionEntityRepository(Protocol):
+    """Repository capability that loads entities by id for move-orphan confirmation."""
+
+    async def find_by_ids(
+        self,
+        session: AsyncSession,
+        ids: list[int],
+    ) -> Sequence[MoveDetectionEntity]:
+        """Return the entities for ``ids`` (one batch)."""
+
+
+class MovedEntitySource(Protocol):
+    """Capability that loads the current facts of candidate moved entities by id."""
+
+    async def load_entity_facts_by_id(
+        self,
+        entity_ids: Sequence[int],
+    ) -> Mapping[int, MovedEntityFacts]:
+        """Return current (path, checksum) facts for each requested entity id (one batch)."""
+
+
+class MoveVacateSource(Protocol):
+    """Capability that reports the move-vacate marker recorded for each path."""
+
+    async def load_vacate_markers(
+        self,
+        file_paths: Sequence[FileIndexPath],
+    ) -> Mapping[FileIndexPath, MoveVacateMarker]:
+        """Return the vacate marker for each of ``file_paths`` that carries one."""
+
+
+class MoveVacateMarkerRow(Protocol):
+    """Marker fields the repository yields for a vacated path."""
+
+    @property
+    def entity_id(self) -> int:
+        """Return the moved entity id recorded on the marker."""
+
+    @property
+    def file_checksum(self) -> str | None:
+        """Return the source content checksum recorded on the marker."""
+
+
+class MoveVacateRepository(Protocol):
+    """Repository capability that resolves outstanding move-vacate markers by path."""
+
+    async def load_vacate_markers(
+        self,
+        session: AsyncSession,
+        file_paths: Sequence[str],
+    ) -> Mapping[str, MoveVacateMarkerRow]:
+        """Return the marker (moved entity id + source checksum) for each marked path."""
+
+
+@dataclass(frozen=True, slots=True)
 class RepositoryIndexedFileChecksumSource:
     """Load indexed file checksums from the entity repository."""
 
@@ -114,11 +202,77 @@ class StorageCurrentFileChecksumSource:
 
 
 @dataclass(frozen=True, slots=True)
+class RepositoryMovedEntitySource:
+    """Load current facts of candidate moved entities by id via one batched repository lookup."""
+
+    session_maker: async_sessionmaker[AsyncSession]
+    entity_repository: MoveDetectionEntityRepository
+
+    async def load_entity_facts_by_id(
+        self,
+        entity_ids: Sequence[int],
+    ) -> Mapping[int, MovedEntityFacts]:
+        """Return current (path, checksum) facts for each requested entity id (one query)."""
+        unique = list({int(entity_id) for entity_id in entity_ids})
+        if not unique:
+            return {}
+        async with self.session_maker() as session:
+            entities = await self.entity_repository.find_by_ids(session, unique)
+        return {
+            int(entity.id): MovedEntityFacts(
+                file_path=str(entity.file_path),
+                checksum=None if entity.checksum is None else str(entity.checksum),
+            )
+            for entity in entities
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryMoveVacateSource:
+    """Resolve outstanding move-vacate markers via one batched repository lookup."""
+
+    session_maker: async_sessionmaker[AsyncSession]
+    vacate_repository: MoveVacateRepository
+
+    async def load_vacate_markers(
+        self,
+        file_paths: Sequence[FileIndexPath],
+    ) -> Mapping[FileIndexPath, MoveVacateMarker]:
+        """Return the vacate marker for each marked path (one query)."""
+        paths = list(file_paths)
+        if not paths:
+            return {}
+        async with self.session_maker() as session:
+            rows = await self.vacate_repository.load_vacate_markers(session, paths)
+        return {
+            path: MoveVacateMarker(entity_id=row.entity_id, checksum=row.file_checksum)
+            for path, row in rows.items()
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _InspectedTarget:
+    """One target's base decision plus the facts the move-orphan gate needs."""
+
+    target: FileIndexTarget
+    decision: FileIndexDecision
+    current_checksum: FileIndexChecksum | None
+    row_present: bool
+
+
+@dataclass(frozen=True, slots=True)
 class FileIndexChecker:
     """Plan content reads using indexed and current file checksums."""
 
     indexed_checksum_source: IndexedFileChecksumSource
     current_checksum_source: CurrentFileChecksumSource
+    # Move-orphan gate (#1601). Both sources must be set for the gate to run: a would-be *create*
+    # (no DB row owns the path) whose content is already indexed elsewhere AND whose path carries a
+    # move-vacate marker is a move's lingering source object — planned `current` instead of `read`
+    # so it is not re-imported as a `-1` duplicate. Requiring the vacate marker is what separates a
+    # ghost from a legitimate byte-identical copy (which has no marker and stays a new file).
+    moved_entity_source: MovedEntitySource | None = None
+    move_vacate_source: MoveVacateSource | None = None
 
     async def detect(self, targets: Sequence[FileIndexTarget]) -> FileIndexPlan:
         """Return the file paths whose current storage object still needs indexing."""
@@ -131,14 +285,24 @@ class FileIndexChecker:
         indexed_checksum_by_path = await self.indexed_checksum_source.load_indexed_file_checksums(
             tuple(target.path for target in targets)
         )
-        decisions: list[FileIndexDecision] = []
+        inspected: list[_InspectedTarget] = []
         for target in targets:
-            decision = await self.inspect_target(
+            decision, current_checksum = await self.inspect_target(
                 target,
                 indexed_checksum=indexed_checksum_by_path.get(target.path),
             )
-            decisions.append(decision)
+            inspected.append(
+                _InspectedTarget(
+                    target=target,
+                    decision=decision,
+                    current_checksum=current_checksum,
+                    # A missing map key means no DB row owns the path (a create); a present key with
+                    # a null value is an incomplete row that must still be read/repaired, not skipped.
+                    row_present=target.path in indexed_checksum_by_path,
+                )
+            )
 
+        decisions = await self._apply_move_orphan_gate(inspected)
         return build_file_index_plan(decisions)
 
     async def inspect_target(
@@ -146,20 +310,78 @@ class FileIndexChecker:
         target: FileIndexTarget,
         *,
         indexed_checksum: FileIndexChecksum | None,
-    ) -> FileIndexDecision:
-        """Inspect one file target without reading its content."""
+    ) -> tuple[FileIndexDecision, FileIndexChecksum | None]:
+        """Inspect one file target, returning its decision and the current checksum it read."""
         observed_decision = plan_file_index_target_from_observed(
             target,
             db_checksum=indexed_checksum,
         )
         if observed_decision is not None:
-            return observed_decision
+            return observed_decision, None
 
         current_checksum = await self.current_checksum_source.load_current_file_checksum(
             target.path
         )
-        return plan_file_index_target_from_current(
+        decision = plan_file_index_target_from_current(
             target,
             db_checksum=indexed_checksum,
             current_checksum=current_checksum,
         )
+        return decision, current_checksum
+
+    async def _apply_move_orphan_gate(
+        self,
+        inspected: Sequence[_InspectedTarget],
+    ) -> list[FileIndexDecision]:
+        """Downgrade a move's leftover source object to `current` in one batch (#1601).
+
+        A create is a candidate only when it would read, no DB row owns the path, and it has a
+        current checksum. Such a candidate is a move orphan only when its path carries a vacate
+        marker AND the object is still the moved note's content: the current checksum equals the
+        marker's recorded source checksum, and the marker's entity now holds that same content at a
+        *different* path. Anything else — an edit, a genuine new file, a copy that has no marker, or
+        a path overwritten with a different note's bytes (checksum no longer matches the marker) —
+        indexes normally, so a legitimate replacement is never suppressed.
+        """
+        decisions = [item.decision for item in inspected]
+        if self.moved_entity_source is None or self.move_vacate_source is None:
+            return decisions
+
+        candidates = [
+            (index, item)
+            for index, item in enumerate(inspected)
+            if item.decision.status == FileIndexDecisionStatus.read
+            and not item.row_present
+            and item.current_checksum is not None
+        ]
+        if not candidates:
+            return decisions
+
+        markers = await self.move_vacate_source.load_vacate_markers(
+            [item.target.path for _, item in candidates]
+        )
+        entity_facts = await self.moved_entity_source.load_entity_facts_by_id(
+            [marker.entity_id for marker in markers.values()]
+        )
+        for index, item in candidates:
+            marker = markers.get(item.target.path)
+            if marker is None:
+                continue
+            moved_entity = entity_facts.get(marker.entity_id)
+            if moved_entity is None or moved_entity.file_path == item.target.path:
+                # The recorded entity is gone, or never actually moved off this path — don't drop
+                # the object (a stale/spurious marker must not lose content).
+                continue
+            if marker.checksum is not None:
+                # Source checksum recorded at move time: the leftover still holds that content, so
+                # a path overwritten with different bytes (checksum changed) is not gated.
+                if marker.checksum != item.current_checksum:
+                    continue
+            elif moved_entity.checksum != item.current_checksum:
+                # Source checksum was unknown at move time (gap (a)): fall back to confirming the
+                # object is the moved entity's current content before treating it as the leftover.
+                continue
+            decisions[index] = move_orphan_file_index_decision(
+                item.target.path, indexed_at=moved_entity.file_path
+            )
+        return decisions

--- a/src/basic_memory/indexing/file_index_planning.py
+++ b/src/basic_memory/indexing/file_index_planning.py
@@ -105,7 +105,7 @@ def current_file_index_decision(file_path: FileIndexPath) -> FileIndexDecision:
 def move_orphan_file_index_decision(
     file_path: FileIndexPath,
     *,
-    indexed_at: FileIndexPath,
+    indexed_at: FileIndexPath | None,
 ) -> FileIndexDecision:
     """Return a no-op decision for a move's still-present source object.
 
@@ -115,10 +115,15 @@ def move_orphan_file_index_decision(
     (basic-memory-cloud#1601). When the object's content is already indexed at another path, treat
     it as current (already represented) instead of creating a duplicate.
     """
+    reason = (
+        f"move orphan: content already indexed at {indexed_at}; not creating a duplicate"
+        if indexed_at is not None
+        else "move orphan tombstone: deleted note's vacated source is pending cleanup"
+    )
     return FileIndexDecision(
         path=file_path,
         status=FileIndexDecisionStatus.current,
-        reason=f"move orphan: content already indexed at {indexed_at}; not creating a duplicate",
+        reason=reason,
     )
 
 

--- a/src/basic_memory/indexing/file_index_planning.py
+++ b/src/basic_memory/indexing/file_index_planning.py
@@ -102,6 +102,26 @@ def current_file_index_decision(file_path: FileIndexPath) -> FileIndexDecision:
     )
 
 
+def move_orphan_file_index_decision(
+    file_path: FileIndexPath,
+    *,
+    indexed_at: FileIndexPath,
+) -> FileIndexDecision:
+    """Return a no-op decision for a move's still-present source object.
+
+    A move updates the note's entity to the destination path, but the physical source object can
+    linger (deferred or skipped cleanup). Indexing that vacated path finds no entity there and would
+    mint a brand-new note whose permalink collides into ``-1`` — the ghost duplicate
+    (basic-memory-cloud#1601). When the object's content is already indexed at another path, treat
+    it as current (already represented) instead of creating a duplicate.
+    """
+    return FileIndexDecision(
+        path=file_path,
+        status=FileIndexDecisionStatus.current,
+        reason=f"move orphan: content already indexed at {indexed_at}; not creating a duplicate",
+    )
+
+
 def plan_file_index_target_from_observed(
     target: FileIndexTarget,
     *,

--- a/src/basic_memory/indexing/file_indexer.py
+++ b/src/basic_memory/indexing/file_indexer.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Protocol
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from basic_memory.indexing.file_index_checking import IndexedFileChecksumRow
+from basic_memory.indexing.file_index_checking import IndexedFileChecksumRow, MoveDetectionEntity
 from basic_memory import db
 from basic_memory.indexing.note_content_reconciliation import (
     NoteContentReconciliationAnchor,
@@ -67,6 +67,13 @@ class IndexMarkdownEntityRepository(Protocol):
         session: AsyncSession,
         file_paths: Sequence[Path | str],
     ) -> Sequence[IndexedFileChecksumRow]: ...
+
+    async def find_by_ids(
+        self,
+        session: AsyncSession,
+        ids: list[int],
+    ) -> Sequence[MoveDetectionEntity]:
+        """Return the entities for ``ids`` (move-orphan confirmation)."""
 
 
 class IndexCurrentMarkdownFileIndexer(Protocol):

--- a/src/basic_memory/indexing/note_file_delete_runner.py
+++ b/src/basic_memory/indexing/note_file_delete_runner.py
@@ -10,7 +10,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from basic_memory import db
 from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
 from basic_memory.runtime.cleanup import (
-    RuntimeDeleteStatus,
     RuntimeFileDeleteResult,
     RuntimeNoteFileDeleteJobRequest,
     plan_note_file_delete_cleanup,
@@ -86,14 +85,10 @@ async def run_note_file_delete(
     )
     if delete_plan.should_delete_file:
         await storage.delete_file(request.file_path)
-    # The source object is gone whether we deleted it now or it was already absent (missing), so
-    # clear the move-vacate marker either way — a stale marker must not survive a delete that then
-    # failed to clear, or a source that vanished on its own (#1601). A guarded skip (the source
-    # changed before cleanup) keeps the marker. Checksum-guarded inside the clear.
-    if vacate_clearer is not None and delete_plan.result.status in (
-        RuntimeDeleteStatus.deleted,
-        RuntimeDeleteStatus.missing,
-    ):
+    # Every guarded outcome proves the moved source object is no longer pending: it was deleted,
+    # was already missing, or was replaced by different content. Retire only the marker for this
+    # accepted checksum; a newer move that refreshed the path marker remains protected.
+    if vacate_clearer is not None:
         await vacate_clearer.clear_move_vacate(
             project_id=request.project_id,
             file_path=request.file_path,

--- a/src/basic_memory/indexing/note_file_delete_runner.py
+++ b/src/basic_memory/indexing/note_file_delete_runner.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Protocol
 
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from basic_memory import db
+from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
 from basic_memory.runtime.cleanup import (
+    RuntimeDeleteStatus,
     RuntimeFileDeleteResult,
     RuntimeNoteFileDeleteJobRequest,
     plan_note_file_delete_cleanup,
 )
 from basic_memory.runtime.note_content import read_runtime_file_checksum
-from basic_memory.runtime.storage import RuntimeFileChecksum, RuntimeFilePath
+from basic_memory.runtime.storage import ProjectId, RuntimeFileChecksum, RuntimeFilePath
 
 
 class NoteFileDeleteStorage(Protocol):
@@ -23,10 +29,44 @@ class NoteFileDeleteStorage(Protocol):
     async def delete_file(self, path: RuntimeFilePath) -> None: ...
 
 
+class MoveVacateClearer(Protocol):
+    """Capability that clears a move-vacate marker once its source object is gone."""
+
+    async def clear_move_vacate(
+        self,
+        *,
+        project_id: ProjectId,
+        file_path: RuntimeFilePath,
+        file_checksum: RuntimeFileChecksum,
+    ) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryMoveVacateClearer:
+    """Clear the move-vacate marker for a deleted source path via the tenant DB."""
+
+    session_maker: async_sessionmaker[AsyncSession]
+
+    async def clear_move_vacate(
+        self,
+        *,
+        project_id: ProjectId,
+        file_path: RuntimeFilePath,
+        file_checksum: RuntimeFileChecksum,
+    ) -> None:
+        async with db.scoped_session(self.session_maker) as session:
+            await NoteFileVacateRepository(project_id).clear_vacate(
+                session,
+                file_path=file_path,
+                file_checksum=file_checksum,
+            )
+
+
 async def run_note_file_delete(
     request: RuntimeNoteFileDeleteJobRequest,
     *,
     storage: NoteFileDeleteStorage,
+    vacate_clearer: MoveVacateClearer | None = None,
 ) -> RuntimeFileDeleteResult:
     """Delete a materialized note file only when storage still matches the accepted guard."""
     if request.file_checksum is None:
@@ -46,4 +86,17 @@ async def run_note_file_delete(
     )
     if delete_plan.should_delete_file:
         await storage.delete_file(request.file_path)
+    # The source object is gone whether we deleted it now or it was already absent (missing), so
+    # clear the move-vacate marker either way — a stale marker must not survive a delete that then
+    # failed to clear, or a source that vanished on its own (#1601). A guarded skip (the source
+    # changed before cleanup) keeps the marker. Checksum-guarded inside the clear.
+    if vacate_clearer is not None and delete_plan.result.status in (
+        RuntimeDeleteStatus.deleted,
+        RuntimeDeleteStatus.missing,
+    ):
+        await vacate_clearer.clear_move_vacate(
+            project_id=request.project_id,
+            file_path=request.file_path,
+            file_checksum=request.file_checksum,
+        )
     return delete_plan.result

--- a/src/basic_memory/indexing/note_file_delete_runner.py
+++ b/src/basic_memory/indexing/note_file_delete_runner.py
@@ -37,7 +37,7 @@ class MoveVacateClearer(Protocol):
         *,
         project_id: ProjectId,
         file_path: RuntimeFilePath,
-        file_checksum: RuntimeFileChecksum,
+        file_checksum: RuntimeFileChecksum | None,
     ) -> None: ...
 
 
@@ -52,7 +52,7 @@ class RepositoryMoveVacateClearer:
         *,
         project_id: ProjectId,
         file_path: RuntimeFilePath,
-        file_checksum: RuntimeFileChecksum,
+        file_checksum: RuntimeFileChecksum | None,
     ) -> None:
         async with db.scoped_session(self.session_maker) as session:
             await NoteFileVacateRepository(project_id).clear_vacate(

--- a/src/basic_memory/indexing/note_materialization_runner.py
+++ b/src/basic_memory/indexing/note_materialization_runner.py
@@ -56,6 +56,7 @@ from basic_memory.runtime.storage import (
     RuntimeFilePath,
 )
 from basic_memory.models import Entity, NoteContent
+from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
 
 type NoteMaterializationPreflightOutcome = (
     RuntimePreparedNoteWrite | RuntimeNoteMaterializationResult
@@ -502,6 +503,14 @@ class RepositoryNoteMaterializationPublisher:
                     file_path=written_file.file_path,
                     file_checksum=written_file.file_checksum,
                 )
+
+            # Trigger: this current materialization made its destination path live.
+            # Why: an older lost move cleanup can leave a marker that would suppress later reuse.
+            # Outcome: retire any prior marker for this path; the newly vacated source is separate.
+            await NoteFileVacateRepository(request.project_id).clear_vacate_path(
+                session,
+                file_path=written_file.file_path,
+            )
             entity.mtime = written_file.file_updated_at.timestamp()
             entity.size = len(prepared_write.markdown_content.encode("utf-8"))
             await session.flush()

--- a/src/basic_memory/models/__init__.py
+++ b/src/basic_memory/models/__init__.py
@@ -2,13 +2,20 @@
 
 import basic_memory
 from basic_memory.models.base import Base
-from basic_memory.models.knowledge import Entity, NoteContent, Observation, Relation
+from basic_memory.models.knowledge import (
+    Entity,
+    NoteContent,
+    NoteFileVacate,
+    Observation,
+    Relation,
+)
 from basic_memory.models.project import Project
 
 __all__ = [
     "Base",
     "Entity",
     "NoteContent",
+    "NoteFileVacate",
     "Observation",
     "Relation",
     "Project",

--- a/src/basic_memory/models/knowledge.py
+++ b/src/basic_memory/models/knowledge.py
@@ -248,11 +248,12 @@ class NoteFileVacate(Base):
         ForeignKey("project.id", ondelete="CASCADE"),
         nullable=False,
     )
-    # The moved entity now living at the destination; if it is deleted the vacate is moot.
-    entity_id: Mapped[int] = mapped_column(
+    # The moved entity now living at the destination. Preserve the marker as a checksum-backed
+    # tombstone if that entity is deleted before the physical source cleanup finishes.
+    entity_id: Mapped[Optional[int]] = mapped_column(
         Integer,
-        ForeignKey("entity.id", ondelete="CASCADE"),
-        nullable=False,
+        ForeignKey("entity.id", ondelete="SET NULL"),
+        nullable=True,
     )
     # The vacated source path (project-relative POSIX), the key the indexer checks.
     file_path: Mapped[str] = mapped_column(String, nullable=False)

--- a/src/basic_memory/models/knowledge.py
+++ b/src/basic_memory/models/knowledge.py
@@ -224,6 +224,52 @@ class NoteContent(Base):
         )
 
 
+class NoteFileVacate(Base):
+    """A source path vacated by a move whose physical object is pending cleanup.
+
+    A ``move_note`` is DB-first: the entity's ``file_path`` flips to the destination while the
+    physical source object is deleted out of band. This row is the durable, index-time-queryable
+    proof that the source path was vacated *by a move* — so the indexer can tell a move's lingering
+    source object (a ghost source: skip re-import) from a legitimate byte-identical copy (index as
+    new). Written atomically with the move; cleared when the source object is deleted
+    (basic-memory-cloud#1601).
+    """
+
+    __tablename__ = "note_file_vacate"
+    __table_args__ = (
+        # One outstanding vacate per source path; the index-time lookup keys on it.
+        UniqueConstraint("project_id", "file_path", name="uix_note_file_vacate_project_file_path"),
+        Index("ix_note_file_vacate_project_id", "project_id"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)  # pyright: ignore [reportIncompatibleVariableOverride]
+    project_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("project.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # The moved entity now living at the destination; if it is deleted the vacate is moot.
+    entity_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("entity.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # The vacated source path (project-relative POSIX), the key the indexer checks.
+    file_path: Mapped[str] = mapped_column(String, nullable=False)
+    # Guard for the physical delete; may be None when the source was never materialized.
+    file_checksum: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now().astimezone(),
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return (
+            f"NoteFileVacate(project_id={self.project_id}, entity_id={self.entity_id}, "
+            f"file_path='{self.file_path}')"
+        )
+
+
 class Observation(Base):
     """An observation about an entity.
 

--- a/src/basic_memory/repository/note_file_vacate_repository.py
+++ b/src/basic_memory/repository/note_file_vacate_repository.py
@@ -4,12 +4,12 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from basic_memory.models.knowledge import NoteFileVacate
+from basic_memory.models.knowledge import Entity, NoteContent, NoteFileVacate
 from basic_memory.repository.repository import Repository
 
 
@@ -19,6 +19,16 @@ class VacateMarker:
 
     entity_id: int | None
     file_checksum: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class RecoverableVacate:
+    """A checksum-guarded source cleanup whose destination is safe."""
+
+    entity_id: int | None
+    file_path: str
+    file_checksum: str
+    live_file_path: str | None
 
 
 class NoteFileVacateRepository(Repository[NoteFileVacate]):
@@ -100,6 +110,53 @@ class NoteFileVacateRepository(Repository[NoteFileVacate]):
             )
             for path, entity_id, file_checksum in result.all()
         }
+
+    async def list_recoverable_vacates(
+        self,
+        session: AsyncSession,
+    ) -> list[RecoverableVacate]:
+        """Return guarded vacates whose destination is synchronized or deleted.
+
+        Recovery must not remove the source while destination materialization is
+        pending or failed: those source bytes may still be the only durable copy.
+        A deleted destination has no live entity to protect, while a synchronized
+        destination carries the live path needed for case-alias protection.
+        """
+        query = self._add_project_filter(
+            select(
+                NoteFileVacate.entity_id,
+                NoteFileVacate.file_path,
+                NoteFileVacate.file_checksum,
+                Entity.file_path,
+            )
+            .outerjoin(Entity, Entity.id == NoteFileVacate.entity_id)
+            .outerjoin(NoteContent, NoteContent.entity_id == Entity.id)
+            .where(
+                NoteFileVacate.file_checksum.is_not(None),
+                or_(
+                    Entity.id.is_(None),
+                    NoteContent.file_write_status == "synced",
+                ),
+            )
+            .order_by(NoteFileVacate.file_path)
+        )
+        result = await session.execute(query)
+        recoverable: list[RecoverableVacate] = []
+        for marker_entity_id, file_path, file_checksum, live_file_path in result.all():
+            assert file_checksum is not None
+            recoverable.append(
+                RecoverableVacate(
+                    entity_id=(
+                        int(marker_entity_id)
+                        if marker_entity_id is not None and live_file_path is not None
+                        else None
+                    ),
+                    file_path=str(file_path),
+                    file_checksum=str(file_checksum),
+                    live_file_path=(str(live_file_path) if live_file_path is not None else None),
+                )
+            )
+        return recoverable
 
     async def clear_vacate(
         self,

--- a/src/basic_memory/repository/note_file_vacate_repository.py
+++ b/src/basic_memory/repository/note_file_vacate_repository.py
@@ -1,0 +1,113 @@
+"""Repository for note_file_vacate markers (move-orphan gate, basic-memory-cloud#1601)."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from basic_memory.models.knowledge import NoteFileVacate
+from basic_memory.repository.repository import Repository
+
+
+@dataclass(frozen=True, slots=True)
+class VacateMarker:
+    """The moved entity and source content checksum recorded for a vacated path."""
+
+    entity_id: int
+    file_checksum: str | None
+
+
+class NoteFileVacateRepository(Repository[NoteFileVacate]):
+    """Records and resolves the source paths a move vacated but that storage may still hold.
+
+    The marker is the durable evidence that a path was vacated *by a move*, which is what lets the
+    indexer skip a move's lingering source object without also suppressing a legitimate
+    byte-identical copy. All operations are project-scoped by the base repository.
+    """
+
+    def __init__(self, project_id: int) -> None:
+        super().__init__(NoteFileVacate, project_id=project_id)
+
+    async def record_vacate(
+        self,
+        session: AsyncSession,
+        *,
+        entity_id: int,
+        file_path: str,
+        file_checksum: str | None,
+    ) -> None:
+        """Record (or refresh) the outstanding vacate for one source path.
+
+        One marker per ``(project, path)``: a fresh move onto the same source path replaces the
+        prior marker rather than colliding with the unique constraint.
+        """
+        path = Path(file_path).as_posix()
+        existing = await self._get_marker(session, path)
+        if existing is not None:
+            existing.entity_id = entity_id
+            existing.file_checksum = file_checksum
+            return
+        session.add(
+            NoteFileVacate(
+                project_id=self.project_id,
+                entity_id=entity_id,
+                file_path=path,
+                file_checksum=file_checksum,
+            )
+        )
+
+    async def load_vacate_markers(
+        self,
+        session: AsyncSession,
+        file_paths: Sequence[str],
+    ) -> dict[str, "VacateMarker"]:
+        """Return the vacate marker (moved entity id + source checksum) for each marked path."""
+        normalized = [Path(file_path).as_posix() for file_path in file_paths]
+        if not normalized:
+            return {}
+        query = self._add_project_filter(
+            select(
+                NoteFileVacate.file_path,
+                NoteFileVacate.entity_id,
+                NoteFileVacate.file_checksum,
+            ).where(NoteFileVacate.file_path.in_(normalized))
+        )
+        result = await session.execute(query)
+        return {
+            str(path): VacateMarker(entity_id=int(entity_id), file_checksum=file_checksum)
+            for path, entity_id, file_checksum in result.all()
+        }
+
+    async def clear_vacate(
+        self,
+        session: AsyncSession,
+        *,
+        file_path: str,
+        file_checksum: str,
+    ) -> None:
+        """Clear the marker once its source object has actually been deleted.
+
+        Guarded by checksum: if a newer move (or a re-created file) replaced the marker with a
+        different checksum, leave it — that path is vacated for a *different* content and must stay
+        gated until its own delete runs.
+        """
+        path = Path(file_path).as_posix()
+        marker = await self._get_marker(session, path)
+        if marker is None:
+            return
+        if marker.file_checksum is not None and marker.file_checksum != file_checksum:
+            return
+        await session.delete(marker)
+
+    async def _get_marker(
+        self,
+        session: AsyncSession,
+        file_path: str,
+    ) -> NoteFileVacate | None:
+        query = self._add_project_filter(
+            select(NoteFileVacate).where(NoteFileVacate.file_path == file_path)
+        )
+        result = await session.execute(query)
+        return result.scalars().one_or_none()

--- a/src/basic_memory/repository/note_file_vacate_repository.py
+++ b/src/basic_memory/repository/note_file_vacate_repository.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from basic_memory.models.knowledge import NoteFileVacate
@@ -41,20 +43,36 @@ class NoteFileVacateRepository(Repository[NoteFileVacate]):
         """Record (or refresh) the outstanding vacate for one source path.
 
         One marker per ``(project, path)``: a fresh move onto the same source path replaces the
-        prior marker rather than colliding with the unique constraint.
+        prior marker rather than colliding with the unique constraint. The upsert is one statement
+        so concurrent cleanup cannot delete a row between a read and ORM update.
         """
         path = Path(file_path).as_posix()
-        existing = await self._get_marker(session, path)
-        if existing is not None:
-            existing.entity_id = entity_id
-            existing.file_checksum = file_checksum
-            return
-        session.add(
-            NoteFileVacate(
-                project_id=self.project_id,
-                entity_id=entity_id,
-                file_path=path,
-                file_checksum=file_checksum,
+        values = {
+            "project_id": self.project_id,
+            "entity_id": entity_id,
+            "file_path": path,
+            "file_checksum": file_checksum,
+        }
+        dialect_name = session.bind.dialect.name if session.bind is not None else None
+        match dialect_name:
+            case "postgresql":
+                statement = pg_insert(NoteFileVacate).values(**values)
+            case "sqlite":
+                statement = sqlite_insert(NoteFileVacate).values(**values)
+            case _:
+                raise ValueError(
+                    f"Unsupported database dialect for move-vacate upsert: {dialect_name}"
+                )
+        await session.execute(
+            statement.on_conflict_do_update(
+                index_elements=[
+                    NoteFileVacate.project_id,
+                    NoteFileVacate.file_path,
+                ],
+                set_={
+                    "entity_id": entity_id,
+                    "file_checksum": file_checksum,
+                },
             )
         )
 

--- a/src/basic_memory/repository/note_file_vacate_repository.py
+++ b/src/basic_memory/repository/note_file_vacate_repository.py
@@ -15,7 +15,7 @@ from basic_memory.repository.repository import Repository
 class VacateMarker:
     """The moved entity and source content checksum recorded for a vacated path."""
 
-    entity_id: int
+    entity_id: int | None
     file_checksum: str | None
 
 
@@ -76,7 +76,10 @@ class NoteFileVacateRepository(Repository[NoteFileVacate]):
         )
         result = await session.execute(query)
         return {
-            str(path): VacateMarker(entity_id=int(entity_id), file_checksum=file_checksum)
+            str(path): VacateMarker(
+                entity_id=None if entity_id is None else int(entity_id),
+                file_checksum=file_checksum,
+            )
             for path, entity_id, file_checksum in result.all()
         }
 
@@ -85,7 +88,7 @@ class NoteFileVacateRepository(Repository[NoteFileVacate]):
         session: AsyncSession,
         *,
         file_path: str,
-        file_checksum: str,
+        file_checksum: str | None,
     ) -> None:
         """Clear the marker once its source object has actually been deleted.
 

--- a/src/basic_memory/repository/note_file_vacate_repository.py
+++ b/src/basic_memory/repository/note_file_vacate_repository.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from sqlalchemy import delete, or_, select
+from sqlalchemy import delete, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -157,6 +157,61 @@ class NoteFileVacateRepository(Repository[NoteFileVacate]):
                 )
             )
         return recoverable
+
+    async def lock_recoverable_vacate(
+        self,
+        session: AsyncSession,
+        *,
+        file_path: str,
+        file_checksum: str,
+    ) -> RecoverableVacate | None:
+        """Lock and reload one recovery candidate immediately before storage cleanup.
+
+        The conditional no-op update locks the marker row on both SQLite and
+        Postgres. Locking the destination entity too serializes recovery with an
+        accepted move back onto the vacated path. The caller must keep this
+        transaction open through guarded storage deletion and marker retirement.
+        """
+        path = Path(file_path).as_posix()
+        await session.execute(
+            update(NoteFileVacate)
+            .where(
+                NoteFileVacate.project_id == self.project_id,
+                NoteFileVacate.file_path == path,
+                NoteFileVacate.file_checksum == file_checksum,
+            )
+            .values(file_checksum=NoteFileVacate.file_checksum)
+        )
+        marker = await self._get_marker(session, path)
+        if marker is None or marker.file_checksum != file_checksum:
+            return None
+
+        if marker.entity_id is None:
+            return RecoverableVacate(
+                entity_id=None,
+                file_path=path,
+                file_checksum=file_checksum,
+                live_file_path=None,
+            )
+
+        entity = await session.get(Entity, marker.entity_id, with_for_update=True)
+        if entity is None or entity.project_id != self.project_id:
+            return RecoverableVacate(
+                entity_id=None,
+                file_path=path,
+                file_checksum=file_checksum,
+                live_file_path=None,
+            )
+
+        note_content = await session.get(NoteContent, entity.id)
+        if note_content is None or note_content.file_write_status != "synced":
+            return None
+        return RecoverableVacate(
+            entity_id=entity.id,
+            file_path=path,
+            file_checksum=file_checksum,
+            live_file_path=entity.file_path,
+        )
 
     async def clear_vacate(
         self,

--- a/src/basic_memory/repository/note_file_vacate_repository.py
+++ b/src/basic_memory/repository/note_file_vacate_repository.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from basic_memory.models.knowledge import NoteFileVacate
@@ -92,17 +92,17 @@ class NoteFileVacateRepository(Repository[NoteFileVacate]):
     ) -> None:
         """Clear the marker once its source object has actually been deleted.
 
-        Guarded by checksum: if a newer move (or a re-created file) replaced the marker with a
-        different checksum, leave it — that path is vacated for a *different* content and must stay
-        gated until its own delete runs.
+        The checksum comparison is part of the DELETE statement so a concurrent move cannot
+        refresh the same path between a Python-side check and marker deletion. A newer checksum
+        represents different vacated content and must remain gated until its own cleanup runs.
         """
         path = Path(file_path).as_posix()
-        marker = await self._get_marker(session, path)
-        if marker is None:
-            return
-        if marker.file_checksum is not None and marker.file_checksum != file_checksum:
-            return
-        await session.delete(marker)
+        query = delete(NoteFileVacate).where(
+            NoteFileVacate.project_id == self.project_id,
+            NoteFileVacate.file_path == path,
+            NoteFileVacate.file_checksum == file_checksum,
+        )
+        await session.execute(query)
 
     async def _get_marker(
         self,

--- a/src/basic_memory/repository/note_file_vacate_repository.py
+++ b/src/basic_memory/repository/note_file_vacate_repository.py
@@ -122,6 +122,20 @@ class NoteFileVacateRepository(Repository[NoteFileVacate]):
         )
         await session.execute(query)
 
+    async def clear_vacate_path(
+        self,
+        session: AsyncSession,
+        *,
+        file_path: str,
+    ) -> None:
+        """Clear any marker once this path is successfully materialized as a live note."""
+        path = Path(file_path).as_posix()
+        query = delete(NoteFileVacate).where(
+            NoteFileVacate.project_id == self.project_id,
+            NoteFileVacate.file_path == path,
+        )
+        await session.execute(query)
+
     async def _get_marker(
         self,
         session: AsyncSession,

--- a/src/basic_memory/runtime/accepted_note_changes.py
+++ b/src/basic_memory/runtime/accepted_note_changes.py
@@ -102,14 +102,18 @@ def select_accepted_note_source_checksum(
     """Select the checksum for source bytes vacated by an accepted path change.
 
     ``accept_write`` deliberately preserves the previously published file fields while the next
-    DB version is pending. During ``pending``, ``writing``, or ``failed``, storage may still
-    contain the previously published bytes or may already contain the accepted DB bytes without
-    recording its result. A live checksum matching either known version resolves that ambiguity.
-    An absent or unexpected object proves neither version owns the path, so cleanup must remain
-    unclaimed. Otherwise only a synchronized file version proves ``file_checksum`` belongs to the
-    current accepted source.
+    DB version is pending. During ``pending``, ``writing``, ``failed``, or
+    ``external_change_detected``, storage may contain either known version or unrelated bytes. A
+    live checksum matching either known version resolves that ambiguity. An absent or unexpected
+    object proves neither version owns the path, so cleanup must remain unclaimed. Otherwise only
+    a synchronized file version proves ``file_checksum`` belongs to the current accepted source.
     """
-    if current_note_content.file_write_status in {"pending", "writing", "failed"}:
+    if current_note_content.file_write_status in {
+        "pending",
+        "writing",
+        "failed",
+        "external_change_detected",
+    }:
         if observed_file_checksum in {
             current_note_content.db_checksum,
             current_note_content.file_checksum,

--- a/src/basic_memory/runtime/accepted_note_changes.py
+++ b/src/basic_memory/runtime/accepted_note_changes.py
@@ -98,26 +98,24 @@ def select_accepted_note_source_checksum(
     current_note_content: RuntimeAcceptedNoteContentWriteSource,
     *,
     observed_file_checksum: RuntimeFileChecksum | None = None,
-) -> RuntimeFileChecksum:
+) -> RuntimeFileChecksum | None:
     """Select the checksum for source bytes vacated by an accepted path change.
 
     ``accept_write`` deliberately preserves the previously published file fields while the next
     DB version is pending. During ``pending``, ``writing``, or ``failed``, storage may still
     contain the previously published bytes or may already contain the accepted DB bytes without
     recording its result. A live checksum matching either known version resolves that ambiguity.
-    Otherwise only a synchronized file version proves ``file_checksum`` belongs to the current
-    accepted source.
+    An absent or unexpected object proves neither version owns the path, so cleanup must remain
+    unclaimed. Otherwise only a synchronized file version proves ``file_checksum`` belongs to the
+    current accepted source.
     """
-    if (
-        current_note_content.file_write_status in {"pending", "writing", "failed"}
-        and observed_file_checksum is not None
-        and observed_file_checksum
-        in {
+    if current_note_content.file_write_status in {"pending", "writing", "failed"}:
+        if observed_file_checksum in {
             current_note_content.db_checksum,
             current_note_content.file_checksum,
-        }
-    ):
-        return observed_file_checksum
+        }:
+            return observed_file_checksum
+        return None
 
     file_version_is_current = (
         current_note_content.file_write_status == "synced"
@@ -177,9 +175,14 @@ def plan_accepted_note_content_write(
     source_file_checksum: RuntimeFileChecksum | None = None,
 ) -> RuntimeAcceptedNoteContentWritePlan:
     """Plan accepted DB versioning and old-file cleanup for a note_content write."""
-    source_checksum = source_file_checksum
-    if source_checksum is None and current_note_content is not None:
-        source_checksum = select_accepted_note_source_checksum(current_note_content)
+    source_checksum = (
+        select_accepted_note_source_checksum(
+            current_note_content,
+            observed_file_checksum=source_file_checksum,
+        )
+        if current_note_content is not None
+        else None
+    )
     return RuntimeAcceptedNoteContentWritePlan(
         db_version=next_runtime_note_content_version(current_note_content),
         previous_file_delete=plan_previous_note_file_delete(

--- a/src/basic_memory/runtime/accepted_note_changes.py
+++ b/src/basic_memory/runtime/accepted_note_changes.py
@@ -96,14 +96,28 @@ def next_runtime_note_content_version(
 
 def select_accepted_note_source_checksum(
     current_note_content: RuntimeAcceptedNoteContentWriteSource,
+    *,
+    observed_file_checksum: RuntimeFileChecksum | None = None,
 ) -> RuntimeFileChecksum:
     """Select the checksum for source bytes vacated by an accepted path change.
 
     ``accept_write`` deliberately preserves the previously published file fields while the next
-    DB version is pending. Only a synchronized file version proves ``file_checksum`` belongs to
-    the current accepted source; otherwise ``db_checksum`` is the identity of the bytes that a
-    publication may already have written without recording its result.
+    DB version is pending. During ``pending`` or ``writing``, storage may still contain the
+    previously published bytes or may already contain the accepted DB bytes without recording its
+    result. A live checksum matching either known version resolves that ambiguity. Otherwise only
+    a synchronized file version proves ``file_checksum`` belongs to the current accepted source.
     """
+    if (
+        current_note_content.file_write_status in {"pending", "writing"}
+        and observed_file_checksum is not None
+        and observed_file_checksum
+        in {
+            current_note_content.db_checksum,
+            current_note_content.file_checksum,
+        }
+    ):
+        return observed_file_checksum
+
     file_version_is_current = (
         current_note_content.file_write_status == "synced"
         and current_note_content.file_version is not None
@@ -159,10 +173,11 @@ def plan_accepted_note_content_write(
     accepted_file_path: RuntimeFilePath,
     current_note_content: RuntimeAcceptedNoteContentWriteSource | None = None,
     existing_file_path: RuntimeFilePath | None = None,
+    source_file_checksum: RuntimeFileChecksum | None = None,
 ) -> RuntimeAcceptedNoteContentWritePlan:
     """Plan accepted DB versioning and old-file cleanup for a note_content write."""
-    source_checksum = None
-    if current_note_content is not None:
+    source_checksum = source_file_checksum
+    if source_checksum is None and current_note_content is not None:
         source_checksum = select_accepted_note_source_checksum(current_note_content)
     return RuntimeAcceptedNoteContentWritePlan(
         db_version=next_runtime_note_content_version(current_note_content),

--- a/src/basic_memory/runtime/accepted_note_changes.py
+++ b/src/basic_memory/runtime/accepted_note_changes.py
@@ -13,7 +13,7 @@ from basic_memory.runtime.note_content_deletes import (
     RuntimeDeletedNoteResponse,
     RuntimeMaterializedNoteSource,
     RuntimePendingNoteFileDelete,
-    plan_previous_materialized_note_file_delete,
+    plan_previous_note_file_delete,
     select_deleted_note_file_checksum,
 )
 from basic_memory.runtime.note_content_responses import (
@@ -33,6 +33,7 @@ from basic_memory.runtime.storage import (
     NoteExternalId,
     ProjectId,
     RuntimeEntityId,
+    RuntimeFileChecksum,
     RuntimeFilePath,
     RuntimeIntegrityErrorMessage,
     RuntimeNoteActorKind,
@@ -64,6 +65,10 @@ class RuntimeAcceptedNoteContentWriteSource(
     Protocol,
 ):
     """Minimal note_content row shape needed to plan accepted writes."""
+
+    @property
+    def db_checksum(self) -> RuntimeFileChecksum:
+        """Return the accepted checksum that identifies the source bytes."""
 
 
 class RuntimeAcceptedNoteWriteContentSource(
@@ -130,14 +135,25 @@ def plan_accepted_note_content_write(
     existing_file_path: RuntimeFilePath | None = None,
 ) -> RuntimeAcceptedNoteContentWritePlan:
     """Plan accepted DB versioning and old-file cleanup for a note_content write."""
+    source_checksum = None
+    if current_note_content is not None:
+        # A source write can reach storage before its publisher records file_checksum. The
+        # accepted DB checksum still identifies those exact bytes, so enqueue guarded cleanup
+        # with it; an absent source then retires the move-vacate marker instead of leaving it
+        # capable of suppressing a future legitimate note.
+        source_checksum = (
+            current_note_content.file_checksum
+            if current_note_content.file_checksum is not None
+            else current_note_content.db_checksum
+        )
     return RuntimeAcceptedNoteContentWritePlan(
         db_version=next_runtime_note_content_version(current_note_content),
-        previous_file_delete=plan_previous_materialized_note_file_delete(
+        previous_file_delete=plan_previous_note_file_delete(
             project_id=project_id,
             entity_id=entity_id,
             existing_file_path=existing_file_path,
             accepted_file_path=accepted_file_path,
-            current_note_content=current_note_content,
+            file_checksum=source_checksum,
         ),
     )
 

--- a/src/basic_memory/runtime/accepted_note_changes.py
+++ b/src/basic_memory/runtime/accepted_note_changes.py
@@ -70,6 +70,12 @@ class RuntimeAcceptedNoteContentWriteSource(
     def db_checksum(self) -> RuntimeFileChecksum:
         """Return the accepted checksum that identifies the source bytes."""
 
+    @property
+    def file_version(self) -> RuntimeNoteContentVersion | None: ...
+
+    @property
+    def file_write_status(self) -> str: ...
+
 
 class RuntimeAcceptedNoteWriteContentSource(
     RuntimeNoteContentStateSource,
@@ -86,6 +92,26 @@ def next_runtime_note_content_version(
     if current_note_content is None:
         return 1
     return int(current_note_content.db_version) + 1
+
+
+def select_accepted_note_source_checksum(
+    current_note_content: RuntimeAcceptedNoteContentWriteSource,
+) -> RuntimeFileChecksum:
+    """Select the checksum for source bytes vacated by an accepted path change.
+
+    ``accept_write`` deliberately preserves the previously published file fields while the next
+    DB version is pending. Only a synchronized file version proves ``file_checksum`` belongs to
+    the current accepted source; otherwise ``db_checksum`` is the identity of the bytes that a
+    publication may already have written without recording its result.
+    """
+    file_version_is_current = (
+        current_note_content.file_write_status == "synced"
+        and current_note_content.file_version is not None
+        and int(current_note_content.file_version) == int(current_note_content.db_version)
+    )
+    if file_version_is_current and current_note_content.file_checksum is not None:
+        return current_note_content.file_checksum
+    return current_note_content.db_checksum
 
 
 def accepted_note_file_path_conflicts(
@@ -137,15 +163,7 @@ def plan_accepted_note_content_write(
     """Plan accepted DB versioning and old-file cleanup for a note_content write."""
     source_checksum = None
     if current_note_content is not None:
-        # A source write can reach storage before its publisher records file_checksum. The
-        # accepted DB checksum still identifies those exact bytes, so enqueue guarded cleanup
-        # with it; an absent source then retires the move-vacate marker instead of leaving it
-        # capable of suppressing a future legitimate note.
-        source_checksum = (
-            current_note_content.file_checksum
-            if current_note_content.file_checksum is not None
-            else current_note_content.db_checksum
-        )
+        source_checksum = select_accepted_note_source_checksum(current_note_content)
     return RuntimeAcceptedNoteContentWritePlan(
         db_version=next_runtime_note_content_version(current_note_content),
         previous_file_delete=plan_previous_note_file_delete(

--- a/src/basic_memory/runtime/accepted_note_changes.py
+++ b/src/basic_memory/runtime/accepted_note_changes.py
@@ -102,13 +102,14 @@ def select_accepted_note_source_checksum(
     """Select the checksum for source bytes vacated by an accepted path change.
 
     ``accept_write`` deliberately preserves the previously published file fields while the next
-    DB version is pending. During ``pending`` or ``writing``, storage may still contain the
-    previously published bytes or may already contain the accepted DB bytes without recording its
-    result. A live checksum matching either known version resolves that ambiguity. Otherwise only
-    a synchronized file version proves ``file_checksum`` belongs to the current accepted source.
+    DB version is pending. During ``pending``, ``writing``, or ``failed``, storage may still
+    contain the previously published bytes or may already contain the accepted DB bytes without
+    recording its result. A live checksum matching either known version resolves that ambiguity.
+    Otherwise only a synchronized file version proves ``file_checksum`` belongs to the current
+    accepted source.
     """
     if (
-        current_note_content.file_write_status in {"pending", "writing"}
+        current_note_content.file_write_status in {"pending", "writing", "failed"}
         and observed_file_checksum is not None
         and observed_file_checksum
         in {

--- a/src/basic_memory/runtime/accepted_note_changes.py
+++ b/src/basic_memory/runtime/accepted_note_changes.py
@@ -105,8 +105,9 @@ def select_accepted_note_source_checksum(
     DB version is pending. During ``pending``, ``writing``, ``failed``, or
     ``external_change_detected``, storage may contain either known version or unrelated bytes. A
     live checksum matching either known version resolves that ambiguity. An absent or unexpected
-    object proves neither version owns the path, so cleanup must remain unclaimed. Otherwise only
-    a synchronized file version proves ``file_checksum`` belongs to the current accepted source.
+    object proves neither version owns the path, so cleanup must remain unclaimed. A synchronized
+    file version identifies the expected checksum, but storage observation still proves that those
+    bytes exist at the source path before cleanup ownership is recorded.
     """
     if current_note_content.file_write_status in {
         "pending",
@@ -126,9 +127,13 @@ def select_accepted_note_source_checksum(
         and current_note_content.file_version is not None
         and int(current_note_content.file_version) == int(current_note_content.db_version)
     )
-    if file_version_is_current and current_note_content.file_checksum is not None:
-        return current_note_content.file_checksum
-    return current_note_content.db_checksum
+    if (
+        file_version_is_current
+        and current_note_content.file_checksum is not None
+        and observed_file_checksum == current_note_content.file_checksum
+    ):
+        return observed_file_checksum
+    return None
 
 
 def accepted_note_file_path_conflicts(

--- a/src/basic_memory/runtime/note_content.py
+++ b/src/basic_memory/runtime/note_content.py
@@ -20,6 +20,7 @@ from basic_memory.runtime.accepted_note_changes import (
     plan_accepted_note_materialization_change,
     plan_accepted_note_response_change,
     plan_accepted_note_write_change,
+    select_accepted_note_source_checksum,
 )
 from basic_memory.runtime.note_content_deletes import (
     RuntimeDeletedNoteEntityChecksumSource,
@@ -150,5 +151,6 @@ __all__ = [
     "runtime_file_conflict",
     "runtime_note_content_payload_as_dict",
     "runtime_note_content_payload_as_json_bytes",
+    "select_accepted_note_source_checksum",
     "select_deleted_note_file_checksum",
 ]

--- a/src/basic_memory/services/initialization.py
+++ b/src/basic_memory/services/initialization.py
@@ -156,6 +156,8 @@ _initial_index_tasks: set[asyncio.Task[None]] = set()
 async def initialize_file_indexing(
     app_config: BasicMemoryConfig,
     quiet: bool = True,
+    *,
+    recovery_complete: asyncio.Event | None = None,
 ) -> None:
     """Initialize file indexing services.
 
@@ -164,6 +166,7 @@ async def initialize_file_indexing(
     Args:
         app_config: The Basic Memory project configuration
         quiet: Whether to suppress Rich console output (True for MCP, False for CLI watch)
+        recovery_complete: Optional startup barrier set after durable recovery finishes.
 
     Returns:
         The watch service task that's monitoring file changes
@@ -173,6 +176,8 @@ async def initialize_file_indexing(
     # Skip file indexing in test environments to avoid interference with tests
     if app_config.is_test_env:
         logger.info("Test environment detected - skipping file indexing initialization")
+        if recovery_complete is not None:
+            recovery_complete.set()
         return None
 
     # delay import
@@ -230,6 +235,13 @@ async def initialize_file_indexing(
     # converge before the initial project index scans them.
     for project in active_projects:
         await recover_project_materializations(project, session_maker)
+
+    # Trigger: the API/MCP lifespan is waiting for durable startup recovery.
+    # Why: serving accepted writes while recovery holds cached vacate work can
+    # delete a path that a concurrent move has just made live again.
+    # Outcome: release startup before background indexing and watching begin.
+    if recovery_complete is not None:
+        recovery_complete.set()
 
     # Start indexing for all projects as background tasks (non-blocking)
     async def index_project_background(project: Project):

--- a/src/basic_memory/services/initialization.py
+++ b/src/basic_memory/services/initialization.py
@@ -58,17 +58,20 @@ async def recover_project_materializations(
     project: Project,
     session_maker: "async_sessionmaker[AsyncSession]",
 ) -> None:
-    """Re-drive note materializations a crash or write error left stuck for one project.
+    """Re-drive note materialization and move cleanup lost across a process exit.
 
     A local note write returns before its markdown file is written; a crash
     between accepting the DB snapshot and writing the file leaves note_content
     stuck in writing/pending (a transient write error leaves it failed) and the
-    source-of-truth file missing. Runs once at
-    startup, before the watch service serves, so the file is (re)written and then
-    picked up by the initial project index. Non-fatal: a recovery failure must not
-    block startup, so it is logged and startup continues.
+    source-of-truth file missing. A moved note can also synchronize its destination
+    before the in-memory source cleanup is lost. Runs once at startup, before the
+    initial index, so both durable states converge. Non-fatal: a recovery failure
+    must not block startup, so it is logged and startup continues.
     """
-    from basic_memory.index.note_content_materialization import recover_stuck_materializations
+    from basic_memory.index.note_content_materialization import (
+        recover_move_vacates,
+        recover_stuck_materializations,
+    )
     from basic_memory.services.file_service import FileService
 
     try:
@@ -80,11 +83,17 @@ async def recover_project_materializations(
             file_service=file_service,
             project_id=project.id,
         )
-        if recovered:
+        recovered_vacates = await recover_move_vacates(
+            session_maker=session_maker,
+            file_service=file_service,
+            project_id=project.id,
+        )
+        if recovered or recovered_vacates:
             logger.info(
-                "Recovered stuck note materializations on startup",
+                "Recovered note materialization state on startup",
                 project=project.name,
-                recovered=recovered,
+                recovered_materializations=recovered,
+                recovered_move_vacates=recovered_vacates,
             )
     except Exception as e:  # pragma: no cover - defensive startup guard
         logger.error(f"Error recovering stuck materializations for project {project.name}: {e}")
@@ -216,9 +225,9 @@ async def initialize_file_indexing(
         active_projects = [p for p in active_projects if p.name not in skip]
         logger.info(f"Skipping projects that are not locally indexable: {skip}")
 
-    # Recover materializations left stuck (writing/pending/failed) before serving.
-    # Runs synchronously here so the source-of-truth files are re-written before the
-    # initial project index scans them; bounded by the count of stuck rows.
+    # Recover materializations left stuck (writing/pending/failed) and source
+    # cleanup whose in-process enqueue was lost. Runs synchronously so the files
+    # converge before the initial project index scans them.
     for project in active_projects:
         await recover_project_materializations(project, session_maker)
 

--- a/test-int/mcp/test_lifespan_shutdown_sync_task_cancellation_integration.py
+++ b/test-int/mcp/test_lifespan_shutdown_sync_task_cancellation_integration.py
@@ -53,7 +53,14 @@ def test_lifespan_shutdown_awaits_watch_task_cancellation(app, monkeypatch):
 
     # Make the watch task long-lived so it must be cancelled on shutdown.
     # Patch at the source module where WatchCoordinator imports it.
-    async def _fake_initialize_file_indexing(_app_config, quiet=True):  # noqa: ANN001, FBT002
+    async def _fake_initialize_file_indexing(  # noqa: ANN001, FBT002
+        _app_config,
+        quiet=True,
+        *,
+        recovery_complete=None,
+    ):
+        assert recovery_complete is not None
+        recovery_complete.set()
         await asyncio.Event().wait()
 
     monkeypatch.setattr(init_module, "initialize_file_indexing", _fake_initialize_file_indexing)

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -5,9 +5,21 @@ Tests the complete move note workflow: MCP client -> MCP server -> FastAPI -> da
 """
 
 import json
+from hashlib import sha256
 
 import pytest
 from fastmcp import Client
+
+from basic_memory import db
+from basic_memory.index.local_project import (
+    LocalProjectIndexRuntimeFactory,
+    run_local_project_index_for_project,
+)
+from basic_memory.index.note_content_materialization import InlineNoteFileDeleteEnqueuer
+from basic_memory.repository.entity_repository import EntityRepository
+from basic_memory.repository.note_content_repository import NoteContentRepository
+from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
+from basic_memory.runtime.cleanup import RuntimeNoteFileDeleteJobRequest
 
 
 @pytest.mark.asyncio
@@ -68,6 +80,98 @@ async def test_move_note_basic_operation(mcp_server, app, test_project):
 
         # Should return "Note Not Found" message
         assert "Note Not Found" in read_original.content[0].text
+
+
+@pytest.mark.parametrize("force_full", [False, True], ids=["observed", "force-full"])
+@pytest.mark.asyncio
+async def test_move_note_lingering_source_is_not_reindexed(
+    mcp_server,
+    app,
+    test_project,
+    project_config,
+    engine_factory,
+    monkeypatch,
+    force_full: bool,
+):
+    """A move-vacated source is skipped even across the unpublished-checksum race."""
+    del app
+    source_relative = "source/Move Orphan Race.md"
+    destination_relative = "archive/move-orphan-race.md"
+    source_path = project_config.home / source_relative
+    _, session_maker = engine_factory
+    entity_repository = EntityRepository(project_id=test_project.id)
+    note_content_repository = NoteContentRepository(project_id=test_project.id)
+    vacate_repository = NoteFileVacateRepository(project_id=test_project.id)
+
+    async with Client(mcp_server) as client:
+        await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Move Orphan Race",
+                "directory": "source",
+                "content": "# Move Orphan Race\n\nThis source object must never become a ghost.",
+            },
+        )
+
+        source_checksum = sha256(source_path.read_bytes()).hexdigest()
+        async with db.scoped_session(session_maker) as session:
+            entity = await entity_repository.get_by_file_path(session, source_relative)
+            assert entity is not None
+            note_content = await note_content_repository.get_by_entity_id(session, entity.id)
+            assert note_content is not None
+            assert note_content.db_checksum == source_checksum
+            moved_entity_id = entity.id
+
+            # Reproduce a write that reached storage before its publisher recorded checksums.
+            entity.checksum = None
+            note_content.file_checksum = None
+
+        async def leave_source_cleanup_pending(
+            self: InlineNoteFileDeleteEnqueuer,
+            request: RuntimeNoteFileDeleteJobRequest,
+        ) -> None:
+            del self, request
+
+        # The enqueue boundary is the only failure injection; move, materialization, repositories,
+        # storage, and the subsequent project index all run through their real integration paths.
+        monkeypatch.setattr(
+            InlineNoteFileDeleteEnqueuer,
+            "enqueue_note_file_delete",
+            leave_source_cleanup_pending,
+        )
+
+        move_result = await client.call_tool(
+            "move_note",
+            {
+                "project": test_project.name,
+                "identifier": "Move Orphan Race",
+                "destination_path": destination_relative,
+            },
+        )
+        assert "✅ Note moved successfully" in move_result.content[0].text
+        assert source_path.exists()
+
+        async with db.scoped_session(session_maker) as session:
+            markers = await vacate_repository.load_vacate_markers(
+                session,
+                [source_relative],
+            )
+        assert markers[source_relative].file_checksum == source_checksum
+
+        await run_local_project_index_for_project(
+            test_project,
+            runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+            force_full=force_full,
+        )
+
+        async with db.scoped_session(session_maker) as session:
+            ghost = await entity_repository.get_by_file_path(session, source_relative)
+            moved = await entity_repository.get_by_file_path(session, destination_relative)
+
+        assert ghost is None
+        assert moved is not None
+        assert moved.id == moved_entity_id
 
 
 @pytest.mark.asyncio

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -313,15 +313,20 @@ async def test_startup_recovery_retries_lost_move_source_cleanup(
         assert await vacate_repository.load_vacate_markers(session, [source_relative]) == {}
 
 
+@pytest.mark.parametrize(
+    "source_publication_state",
+    ["unpublished", "synced"],
+)
 @pytest.mark.asyncio
-async def test_move_preserves_recreated_source_when_unpublished_source_is_absent(
+async def test_move_preserves_recreated_source_when_source_is_absent(
     mcp_server,
     app,
     test_project,
     project_config,
     engine_factory,
+    source_publication_state: str,
 ):
-    """An absent source does not authorize delayed deletion of a later identical file."""
+    """An absent source never authorizes delayed deletion of a later identical file."""
     del app
     source_relative = "source/Absent Before Move.md"
     destination_relative = "archive/absent-before-move.md"
@@ -351,11 +356,13 @@ async def test_move_preserves_recreated_source_when_unpublished_source_is_absent
             note_content = await note_content_repository.get_by_entity_id(session, entity.id)
             assert note_content is not None
             assert note_content.db_checksum == source_checksum
-            entity.checksum = None
-            note_content.file_checksum = None
+            if source_publication_state == "unpublished":
+                entity.checksum = None
+                note_content.file_checksum = None
 
-        # Reproduce the no-materialized-source side of the publisher race. Absence must remain
-        # absence rather than borrowing the DB checksum as authority to delete this path later.
+        # Reproduce the source disappearing before the move observes it. Absence must remain
+        # absence rather than borrowing either a pending or synchronized DB checksum as authority
+        # to delete this path later.
         source_path.unlink()
         move_result = await client.call_tool(
             "move_note",

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -235,6 +235,132 @@ async def test_move_retires_vacate_marker_when_unpublished_source_is_absent(
     assert markers == {}
 
 
+@pytest.mark.asyncio
+async def test_move_retires_vacate_marker_after_source_replacement(
+    mcp_server,
+    app,
+    test_project,
+    project_config,
+    engine_factory,
+    monkeypatch,
+):
+    """A cleanup checksum mismatch retires stale move evidence before future path reuse."""
+    del app
+    source_relative = "source/Move Replacement Lifecycle.md"
+    destination_relative = "archive/move-replacement-lifecycle.md"
+    source_path = project_config.home / source_relative
+    _, session_maker = engine_factory
+    entity_repository = EntityRepository(project_id=test_project.id)
+    vacate_repository = NoteFileVacateRepository(project_id=test_project.id)
+    original_cleanup = InlineNoteFileDeleteEnqueuer.enqueue_note_file_delete
+    pending_cleanup: (
+        tuple[
+            InlineNoteFileDeleteEnqueuer,
+            RuntimeNoteFileDeleteJobRequest,
+        ]
+        | None
+    ) = None
+
+    async def capture_source_cleanup(
+        self: InlineNoteFileDeleteEnqueuer,
+        request: RuntimeNoteFileDeleteJobRequest,
+    ) -> None:
+        nonlocal pending_cleanup
+        pending_cleanup = (self, request)
+
+    monkeypatch.setattr(
+        InlineNoteFileDeleteEnqueuer,
+        "enqueue_note_file_delete",
+        capture_source_cleanup,
+    )
+
+    async with Client(mcp_server) as client:
+        await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Move Replacement Lifecycle",
+                "directory": "source",
+                "content": (
+                    "# Move Replacement Lifecycle\n\n"
+                    "This content may later be copied back legitimately."
+                ),
+            },
+        )
+        original_source = source_path.read_bytes()
+        source_checksum = sha256(original_source).hexdigest()
+
+        move_result = await client.call_tool(
+            "move_note",
+            {
+                "project": test_project.name,
+                "identifier": "Move Replacement Lifecycle",
+                "destination_path": destination_relative,
+            },
+        )
+        assert "✅ Note moved successfully" in move_result.content[0].text
+        assert pending_cleanup is not None
+
+        cleanup_enqueuer, cleanup_request = pending_cleanup
+        source_path.write_text(
+            "# Source Replacement\n\nThis independent file replaced the moved source.",
+            encoding="utf-8",
+        )
+        await original_cleanup(cleanup_enqueuer, cleanup_request)
+
+        # Restore normal inline cleanup before deleting the indexed replacement below.
+        monkeypatch.setattr(
+            InlineNoteFileDeleteEnqueuer,
+            "enqueue_note_file_delete",
+            original_cleanup,
+        )
+
+        async with db.scoped_session(session_maker) as session:
+            markers = await vacate_repository.load_vacate_markers(session, [source_relative])
+        assert markers == {}
+
+        await run_local_project_index_for_project(
+            test_project,
+            runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+            force_full=True,
+        )
+        async with db.scoped_session(session_maker) as session:
+            replacement = await entity_repository.get_by_file_path(session, source_relative)
+            moved = await entity_repository.get_by_file_path(session, destination_relative)
+        assert replacement is not None
+        assert moved is not None
+        assert replacement.id != moved.id
+        replacement_external_id = replacement.external_id
+        moved_entity_id = moved.id
+
+        delete_result = await client.call_tool(
+            "delete_note",
+            {
+                "project": test_project.name,
+                "identifier": source_relative,
+            },
+        )
+        assert "true" in delete_result.content[0].text.lower()
+        assert not source_path.exists()
+
+        source_path.write_bytes(original_source)
+        assert sha256(source_path.read_bytes()).hexdigest() == source_checksum
+        await run_local_project_index_for_project(
+            test_project,
+            runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+            force_full=True,
+        )
+
+    async with db.scoped_session(session_maker) as session:
+        legitimate_copy = await entity_repository.get_by_file_path(session, source_relative)
+        markers = await vacate_repository.load_vacate_markers(session, [source_relative])
+
+    assert legitimate_copy is not None
+    assert legitimate_copy.id != moved_entity_id
+    assert legitimate_copy.external_id != replacement_external_id
+    assert markers == {}
+
+
 @pytest.mark.parametrize("force_full", [False, True], ids=["observed", "force-full"])
 @pytest.mark.asyncio
 async def test_put_rename_lingering_source_is_not_reindexed(

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -253,6 +253,94 @@ async def test_put_rename_lingering_source_is_not_reindexed(
     assert renamed.id == created["id"]
 
 
+@pytest.mark.parametrize("force_full", [False, True], ids=["observed", "force-full"])
+@pytest.mark.asyncio
+async def test_deleted_move_lingering_source_is_not_resurrected(
+    mcp_server,
+    app,
+    test_project,
+    project_config,
+    engine_factory,
+    monkeypatch,
+    force_full: bool,
+):
+    """A move marker survives destination deletion until the lingering source is cleaned."""
+    del app
+    source_relative = "source/Delete After Move.md"
+    destination_relative = "archive/delete-after-move.md"
+    source_path = project_config.home / source_relative
+    destination_path = project_config.home / destination_relative
+    _, session_maker = engine_factory
+    entity_repository = EntityRepository(project_id=test_project.id)
+    vacate_repository = NoteFileVacateRepository(project_id=test_project.id)
+    original_cleanup = InlineNoteFileDeleteEnqueuer.enqueue_note_file_delete
+
+    async def leave_only_move_source_cleanup_pending(
+        self: InlineNoteFileDeleteEnqueuer,
+        request: RuntimeNoteFileDeleteJobRequest,
+    ) -> None:
+        if request.file_path == source_relative:
+            return
+        await original_cleanup(self, request)
+
+    monkeypatch.setattr(
+        InlineNoteFileDeleteEnqueuer,
+        "enqueue_note_file_delete",
+        leave_only_move_source_cleanup_pending,
+    )
+
+    async with Client(mcp_server) as client:
+        await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Delete After Move",
+                "directory": "source",
+                "content": "# Delete After Move\n\nDo not resurrect this deleted note.",
+            },
+        )
+        source_checksum = sha256(source_path.read_bytes()).hexdigest()
+
+        move_result = await client.call_tool(
+            "move_note",
+            {
+                "project": test_project.name,
+                "identifier": "Delete After Move",
+                "destination_path": destination_relative,
+            },
+        )
+        assert "✅ Note moved successfully" in move_result.content[0].text
+        assert source_path.exists()
+        assert destination_path.exists()
+
+        delete_result = await client.call_tool(
+            "delete_note",
+            {
+                "project": test_project.name,
+                "identifier": destination_relative,
+            },
+        )
+        assert "true" in delete_result.content[0].text.lower()
+        assert source_path.exists()
+        assert not destination_path.exists()
+
+    async with db.scoped_session(session_maker) as session:
+        markers = await vacate_repository.load_vacate_markers(session, [source_relative])
+    assert markers[source_relative].entity_id is None
+    assert markers[source_relative].file_checksum == source_checksum
+
+    await run_local_project_index_for_project(
+        test_project,
+        runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+        force_full=force_full,
+    )
+
+    async with db.scoped_session(session_maker) as session:
+        resurrected = await entity_repository.get_by_file_path(session, source_relative)
+
+    assert resurrected is None
+
+
 @pytest.mark.asyncio
 async def test_move_note_using_permalink(mcp_server, app, test_project):
     """Test moving a note using its permalink as identifier."""

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -235,6 +235,10 @@ async def test_move_retires_vacate_marker_when_unpublished_source_is_absent(
     assert markers == {}
 
 
+@pytest.mark.parametrize(
+    "retirement_trigger",
+    ["cleanup-worker", "index-observation"],
+)
 @pytest.mark.asyncio
 async def test_move_retires_vacate_marker_after_source_replacement(
     mcp_server,
@@ -243,8 +247,9 @@ async def test_move_retires_vacate_marker_after_source_replacement(
     project_config,
     engine_factory,
     monkeypatch,
+    retirement_trigger: str,
 ):
-    """A cleanup checksum mismatch retires stale move evidence before future path reuse."""
+    """Cleanup or replacement observation retires stale move evidence before path reuse."""
     del app
     source_relative = "source/Move Replacement Lifecycle.md"
     destination_relative = "archive/move-replacement-lifecycle.md"
@@ -306,7 +311,8 @@ async def test_move_retires_vacate_marker_after_source_replacement(
             "# Source Replacement\n\nThis independent file replaced the moved source.",
             encoding="utf-8",
         )
-        await original_cleanup(cleanup_enqueuer, cleanup_request)
+        if retirement_trigger == "cleanup-worker":
+            await original_cleanup(cleanup_enqueuer, cleanup_request)
 
         # Restore normal inline cleanup before deleting the indexed replacement below.
         monkeypatch.setattr(
@@ -314,10 +320,6 @@ async def test_move_retires_vacate_marker_after_source_replacement(
             "enqueue_note_file_delete",
             original_cleanup,
         )
-
-        async with db.scoped_session(session_maker) as session:
-            markers = await vacate_repository.load_vacate_markers(session, [source_relative])
-        assert markers == {}
 
         await run_local_project_index_for_project(
             test_project,
@@ -327,9 +329,11 @@ async def test_move_retires_vacate_marker_after_source_replacement(
         async with db.scoped_session(session_maker) as session:
             replacement = await entity_repository.get_by_file_path(session, source_relative)
             moved = await entity_repository.get_by_file_path(session, destination_relative)
+            markers = await vacate_repository.load_vacate_markers(session, [source_relative])
         assert replacement is not None
         assert moved is not None
         assert replacement.id != moved.id
+        assert markers == {}
         replacement_external_id = replacement.external_id
         moved_entity_id = moved.id
 
@@ -363,7 +367,7 @@ async def test_move_retires_vacate_marker_after_source_replacement(
 
 @pytest.mark.parametrize(
     "publication_state",
-    ["synced", "published-checksum-stale"],
+    ["synced", "pending-before-write", "published-checksum-stale"],
 )
 @pytest.mark.parametrize("force_full", [False, True], ids=["observed", "force-full"])
 @pytest.mark.asyncio
@@ -400,13 +404,15 @@ async def test_put_rename_lingering_source_is_not_reindexed(
     materialized_checksum = sha256(source_path.read_bytes()).hexdigest()
     source_checksum = materialized_checksum
 
-    if publication_state == "published-checksum-stale":
+    if publication_state in {"pending-before-write", "published-checksum-stale"}:
         pending_markdown = (
             source_path.read_text(encoding="utf-8").rstrip()
             + "\n\nThese accepted bytes reached storage before publication.\n"
         )
-        source_path.write_text(pending_markdown, encoding="utf-8")
-        source_checksum = sha256(source_path.read_bytes()).hexdigest()
+        accepted_checksum = sha256(pending_markdown.encode()).hexdigest()
+        if publication_state == "published-checksum-stale":
+            source_path.write_text(pending_markdown, encoding="utf-8")
+            source_checksum = sha256(source_path.read_bytes()).hexdigest()
         async with db.scoped_session(session_maker) as session:
             entity = await entity_repository.get_by_file_path(session, source_relative)
             assert entity is not None
@@ -414,8 +420,10 @@ async def test_put_rename_lingering_source_is_not_reindexed(
             assert note_content is not None
             note_content.markdown_content = pending_markdown
             note_content.db_version += 1
-            note_content.db_checksum = source_checksum
-            note_content.file_write_status = "writing"
+            note_content.db_checksum = accepted_checksum
+            note_content.file_write_status = (
+                "writing" if publication_state == "published-checksum-stale" else "pending"
+            )
             assert note_content.file_version is not None
             assert note_content.file_version < note_content.db_version
             assert note_content.file_checksum == materialized_checksum

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -258,14 +258,14 @@ async def test_startup_recovery_retries_lost_move_source_cleanup(
 
 
 @pytest.mark.asyncio
-async def test_move_retires_vacate_marker_when_unpublished_source_is_absent(
+async def test_move_preserves_recreated_source_when_unpublished_source_is_absent(
     mcp_server,
     app,
     test_project,
     project_config,
     engine_factory,
 ):
-    """Accepted DB checksum schedules cleanup even when no file checksum was published."""
+    """An absent source does not authorize delayed deletion of a later identical file."""
     del app
     source_relative = "source/Absent Before Move.md"
     destination_relative = "archive/absent-before-move.md"
@@ -287,7 +287,8 @@ async def test_move_retires_vacate_marker_when_unpublished_source_is_absent(
             },
         )
 
-        source_checksum = sha256(source_path.read_bytes()).hexdigest()
+        source_bytes = source_path.read_bytes()
+        source_checksum = sha256(source_bytes).hexdigest()
         async with db.scoped_session(session_maker) as session:
             entity = await entity_repository.get_by_file_path(session, source_relative)
             assert entity is not None
@@ -297,8 +298,8 @@ async def test_move_retires_vacate_marker_when_unpublished_source_is_absent(
             entity.checksum = None
             note_content.file_checksum = None
 
-        # Reproduce the no-materialized-source side of the publisher race. The accepted checksum
-        # still drives a cleanup job, which observes the missing source and clears the marker.
+        # Reproduce the no-materialized-source side of the publisher race. Absence must remain
+        # absence rather than borrowing the DB checksum as authority to delete this path later.
         source_path.unlink()
         move_result = await client.call_tool(
             "move_note",
@@ -312,6 +313,19 @@ async def test_move_retires_vacate_marker_when_unpublished_source_is_absent(
     assert "✅ Note moved successfully" in move_result.content[0].text
     assert not source_path.exists()
     assert destination_path.exists()
+
+    # A user may legitimately reuse the vacated path after the move. Even byte-identical content
+    # must survive because no source object existed when the move claimed its cleanup work.
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_bytes(source_bytes)
+    recovered = await recover_move_vacates(
+        session_maker=session_maker,
+        file_service=FileService(project_config.home),
+        project_id=test_project.id,
+    )
+
+    assert recovered == 0
+    assert source_path.read_bytes() == source_bytes
     async with db.scoped_session(session_maker) as session:
         markers = await vacate_repository.load_vacate_markers(session, [source_relative])
     assert markers == {}

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -16,11 +16,15 @@ from basic_memory.index.local_project import (
     LocalProjectIndexRuntimeFactory,
     run_local_project_index_for_project,
 )
-from basic_memory.index.note_content_materialization import InlineNoteFileDeleteEnqueuer
+from basic_memory.index.note_content_materialization import (
+    InlineNoteFileDeleteEnqueuer,
+    recover_move_vacates,
+)
 from basic_memory.repository.entity_repository import EntityRepository
 from basic_memory.repository.note_content_repository import NoteContentRepository
 from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
 from basic_memory.runtime.cleanup import RuntimeNoteFileDeleteJobRequest
+from basic_memory.services.file_service import FileService
 
 
 @pytest.mark.asyncio
@@ -173,6 +177,84 @@ async def test_move_note_lingering_source_is_not_reindexed(
         assert ghost is None
         assert moved is not None
         assert moved.id == moved_entity_id
+
+
+@pytest.mark.asyncio
+async def test_startup_recovery_retries_lost_move_source_cleanup(
+    mcp_server,
+    app,
+    test_project,
+    project_config,
+    engine_factory,
+    monkeypatch,
+):
+    """A synchronized move converges after its in-memory cleanup enqueue is lost."""
+    del app
+    source_relative = "source/Lost Cleanup.md"
+    destination_relative = "archive/lost-cleanup.md"
+    source_path = project_config.home / source_relative
+    destination_path = project_config.home / destination_relative
+    _, session_maker = engine_factory
+    vacate_repository = NoteFileVacateRepository(project_id=test_project.id)
+    original_cleanup = InlineNoteFileDeleteEnqueuer.enqueue_note_file_delete
+
+    async def lose_source_cleanup(
+        self: InlineNoteFileDeleteEnqueuer,
+        request: RuntimeNoteFileDeleteJobRequest,
+    ) -> None:
+        del self, request
+
+    monkeypatch.setattr(
+        InlineNoteFileDeleteEnqueuer,
+        "enqueue_note_file_delete",
+        lose_source_cleanup,
+    )
+
+    async with Client(mcp_server) as client:
+        await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Lost Cleanup",
+                "directory": "source",
+                "content": "# Lost Cleanup\n\nStartup must retry this source deletion.",
+            },
+        )
+        move_result = await client.call_tool(
+            "move_note",
+            {
+                "project": test_project.name,
+                "identifier": "Lost Cleanup",
+                "destination_path": destination_relative,
+            },
+        )
+
+    assert "✅ Note moved successfully" in move_result.content[0].text
+    assert source_path.exists()
+    assert destination_path.exists()
+    async with db.scoped_session(session_maker) as session:
+        assert source_relative in await vacate_repository.load_vacate_markers(
+            session,
+            [source_relative],
+        )
+
+    # Re-enable the real cleanup adapter, matching a fresh process startup.
+    monkeypatch.setattr(
+        InlineNoteFileDeleteEnqueuer,
+        "enqueue_note_file_delete",
+        original_cleanup,
+    )
+    recovered = await recover_move_vacates(
+        session_maker=session_maker,
+        file_service=FileService(project_config.home),
+        project_id=test_project.id,
+    )
+
+    assert recovered == 1
+    assert not source_path.exists()
+    assert destination_path.exists()
+    async with db.scoped_session(session_maker) as session:
+        assert await vacate_repository.load_vacate_markers(session, [source_relative]) == {}
 
 
 @pytest.mark.asyncio
@@ -567,6 +649,16 @@ async def test_deleted_move_lingering_source_is_not_resurrected(
         resurrected = await entity_repository.get_by_file_path(session, source_relative)
 
     assert resurrected is None
+
+    recovered = await recover_move_vacates(
+        session_maker=session_maker,
+        file_service=FileService(project_config.home),
+        project_id=test_project.id,
+    )
+    assert recovered == 1
+    assert not source_path.exists()
+    async with db.scoped_session(session_maker) as session:
+        assert await vacate_repository.load_vacate_markers(session, [source_relative]) == {}
 
 
 @pytest.mark.asyncio

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -361,6 +361,10 @@ async def test_move_retires_vacate_marker_after_source_replacement(
     assert markers == {}
 
 
+@pytest.mark.parametrize(
+    "publication_state",
+    ["synced", "published-checksum-stale"],
+)
 @pytest.mark.parametrize("force_full", [False, True], ids=["observed", "force-full"])
 @pytest.mark.asyncio
 async def test_put_rename_lingering_source_is_not_reindexed(
@@ -371,11 +375,13 @@ async def test_put_rename_lingering_source_is_not_reindexed(
     engine_factory,
     monkeypatch,
     force_full: bool,
+    publication_state: str,
 ):
-    """A PUT rename records its vacated path so delayed cleanup cannot mint a ghost."""
+    """A PUT rename records current accepted bytes despite stale publication fields."""
     del app
     _, session_maker = engine_factory
     entity_repository = EntityRepository(project_id=test_project.id)
+    note_content_repository = NoteContentRepository(project_id=test_project.id)
     vacate_repository = NoteFileVacateRepository(project_id=test_project.id)
     project_url = f"/v2/projects/{test_project.external_id}"
 
@@ -391,7 +397,28 @@ async def test_put_rename_lingering_source_is_not_reindexed(
     created = create_response.json()
     source_relative = created["file_path"]
     source_path = project_config.home / source_relative
-    source_checksum = sha256(source_path.read_bytes()).hexdigest()
+    materialized_checksum = sha256(source_path.read_bytes()).hexdigest()
+    source_checksum = materialized_checksum
+
+    if publication_state == "published-checksum-stale":
+        pending_markdown = (
+            source_path.read_text(encoding="utf-8").rstrip()
+            + "\n\nThese accepted bytes reached storage before publication.\n"
+        )
+        source_path.write_text(pending_markdown, encoding="utf-8")
+        source_checksum = sha256(source_path.read_bytes()).hexdigest()
+        async with db.scoped_session(session_maker) as session:
+            entity = await entity_repository.get_by_file_path(session, source_relative)
+            assert entity is not None
+            note_content = await note_content_repository.get_by_entity_id(session, entity.id)
+            assert note_content is not None
+            note_content.markdown_content = pending_markdown
+            note_content.db_version += 1
+            note_content.db_checksum = source_checksum
+            note_content.file_write_status = "writing"
+            assert note_content.file_version is not None
+            assert note_content.file_version < note_content.db_version
+            assert note_content.file_checksum == materialized_checksum
 
     async def leave_source_cleanup_pending(
         self: InlineNoteFileDeleteEnqueuer,

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -463,7 +463,13 @@ async def test_move_retires_vacate_marker_after_source_replacement(
 
 @pytest.mark.parametrize(
     "publication_state",
-    ["synced", "pending-before-write", "failed-before-write", "published-checksum-stale"],
+    [
+        "synced",
+        "pending-before-write",
+        "failed-before-write",
+        "published-checksum-stale",
+        "external-change-restored-published",
+    ],
 )
 @pytest.mark.parametrize("force_full", [False, True], ids=["observed", "force-full"])
 @pytest.mark.asyncio
@@ -504,6 +510,7 @@ async def test_put_rename_lingering_source_is_not_reindexed(
         "pending-before-write",
         "failed-before-write",
         "published-checksum-stale",
+        "external-change-restored-published",
     }:
         pending_markdown = (
             source_path.read_text(encoding="utf-8").rstrip()
@@ -525,6 +532,7 @@ async def test_put_rename_lingering_source_is_not_reindexed(
                 "pending-before-write": "pending",
                 "failed-before-write": "failed",
                 "published-checksum-stale": "writing",
+                "external-change-restored-published": "external_change_detected",
             }[publication_state]
             assert note_content.file_version is not None
             assert note_content.file_version < note_content.db_version

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -411,7 +411,7 @@ async def test_put_rename_lingering_source_is_not_reindexed(
         )
         accepted_checksum = sha256(pending_markdown.encode()).hexdigest()
         if publication_state == "published-checksum-stale":
-            source_path.write_text(pending_markdown, encoding="utf-8")
+            source_path.write_bytes(pending_markdown.encode())
             source_checksum = sha256(source_path.read_bytes()).hexdigest()
         async with db.scoped_session(session_maker) as session:
             entity = await entity_repository.get_by_file_path(session, source_relative)

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -564,6 +564,126 @@ async def test_deleted_move_lingering_source_is_not_resurrected(
 
 
 @pytest.mark.asyncio
+async def test_move_back_retires_old_destination_marker_before_path_reuse(
+    mcp_server,
+    app,
+    test_project,
+    project_config,
+    engine_factory,
+    monkeypatch,
+):
+    """Publishing a moved-back note supersedes older move evidence for that destination."""
+    del app
+    source_relative = "source/Move Back Lifecycle.md"
+    destination_relative = "archive/move-back-lifecycle.md"
+    source_path = project_config.home / source_relative
+    destination_path = project_config.home / destination_relative
+    _, session_maker = engine_factory
+    entity_repository = EntityRepository(project_id=test_project.id)
+    vacate_repository = NoteFileVacateRepository(project_id=test_project.id)
+    original_cleanup = InlineNoteFileDeleteEnqueuer.enqueue_note_file_delete
+
+    async def leave_move_source_cleanup_pending(
+        self: InlineNoteFileDeleteEnqueuer,
+        request: RuntimeNoteFileDeleteJobRequest,
+    ) -> None:
+        if request.live_file_path is not None:
+            return
+        await original_cleanup(self, request)
+
+    monkeypatch.setattr(
+        InlineNoteFileDeleteEnqueuer,
+        "enqueue_note_file_delete",
+        leave_move_source_cleanup_pending,
+    )
+
+    async with Client(mcp_server) as client:
+        await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Move Back Lifecycle",
+                "directory": "source",
+                "content": "# Move Back Lifecycle\n\nThese original bytes will be reused later.",
+            },
+        )
+        original_source = source_path.read_bytes()
+
+        move_away = await client.call_tool(
+            "move_note",
+            {
+                "project": test_project.name,
+                "identifier": "Move Back Lifecycle",
+                "destination_path": destination_relative,
+            },
+        )
+        assert "✅ Note moved successfully" in move_away.content[0].text
+        assert source_path.exists()
+        assert destination_path.exists()
+
+        edit_result = await client.call_tool(
+            "edit_note",
+            {
+                "project": test_project.name,
+                "identifier": destination_relative,
+                "operation": "append",
+                "content": "\n\nThe moved-back note now has different bytes.",
+            },
+        )
+        assert "# Edited note (append)" in edit_result.content[0].text
+        assert destination_path.read_bytes() != original_source
+
+        # Simulate the first move's physical cleanup completing without its durable marker being
+        # retired. The stale marker must not outlive the next successful publication at this path.
+        source_path.unlink()
+        move_back = await client.call_tool(
+            "move_note",
+            {
+                "project": test_project.name,
+                "identifier": destination_relative,
+                "destination_path": source_relative,
+            },
+        )
+        assert "✅ Note moved successfully" in move_back.content[0].text
+
+        async with db.scoped_session(session_maker) as session:
+            moved_back = await entity_repository.get_by_file_path(session, source_relative)
+            markers = await vacate_repository.load_vacate_markers(
+                session,
+                [source_relative, destination_relative],
+            )
+        assert moved_back is not None
+        moved_external_id = moved_back.external_id
+        assert source_relative not in markers
+        assert destination_relative in markers
+
+        delete_result = await client.call_tool(
+            "delete_note",
+            {
+                "project": test_project.name,
+                "identifier": source_relative,
+            },
+        )
+        assert "true" in delete_result.content[0].text.lower()
+        assert not source_path.exists()
+
+    source_path.write_bytes(original_source)
+    await run_local_project_index_for_project(
+        test_project,
+        runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+        force_full=True,
+    )
+
+    async with db.scoped_session(session_maker) as session:
+        legitimate_reuse = await entity_repository.get_by_file_path(session, source_relative)
+        markers = await vacate_repository.load_vacate_markers(session, [source_relative])
+
+    assert legitimate_reuse is not None
+    assert legitimate_reuse.external_id != moved_external_id
+    assert markers == {}
+
+
+@pytest.mark.asyncio
 async def test_move_note_using_permalink(mcp_server, app, test_project):
     """Test moving a note using its permalink as identifier."""
 

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -512,7 +512,8 @@ async def test_deleted_move_lingering_source_is_not_resurrected(
 
     async with db.scoped_session(session_maker) as session:
         markers = await vacate_repository.load_vacate_markers(session, [source_relative])
-    assert markers[source_relative].entity_id is None
+    # SQLite backends can expose either a null or dangling destination ID after deletion. The
+    # durable checksum is the portable invariant that keeps these exact source bytes suppressed.
     assert markers[source_relative].file_checksum == source_checksum
 
     await run_local_project_index_for_project(

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -175,6 +175,66 @@ async def test_move_note_lingering_source_is_not_reindexed(
         assert moved.id == moved_entity_id
 
 
+@pytest.mark.asyncio
+async def test_move_retires_vacate_marker_when_unpublished_source_is_absent(
+    mcp_server,
+    app,
+    test_project,
+    project_config,
+    engine_factory,
+):
+    """Accepted DB checksum schedules cleanup even when no file checksum was published."""
+    del app
+    source_relative = "source/Absent Before Move.md"
+    destination_relative = "archive/absent-before-move.md"
+    source_path = project_config.home / source_relative
+    destination_path = project_config.home / destination_relative
+    _, session_maker = engine_factory
+    entity_repository = EntityRepository(project_id=test_project.id)
+    note_content_repository = NoteContentRepository(project_id=test_project.id)
+    vacate_repository = NoteFileVacateRepository(project_id=test_project.id)
+
+    async with Client(mcp_server) as client:
+        await client.call_tool(
+            "write_note",
+            {
+                "project": test_project.name,
+                "title": "Absent Before Move",
+                "directory": "source",
+                "content": "# Absent Before Move\n\nCleanup should retire its marker.",
+            },
+        )
+
+        source_checksum = sha256(source_path.read_bytes()).hexdigest()
+        async with db.scoped_session(session_maker) as session:
+            entity = await entity_repository.get_by_file_path(session, source_relative)
+            assert entity is not None
+            note_content = await note_content_repository.get_by_entity_id(session, entity.id)
+            assert note_content is not None
+            assert note_content.db_checksum == source_checksum
+            entity.checksum = None
+            note_content.file_checksum = None
+
+        # Reproduce the no-materialized-source side of the publisher race. The accepted checksum
+        # still drives a cleanup job, which observes the missing source and clears the marker.
+        source_path.unlink()
+        move_result = await client.call_tool(
+            "move_note",
+            {
+                "project": test_project.name,
+                "identifier": "Absent Before Move",
+                "destination_path": destination_relative,
+            },
+        )
+
+    assert "✅ Note moved successfully" in move_result.content[0].text
+    assert not source_path.exists()
+    assert destination_path.exists()
+    async with db.scoped_session(session_maker) as session:
+        markers = await vacate_repository.load_vacate_markers(session, [source_relative])
+    assert markers == {}
+
+
 @pytest.mark.parametrize("force_full", [False, True], ids=["observed", "force-full"])
 @pytest.mark.asyncio
 async def test_put_rename_lingering_source_is_not_reindexed(

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -9,6 +9,7 @@ from hashlib import sha256
 
 import pytest
 from fastmcp import Client
+from httpx import AsyncClient
 
 from basic_memory import db
 from basic_memory.index.local_project import (
@@ -172,6 +173,84 @@ async def test_move_note_lingering_source_is_not_reindexed(
         assert ghost is None
         assert moved is not None
         assert moved.id == moved_entity_id
+
+
+@pytest.mark.parametrize("force_full", [False, True], ids=["observed", "force-full"])
+@pytest.mark.asyncio
+async def test_put_rename_lingering_source_is_not_reindexed(
+    client: AsyncClient,
+    app,
+    test_project,
+    project_config,
+    engine_factory,
+    monkeypatch,
+    force_full: bool,
+):
+    """A PUT rename records its vacated path so delayed cleanup cannot mint a ghost."""
+    del app
+    _, session_maker = engine_factory
+    entity_repository = EntityRepository(project_id=test_project.id)
+    vacate_repository = NoteFileVacateRepository(project_id=test_project.id)
+    project_url = f"/v2/projects/{test_project.external_id}"
+
+    create_response = await client.post(
+        f"{project_url}/knowledge/entities",
+        json={
+            "title": "PUT Rename Race",
+            "directory": "source",
+            "content": "This source object must remain represented only by its renamed entity.",
+        },
+    )
+    assert create_response.status_code == 202
+    created = create_response.json()
+    source_relative = created["file_path"]
+    source_path = project_config.home / source_relative
+    source_checksum = sha256(source_path.read_bytes()).hexdigest()
+
+    async def leave_source_cleanup_pending(
+        self: InlineNoteFileDeleteEnqueuer,
+        request: RuntimeNoteFileDeleteJobRequest,
+    ) -> None:
+        del self, request
+
+    monkeypatch.setattr(
+        InlineNoteFileDeleteEnqueuer,
+        "enqueue_note_file_delete",
+        leave_source_cleanup_pending,
+    )
+
+    update_response = await client.put(
+        f"{project_url}/knowledge/entities/{created['external_id']}",
+        json={
+            "title": "PUT Rename Race",
+            "directory": "archive",
+            "content": "The renamed destination also carries updated content.",
+        },
+    )
+    assert update_response.status_code == 202
+    updated = update_response.json()
+    destination_relative = updated["file_path"]
+    assert destination_relative != source_relative
+    assert source_path.exists()
+
+    async with db.scoped_session(session_maker) as session:
+        markers = await vacate_repository.load_vacate_markers(session, [source_relative])
+    assert markers[source_relative].entity_id == created["id"]
+    assert markers[source_relative].file_checksum == source_checksum
+
+    await run_local_project_index_for_project(
+        test_project,
+        runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+        force_full=force_full,
+    )
+
+    async with db.scoped_session(session_maker) as session:
+        ghost = await entity_repository.get_by_file_path(session, source_relative)
+        renamed = await entity_repository.get_by_file_path(session, destination_relative)
+
+    assert ghost is None
+    assert renamed is not None
+    assert renamed.id == created["id"]
 
 
 @pytest.mark.asyncio

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -179,6 +179,11 @@ async def test_move_note_lingering_source_is_not_reindexed(
         assert moved.id == moved_entity_id
 
 
+@pytest.mark.parametrize(
+    "move_back_before_recovery",
+    [False, True],
+    ids=["cleanup-current-source", "cancel-stale-snapshot"],
+)
 @pytest.mark.asyncio
 async def test_startup_recovery_retries_lost_move_source_cleanup(
     mcp_server,
@@ -187,6 +192,7 @@ async def test_startup_recovery_retries_lost_move_source_cleanup(
     project_config,
     engine_factory,
     monkeypatch,
+    move_back_before_recovery: bool,
 ):
     """A synchronized move converges after its in-memory cleanup enqueue is lost."""
     del app
@@ -195,6 +201,8 @@ async def test_startup_recovery_retries_lost_move_source_cleanup(
     source_path = project_config.home / source_relative
     destination_path = project_config.home / destination_relative
     _, session_maker = engine_factory
+    entity_repository = EntityRepository(project_id=test_project.id)
+    note_content_repository = NoteContentRepository(project_id=test_project.id)
     vacate_repository = NoteFileVacateRepository(project_id=test_project.id)
     original_cleanup = InlineNoteFileDeleteEnqueuer.enqueue_note_file_delete
 
@@ -238,6 +246,52 @@ async def test_startup_recovery_retries_lost_move_source_cleanup(
             [source_relative],
         )
 
+    if move_back_before_recovery:
+        original_lock = NoteFileVacateRepository.lock_recoverable_vacate
+        moved_back = False
+
+        async def move_back_before_recovery_lock(
+            self: NoteFileVacateRepository,
+            session,
+            *,
+            file_path: str,
+            file_checksum: str,
+        ):
+            nonlocal moved_back
+            if not moved_back:
+                # This second committed session models another local server accepting
+                # B -> A after recovery took its initial candidate snapshot.
+                async with db.scoped_session(session_maker) as concurrent_session:
+                    entity = await entity_repository.get_by_file_path(
+                        concurrent_session,
+                        destination_relative,
+                    )
+                    assert entity is not None
+                    note_content = await note_content_repository.get_by_entity_id(
+                        concurrent_session,
+                        entity.id,
+                    )
+                    assert note_content is not None
+                    entity.file_path = source_relative
+                    note_content.file_path = source_relative
+                    await vacate_repository.clear_vacate_path(
+                        concurrent_session,
+                        file_path=source_relative,
+                    )
+                moved_back = True
+            return await original_lock(
+                self,
+                session,
+                file_path=file_path,
+                file_checksum=file_checksum,
+            )
+
+        monkeypatch.setattr(
+            NoteFileVacateRepository,
+            "lock_recoverable_vacate",
+            move_back_before_recovery_lock,
+        )
+
     # Re-enable the real cleanup adapter, matching a fresh process startup.
     monkeypatch.setattr(
         InlineNoteFileDeleteEnqueuer,
@@ -250,10 +304,12 @@ async def test_startup_recovery_retries_lost_move_source_cleanup(
         project_id=test_project.id,
     )
 
-    assert recovered == 1
-    assert not source_path.exists()
+    assert recovered == (0 if move_back_before_recovery else 1)
+    assert source_path.exists() is move_back_before_recovery
     assert destination_path.exists()
     async with db.scoped_session(session_maker) as session:
+        if move_back_before_recovery:
+            assert await entity_repository.get_by_file_path(session, source_relative) is not None
         assert await vacate_repository.load_vacate_markers(session, [source_relative]) == {}
 
 

--- a/test-int/mcp/test_move_note_integration.py
+++ b/test-int/mcp/test_move_note_integration.py
@@ -367,7 +367,7 @@ async def test_move_retires_vacate_marker_after_source_replacement(
 
 @pytest.mark.parametrize(
     "publication_state",
-    ["synced", "pending-before-write", "published-checksum-stale"],
+    ["synced", "pending-before-write", "failed-before-write", "published-checksum-stale"],
 )
 @pytest.mark.parametrize("force_full", [False, True], ids=["observed", "force-full"])
 @pytest.mark.asyncio
@@ -404,10 +404,14 @@ async def test_put_rename_lingering_source_is_not_reindexed(
     materialized_checksum = sha256(source_path.read_bytes()).hexdigest()
     source_checksum = materialized_checksum
 
-    if publication_state in {"pending-before-write", "published-checksum-stale"}:
+    if publication_state in {
+        "pending-before-write",
+        "failed-before-write",
+        "published-checksum-stale",
+    }:
         pending_markdown = (
             source_path.read_text(encoding="utf-8").rstrip()
-            + "\n\nThese accepted bytes reached storage before publication.\n"
+            + "\n\nThese accepted bytes differ from the last published bytes.\n"
         )
         accepted_checksum = sha256(pending_markdown.encode()).hexdigest()
         if publication_state == "published-checksum-stale":
@@ -421,9 +425,11 @@ async def test_put_rename_lingering_source_is_not_reindexed(
             note_content.markdown_content = pending_markdown
             note_content.db_version += 1
             note_content.db_checksum = accepted_checksum
-            note_content.file_write_status = (
-                "writing" if publication_state == "published-checksum-stale" else "pending"
-            )
+            note_content.file_write_status = {
+                "pending-before-write": "pending",
+                "failed-before-write": "failed",
+                "published-checksum-stale": "writing",
+            }[publication_state]
             assert note_content.file_version is not None
             assert note_content.file_version < note_content.db_version
             assert note_content.file_checksum == materialized_checksum

--- a/test-int/test_note_file_vacate_atomicity.py
+++ b/test-int/test_note_file_vacate_atomicity.py
@@ -1,0 +1,70 @@
+"""Integration tests for atomic move-vacate marker retirement."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from basic_memory.models.knowledge import Entity
+from basic_memory.models.project import Project
+from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
+
+
+@pytest.mark.asyncio
+async def test_stale_cleanup_preserves_concurrently_refreshed_marker(
+    engine_factory,
+    test_project: Project,
+) -> None:
+    """A cleanup holding stale ORM state cannot delete the next move's marker."""
+    _, session_maker = engine_factory
+    repo = NoteFileVacateRepository(project_id=test_project.id)
+    file_path = "koncept/reused-source.md"
+
+    async with session_maker() as session:
+        entity = Entity(
+            project_id=test_project.id,
+            title="Moved Twice",
+            note_type="note",
+            permalink="koncept/moved-twice",
+            file_path="archive/moved-twice.md",
+            content_type="text/markdown",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        session.add(entity)
+        await session.flush()
+        entity_id = entity.id
+        await repo.record_vacate(
+            session,
+            entity_id=entity_id,
+            file_path=file_path,
+            file_checksum="old",
+        )
+        await session.commit()
+
+    async with session_maker() as cleanup_session:
+        # Model the old read/check/delete race: cleanup observed checksum "old", then another
+        # transaction refreshed the same marker before cleanup attempted to retire it.
+        stale_marker = await repo._get_marker(cleanup_session, file_path)
+        assert stale_marker is not None
+        assert stale_marker.file_checksum == "old"
+        await cleanup_session.commit()
+
+        async with session_maker() as new_move_session:
+            await repo.record_vacate(
+                new_move_session,
+                entity_id=entity_id,
+                file_path=file_path,
+                file_checksum="new",
+            )
+            await new_move_session.commit()
+
+        await repo.clear_vacate(
+            cleanup_session,
+            file_path=file_path,
+            file_checksum="old",
+        )
+        await cleanup_session.commit()
+
+    async with session_maker() as session:
+        markers = await repo.load_vacate_markers(session, [file_path])
+    assert markers[file_path].file_checksum == "new"

--- a/test-int/test_note_file_vacate_atomicity.py
+++ b/test-int/test_note_file_vacate_atomicity.py
@@ -1,5 +1,6 @@
 """Integration tests for atomic move-vacate marker retirement."""
 
+import asyncio
 from datetime import datetime, timezone
 
 import pytest
@@ -7,6 +8,19 @@ import pytest
 from basic_memory.models.knowledge import Entity
 from basic_memory.models.project import Project
 from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
+
+
+def _moved_entity(project_id: int) -> Entity:
+    return Entity(
+        project_id=project_id,
+        title="Moved Twice",
+        note_type="note",
+        permalink="koncept/moved-twice",
+        file_path="archive/moved-twice.md",
+        content_type="text/markdown",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
 
 
 @pytest.mark.asyncio
@@ -20,16 +34,7 @@ async def test_stale_cleanup_preserves_concurrently_refreshed_marker(
     file_path = "koncept/reused-source.md"
 
     async with session_maker() as session:
-        entity = Entity(
-            project_id=test_project.id,
-            title="Moved Twice",
-            note_type="note",
-            permalink="koncept/moved-twice",
-            file_path="archive/moved-twice.md",
-            content_type="text/markdown",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
-        )
+        entity = _moved_entity(test_project.id)
         session.add(entity)
         await session.flush()
         entity_id = entity.id
@@ -64,6 +69,60 @@ async def test_stale_cleanup_preserves_concurrently_refreshed_marker(
             file_checksum="old",
         )
         await cleanup_session.commit()
+
+    async with session_maker() as session:
+        markers = await repo.load_vacate_markers(session, [file_path])
+    assert markers[file_path].file_checksum == "new"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cleanup_cannot_break_marker_refresh(
+    engine_factory,
+    test_project: Project,
+) -> None:
+    """A refresh succeeds when cleanup retires the previous marker at the same time."""
+    _, session_maker = engine_factory
+    repo = NoteFileVacateRepository(project_id=test_project.id)
+    file_path = "koncept/reused-source.md"
+
+    async with session_maker() as session:
+        entity = _moved_entity(test_project.id)
+        session.add(entity)
+        await session.flush()
+        entity_id = entity.id
+        await repo.record_vacate(
+            session,
+            entity_id=entity_id,
+            file_path=file_path,
+            file_checksum="old",
+        )
+        await session.commit()
+
+    async with session_maker() as refresh_session:
+        await repo.record_vacate(
+            refresh_session,
+            entity_id=entity_id,
+            file_path=file_path,
+            file_checksum="new",
+        )
+
+        cleanup_started = asyncio.Event()
+
+        async def retire_previous_marker() -> None:
+            async with session_maker() as cleanup_session:
+                cleanup_started.set()
+                await repo.clear_vacate(
+                    cleanup_session,
+                    file_path=file_path,
+                    file_checksum="old",
+                )
+                await cleanup_session.commit()
+
+        cleanup_task = asyncio.create_task(retire_previous_marker())
+        await cleanup_started.wait()
+        await asyncio.sleep(0.05)
+        await refresh_session.commit()
+        await cleanup_task
 
     async with session_maker() as session:
         markers = await repo.load_vacate_markers(session, [file_path])

--- a/tests/cloud/test_note_content_materialization.py
+++ b/tests/cloud/test_note_content_materialization.py
@@ -16,6 +16,7 @@ from basic_memory.index.note_content_materialization import (
     InlineNoteFileDeleteEnqueuer,
     LocalNoteContentMaterializationProvider,
     LocalNoteContentStorage,
+    recover_move_vacates,
     recover_stuck_materializations,
     run_recovery_materialization,
 )
@@ -25,6 +26,7 @@ from basic_memory.repository.note_content_repository import (
     AcceptedNoteContentWrite,
     NoteContentRepository,
 )
+from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
 from basic_memory.runtime.cleanup import RuntimeNoteFileDeleteJobRequest
 from basic_memory.indexing.models import FileIndexOperation, FileIndexResult
 from basic_memory.runtime.note_content import (
@@ -540,6 +542,72 @@ async def test_recover_stuck_materializations_writes_file_and_marks_synced(
     assert row.file_write_status == "synced"
     assert row.file_checksum is not None
     assert row.file_version == 1
+
+
+@pytest.mark.asyncio
+async def test_move_vacate_recovery_waits_for_destination_then_cleans_source(
+    session_maker,
+    test_project: Project,
+    sample_entity,
+    file_service: FileService,
+) -> None:
+    """A crash-lost move cleanup waits for destination recovery, then converges."""
+    markdown_content = "# Moved across restart\n"
+    source_relative = "old/moved-across-restart.md"
+    source = file_service.base_path / source_relative
+    source.parent.mkdir(parents=True)
+    source.write_bytes(markdown_content.encode())
+    source_checksum = sha256(source.read_bytes()).hexdigest()
+    await _seed_stuck_note_content(
+        session_maker,
+        project_id=test_project.id,
+        entity_id=sample_entity.id,
+        markdown_content=markdown_content,
+        db_version=1,
+        db_checksum=sha256(markdown_content.encode()).hexdigest(),
+        file_write_status="writing",
+    )
+    vacate_repository = NoteFileVacateRepository(project_id=test_project.id)
+    async with db.scoped_session(session_maker) as session:
+        await vacate_repository.record_vacate(
+            session,
+            entity_id=sample_entity.id,
+            file_path=source_relative,
+            file_checksum=source_checksum,
+        )
+
+    # The old source is still the only materialized copy, so cleanup must wait.
+    assert (
+        await recover_move_vacates(
+            session_maker=session_maker,
+            file_service=file_service,
+            project_id=test_project.id,
+        )
+        == 0
+    )
+    assert source.exists()
+
+    assert (
+        await recover_stuck_materializations(
+            session_maker=session_maker,
+            file_service=file_service,
+            project_id=test_project.id,
+        )
+        == 1
+    )
+    assert (
+        await recover_move_vacates(
+            session_maker=session_maker,
+            file_service=file_service,
+            project_id=test_project.id,
+        )
+        == 1
+    )
+
+    assert not source.exists()
+    assert (file_service.base_path / sample_entity.file_path).read_text() == markdown_content
+    async with db.scoped_session(session_maker) as session:
+        assert await vacate_repository.load_vacate_markers(session, [source_relative]) == {}
 
 
 @pytest.mark.asyncio

--- a/tests/cloud/test_note_content_materialization.py
+++ b/tests/cloud/test_note_content_materialization.py
@@ -140,8 +140,22 @@ async def test_inline_delete_skips_old_path_aliasing_live_file(tmp_path) -> None
     old_alias = tmp_path / "notes" / "alias.md"
     os.link(live, old_alias)  # same inode, as a case-only rename produces on APFS/NTFS
     checksum = sha256(content).hexdigest()
+    cleared: list[tuple[int, str, str | None]] = []
 
-    enqueuer = InlineNoteFileDeleteEnqueuer(LocalNoteContentStorage(FileService(tmp_path)))
+    class RecordingVacateClearer:
+        async def clear_move_vacate(
+            self,
+            *,
+            project_id: int,
+            file_path: str,
+            file_checksum: str | None,
+        ) -> None:
+            cleared.append((project_id, file_path, file_checksum))
+
+    enqueuer = InlineNoteFileDeleteEnqueuer(
+        LocalNoteContentStorage(FileService(tmp_path)),
+        vacate_clearer=RecordingVacateClearer(),
+    )
     await enqueuer.enqueue_note_file_delete(
         RuntimeNoteFileDeleteJobRequest(
             project_id=1,
@@ -153,6 +167,7 @@ async def test_inline_delete_skips_old_path_aliasing_live_file(tmp_path) -> None
     )
 
     assert live.exists(), "case-only rename deleted the note's only file"
+    assert cleared == [(1, "notes/alias.md", checksum)]
 
 
 @pytest.mark.asyncio

--- a/tests/index/test_watch_coordinator.py
+++ b/tests/index/test_watch_coordinator.py
@@ -11,6 +11,74 @@ from basic_memory.index.watch_coordinator import WatchCoordinator, WatchStatus
 
 
 @pytest.mark.asyncio
+async def test_start_waits_for_recovery_before_reporting_running(
+    app_config: BasicMemoryConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The API/MCP lifespan must not accept writes while startup recovery is active."""
+    allow_recovery_to_finish = asyncio.Event()
+    keep_watcher_running = asyncio.Event()
+
+    async def initialize_after_recovery(
+        config: BasicMemoryConfig,
+        quiet: bool = True,
+        *,
+        recovery_complete: asyncio.Event | None = None,
+    ) -> None:
+        del config, quiet
+        await allow_recovery_to_finish.wait()
+        assert recovery_complete is not None
+        recovery_complete.set()
+        await keep_watcher_running.wait()
+
+    monkeypatch.setattr(
+        "basic_memory.services.initialization.initialize_file_indexing",
+        initialize_after_recovery,
+    )
+    coordinator = WatchCoordinator(config=app_config)
+
+    start_task = asyncio.create_task(coordinator.start())
+    await asyncio.sleep(0)
+
+    assert coordinator.status == WatchStatus.STARTING
+    assert not start_task.done()
+
+    allow_recovery_to_finish.set()
+    await start_task
+
+    assert coordinator.status == WatchStatus.RUNNING
+    await coordinator.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_propagates_failure_before_recovery_completes(
+    app_config: BasicMemoryConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed recovery must unblock startup and preserve the error state."""
+
+    async def fail_before_recovery(
+        config: BasicMemoryConfig,
+        quiet: bool = True,
+        *,
+        recovery_complete: asyncio.Event | None = None,
+    ) -> None:
+        del config, quiet, recovery_complete
+        raise RuntimeError("recovery boom")
+
+    monkeypatch.setattr(
+        "basic_memory.services.initialization.initialize_file_indexing",
+        fail_before_recovery,
+    )
+    coordinator = WatchCoordinator(config=app_config)
+
+    with pytest.raises(RuntimeError, match="recovery boom"):
+        await coordinator.start()
+
+    assert coordinator.status == WatchStatus.ERROR
+
+
+@pytest.mark.asyncio
 async def test_stop_does_not_propagate_prior_watcher_crash(
     app_config: BasicMemoryConfig,
 ) -> None:

--- a/tests/indexing/test_accepted_note_mutation_runner.py
+++ b/tests/indexing/test_accepted_note_mutation_runner.py
@@ -1498,7 +1498,7 @@ async def test_run_accepted_note_edit_threads_metadata_into_preparer() -> None:
     ("publication_state", "current_file_checksum", "expected_source_checksum"),
     [
         ("synced", None, "file-checksum"),
-        ("checksum-missing", None, "old-checksum"),
+        ("checksum-missing", None, None),
         ("pending-before-write", "file-checksum", "file-checksum"),
         ("failed-before-write", "file-checksum", "file-checksum"),
         ("published-checksum-stale", "accepted-checksum", "accepted-checksum"),
@@ -1507,7 +1507,7 @@ async def test_run_accepted_note_edit_threads_metadata_into_preparer() -> None:
 async def test_run_accepted_note_move_carries_previous_path_and_materialized_cleanup(
     publication_state: str,
     current_file_checksum: str | None,
-    expected_source_checksum: str,
+    expected_source_checksum: str | None,
     persistence_calls: tuple[AsyncMock, AsyncMock],
 ) -> None:
     session = _MutationSession()
@@ -1584,9 +1584,12 @@ async def test_run_accepted_note_move_carries_previous_path_and_materialized_cle
     assert change.materialization is not None
     assert change.materialization.previous_file_path == "notes/accepted.md"
     cleanup = change.materialization.cleanup_after_write
-    assert cleanup is not None
-    assert cleanup.file_path == "notes/accepted.md"
-    assert cleanup.file_checksum == expected_source_checksum
+    if expected_source_checksum is None:
+        assert cleanup is None
+    else:
+        assert cleanup is not None
+        assert cleanup.file_path == "notes/accepted.md"
+        assert cleanup.file_checksum == expected_source_checksum
     assert preparer_factory.checksum_calls == (
         [] if publication_state == "synced" else [(project, "notes/accepted.md")]
     )

--- a/tests/indexing/test_accepted_note_mutation_runner.py
+++ b/tests/indexing/test_accepted_note_mutation_runner.py
@@ -127,13 +127,32 @@ def persistence_calls(monkeypatch: pytest.MonkeyPatch) -> tuple[AsyncMock, Async
     return snapshot, move
 
 
+class _EmptyResult:
+    def scalars(self) -> "_EmptyResult":
+        return self
+
+    def one_or_none(self) -> None:
+        return None
+
+    def all(self) -> list[object]:
+        return []
+
+
 class _MutationSession:
     def __init__(self) -> None:
         self.deleted: list[object] = []
+        self.added: list[object] = []
         self.flush_count = 0
 
     async def delete(self, value: object) -> None:
         self.deleted.append(value)
+
+    def add(self, value: object) -> None:
+        self.added.append(value)
+
+    async def execute(self, query: object) -> _EmptyResult:
+        # No existing note_file_vacate marker for this test; the move records a fresh one via add().
+        return _EmptyResult()
 
     async def flush(self) -> None:
         self.flush_count += 1

--- a/tests/indexing/test_accepted_note_mutation_runner.py
+++ b/tests/indexing/test_accepted_note_mutation_runner.py
@@ -1500,6 +1500,7 @@ async def test_run_accepted_note_edit_threads_metadata_into_preparer() -> None:
         ("synced", None, "file-checksum"),
         ("checksum-missing", None, "old-checksum"),
         ("pending-before-write", "file-checksum", "file-checksum"),
+        ("failed-before-write", "file-checksum", "file-checksum"),
         ("published-checksum-stale", "accepted-checksum", "accepted-checksum"),
     ],
 )
@@ -1524,6 +1525,10 @@ async def test_run_accepted_note_move_carries_previous_path_and_materialized_cle
         note_content.db_version = 2
         note_content.db_checksum = "accepted-checksum"
         note_content.file_write_status = "writing"
+    elif publication_state == "failed-before-write":
+        note_content.db_version = 2
+        note_content.db_checksum = "accepted-checksum"
+        note_content.file_write_status = "failed"
     else:
         note_content.db_version = 2
         note_content.db_checksum = "accepted-checksum"

--- a/tests/indexing/test_accepted_note_mutation_runner.py
+++ b/tests/indexing/test_accepted_note_mutation_runner.py
@@ -295,13 +295,24 @@ class _CreatePreparer:
 
 
 class _PreparerFactory:
-    def __init__(self, preparer: _CreatePreparer) -> None:
+    def __init__(
+        self,
+        preparer: _CreatePreparer,
+        *,
+        current_file_checksum: str | None = None,
+    ) -> None:
         self.preparer = preparer
+        self.current_file_checksum = current_file_checksum
         self.projects: list[Project] = []
+        self.checksum_calls: list[tuple[Project, str]] = []
 
     def create_note_preparer(self, project: Project) -> _CreatePreparer:
         self.projects.append(project)
         return self.preparer
+
+    async def load_current_file_checksum(self, project: Project, file_path: str) -> str | None:
+        self.checksum_calls.append((project, file_path))
+        return self.current_file_checksum
 
 
 class _ProjectRepository:
@@ -1484,15 +1495,17 @@ async def test_run_accepted_note_edit_threads_metadata_into_preparer() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("publication_state", "expected_source_checksum"),
+    ("publication_state", "current_file_checksum", "expected_source_checksum"),
     [
-        ("synced", "file-checksum"),
-        ("checksum-missing", "old-checksum"),
-        ("published-checksum-stale", "accepted-checksum"),
+        ("synced", None, "file-checksum"),
+        ("checksum-missing", None, "old-checksum"),
+        ("pending-before-write", "file-checksum", "file-checksum"),
+        ("published-checksum-stale", "accepted-checksum", "accepted-checksum"),
     ],
 )
 async def test_run_accepted_note_move_carries_previous_path_and_materialized_cleanup(
     publication_state: str,
+    current_file_checksum: str | None,
     expected_source_checksum: str,
     persistence_calls: tuple[AsyncMock, AsyncMock],
 ) -> None:
@@ -1507,15 +1520,22 @@ async def test_run_accepted_note_move_carries_previous_path_and_materialized_cle
     elif publication_state == "checksum-missing":
         note_content.file_version = None
         note_content.file_checksum = None
-    else:
+    elif publication_state == "published-checksum-stale":
         note_content.db_version = 2
         note_content.db_checksum = "accepted-checksum"
         note_content.file_write_status = "writing"
+    else:
+        note_content.db_version = 2
+        note_content.db_checksum = "accepted-checksum"
+        note_content.file_write_status = "pending"
     project_repository = _ProjectRepository(project)
     entity_lookup_repository = _EntityLookupRepository(by_external_id=entity)
     note_content_lookup_repository = _NoteContentLookupRepository(note_content)
     preparer = _CreatePreparer(prepared, prepared_move=prepared_move)
-    preparer_factory = _PreparerFactory(preparer)
+    preparer_factory = _PreparerFactory(
+        preparer,
+        current_file_checksum=current_file_checksum,
+    )
     pending_entity_repository = _PendingEntityRepository(entity)
     note_content_accept_repository = _NoteContentAcceptRepository(note_content)
     search_repository = _SearchRepository()
@@ -1562,6 +1582,9 @@ async def test_run_accepted_note_move_carries_previous_path_and_materialized_cle
     assert cleanup is not None
     assert cleanup.file_path == "notes/accepted.md"
     assert cleanup.file_checksum == expected_source_checksum
+    assert preparer_factory.checksum_calls == (
+        [] if publication_state == "synced" else [(project, "notes/accepted.md")]
+    )
     assert persistence_calls[0].await_count == 0
     assert persistence_calls[1].await_count == 1
 

--- a/tests/indexing/test_accepted_note_mutation_runner.py
+++ b/tests/indexing/test_accepted_note_mutation_runner.py
@@ -1497,7 +1497,8 @@ async def test_run_accepted_note_edit_threads_metadata_into_preparer() -> None:
 @pytest.mark.parametrize(
     ("publication_state", "current_file_checksum", "expected_source_checksum"),
     [
-        ("synced", None, "file-checksum"),
+        ("synced", "file-checksum", "file-checksum"),
+        ("synced-source-absent", None, None),
         ("checksum-missing", None, None),
         ("pending-before-write", "file-checksum", "file-checksum"),
         ("failed-before-write", "file-checksum", "file-checksum"),
@@ -1516,7 +1517,7 @@ async def test_run_accepted_note_move_carries_previous_path_and_materialized_cle
     prepared_move = _prepared_move()
     entity = _entity(file_path="notes/accepted.md")
     note_content = _note_content(entity)
-    if publication_state == "synced":
+    if publication_state.startswith("synced"):
         note_content.file_write_status = "synced"
     elif publication_state == "checksum-missing":
         note_content.file_version = None
@@ -1590,9 +1591,7 @@ async def test_run_accepted_note_move_carries_previous_path_and_materialized_cle
         assert cleanup is not None
         assert cleanup.file_path == "notes/accepted.md"
         assert cleanup.file_checksum == expected_source_checksum
-    assert preparer_factory.checksum_calls == (
-        [] if publication_state == "synced" else [(project, "notes/accepted.md")]
-    )
+    assert preparer_factory.checksum_calls == [(project, "notes/accepted.md")]
     assert persistence_calls[0].await_count == 0
     assert persistence_calls[1].await_count == 1
 

--- a/tests/indexing/test_accepted_note_mutation_runner.py
+++ b/tests/indexing/test_accepted_note_mutation_runner.py
@@ -41,6 +41,7 @@ from basic_memory.markdown.schemas import (
     Relation as MarkdownRelation,
 )
 from basic_memory.models import Entity, NoteContent, Project
+from basic_memory.models.knowledge import NoteFileVacate
 from basic_memory.repository import (
     AcceptedNoteContentWrite,
     AcceptedObservationWrite,
@@ -1482,9 +1483,17 @@ async def test_run_accepted_note_edit_threads_metadata_into_preparer() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("file_checksum", ["file-checksum", None])
+@pytest.mark.parametrize(
+    ("publication_state", "expected_source_checksum"),
+    [
+        ("synced", "file-checksum"),
+        ("checksum-missing", "old-checksum"),
+        ("published-checksum-stale", "accepted-checksum"),
+    ],
+)
 async def test_run_accepted_note_move_carries_previous_path_and_materialized_cleanup(
-    file_checksum: str | None,
+    publication_state: str,
+    expected_source_checksum: str,
     persistence_calls: tuple[AsyncMock, AsyncMock],
 ) -> None:
     session = _MutationSession()
@@ -1493,7 +1502,15 @@ async def test_run_accepted_note_move_carries_previous_path_and_materialized_cle
     prepared_move = _prepared_move()
     entity = _entity(file_path="notes/accepted.md")
     note_content = _note_content(entity)
-    note_content.file_checksum = file_checksum
+    if publication_state == "synced":
+        note_content.file_write_status = "synced"
+    elif publication_state == "checksum-missing":
+        note_content.file_version = None
+        note_content.file_checksum = None
+    else:
+        note_content.db_version = 2
+        note_content.db_checksum = "accepted-checksum"
+        note_content.file_write_status = "writing"
     project_repository = _ProjectRepository(project)
     entity_lookup_repository = _EntityLookupRepository(by_external_id=entity)
     note_content_lookup_repository = _NoteContentLookupRepository(note_content)
@@ -1544,9 +1561,10 @@ async def test_run_accepted_note_move_carries_previous_path_and_materialized_cle
     cleanup = change.materialization.cleanup_after_write
     assert cleanup is not None
     assert cleanup.file_path == "notes/accepted.md"
-    assert cleanup.file_checksum == (
-        "file-checksum" if file_checksum is not None else "old-checksum"
-    )
+    assert cleanup.file_checksum == expected_source_checksum
+    marker = next(value for value in session.added if isinstance(value, NoteFileVacate))
+    assert marker.file_path == "notes/accepted.md"
+    assert marker.file_checksum == expected_source_checksum
     assert persistence_calls[0].await_count == 0
     assert persistence_calls[1].await_count == 1
 

--- a/tests/indexing/test_accepted_note_mutation_runner.py
+++ b/tests/indexing/test_accepted_note_mutation_runner.py
@@ -41,7 +41,6 @@ from basic_memory.markdown.schemas import (
     Relation as MarkdownRelation,
 )
 from basic_memory.models import Entity, NoteContent, Project
-from basic_memory.models.knowledge import NoteFileVacate
 from basic_memory.repository import (
     AcceptedNoteContentWrite,
     AcceptedObservationWrite,
@@ -144,6 +143,7 @@ class _MutationSession:
         self.deleted: list[object] = []
         self.added: list[object] = []
         self.flush_count = 0
+        self.bind = SimpleNamespace(dialect=SimpleNamespace(name="sqlite"))
 
     async def delete(self, value: object) -> None:
         self.deleted.append(value)
@@ -1562,9 +1562,6 @@ async def test_run_accepted_note_move_carries_previous_path_and_materialized_cle
     assert cleanup is not None
     assert cleanup.file_path == "notes/accepted.md"
     assert cleanup.file_checksum == expected_source_checksum
-    marker = next(value for value in session.added if isinstance(value, NoteFileVacate))
-    assert marker.file_path == "notes/accepted.md"
-    assert marker.file_checksum == expected_source_checksum
     assert persistence_calls[0].await_count == 0
     assert persistence_calls[1].await_count == 1
 

--- a/tests/indexing/test_accepted_note_mutation_runner.py
+++ b/tests/indexing/test_accepted_note_mutation_runner.py
@@ -1542,12 +1542,11 @@ async def test_run_accepted_note_move_carries_previous_path_and_materialized_cle
     assert change.materialization is not None
     assert change.materialization.previous_file_path == "notes/accepted.md"
     cleanup = change.materialization.cleanup_after_write
-    if file_checksum is None:
-        assert cleanup is None
-    else:
-        assert cleanup is not None
-        assert cleanup.file_path == "notes/accepted.md"
-        assert cleanup.file_checksum == "file-checksum"
+    assert cleanup is not None
+    assert cleanup.file_path == "notes/accepted.md"
+    assert cleanup.file_checksum == (
+        "file-checksum" if file_checksum is not None else "old-checksum"
+    )
     assert persistence_calls[0].await_count == 0
     assert persistence_calls[1].await_count == 1
 

--- a/tests/indexing/test_accepted_note_write_runner.py
+++ b/tests/indexing/test_accepted_note_write_runner.py
@@ -951,6 +951,7 @@ async def test_persist_accepted_note_snapshot_persists_content_search_and_graph(
         current_note_content=current_note_content,
         existing_file_path="notes/old.md",
         accepted_file_path="notes/new.md",
+        source_file_checksum="db-checksum",
         repositories=_repository_provider(
             note_content_repository=content_repository,
             search_repository=search_repository,

--- a/tests/indexing/test_accepted_note_write_runner.py
+++ b/tests/indexing/test_accepted_note_write_runner.py
@@ -964,7 +964,9 @@ async def test_persist_accepted_note_snapshot_persists_content_search_and_graph(
     assert result.previous_file_delete.project_id == entity.project_id
     assert result.previous_file_delete.entity_id == entity.id
     assert result.previous_file_delete.file_path == "notes/old.md"
-    assert result.previous_file_delete.file_checksum == "old-file-checksum"
+    # The accepted DB version is ahead of the published file version, so the old file checksum is
+    # stale. Cleanup follows the accepted checksum that may already have reached storage.
+    assert result.previous_file_delete.file_checksum == "db-checksum"
     assert content_repository.calls == [
         (
             session,

--- a/tests/indexing/test_file_index_checking.py
+++ b/tests/indexing/test_file_index_checking.py
@@ -7,6 +7,7 @@ from typing import cast
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from basic_memory.file_utils import FileError
 from basic_memory.indexing.file_index_checking import (
     CurrentFileMetadataSource,
     FileIndexChecker,
@@ -293,6 +294,17 @@ async def test_storage_current_file_checksum_source_treats_file_errors_as_missin
     class VanishingMetadataSource:
         async def load_current_file_metadata(self, file_path: str) -> StubCurrentMetadata | None:
             raise FileOperationError(f"file vanished: {file_path}")
+
+    source = StorageCurrentFileChecksumSource(metadata_source=VanishingMetadataSource())
+
+    assert await source.load_current_file_checksum("vanished.md") is None
+
+
+@pytest.mark.asyncio
+async def test_storage_current_file_checksum_source_treats_checksum_race_as_missing() -> None:
+    class VanishingMetadataSource:
+        async def load_current_file_metadata(self, file_path: str) -> StubCurrentMetadata | None:
+            raise FileError(f"checksum target vanished: {file_path}")
 
     source = StorageCurrentFileChecksumSource(metadata_source=VanishingMetadataSource())
 

--- a/tests/indexing/test_file_index_checking.py
+++ b/tests/indexing/test_file_index_checking.py
@@ -59,6 +59,9 @@ class FakeSessionMaker:
     def __call__(self) -> FakeSessionContext:
         return FakeSessionContext(session=self.session)
 
+    def begin(self) -> FakeSessionContext:
+        return FakeSessionContext(session=self.session)
+
 
 @dataclass(slots=True)
 class RecordingChecksumRepository:
@@ -125,10 +128,14 @@ class StubMoveVacateSource:
 
     markers: dict[str, MoveVacateMarker] = field(default_factory=dict)
     calls: list[tuple[str, ...]] = field(default_factory=list)
+    clear_calls: list[tuple[str, str]] = field(default_factory=list)
 
     async def load_vacate_markers(self, file_paths: Sequence[str]) -> dict[str, MoveVacateMarker]:
         self.calls.append(tuple(file_paths))
         return {p: self.markers[p] for p in file_paths if p in self.markers}
+
+    async def clear_vacate_marker(self, file_path: str, file_checksum: str) -> None:
+        self.clear_calls.append((file_path, file_checksum))
 
 
 @dataclass(frozen=True, slots=True)
@@ -162,6 +169,7 @@ class FakeVacateMarkerRow:
 class FakeVacateRepository:
     markers: dict[str, FakeVacateMarkerRow]
     calls: list[tuple[object, tuple[str, ...]]] = field(default_factory=list)
+    clear_calls: list[tuple[object, str, str | None]] = field(default_factory=list)
 
     async def load_vacate_markers(
         self,
@@ -170,6 +178,15 @@ class FakeVacateRepository:
     ) -> dict[str, FakeVacateMarkerRow]:
         self.calls.append((session, tuple(file_paths)))
         return {p: self.markers[p] for p in file_paths if p in self.markers}
+
+    async def clear_vacate(
+        self,
+        session: AsyncSession,
+        *,
+        file_path: str,
+        file_checksum: str | None,
+    ) -> None:
+        self.clear_calls.append((session, file_path, file_checksum))
 
 
 @pytest.mark.asyncio
@@ -421,7 +438,7 @@ async def test_checker_indexes_replacement_note_at_a_vacated_path() -> None:
     The current checksum no longer matches the marker's source checksum, so it is indexed as new
     even though a checksum twin exists — the P1 false-skip Codex flagged.
     """
-    checker, _, _ = _orphan_checker(
+    checker, moved, vacate = _orphan_checker(
         indexed={},
         current={"koncept/note.md": "other-note-checksum"},
         markers={"koncept/note.md": MoveVacateMarker(entity_id=42, checksum="original-checksum")},
@@ -436,6 +453,8 @@ async def test_checker_indexes_replacement_note_at_a_vacated_path() -> None:
     )
 
     assert plan.paths_to_read == ("koncept/note.md",)
+    assert vacate.clear_calls == [("koncept/note.md", "original-checksum")]
+    assert moved.calls == []
 
 
 @pytest.mark.asyncio
@@ -628,11 +647,13 @@ async def test_checker_batches_move_detection_across_create_candidates() -> None
     assert [(d.path, d.status) for d in plan.decisions] == [
         ("a.md", FileIndexDecisionStatus.current),
     ]
-    # One marker query over all three candidates; one entity query over the markers found.
+    # One marker query over all three candidates; the checksum mismatch is retired before the
+    # entity lookup, so only the candidate that can still be gated needs entity facts.
     assert len(vacate.calls) == 1
     assert set(vacate.calls[0]) == {"a.md", "b.md", "c.md"}
+    assert vacate.clear_calls == [("b.md", "mismatch")]
     assert len(moved.calls) == 1
-    assert set(moved.calls[0]) == {1, 2}
+    assert moved.calls[0] == (1,)
 
 
 @pytest.mark.asyncio
@@ -687,4 +708,6 @@ async def test_repository_move_vacate_source_delegates_to_repository() -> None:
     markers = await source.load_vacate_markers(["koncept/note.md", "other.md"])
     assert markers == {"koncept/note.md": MoveVacateMarker(entity_id=42, checksum="ck")}
     assert await source.load_vacate_markers([]) == {}
+    await source.clear_vacate_marker("koncept/note.md", "ck")
     assert repo.calls == [(session, ("koncept/note.md", "other.md"))]
+    assert repo.clear_calls == [(session, "koncept/note.md", "ck")]

--- a/tests/indexing/test_file_index_checking.py
+++ b/tests/indexing/test_file_index_checking.py
@@ -422,6 +422,49 @@ async def test_checker_indexes_overwrite_of_null_checksum_marker_path() -> None:
 
 
 @pytest.mark.asyncio
+async def test_checker_skips_checksum_backed_tombstone_after_moved_entity_delete() -> None:
+    """Deleting the moved entity does not let its still-present source resurrect."""
+    checker, moved, _ = _orphan_checker(
+        indexed={},
+        current={"koncept/deleted.md": "vacated-content"},
+        markers={
+            "koncept/deleted.md": MoveVacateMarker(
+                entity_id=None,
+                checksum="vacated-content",
+            )
+        },
+        entity_facts={},
+    )
+
+    plan = await checker.detect(
+        [FileIndexTarget(path="koncept/deleted.md", observed_checksum="vacated-content")]
+    )
+
+    assert plan.paths_to_read == ()
+    assert [(decision.path, decision.status) for decision in plan.decisions] == [
+        ("koncept/deleted.md", FileIndexDecisionStatus.current)
+    ]
+    assert moved.calls == []
+
+
+@pytest.mark.asyncio
+async def test_checker_does_not_trust_null_checksum_tombstone() -> None:
+    """A tombstone without either an entity or checksum cannot identify the source bytes."""
+    checker, _, _ = _orphan_checker(
+        indexed={},
+        current={"koncept/unknown.md": "current-content"},
+        markers={"koncept/unknown.md": MoveVacateMarker(entity_id=None, checksum=None)},
+        entity_facts={},
+    )
+
+    plan = await checker.detect(
+        [FileIndexTarget(path="koncept/unknown.md", observed_checksum="current-content")]
+    )
+
+    assert plan.paths_to_read == ("koncept/unknown.md",)
+
+
+@pytest.mark.asyncio
 async def test_checker_indexes_byte_identical_copy_without_marker() -> None:
     """A byte-identical copy has no vacate marker, so it is indexed as a new note."""
     checker, _, _ = _orphan_checker(

--- a/tests/indexing/test_file_index_checking.py
+++ b/tests/indexing/test_file_index_checking.py
@@ -125,9 +125,7 @@ class StubMoveVacateSource:
     markers: dict[str, MoveVacateMarker] = field(default_factory=dict)
     calls: list[tuple[str, ...]] = field(default_factory=list)
 
-    async def load_vacate_markers(
-        self, file_paths: Sequence[str]
-    ) -> dict[str, MoveVacateMarker]:
+    async def load_vacate_markers(self, file_paths: Sequence[str]) -> dict[str, MoveVacateMarker]:
         self.calls.append(tuple(file_paths))
         return {p: self.markers[p] for p in file_paths if p in self.markers}
 
@@ -357,7 +355,9 @@ async def test_checker_indexes_replacement_note_at_a_vacated_path() -> None:
         current={"koncept/note.md": "other-note-checksum"},
         markers={"koncept/note.md": MoveVacateMarker(entity_id=42, checksum="original-checksum")},
         # The other note (a real twin) exists, but it is not the marker's entity.
-        entity_facts={42: MovedEntityFacts(file_path="arkiv/note.md", checksum="original-checksum")},
+        entity_facts={
+            42: MovedEntityFacts(file_path="arkiv/note.md", checksum="original-checksum")
+        },
     )
 
     plan = await checker.detect(
@@ -419,9 +419,7 @@ async def test_checker_indexes_byte_identical_copy_without_marker() -> None:
         entity_facts={7: MovedEntityFacts(file_path="notes/original.md", checksum="shared")},
     )
 
-    plan = await checker.detect(
-        [FileIndexTarget(path="notes/copy.md", observed_checksum="shared")]
-    )
+    plan = await checker.detect([FileIndexTarget(path="notes/copy.md", observed_checksum="shared")])
 
     assert plan.paths_to_read == ("notes/copy.md",)
 

--- a/tests/indexing/test_file_index_checking.py
+++ b/tests/indexing/test_file_index_checking.py
@@ -539,9 +539,10 @@ async def test_checker_indexes_byte_identical_copy_without_marker() -> None:
 
 
 @pytest.mark.asyncio
-async def test_checker_indexes_when_marker_entity_is_gone_or_still_present() -> None:
-    """If the marked entity no longer exists (or never moved), don't drop the object."""
-    # Marker entity gone -> do not skip (would otherwise lose the content).
+async def test_checker_handles_dangling_marker_entity_and_entity_still_at_source() -> None:
+    """A dangling destination ID is a tombstone, but an entity still at source is not."""
+    # SQLite can retain the deleted entity ID instead of applying ON DELETE SET NULL. The
+    # checksum-backed marker still proves these exact bytes are the vacated source.
     checker, _, _ = _orphan_checker(
         indexed={},
         current={"koncept/gone.md": "ck"},
@@ -549,7 +550,10 @@ async def test_checker_indexes_when_marker_entity_is_gone_or_still_present() -> 
         entity_facts={},  # entity 42 not found
     )
     plan = await checker.detect([FileIndexTarget(path="koncept/gone.md", observed_checksum="ck")])
-    assert plan.paths_to_read == ("koncept/gone.md",)
+    assert plan.paths_to_read == ()
+    assert [(decision.path, decision.status) for decision in plan.decisions] == [
+        ("koncept/gone.md", FileIndexDecisionStatus.current)
+    ]
 
     # Marker entity still owns THIS path (not actually moved away) -> do not skip.
     checker2, _, _ = _orphan_checker(

--- a/tests/indexing/test_file_index_checking.py
+++ b/tests/indexing/test_file_index_checking.py
@@ -10,7 +10,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from basic_memory.indexing.file_index_checking import (
     CurrentFileMetadataSource,
     FileIndexChecker,
+    MoveVacateMarker,
+    MovedEntityFacts,
     RepositoryIndexedFileChecksumSource,
+    RepositoryMoveVacateSource,
+    RepositoryMovedEntitySource,
     StorageCurrentFileChecksumSource,
 )
 from basic_memory.indexing.file_index_planning import FileIndexDecisionStatus, FileIndexTarget
@@ -98,6 +102,75 @@ class StubCurrentChecksumSource:
     async def load_current_file_checksum(self, file_path: str) -> str | None:
         self.requested_paths.append(file_path)
         return self.checksums_by_path[file_path]
+
+
+@dataclass(slots=True)
+class StubMovedEntitySource:
+    """Loads current (path, checksum) facts for moved entities by id (batched)."""
+
+    facts_by_id: dict[int, MovedEntityFacts] = field(default_factory=dict)
+    calls: list[tuple[int, ...]] = field(default_factory=list)
+
+    async def load_entity_facts_by_id(
+        self, entity_ids: Sequence[int]
+    ) -> dict[int, MovedEntityFacts]:
+        self.calls.append(tuple(entity_ids))
+        return {eid: self.facts_by_id[eid] for eid in entity_ids if eid in self.facts_by_id}
+
+
+@dataclass(slots=True)
+class StubMoveVacateSource:
+    """Returns the move-vacate marker recorded for each of the given paths."""
+
+    markers: dict[str, MoveVacateMarker] = field(default_factory=dict)
+    calls: list[tuple[str, ...]] = field(default_factory=list)
+
+    async def load_vacate_markers(
+        self, file_paths: Sequence[str]
+    ) -> dict[str, MoveVacateMarker]:
+        self.calls.append(tuple(file_paths))
+        return {p: self.markers[p] for p in file_paths if p in self.markers}
+
+
+@dataclass(frozen=True, slots=True)
+class FakeEntity:
+    id: int
+    file_path: str
+    checksum: str | None
+
+
+@dataclass(slots=True)
+class FakeEntityRepository:
+    entities: list[FakeEntity]
+    calls: list[tuple[object, tuple[int, ...]]] = field(default_factory=list)
+
+    async def find_by_ids(
+        self,
+        session: AsyncSession,
+        ids: list[int],
+    ) -> list[FakeEntity]:
+        self.calls.append((session, tuple(ids)))
+        return [entity for entity in self.entities if entity.id in ids]
+
+
+@dataclass(slots=True)
+class FakeVacateMarkerRow:
+    entity_id: int
+    file_checksum: str | None
+
+
+@dataclass(slots=True)
+class FakeVacateRepository:
+    markers: dict[str, FakeVacateMarkerRow]
+    calls: list[tuple[object, tuple[str, ...]]] = field(default_factory=list)
+
+    async def load_vacate_markers(
+        self,
+        session: AsyncSession,
+        file_paths: Sequence[str],
+    ) -> dict[str, FakeVacateMarkerRow]:
+        self.calls.append((session, tuple(file_paths)))
+        return {p: self.markers[p] for p in file_paths if p in self.markers}
 
 
 @pytest.mark.asyncio
@@ -226,3 +299,276 @@ async def test_storage_current_file_checksum_source_treats_file_errors_as_missin
     source = StorageCurrentFileChecksumSource(metadata_source=VanishingMetadataSource())
 
     assert await source.load_current_file_checksum("vanished.md") is None
+
+
+def _orphan_checker(
+    *,
+    indexed: dict[str, str | None],
+    current: dict[str, str | None],
+    markers: dict[str, MoveVacateMarker],
+    entity_facts: dict[int, MovedEntityFacts],
+) -> tuple[FileIndexChecker, StubMovedEntitySource, StubMoveVacateSource]:
+    moved = StubMovedEntitySource(facts_by_id=entity_facts)
+    vacate = StubMoveVacateSource(markers=markers)
+    checker = FileIndexChecker(
+        indexed_checksum_source=StubIndexedChecksumSource(indexed),
+        current_checksum_source=StubCurrentChecksumSource(current),
+        moved_entity_source=moved,
+        move_vacate_source=vacate,
+    )
+    return checker, moved, vacate
+
+
+@pytest.mark.asyncio
+async def test_checker_skips_leftover_source_of_a_move() -> None:
+    """The lingering source object of a move is planned `current`, not re-imported (#1601).
+
+    Gate condition: no DB row owns the path, its content checksum matches the vacate marker's
+    recorded source checksum, and the marker's entity now holds that same content at another path.
+    """
+    checker, moved, vacate = _orphan_checker(
+        indexed={},  # no entity owns the source path -> would create
+        current={"koncept/note.md": "checksum-shared"},
+        markers={"koncept/note.md": MoveVacateMarker(entity_id=42, checksum="checksum-shared")},
+        entity_facts={42: MovedEntityFacts(file_path="arkiv/note.md", checksum="checksum-shared")},
+    )
+
+    plan = await checker.detect(
+        [FileIndexTarget(path="koncept/note.md", observed_checksum="checksum-shared")]
+    )
+
+    assert plan.paths_to_read == ()
+    assert [(d.path, d.status) for d in plan.decisions] == [
+        ("koncept/note.md", FileIndexDecisionStatus.current),
+    ]
+    assert vacate.calls == [("koncept/note.md",)]
+    assert moved.calls == [(42,)]
+
+
+@pytest.mark.asyncio
+async def test_checker_indexes_replacement_note_at_a_vacated_path() -> None:
+    """A vacated path overwritten with a DIFFERENT note's bytes is a legit replacement, not a ghost.
+
+    The current checksum no longer matches the marker's source checksum, so it is indexed as new
+    even though a checksum twin exists — the P1 false-skip Codex flagged.
+    """
+    checker, _, _ = _orphan_checker(
+        indexed={},
+        current={"koncept/note.md": "other-note-checksum"},
+        markers={"koncept/note.md": MoveVacateMarker(entity_id=42, checksum="original-checksum")},
+        # The other note (a real twin) exists, but it is not the marker's entity.
+        entity_facts={42: MovedEntityFacts(file_path="arkiv/note.md", checksum="original-checksum")},
+    )
+
+    plan = await checker.detect(
+        [FileIndexTarget(path="koncept/note.md", observed_checksum="other-note-checksum")]
+    )
+
+    assert plan.paths_to_read == ("koncept/note.md",)
+
+
+@pytest.mark.asyncio
+async def test_checker_skips_leftover_when_marker_checksum_unknown() -> None:
+    """A move accepted before its source was materialized records a null-checksum marker.
+
+    The gap-(a) case (basic-memory-cloud#1601): the source checksum was unknown at move time, so
+    the gate falls back to confirming the object is the moved entity's current content. The
+    lingering source must still be skipped, not minted as a duplicate.
+    """
+    checker, _, _ = _orphan_checker(
+        indexed={},
+        current={"koncept/note.md": "content-ck"},
+        markers={"koncept/note.md": MoveVacateMarker(entity_id=42, checksum=None)},
+        entity_facts={42: MovedEntityFacts(file_path="arkiv/note.md", checksum="content-ck")},
+    )
+
+    plan = await checker.detect(
+        [FileIndexTarget(path="koncept/note.md", observed_checksum="content-ck")]
+    )
+
+    assert plan.paths_to_read == ()
+    assert [(d.path, d.status) for d in plan.decisions] == [
+        ("koncept/note.md", FileIndexDecisionStatus.current),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_checker_indexes_overwrite_of_null_checksum_marker_path() -> None:
+    """A null-checksum marker still does not gate a path overwritten with different content."""
+    checker, _, _ = _orphan_checker(
+        indexed={},
+        current={"koncept/note.md": "different-content"},
+        markers={"koncept/note.md": MoveVacateMarker(entity_id=42, checksum=None)},
+        entity_facts={42: MovedEntityFacts(file_path="arkiv/note.md", checksum="moved-content")},
+    )
+
+    plan = await checker.detect(
+        [FileIndexTarget(path="koncept/note.md", observed_checksum="different-content")]
+    )
+
+    assert plan.paths_to_read == ("koncept/note.md",)
+
+
+@pytest.mark.asyncio
+async def test_checker_indexes_byte_identical_copy_without_marker() -> None:
+    """A byte-identical copy has no vacate marker, so it is indexed as a new note."""
+    checker, _, _ = _orphan_checker(
+        indexed={},
+        current={"notes/copy.md": "shared"},
+        markers={},  # no move vacated this path
+        entity_facts={7: MovedEntityFacts(file_path="notes/original.md", checksum="shared")},
+    )
+
+    plan = await checker.detect(
+        [FileIndexTarget(path="notes/copy.md", observed_checksum="shared")]
+    )
+
+    assert plan.paths_to_read == ("notes/copy.md",)
+
+
+@pytest.mark.asyncio
+async def test_checker_indexes_when_marker_entity_is_gone_or_still_present() -> None:
+    """If the marked entity no longer exists (or never moved), don't drop the object."""
+    # Marker entity gone -> do not skip (would otherwise lose the content).
+    checker, _, _ = _orphan_checker(
+        indexed={},
+        current={"koncept/gone.md": "ck"},
+        markers={"koncept/gone.md": MoveVacateMarker(entity_id=42, checksum="ck")},
+        entity_facts={},  # entity 42 not found
+    )
+    plan = await checker.detect([FileIndexTarget(path="koncept/gone.md", observed_checksum="ck")])
+    assert plan.paths_to_read == ("koncept/gone.md",)
+
+    # Marker entity still owns THIS path (not actually moved away) -> do not skip.
+    checker2, _, _ = _orphan_checker(
+        indexed={},
+        current={"koncept/here.md": "ck"},
+        markers={"koncept/here.md": MoveVacateMarker(entity_id=42, checksum="ck")},
+        entity_facts={42: MovedEntityFacts(file_path="koncept/here.md", checksum="ck")},
+    )
+    plan2 = await checker2.detect([FileIndexTarget(path="koncept/here.md", observed_checksum="ck")])
+    assert plan2.paths_to_read == ("koncept/here.md",)
+
+
+@pytest.mark.asyncio
+async def test_checker_does_not_gate_updates_or_null_checksum_rows() -> None:
+    """An existing row (even one with a null checksum) is an edit/repair, never move-gated.
+
+    A present-but-null indexed checksum is an incomplete row that must still be read, not skipped
+    as a create — the gate keys on row *absence*, not on a null value.
+    """
+    checker, moved, vacate = _orphan_checker(
+        indexed={"notes/edited.md": "old", "notes/pending.md": None},
+        current={"notes/edited.md": "new", "notes/pending.md": "materialized"},
+        markers={
+            "notes/edited.md": MoveVacateMarker(entity_id=1, checksum="new"),
+            "notes/pending.md": MoveVacateMarker(entity_id=2, checksum="materialized"),
+        },
+        entity_facts={
+            1: MovedEntityFacts(file_path="x.md", checksum="new"),
+            2: MovedEntityFacts(file_path="y.md", checksum="materialized"),
+        },
+    )
+
+    plan = await checker.detect(
+        [
+            FileIndexTarget(path="notes/edited.md", observed_checksum="new"),
+            FileIndexTarget(path="notes/pending.md", observed_checksum="materialized"),
+        ]
+    )
+
+    assert set(plan.paths_to_read) == {"notes/edited.md", "notes/pending.md"}
+    # No create candidates -> move detection is never consulted.
+    assert moved.calls == []
+    assert vacate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_checker_batches_move_detection_across_create_candidates() -> None:
+    """Multiple create candidates share one marker query and one entity query (no per-file round-trips)."""
+    checker, moved, vacate = _orphan_checker(
+        indexed={},
+        current={"a.md": "ck-a", "b.md": "ck-b", "c.md": "ck-c"},
+        markers={
+            "a.md": MoveVacateMarker(entity_id=1, checksum="ck-a"),  # orphan -> skip
+            "b.md": MoveVacateMarker(entity_id=2, checksum="mismatch"),  # marker != current -> read
+            # c.md has no marker -> read
+        },
+        entity_facts={
+            1: MovedEntityFacts(file_path="dest-a.md", checksum="ck-a"),
+            2: MovedEntityFacts(file_path="dest-b.md", checksum="ck-b"),
+        },
+    )
+
+    plan = await checker.detect(
+        [
+            FileIndexTarget(path="a.md", observed_checksum="ck-a"),
+            FileIndexTarget(path="b.md", observed_checksum="ck-b"),
+            FileIndexTarget(path="c.md", observed_checksum="ck-c"),
+        ]
+    )
+
+    assert set(plan.paths_to_read) == {"b.md", "c.md"}
+    assert [(d.path, d.status) for d in plan.decisions] == [
+        ("a.md", FileIndexDecisionStatus.current),
+    ]
+    # One marker query over all three candidates; one entity query over the markers found.
+    assert len(vacate.calls) == 1
+    assert set(vacate.calls[0]) == {"a.md", "b.md", "c.md"}
+    assert len(moved.calls) == 1
+    assert set(moved.calls[0]) == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_checker_gate_inert_without_both_sources() -> None:
+    """The gate never fires unless both sources are configured."""
+    plan = await FileIndexChecker(
+        indexed_checksum_source=StubIndexedChecksumSource({}),
+        current_checksum_source=StubCurrentChecksumSource({"koncept/note.md": "ck"}),
+        move_vacate_source=StubMoveVacateSource(
+            markers={"koncept/note.md": MoveVacateMarker(entity_id=42, checksum="ck")}
+        ),
+        # moved_entity_source omitted
+    ).detect([FileIndexTarget(path="koncept/note.md", observed_checksum="ck")])
+
+    assert plan.paths_to_read == ("koncept/note.md",)
+
+
+@pytest.mark.asyncio
+async def test_repository_moved_entity_source_loads_facts_by_id() -> None:
+    session = object()
+    session_maker = cast(async_sessionmaker[AsyncSession], FakeSessionMaker(session))
+
+    repo = FakeEntityRepository(
+        [
+            FakeEntity(id=1, file_path="arkiv/note.md", checksum="ck-1"),
+            FakeEntity(id=2, file_path="arkiv/other.md", checksum=None),
+        ]
+    )
+    source = RepositoryMovedEntitySource(session_maker=session_maker, entity_repository=repo)
+
+    facts = await source.load_entity_facts_by_id([1, 2, 1])
+    assert facts == {
+        1: MovedEntityFacts(file_path="arkiv/note.md", checksum="ck-1"),
+        2: MovedEntityFacts(file_path="arkiv/other.md", checksum=None),
+    }
+    # One batched query over the deduped ids.
+    assert len(repo.calls) == 1
+    assert set(repo.calls[0][1]) == {1, 2}
+    assert await source.load_entity_facts_by_id([]) == {}
+
+
+@pytest.mark.asyncio
+async def test_repository_move_vacate_source_delegates_to_repository() -> None:
+    session = object()
+    session_maker = cast(async_sessionmaker[AsyncSession], FakeSessionMaker(session))
+    repo = FakeVacateRepository(
+        markers={"koncept/note.md": FakeVacateMarkerRow(entity_id=42, file_checksum="ck")}
+    )
+
+    source = RepositoryMoveVacateSource(session_maker=session_maker, vacate_repository=repo)
+
+    markers = await source.load_vacate_markers(["koncept/note.md", "other.md"])
+    assert markers == {"koncept/note.md": MoveVacateMarker(entity_id=42, checksum="ck")}
+    assert await source.load_vacate_markers([]) == {}
+    assert repo.calls == [(session, ("koncept/note.md", "other.md"))]

--- a/tests/indexing/test_file_index_checking.py
+++ b/tests/indexing/test_file_index_checking.py
@@ -293,7 +293,9 @@ async def test_storage_current_file_checksum_source_loads_metadata_checksum() ->
 async def test_storage_current_file_checksum_source_treats_file_errors_as_missing() -> None:
     class VanishingMetadataSource:
         async def load_current_file_metadata(self, file_path: str) -> StubCurrentMetadata | None:
-            raise FileOperationError(f"file vanished: {file_path}")
+            raise FileOperationError(f"file vanished: {file_path}") from FileNotFoundError(
+                file_path
+            )
 
     source = StorageCurrentFileChecksumSource(metadata_source=VanishingMetadataSource())
 
@@ -304,11 +306,25 @@ async def test_storage_current_file_checksum_source_treats_file_errors_as_missin
 async def test_storage_current_file_checksum_source_treats_checksum_race_as_missing() -> None:
     class VanishingMetadataSource:
         async def load_current_file_metadata(self, file_path: str) -> StubCurrentMetadata | None:
-            raise FileError(f"checksum target vanished: {file_path}")
+            raise FileError(f"checksum target vanished: {file_path}") from FileNotFoundError(
+                file_path
+            )
 
     source = StorageCurrentFileChecksumSource(metadata_source=VanishingMetadataSource())
 
     assert await source.load_current_file_checksum("vanished.md") is None
+
+
+@pytest.mark.asyncio
+async def test_storage_current_file_checksum_source_propagates_non_missing_failures() -> None:
+    class UnreadableMetadataSource:
+        async def load_current_file_metadata(self, file_path: str) -> StubCurrentMetadata | None:
+            raise FileError(f"permission denied: {file_path}") from PermissionError(file_path)
+
+    source = StorageCurrentFileChecksumSource(metadata_source=UnreadableMetadataSource())
+
+    with pytest.raises(FileError, match="permission denied"):
+        await source.load_current_file_checksum("unreadable.md")
 
 
 def _orphan_checker(
@@ -327,6 +343,49 @@ def _orphan_checker(
         move_vacate_source=vacate,
     )
     return checker, moved, vacate
+
+
+@pytest.mark.asyncio
+async def test_checker_forced_full_hashes_only_marked_create_candidates() -> None:
+    """Forced-full keeps its one content-read pass for paths with no move evidence."""
+    current = StubCurrentChecksumSource({"notes/marked.md": "vacated-checksum"})
+    moved = StubMovedEntitySource(
+        facts_by_id={
+            42: MovedEntityFacts(
+                file_path="archive/marked.md",
+                checksum="vacated-checksum",
+            )
+        }
+    )
+    vacate = StubMoveVacateSource(
+        markers={
+            "notes/marked.md": MoveVacateMarker(
+                entity_id=42,
+                checksum="vacated-checksum",
+            )
+        }
+    )
+    checker = FileIndexChecker(
+        indexed_checksum_source=StubIndexedChecksumSource(
+            {"notes/existing.md": "accepted-checksum"}
+        ),
+        current_checksum_source=current,
+        moved_entity_source=moved,
+        move_vacate_source=vacate,
+    )
+
+    plan = await checker.detect(
+        [
+            FileIndexTarget(path="notes/marked.md"),
+            FileIndexTarget(path="notes/unmarked.md"),
+            FileIndexTarget(path="notes/existing.md"),
+        ]
+    )
+
+    assert plan.paths_to_read == ("notes/unmarked.md", "notes/existing.md")
+    assert current.requested_paths == ["notes/marked.md"]
+    assert vacate.calls == [("notes/marked.md", "notes/unmarked.md")]
+    assert moved.calls == [(42,)]
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_note_file_delete_runner.py
+++ b/tests/indexing/test_note_file_delete_runner.py
@@ -128,16 +128,16 @@ async def test_run_note_file_delete_clears_vacate_marker_on_delete() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_note_file_delete_does_not_clear_marker_on_skip() -> None:
-    """A guarded skip (the source changed before cleanup) leaves the marker in place."""
+async def test_run_note_file_delete_clears_marker_after_source_replacement() -> None:
+    """A guarded replacement proves the moved source object no longer needs suppression."""
     storage = FakeNoteFileStorage(checksum="changed-on-disk")  # != request checksum -> skip
     clearer = FakeVacateClearer()
 
     result = await run_note_file_delete(delete_request(), storage=storage, vacate_clearer=clearer)
 
-    assert result.status != RuntimeDeleteStatus.deleted
+    assert result.status == RuntimeDeleteStatus.skipped
     assert storage.delete_calls == []
-    assert clearer.cleared == []
+    assert clearer.cleared == [(101, "notes/a.md", "file-sum")]
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_note_file_delete_runner.py
+++ b/tests/indexing/test_note_file_delete_runner.py
@@ -109,7 +109,9 @@ class FakeVacateClearer:
     def __init__(self) -> None:
         self.cleared: list[tuple[int, str, str]] = []
 
-    async def clear_move_vacate(self, *, project_id: int, file_path: str, file_checksum: str) -> None:
+    async def clear_move_vacate(
+        self, *, project_id: int, file_path: str, file_checksum: str
+    ) -> None:
         self.cleared.append((project_id, file_path, file_checksum))
 
 

--- a/tests/indexing/test_note_file_delete_runner.py
+++ b/tests/indexing/test_note_file_delete_runner.py
@@ -107,10 +107,10 @@ async def test_run_note_file_delete_propagates_delete_failures() -> None:
 
 class FakeVacateClearer:
     def __init__(self) -> None:
-        self.cleared: list[tuple[int, str, str]] = []
+        self.cleared: list[tuple[int, str, str | None]] = []
 
     async def clear_move_vacate(
-        self, *, project_id: int, file_path: str, file_checksum: str
+        self, *, project_id: int, file_path: str, file_checksum: str | None
     ) -> None:
         self.cleared.append((project_id, file_path, file_checksum))
 

--- a/tests/indexing/test_note_file_delete_runner.py
+++ b/tests/indexing/test_note_file_delete_runner.py
@@ -103,3 +103,48 @@ async def test_run_note_file_delete_propagates_delete_failures() -> None:
 
     with pytest.raises(FileOperationError, match="delete failed"):
         await run_note_file_delete(delete_request(), storage=storage)
+
+
+class FakeVacateClearer:
+    def __init__(self) -> None:
+        self.cleared: list[tuple[int, str, str]] = []
+
+    async def clear_move_vacate(self, *, project_id: int, file_path: str, file_checksum: str) -> None:
+        self.cleared.append((project_id, file_path, file_checksum))
+
+
+@pytest.mark.asyncio
+async def test_run_note_file_delete_clears_vacate_marker_on_delete() -> None:
+    """When the source object is actually deleted, the move-vacate marker is cleared (#1601)."""
+    storage = FakeNoteFileStorage(checksum="file-sum")
+    clearer = FakeVacateClearer()
+
+    result = await run_note_file_delete(delete_request(), storage=storage, vacate_clearer=clearer)
+
+    assert result.status == RuntimeDeleteStatus.deleted
+    assert clearer.cleared == [(101, "notes/a.md", "file-sum")]
+
+
+@pytest.mark.asyncio
+async def test_run_note_file_delete_does_not_clear_marker_on_skip() -> None:
+    """A guarded skip (the source changed before cleanup) leaves the marker in place."""
+    storage = FakeNoteFileStorage(checksum="changed-on-disk")  # != request checksum -> skip
+    clearer = FakeVacateClearer()
+
+    result = await run_note_file_delete(delete_request(), storage=storage, vacate_clearer=clearer)
+
+    assert result.status != RuntimeDeleteStatus.deleted
+    assert storage.delete_calls == []
+    assert clearer.cleared == []
+
+
+@pytest.mark.asyncio
+async def test_run_note_file_delete_clears_marker_when_source_already_absent() -> None:
+    """If the source is already gone (missing), still clear the marker (#1601 P2)."""
+    storage = FakeNoteFileStorage(checksum=None)  # object already absent -> missing
+    clearer = FakeVacateClearer()
+
+    result = await run_note_file_delete(delete_request(), storage=storage, vacate_clearer=clearer)
+
+    assert result.status == RuntimeDeleteStatus.missing
+    assert clearer.cleared == [(101, "notes/a.md", "file-sum")]

--- a/tests/indexing/test_note_materialization_runner.py
+++ b/tests/indexing/test_note_materialization_runner.py
@@ -24,6 +24,7 @@ from basic_memory.indexing.note_materialization_runner import (
 )
 from basic_memory.indexing.note_content_reconciliation import NoteContentState
 from basic_memory.models import Entity, NoteContent
+from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
 from basic_memory.runtime.cleanup import RuntimeNoteFileDeleteJobRequest
 from basic_memory.runtime.note_content import (
     RuntimeFileConflict,
@@ -522,15 +523,31 @@ async def test_repository_note_materialization_publisher_updates_current_written
     session = FakeRepositorySession(entity=entity, note_content=note_content)
     session_lock = FakeSessionLock()
     repository = RecordingNoteContentRepository()
+    cleared_vacate_paths: list[tuple[AsyncSession, str]] = []
     scoped_session = RecordingScopedSession(
         scoped_session=FakeScopedSession(session),
         opened_session_makers=[],
     )
 
     with pytest.MonkeyPatch.context() as monkeypatch:
+
+        async def record_clear_vacate_path(
+            vacate_repository: NoteFileVacateRepository,
+            current_session: AsyncSession,
+            *,
+            file_path: str,
+        ) -> None:
+            assert vacate_repository.project_id == 7
+            cleared_vacate_paths.append((current_session, file_path))
+
         monkeypatch.setattr(
             "basic_memory.indexing.note_materialization_runner.db.scoped_session",
             scoped_session,
+        )
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner."
+            "NoteFileVacateRepository.clear_vacate_path",
+            record_clear_vacate_path,
         )
         result = await RepositoryNoteMaterializationPublisher(
             session_maker=cast(async_sessionmaker[AsyncSession], object()),
@@ -565,6 +582,7 @@ async def test_repository_note_materialization_publisher_updates_current_written
     assert entity.mtime == written.file_updated_at.timestamp()
     assert entity.size == len(b"# A note\n")
     assert session.flush_count == 1
+    assert cleared_vacate_paths == [(cast(AsyncSession, session), "notes/a.md")]
 
 
 @pytest.mark.asyncio

--- a/tests/repository/test_note_file_vacate_repository.py
+++ b/tests/repository/test_note_file_vacate_repository.py
@@ -143,3 +143,32 @@ async def test_clear_vacate_clears_null_checksum_marker(session_maker) -> None:
         await session.commit()
     async with session_maker() as session:
         assert set(await repo.load_vacate_markers(session, ["koncept/note.md"])) == set()
+
+
+@pytest.mark.asyncio
+async def test_clear_vacate_path_retires_only_the_live_project_path(session_maker) -> None:
+    """A successful publication supersedes any older marker for its exact project path."""
+    project_one = NoteFileVacateRepository(project_id=1)
+    project_two = NoteFileVacateRepository(project_id=2)
+    async with session_maker() as session:
+        await project_one.record_vacate(
+            session, entity_id=10, file_path="notes/live.md", file_checksum="old"
+        )
+        await project_one.record_vacate(
+            session, entity_id=11, file_path="notes/other.md", file_checksum="other"
+        )
+        await project_two.record_vacate(
+            session, entity_id=20, file_path="notes/live.md", file_checksum="second-project"
+        )
+        await project_one.clear_vacate_path(session, file_path="notes/live.md")
+        await session.commit()
+
+    async with session_maker() as session:
+        project_one_markers = await project_one.load_vacate_markers(
+            session,
+            ["notes/live.md", "notes/other.md"],
+        )
+        project_two_markers = await project_two.load_vacate_markers(session, ["notes/live.md"])
+
+    assert set(project_one_markers) == {"notes/other.md"}
+    assert project_two_markers["notes/live.md"].file_checksum == "second-project"

--- a/tests/repository/test_note_file_vacate_repository.py
+++ b/tests/repository/test_note_file_vacate_repository.py
@@ -89,8 +89,48 @@ async def test_clear_vacate_is_checksum_guarded(session_maker) -> None:
 
 
 @pytest.mark.asyncio
+async def test_clear_vacate_does_not_delete_concurrently_refreshed_marker(session_maker) -> None:
+    """A stale cleanup cannot delete a newer move marker for the same source path."""
+    repo = NoteFileVacateRepository(project_id=1)
+    async with session_maker() as session:
+        await repo.record_vacate(
+            session, entity_id=10, file_path="koncept/note.md", file_checksum="old"
+        )
+        await session.commit()
+
+    async with session_maker() as cleanup_session:
+        # Keep the old marker in this session's identity map, matching the stale read that made
+        # the previous Python check + ORM delete sequence vulnerable.
+        stale_marker = await repo._get_marker(cleanup_session, "koncept/note.md")
+        assert stale_marker is not None
+        assert stale_marker.file_checksum == "old"
+        await cleanup_session.commit()
+
+        async with session_maker() as new_move_session:
+            await repo.record_vacate(
+                new_move_session,
+                entity_id=11,
+                file_path="koncept/note.md",
+                file_checksum="new",
+            )
+            await new_move_session.commit()
+
+        await repo.clear_vacate(
+            cleanup_session,
+            file_path="koncept/note.md",
+            file_checksum="old",
+        )
+        await cleanup_session.commit()
+
+    async with session_maker() as session:
+        markers = await repo.load_vacate_markers(session, ["koncept/note.md"])
+    assert markers["koncept/note.md"].entity_id == 11
+    assert markers["koncept/note.md"].file_checksum == "new"
+
+
+@pytest.mark.asyncio
 async def test_clear_vacate_clears_null_checksum_marker(session_maker) -> None:
-    """A marker recorded with an unknown source checksum is cleared once the file is gone."""
+    """A cleanup with the same unknown checksum clears an unknown-checksum marker."""
     repo = NoteFileVacateRepository(project_id=1)
     async with session_maker() as session:
         await repo.record_vacate(
@@ -99,7 +139,7 @@ async def test_clear_vacate_clears_null_checksum_marker(session_maker) -> None:
         await session.commit()
 
     async with session_maker() as session:
-        await repo.clear_vacate(session, file_path="koncept/note.md", file_checksum="whatever")
+        await repo.clear_vacate(session, file_path="koncept/note.md", file_checksum=None)
         await session.commit()
     async with session_maker() as session:
         assert set(await repo.load_vacate_markers(session, ["koncept/note.md"])) == set()

--- a/tests/repository/test_note_file_vacate_repository.py
+++ b/tests/repository/test_note_file_vacate_repository.py
@@ -77,7 +77,9 @@ async def test_clear_vacate_is_checksum_guarded(session_maker) -> None:
         await repo.clear_vacate(session, file_path="koncept/note.md", file_checksum="WRONG")
         await session.commit()
     async with session_maker() as session:
-        assert set(await repo.load_vacate_markers(session, ["koncept/note.md"])) == {"koncept/note.md"}
+        assert set(await repo.load_vacate_markers(session, ["koncept/note.md"])) == {
+            "koncept/note.md"
+        }
 
     async with session_maker() as session:
         await repo.clear_vacate(session, file_path="koncept/note.md", file_checksum="def")

--- a/tests/repository/test_note_file_vacate_repository.py
+++ b/tests/repository/test_note_file_vacate_repository.py
@@ -1,0 +1,103 @@
+"""Tests for NoteFileVacateRepository (move-orphan gate, basic-memory-cloud#1601)."""
+
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from basic_memory.models.base import Base
+from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
+
+
+@pytest_asyncio.fixture
+async def session_maker() -> AsyncIterator[async_sessionmaker]:
+    engine = create_async_engine("sqlite+aiosqlite://")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield async_sessionmaker(engine, expire_on_commit=False)
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_record_and_find_vacated_paths_is_project_scoped(session_maker) -> None:
+    project_one = NoteFileVacateRepository(project_id=1)
+    project_two = NoteFileVacateRepository(project_id=2)
+    async with session_maker() as session:
+        await project_one.record_vacate(
+            session, entity_id=10, file_path="koncept/note.md", file_checksum="abc"
+        )
+        # Same path in another project must stay isolated.
+        await project_two.record_vacate(
+            session, entity_id=99, file_path="koncept/note.md", file_checksum="zzz"
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        markers = await project_one.load_vacate_markers(session, ["koncept/note.md", "other.md"])
+        assert set(markers) == {"koncept/note.md"}
+        # The marker carries the moved entity and source checksum the gate matches against.
+        assert markers["koncept/note.md"].entity_id == 10
+        assert markers["koncept/note.md"].file_checksum == "abc"
+        assert await project_one.load_vacate_markers(session, ["other.md"]) == {}
+        assert await project_one.load_vacate_markers(session, []) == {}
+
+
+@pytest.mark.asyncio
+async def test_record_vacate_upserts_on_same_path(session_maker) -> None:
+    repo = NoteFileVacateRepository(project_id=1)
+    async with session_maker() as session:
+        await repo.record_vacate(
+            session, entity_id=10, file_path="koncept/note.md", file_checksum="abc"
+        )
+        # A fresh move onto the same source path replaces the marker (no unique-constraint error).
+        await repo.record_vacate(
+            session, entity_id=11, file_path="koncept/note.md", file_checksum="def"
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        marker = await repo._get_marker(session, "koncept/note.md")
+        assert marker is not None
+        assert marker.entity_id == 11
+        assert marker.file_checksum == "def"
+
+
+@pytest.mark.asyncio
+async def test_clear_vacate_is_checksum_guarded(session_maker) -> None:
+    repo = NoteFileVacateRepository(project_id=1)
+    async with session_maker() as session:
+        await repo.record_vacate(
+            session, entity_id=10, file_path="koncept/note.md", file_checksum="def"
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        # A mismatched checksum (a different file now sits at the path) does not clear it.
+        await repo.clear_vacate(session, file_path="koncept/note.md", file_checksum="WRONG")
+        await session.commit()
+    async with session_maker() as session:
+        assert set(await repo.load_vacate_markers(session, ["koncept/note.md"])) == {"koncept/note.md"}
+
+    async with session_maker() as session:
+        await repo.clear_vacate(session, file_path="koncept/note.md", file_checksum="def")
+        await session.commit()
+    async with session_maker() as session:
+        assert set(await repo.load_vacate_markers(session, ["koncept/note.md"])) == set()
+
+
+@pytest.mark.asyncio
+async def test_clear_vacate_clears_null_checksum_marker(session_maker) -> None:
+    """A marker recorded with an unknown source checksum is cleared once the file is gone."""
+    repo = NoteFileVacateRepository(project_id=1)
+    async with session_maker() as session:
+        await repo.record_vacate(
+            session, entity_id=10, file_path="koncept/note.md", file_checksum=None
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        await repo.clear_vacate(session, file_path="koncept/note.md", file_checksum="whatever")
+        await session.commit()
+    async with session_maker() as session:
+        assert set(await repo.load_vacate_markers(session, ["koncept/note.md"])) == set()

--- a/tests/repository/test_note_file_vacate_repository.py
+++ b/tests/repository/test_note_file_vacate_repository.py
@@ -7,7 +7,10 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from basic_memory.models.base import Base
-from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
+from basic_memory.repository.note_file_vacate_repository import (
+    NoteFileVacateRepository,
+    RecoverableVacate,
+)
 
 
 @pytest_asyncio.fixture
@@ -61,6 +64,38 @@ async def test_record_vacate_upserts_on_same_path(session_maker) -> None:
         assert marker is not None
         assert marker.entity_id == 11
         assert marker.file_checksum == "def"
+
+
+@pytest.mark.asyncio
+async def test_list_recoverable_vacates_is_project_scoped_and_guarded(session_maker) -> None:
+    """Startup cleanup returns only checksum-backed markers from its project."""
+    project_one = NoteFileVacateRepository(project_id=1)
+    project_two = NoteFileVacateRepository(project_id=2)
+    async with session_maker() as session:
+        await project_one.record_vacate(
+            session, entity_id=10, file_path="notes/ready.md", file_checksum="abc"
+        )
+        await project_one.record_vacate(
+            session, entity_id=11, file_path="notes/unguarded.md", file_checksum=None
+        )
+        await project_two.record_vacate(
+            session, entity_id=20, file_path="notes/other-project.md", file_checksum="xyz"
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        recoverable = await project_one.list_recoverable_vacates(session)
+
+    # These lightweight repository tests use dangling entity ids, matching a
+    # destination tombstone on backends that enforce ON DELETE SET NULL.
+    assert recoverable == [
+        RecoverableVacate(
+            entity_id=None,
+            file_path="notes/ready.md",
+            file_checksum="abc",
+            live_file_path=None,
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_pending_note_materialization.py
+++ b/tests/runtime/test_pending_note_materialization.py
@@ -180,8 +180,8 @@ def test_plan_accepted_note_content_write_advances_and_cleans_moved_materialized
     )
 
 
-def test_plan_accepted_note_content_write_skips_unmaterialized_file_cleanup() -> None:
-    assert plan_accepted_note_content_write(
+def test_plan_accepted_note_content_write_uses_db_checksum_for_unpublished_file_cleanup() -> None:
+    plan = plan_accepted_note_content_write(
         project_id=7,
         entity_id=42,
         existing_file_path="notes/old.md",
@@ -192,7 +192,18 @@ def test_plan_accepted_note_content_write_skips_unmaterialized_file_cleanup() ->
             last_source="api",
             file_checksum=None,
         ),
-    ) == RuntimeAcceptedNoteContentWritePlan(db_version=5)
+    )
+
+    assert plan == RuntimeAcceptedNoteContentWritePlan(
+        db_version=5,
+        previous_file_delete=RuntimePendingNoteFileDelete(
+            project_id=7,
+            entity_id=42,
+            file_path="notes/old.md",
+            file_checksum="db-checksum",
+            live_file_path="notes/new.md",
+        ),
+    )
 
 
 def test_plan_accepted_note_materialization_change_wraps_response_and_marker() -> None:

--- a/tests/runtime/test_pending_note_materialization.py
+++ b/tests/runtime/test_pending_note_materialization.py
@@ -184,7 +184,7 @@ def test_plan_accepted_note_content_write_advances_and_cleans_moved_materialized
     )
 
 
-def test_plan_accepted_note_content_write_uses_db_checksum_for_unpublished_file_cleanup() -> None:
+def test_plan_accepted_note_content_write_omits_cleanup_when_unpublished_source_is_absent() -> None:
     plan = plan_accepted_note_content_write(
         project_id=7,
         entity_id=42,
@@ -198,20 +198,11 @@ def test_plan_accepted_note_content_write_uses_db_checksum_for_unpublished_file_
         ),
     )
 
-    assert plan == RuntimeAcceptedNoteContentWritePlan(
-        db_version=5,
-        previous_file_delete=RuntimePendingNoteFileDelete(
-            project_id=7,
-            entity_id=42,
-            file_path="notes/old.md",
-            file_checksum="db-checksum",
-            live_file_path="notes/new.md",
-        ),
-    )
+    assert plan == RuntimeAcceptedNoteContentWritePlan(db_version=5)
 
 
 def test_plan_accepted_note_content_write_ignores_stale_published_checksum() -> None:
-    """A pending accepted version uses its DB checksum even when older file state remains."""
+    """A pending accepted version uses observed DB bytes instead of stale published state."""
     plan = plan_accepted_note_content_write(
         project_id=7,
         entity_id=42,
@@ -225,6 +216,7 @@ def test_plan_accepted_note_content_write_ignores_stale_published_checksum() -> 
             file_checksum="previous-file-checksum",
             file_write_status="writing",
         ),
+        source_file_checksum="accepted-checksum",
     )
 
     assert plan.previous_file_delete is not None

--- a/tests/runtime/test_pending_note_materialization.py
+++ b/tests/runtime/test_pending_note_materialization.py
@@ -20,7 +20,9 @@ class _NoteContentState:
     db_version: int | str
     db_checksum: str
     last_source: str | None
+    file_version: int | None = None
     file_checksum: str | None = None
+    file_write_status: str = "pending"
 
 
 def test_plan_pending_note_materialization_uses_fallback_source_when_missing() -> None:
@@ -162,7 +164,9 @@ def test_plan_accepted_note_content_write_advances_and_cleans_moved_materialized
             db_version=4,
             db_checksum="db-checksum",
             last_source="api",
+            file_version=4,
             file_checksum="old-file-checksum",
+            file_write_status="synced",
         ),
     )
 
@@ -204,6 +208,27 @@ def test_plan_accepted_note_content_write_uses_db_checksum_for_unpublished_file_
             live_file_path="notes/new.md",
         ),
     )
+
+
+def test_plan_accepted_note_content_write_ignores_stale_published_checksum() -> None:
+    """A pending accepted version uses its DB checksum even when older file state remains."""
+    plan = plan_accepted_note_content_write(
+        project_id=7,
+        entity_id=42,
+        existing_file_path="notes/old.md",
+        accepted_file_path="notes/new.md",
+        current_note_content=_NoteContentState(
+            db_version=4,
+            db_checksum="accepted-checksum",
+            last_source="api",
+            file_version=3,
+            file_checksum="previous-file-checksum",
+            file_write_status="writing",
+        ),
+    )
+
+    assert plan.previous_file_delete is not None
+    assert plan.previous_file_delete.file_checksum == "accepted-checksum"
 
 
 def test_plan_accepted_note_materialization_change_wraps_response_and_marker() -> None:

--- a/tests/runtime/test_pending_note_materialization.py
+++ b/tests/runtime/test_pending_note_materialization.py
@@ -168,6 +168,7 @@ def test_plan_accepted_note_content_write_advances_and_cleans_moved_materialized
             file_checksum="old-file-checksum",
             file_write_status="synced",
         ),
+        source_file_checksum="old-file-checksum",
     )
 
     assert plan == RuntimeAcceptedNoteContentWritePlan(

--- a/tests/services/test_initialization.py
+++ b/tests/services/test_initialization.py
@@ -227,6 +227,33 @@ async def test_initialize_file_indexing_no_constraint_when_env_unset(
 
 
 @pytest.mark.asyncio
+async def test_initialize_file_indexing_releases_startup_after_recovery(
+    app_config: BasicMemoryConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The watch coordinator barrier is released before long-lived watching starts."""
+    _disable_test_env_short_circuit(monkeypatch)
+    recovery_complete = asyncio.Event()
+
+    class RecoveryAwareWatchService(_FakeWatchService):
+        async def run(self) -> None:
+            assert recovery_complete.is_set()
+
+    monkeypatch.setattr(
+        "basic_memory.index.watch_service.WatchService",
+        RecoveryAwareWatchService,
+    )
+
+    await initialize_file_indexing(
+        app_config,
+        quiet=True,
+        recovery_complete=recovery_complete,
+    )
+
+    assert recovery_complete.is_set()
+
+
+@pytest.mark.asyncio
 async def test_initialize_file_indexing_wires_event_index_runtime_by_default(
     app_config: BasicMemoryConfig, monkeypatch
 ):

--- a/tests/services/test_initialization_cloud_mode_branches.py
+++ b/tests/services/test_initialization_cloud_mode_branches.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from basic_memory.config import DatabaseBackend
@@ -103,4 +105,8 @@ def test_ensure_initialization_runs_for_local_postgres(app_config, monkeypatch):
 async def test_initialize_file_indexing_skips_in_test_env(app_config):
     # app_config fixture uses env="test"
     assert app_config.is_test_env is True
-    await initialize_file_indexing(app_config)
+    recovery_complete = asyncio.Event()
+
+    await initialize_file_indexing(app_config, recovery_complete=recovery_complete)
+
+    assert recovery_complete.is_set()


### PR DESCRIPTION
Fixes the ghost-creation root cause behind basicmachines-co/basic-memory-cloud#1601.

## Why

`move_note` accepts a move in the database before destination materialization and source cleanup
finish. If the old source object remains, a later index sees an unowned file path and can mint a
new entity with a `-1` permalink suffix.

A checksum-twin check alone is unsafe because a legitimate byte-identical copy has the same shape.
The indexer needs durable positive evidence that the source path was vacated by a move.

## What Changed

- Added a per-project `note_file_vacate` marker, repository, and Alembic migration.
- Records or refreshes the vacated source path with a single database upsert for explicit moves
  and accepted `PUT` renames.
- Gates a would-be create only when the path has a matching marker and the recorded entity now
  exists at a different path or has been deleted.
- Clears the marker after checksum-guarded source cleanup, a confirmed missing source, or a
  checksum mismatch proving the moved source was replaced, using one conditional delete so a
  concurrent move cannot lose its newer marker.
- Preserves checksum-backed markers as tombstones if the destination entity is deleted before
  source cleanup, preventing the deleted note from being resurrected at its old path.
- Treats both null and dangling destination IDs as deleted-entity tombstones, because SQLite
  backends do not apply `ON DELETE SET NULL` consistently.
- Clears markers when a case-only rename makes the old and live paths aliases of the same object,
  because no independent source object remains to clean up.
- Clears any older marker for a destination only after current materialization successfully
  publishes that path as live, so a lost cleanup cannot suppress later path reuse after a move back.
- Reconciles the current source checksum once for every path-changing write, including `synced`
  rows, so only source bytes currently present and matching a known accepted or published version
  carry the cleanup guard.
- Omits cleanup and move-vacate markers when that source observation finds no object, preserving
  the path for legitimate reuse instead of borrowing the accepted database checksum as authority.
- Wires the marker gate into local event, project-index, and materialization runtimes.
- Keeps the gate active during forced-full indexing instead of bypassing it through the legacy
  unconditional-read path, while hashing only DB-absent paths that actually carry markers.
- Treats only a confirmed disappearance during the forced-full checksum pass as missing; permission
  and other I/O failures continue to fail the indexing job.
- Re-drives checksum-backed source cleanup on startup once the destination is synchronized or
  deleted, while preserving the old source during pending or failed destination publication.
- Keeps API/MCP startup in `STARTING` until durable recovery finishes, so a request cannot reuse a
  cached vacated path while the recovery sweep is still eligible to delete it.
- Revalidates each cached recovery candidate under its marker and destination-entity locks before
  touching storage, serializing cleanup with a second local process moving the note back.
- Adds integration regressions for both MCP moves and accepted `PUT` renames through real API,
  repository, storage, cleanup, and project-index paths.

## Implementation Details

The move reads the current source checksum once before persistence mutates `NoteContent`. A
`synced` row authorizes cleanup only when the observed bytes match its current published
`file_checksum`. For ambiguous `pending`, `writing`, `failed`, and `external_change_detected`
states, the observed bytes may match either the last published `file_checksum` or the accepted
`db_checksum`. That observed checksum guards both the marker and cleanup job. If storage is absent
or contains unrelated bytes, the move creates neither cleanup work nor a marker because no source
object was confirmed.

The index gate remains conjunctive:

1. No entity row owns the candidate source path.
2. The path has a move-vacate marker.
3. The current source object matches the marker checksum.
4. The marker's entity either exists at a different path, or has been deleted while its
   checksum-backed source tombstone is still awaiting cleanup.

Legitimate copies and replacements without matching move evidence continue to index normally.
A guarded cleanup retires only the checksum-matching marker for the replaced moved source. The
project, path, and expected checksum are predicates in one SQL `DELETE`, so a concurrent move that
refreshes the same marker remains protected. Marker refresh is likewise one SQLite/Postgres
`INSERT ... ON CONFLICT DO UPDATE`, so concurrent cleanup cannot make an accepted move roll back
with stale ORM state.
Successful current publication also retires any older marker for its destination in the same
transaction. Stale, failed, and version-superseded materializations leave markers untouched.
Startup recovery selects only checksum-backed vacates whose destination is already `synced` or
gone, then runs the same guarded cleanup before the initial project index. This lets a durable
marker recover cleanup work lost with the process without deleting the old source while it may
still be the only materialized copy.
Both API and MCP lifespans await the watch coordinator. The coordinator now waits on a finite
recovery barrier before reporting `RUNNING`; initial indexing and the watcher remain background
work after that barrier. This removes the startup-only path-reuse race without adding marker
generations or a second cleanup state machine.
For another local process sharing the same project, recovery conditionally locks the current
marker row and reloads the destination entity under `FOR UPDATE`. The transaction stays open
through checksum-guarded storage deletion and marker retirement. A committed move-back is observed
and cancels the stale cleanup; when recovery acquires the locks first, the competing move waits
until the old source is removed and then materializes the new canonical path.
For legacy null-checksum markers only, the gate falls back to requiring the source object to match
the moved entity's current content; a null-checksum marker whose entity has also been deleted is
not trusted.
When forced-full or an old path-only batch is processed with the safety sources wired, the checker
queries markers for DB-absent candidates first, loads current metadata only for marked paths, and
preserves unconditional reads for every non-orphan target.
When either safety source is absent, legacy behavior remains unchanged.

## Testing

### Automated

- `just fast-check`: passed (ruff fix/format and `ty check`; only existing Python 3.14 asyncio
  deprecation diagnostics).
- `BASIC_MEMORY_ENV=test LOGFIRE_IGNORE_NO_CONFIG=1 uv run pytest --no-cov -q tests/runtime/test_pending_note_materialization.py tests/runtime/test_previous_materialized_note_file_delete.py tests/indexing/test_file_index_checking.py tests/indexing/test_note_file_delete_runner.py tests/indexing/test_accepted_note_mutation_runner.py tests/indexing/test_accepted_note_write_runner.py tests/indexing/test_note_materialization_runner.py tests/repository/test_note_file_vacate_repository.py tests/cloud/test_note_content_materialization.py test-int/mcp/test_move_note_integration.py test-int/test_note_file_vacate_atomicity.py`:
  177 passed on SQLite and 177 passed on Postgres.
- Exact-head failed-write regressions: 5 accepted-move unit cases passed, plus 8 parameterized
  rename integration cases on SQLite and 8 on Postgres.
- Exact-head absence-safety scope: all 79 targeted planner, mutation-runner, and real MCP move
  tests passed on SQLite and all 79 passed on Postgres.
- Exact-head external-change regression: both observed and force-full `PUT` rename cases passed on
  SQLite and Postgres, and all 64 affected unit tests passed.
- Startup-recovery scope: all 75 touched tests passed on SQLite and all 75 passed on
  Postgres, including crash-before-destination, lost-enqueue-after-sync, and deleted-destination
  cleanup.
- Exact-head startup barrier: 23 initialization/coordinator/lifespan tests passed; the focused
  lost-cleanup recovery integration passed on SQLite and Postgres.
- Exact-head cross-process recovery: the current-cleanup and stale-move-back matrix passed twice
  on SQLite and twice on Postgres; 15 focused repository/recovery tests and `just fast-check`
  also passed.
- Exact-head source-observation regression: 43 focused planner/mutation tests passed; the
  unpublished and synchronized absent-source integration cases both passed on SQLite and
  Postgres; `just fast-check` passed.
- `just doctor`: passed.

### Integration Regression

The parameterized move test writes a note through MCP, reproduces a source object whose checksum
publisher has not completed, delays the real cleanup enqueue boundary, moves the note through MCP,
and runs both observed and `force_full=True` project indexing.

The parameterized `PUT` test creates and renames a note through the v2 API while also changing its
content, delays cleanup, and runs the same two indexing modes. It covers synchronized file state
and all four ambiguous publication states: pending or failed before the write leaves the old
published bytes in storage, a write whose checksum publication is stale leaves the newer accepted
bytes there, and `external_change_detected` restores the previously published bytes. The tests
assert that the marker carries the source checksum actually present, the entity keeps its identity,
and no entity is created at the lingering source path. The forced-full checksum source also has a
focused regression for a file that vanishes between metadata observation and checksum computation.

A third MCP regression deletes the destination while delayed source cleanup is still pending,
then runs observed and forced-full indexing. It asserts the checksum-backed marker survives either
a null or dangling destination ID and that the deleted note does not resurrect. A materialization
regression also covers the case-only alias path and asserts that its completed physical rename
clears the marker.

A fourth MCP regression removes the source before moving a note in both pending-publication and
fully synchronized DB states, then recreates byte-identical content at that path after the move.
It proves the absent source creates neither cleanup nor a marker, and that startup recovery
preserves the legitimate replacement on both SQLite and Postgres.

A fifth MCP regression overwrites the delayed source and exercises both normal guarded cleanup and
a crash before cleanup enqueue. In the crash variant, project indexing observes the different
bytes and checksum-conditionally retires the stale marker. Both variants index and delete the
replacement, recreate the original bytes, and prove the legitimate copy indexes on SQLite and
Postgres.

A sixth MCP regression loses cleanup for a move from A to B, changes the note, moves it back from B
to A, deletes it, restores A's original bytes, and runs a full index. It proves successful
destination publication retires A's older marker and that the legitimate reuse indexes on SQLite
and Postgres.

A seventh recovery regression leaves the destination in `writing` after a crash and proves the
startup sweep preserves the old source until materialization reaches `synced`, then deletes it and
retires the marker. A real MCP regression separately loses cleanup after destination publication
and proves the next startup converges the source, destination, and marker on SQLite and Postgres.

Two-session repository integration regressions exercise both race orderings: stale cleanup after a
refresh to checksum B cannot delete B, and cleanup attempting to retire checksum A cannot break or
roll back the concurrent refresh to B. Both run against SQLite and Postgres.

## Risks / Follow-ups

- This adds one per-project table and runs a migration across existing databases. Its nullable
  entity foreign key uses `ON DELETE SET NULL` so cleanup evidence survives destination deletion.
- Forced-full batches with the gate wired perform marker lookups for DB-absent candidates and
  metadata checksum reads only for the marked subset.
- Path-changing writes perform one source checksum read during acceptance for every publication
  state; this prevents stale synchronized DB state from claiming cleanup for an absent local file.
- The cloud webhook indexer must pass the marker/entity sources and clear markers after cloud
  cleanup before the protection is active there.
- The bulk `batch_indexer` mint site can adopt the same guard.
