### PR TITLE
docs(mcp): add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![MCP Toplist](https://mcptoplist.com/badge/io.github.basicmachines-co%2Fbasic-memory.svg)](https://mcptoplist.com/server/io.github.basicmachines-co%2Fbasic-memory)
+
 <!-- mcp-name: io.github.basicmachines-co/basic-memory -->
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![PyPI version](https://badge.fury.io/py/basic-memory.svg)](https://badge.fury.io/py/basic-memory)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
+<!-- mcp-name: io.github.basicmachines-co/basic-memory -->
 [![MCP Toplist](https://mcptoplist.com/badge/io.github.basicmachines-co%2Fbasic-memory.svg)](https://mcptoplist.com/server/io.github.basicmachines-co%2Fbasic-memory)
 
-<!-- mcp-name: io.github.basicmachines-co/basic-memory -->
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![PyPI version](https://badge.fury.io/py/basic-memory.svg)](https://badge.fury.io/py/basic-memory)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)


### PR DESCRIPTION
## Why

Basic Memory is ranked on MCP Toplist, and surfacing the live rank in the README gives visitors a quick link to that listing. This reimplements #1150 on a maintainer-owned branch.

## What Changed

- Added the MCP Toplist badge at the top of `README.md`.
- Linked the badge to Basic Memory's MCP Toplist server page.

## Implementation Details

The badge uses Basic Memory's canonical MCP Registry name, `io.github.basicmachines-co/basic-memory`, with the slash URL-encoded for the badge endpoint. The change is intentionally limited to the README.

## Testing

### Automated

- `git diff --check`: passed

### Manual

- Requested the badge SVG URL: HTTP 200
- Requested the linked MCP Toplist server page: HTTP 200

## Risks / Follow-ups

- The badge depends on MCP Toplist remaining available and continuing to serve this identifier.
- No code or package behavior changes.