### PR TITLE
fix(core): give the move-orphan gate a content-checksum source

### DIFF
--- a/src/basic_memory/indexing/file_index_checking.py
+++ b/src/basic_memory/indexing/file_index_checking.py
@@ -310,6 +310,14 @@ class FileIndexChecker:
     # ghost from a legitimate byte-identical copy (which has no marker and stays a new file).
     moved_entity_source: MovedEntitySource | None = None
     move_vacate_source: MoveVacateSource | None = None
+    # The move-vacate marker stores the moved note's *content* checksum. When storage freshness
+    # keys on a different checksum domain than note content (e.g. cloud indexes by S3 ETag but
+    # note content is SHA-256), the gate must compare the marker against the current object's
+    # content checksum, not the freshness checksum, or the marker never matches and every orphan
+    # is either ignored or wrongly retired (basic-memory-cloud#1601). Left unset when the two
+    # domains coincide (local uses one SHA-256 checksum everywhere), in which case the gate falls
+    # back to the freshness `current_checksum` and behavior is unchanged.
+    move_orphan_checksum_source: CurrentFileChecksumSource | None = None
 
     async def detect(self, targets: Sequence[FileIndexTarget]) -> FileIndexPlan:
         """Return the file paths whose current storage object still needs indexing."""
@@ -431,12 +439,23 @@ class FileIndexChecker:
                 [item.target.path for _, item in candidates]
             )
         )
-        gated_candidates: list[tuple[int, _InspectedTarget, MoveVacateMarker]] = []
+        # The marker records the moved note's content checksum. Compare it against the object's
+        # content checksum (from move_orphan_checksum_source when the freshness domain differs),
+        # falling back to the freshness checksum when the two domains coincide. The moved-entity
+        # checksum below stays in the freshness/entity domain, so gap-(a) keeps using current.
+        gated_candidates: list[
+            tuple[int, _InspectedTarget, MoveVacateMarker, FileIndexChecksum | None]
+        ] = []
         for index, item in candidates:
             marker = markers.get(item.target.path)
             if marker is None:
                 continue
-            if marker.checksum is not None and marker.checksum != item.current_checksum:
+            content_checksum = (
+                await self.move_orphan_checksum_source.load_current_file_checksum(item.target.path)
+                if self.move_orphan_checksum_source is not None
+                else item.current_checksum
+            )
+            if marker.checksum is not None and marker.checksum != content_checksum:
                 # Trigger: a different source object now occupies the vacated path.
                 # Why: even if the process died before cleanup was enqueued, the moved bytes are
                 # gone and their marker must not suppress a later legitimate reuse of those bytes.
@@ -447,17 +466,17 @@ class FileIndexChecker:
                     marker.checksum,
                 )
                 continue
-            gated_candidates.append((index, item, marker))
+            gated_candidates.append((index, item, marker, content_checksum))
 
         marked_entity_ids = [
-            marker.entity_id for _, _, marker in gated_candidates if marker.entity_id is not None
+            marker.entity_id for _, _, marker, _ in gated_candidates if marker.entity_id is not None
         ]
         entity_facts = (
             await self.moved_entity_source.load_entity_facts_by_id(marked_entity_ids)
             if marked_entity_ids
             else {}
         )
-        for index, item, marker in gated_candidates:
+        for index, item, marker, content_checksum in gated_candidates:
             moved_entity = (
                 entity_facts.get(marker.entity_id) if marker.entity_id is not None else None
             )
@@ -467,7 +486,7 @@ class FileIndexChecker:
                 # transactionally recorded source checksum proves both forms are tombstones for
                 # these exact bytes; keep suppressing resurrection until guarded cleanup clears
                 # the marker. Without that checksum proof, the file remains a normal create.
-                if marker.checksum is None or marker.checksum != item.current_checksum:
+                if marker.checksum is None or marker.checksum != content_checksum:
                     continue
                 decisions[index] = move_orphan_file_index_decision(
                     item.target.path,
@@ -481,6 +500,7 @@ class FileIndexChecker:
             if marker.checksum is None and moved_entity.checksum != item.current_checksum:
                 # Source checksum was unknown at move time (gap (a)): fall back to confirming the
                 # object is the moved entity's current content before treating it as the leftover.
+                # Both sides are the entity/freshness domain, so this uses current, not content.
                 continue
             decisions[index] = move_orphan_file_index_decision(
                 item.target.path, indexed_at=moved_entity.file_path

--- a/tests/indexing/test_file_index_checking.py
+++ b/tests/indexing/test_file_index_checking.py
@@ -432,6 +432,44 @@ async def test_checker_skips_leftover_source_of_a_move() -> None:
 
 
 @pytest.mark.asyncio
+async def test_checker_gate_uses_content_checksum_source_when_domains_differ() -> None:
+    """The gate compares the marker against a distinct content-checksum source when set (#1601).
+
+    Cloud freshness keys on the S3 ETag while note content (and the marker) use a SHA-256 content
+    checksum. With move_orphan_checksum_source wired, the gate must compare the marker against the
+    content checksum, not the ETag freshness checksum — otherwise the marker never matches and the
+    leftover source is wrongly retired and re-indexed as a ghost.
+    """
+    content_source = StubCurrentChecksumSource({"koncept/note.md": "sha-content"})
+    moved = StubMovedEntitySource(
+        facts_by_id={42: MovedEntityFacts(file_path="arkiv/note.md", checksum="etag-freshness")}
+    )
+    vacate = StubMoveVacateSource(
+        markers={"koncept/note.md": MoveVacateMarker(entity_id=42, checksum="sha-content")}
+    )
+    checker = FileIndexChecker(
+        indexed_checksum_source=StubIndexedChecksumSource({}),
+        # Freshness domain (ETag) differs from the marker's content checksum on purpose.
+        current_checksum_source=StubCurrentChecksumSource({"koncept/note.md": "etag-freshness"}),
+        moved_entity_source=moved,
+        move_vacate_source=vacate,
+        move_orphan_checksum_source=content_source,
+    )
+
+    plan = await checker.detect(
+        [FileIndexTarget(path="koncept/note.md", observed_checksum="etag-freshness")]
+    )
+
+    assert plan.paths_to_read == ()
+    assert [(d.path, d.status) for d in plan.decisions] == [
+        ("koncept/note.md", FileIndexDecisionStatus.current),
+    ]
+    # The gate consulted the content source and did NOT retire the marker on a domain mismatch.
+    assert content_source.requested_paths == ["koncept/note.md"]
+    assert vacate.clear_calls == []
+
+
+@pytest.mark.asyncio
 async def test_checker_indexes_replacement_note_at_a_vacated_path() -> None:
     """A vacated path overwritten with a DIFFERENT note's bytes is a legit replacement, not a ghost.
 


### PR DESCRIPTION
## Summary

The move-vacate gate added in #1152 (basic-memory-cloud#1601) compares a path's vacate marker against the current object's checksum using the checker's single `current_checksum_source`. That same source drives the **freshness** decision, so it is effectively locked to whatever checksum domain the store indexes by.

- **Local**: one SHA-256 content checksum is used everywhere (freshness, index, note content, marker), so the gate works.
- **Basic Memory Cloud**: the S3 index pipeline keys on the object **ETag**, but note content (and therefore the vacate marker, recorded from the note's source checksum) is **SHA-256**. These are different domains, and a single marker value cannot satisfy both the gate (compared against the ETag freshness checksum) and the delete-guard/clear lifecycle (SHA-256). The result is that the gate never matches a real orphan and instead **retires the marker and re-imports the ghost** — i.e. the fix is inert in cloud.

## Change

Add an optional `move_orphan_checksum_source: CurrentFileChecksumSource | None = None` to `FileIndexChecker`, used **only** for the marker comparison in `_apply_move_orphan_gate` (the retire and tombstone paths). When it is `None` the gate falls back to `current_checksum`, so behavior is **unchanged for local and any single-domain store**. The gap-(a) moved-entity comparison keeps using `current_checksum` because both sides are the entity/freshness domain.

Cloud will pass a SHA-256 (`bm-file-checksum` object metadata) source here.

## Risk

Backward-compatible and opt-in: the new field defaults to `None`. No existing caller passes it, so local indexing is byte-for-byte unchanged (verified: the 22 existing checker tests pass untouched).

## Testing

`ty` + `ruff` clean. Added `test_checker_gate_uses_content_checksum_source_when_domains_differ`: with a freshness checksum (ETag) deliberately different from the marker's content checksum, the gate consults the content source, suppresses the leftover, and does **not** retire the marker. 23 checker tests pass.

Companion: basic-memory-cloud#1613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)