### PR TITLE
fix(core): refresh pending relations from accepted content

### DIFF
--- a/src/basic_memory/deps/services.py
+++ b/src/basic_memory/deps/services.py
@@ -41,6 +41,7 @@ from basic_memory.index.local_notes import (
     LocalDirectoryDeleteRelationCleanupRefresher,
     LocalDirectoryFileDeleteEnqueuer,
 )
+from basic_memory.repository import NoteContentRepository
 from basic_memory.repository.accepted_note_repositories import AcceptedNoteRepositories
 from basic_memory.repository.search_repository import create_search_repository
 from basic_memory.index.local_project import (
@@ -429,10 +430,14 @@ async def get_relation_resolution_scheduler(
 ) -> RelationResolutionScheduler:
     # Build the project-scoped resolution runtime. It owns its own sessions via
     # session_maker, so it is safe to run from a detached background task.
+    project_id = entity_repository.project_id
+    if project_id is None:
+        raise RuntimeError("Relation resolution requires a project-scoped entity repository")
     runtime = RepositoryRelationResolutionRuntime(
         session_maker=session_maker,
         relation_repository=relation_repository,
         entity_repository=entity_repository,
+        note_content_repository=NoteContentRepository(project_id=project_id),
         link_resolver=link_resolver,
         entity_indexer=search_service,
     )

--- a/src/basic_memory/index/local_project.py
+++ b/src/basic_memory/index/local_project.py
@@ -80,6 +80,7 @@ from basic_memory.indexing.relation_resolution import (
     resolve_project_index_completion_relations,
 )
 from basic_memory.models import Entity, Project
+from basic_memory.repository import NoteContentRepository
 from basic_memory.runtime.jobs import (
     RuntimeIndexFileBatchJobRequest,
     RuntimeJobId,
@@ -649,6 +650,7 @@ class LocalProjectIndexRuntimeFactory:
                 session_maker=dependencies.session_maker,
                 relation_repository=dependencies.relation_repository,
                 entity_repository=dependencies.entity_repository,
+                note_content_repository=NoteContentRepository(project_id=dependencies.project_id),
                 link_resolver=dependencies.link_resolver,
                 entity_indexer=dependencies.search_service,
             ),

--- a/src/basic_memory/index/local_runtime.py
+++ b/src/basic_memory/index/local_runtime.py
@@ -57,6 +57,7 @@ from basic_memory.indexing.external_file_delete_runner import (
     RepositoryExternalFileDeleteEntities,
 )
 from basic_memory.models import Entity, Project
+from basic_memory.repository import NoteContentRepository
 from basic_memory.runtime.projects import ProjectRuntimeReference
 from basic_memory.runtime.storage import (
     ProjectPath,
@@ -313,6 +314,9 @@ class LocalWatchEventIndexRuntimeFactory:
                     session_maker=dependencies.session_maker,
                     relation_repository=dependencies.relation_repository,
                     entity_repository=dependencies.entity_repository,
+                    note_content_repository=NoteContentRepository(
+                        project_id=dependencies.project_id
+                    ),
                     link_resolver=dependencies.link_resolver,
                     entity_indexer=dependencies.search_service,
                 ),

--- a/src/basic_memory/indexing/relation_resolution.py
+++ b/src/basic_memory/indexing/relation_resolution.py
@@ -12,13 +12,14 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory import db
+from basic_memory.indexing.accepted_note_search import accepted_search_content_from_markdown
 from basic_memory.indexing.models import IndexFileJobStatus
-from basic_memory.services.exceptions import AmbiguousIdentifierError
 from basic_memory.models import Entity
 from basic_memory.repository.relation_repository import (
     ResolvedRelationWrite,
     ResolvedRelationWriteResult,
 )
+from basic_memory.services.exceptions import AmbiguousIdentifierError
 
 type EntityId = int
 type AffectedEntityIds = set[EntityId]
@@ -93,6 +94,25 @@ class BatchRelationResolutionEntityRepository(Protocol):
         """Return source entities by database id."""
 
 
+class RelationResolutionNoteContent(Protocol):
+    """Accepted note-content fields needed for a state-aware search refresh."""
+
+    entity_id: EntityId
+    markdown_content: str
+    file_write_status: str
+
+
+class BatchRelationResolutionNoteContentRepository(Protocol):
+    """Repository capability for loading accepted content for affected sources."""
+
+    async def find_by_ids(
+        self,
+        session: AsyncSession,
+        ids: list[EntityId],
+    ) -> Sequence[RelationResolutionNoteContent]:
+        """Return accepted note content by source entity id."""
+
+
 class RelationResolutionLinkResolver(Protocol):
     """Capability for resolving a relation target by link text."""
 
@@ -116,8 +136,24 @@ class RelationResolutionEntityIndexer(Protocol):
 class BatchRelationResolutionEntityIndexer(Protocol):
     """Capability for refreshing a batch of derived entity search rows."""
 
-    async def index_entities(self, entities: Sequence[Entity]) -> None:
+    async def index_entities(
+        self,
+        entities: Sequence[Entity],
+        *,
+        content_by_entity_id: Mapping[EntityId, str],
+    ) -> None:
         """Refresh derived index rows for a group of entities."""
+
+
+def accepted_search_content_for_pending_notes(
+    note_contents: Sequence[RelationResolutionNoteContent],
+) -> dict[EntityId, str]:
+    """Return accepted search content while Markdown projections are not synchronized."""
+    return {
+        note_content.entity_id: accepted_search_content_from_markdown(note_content.markdown_content)
+        for note_content in note_contents
+        if note_content.file_write_status != "synced"
+    }
 
 
 @dataclass(frozen=True, slots=True)
@@ -127,6 +163,7 @@ class RepositoryRelationResolutionRuntime:
     session_maker: async_sessionmaker[AsyncSession]
     relation_repository: RelationResolutionRelationRepository
     entity_repository: BatchRelationResolutionEntityRepository
+    note_content_repository: BatchRelationResolutionNoteContentRepository
     link_resolver: RelationResolutionLinkResolver
     entity_indexer: BatchRelationResolutionEntityIndexer
 
@@ -217,13 +254,25 @@ class RepositoryRelationResolutionRuntime:
                 )
 
         if affected_entity_ids:
+            sorted_affected_entity_ids = sorted(affected_entity_ids)
             async with db.scoped_session(self.session_maker) as session:
                 source_entities = await self.entity_repository.find_by_ids(
                     session,
-                    sorted(affected_entity_ids),
+                    sorted_affected_entity_ids,
                 )
+                note_contents = await self.note_content_repository.find_by_ids(
+                    session,
+                    sorted_affected_entity_ids,
+                )
+
+            # Trigger: an accepted note has not reached a synchronized Markdown projection.
+            # Why: relation repair must refresh its search row without racing the async file
+            # materializer, while synchronized notes still need missing files to surface.
+            # Outcome: pending sources use accepted DB content; all others retain disk fallback.
+            content_by_entity_id = accepted_search_content_for_pending_notes(note_contents)
             await self.entity_indexer.index_entities(
-                sorted(source_entities, key=lambda entity: entity.id)
+                sorted(source_entities, key=lambda entity: entity.id),
+                content_by_entity_id=content_by_entity_id,
             )
 
         return affected_entity_ids

--- a/src/basic_memory/services/composition.py
+++ b/src/basic_memory/services/composition.py
@@ -12,6 +12,7 @@ from basic_memory.indexing.relation_resolution import RepositoryRelationResoluti
 from basic_memory.markdown import EntityParser
 from basic_memory.repository import (
     EntityRepository,
+    NoteContentRepository,
     ObservationRepository,
     ProjectRepository,
     RelationRepository,
@@ -164,6 +165,7 @@ def build_default_project_runtime_bundle(
         session_maker=session_maker,
         relation_repository=relation_resolution_repository,
         entity_repository=entity_repository,
+        note_content_repository=NoteContentRepository(project_id=project_id),
         link_resolver=link_resolver,
         entity_indexer=search_service,
     )

--- a/src/basic_memory/services/search_service.py
+++ b/src/basic_memory/services/search_service.py
@@ -3,7 +3,7 @@
 import asyncio
 import ast
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, List, Optional, Set, Dict
@@ -398,15 +398,25 @@ class SearchService:
         else:
             await self.index_entity_data(entity, content)
 
-    async def index_entities(self, entities: Sequence[Entity]) -> None:
+    async def index_entities(
+        self,
+        entities: Sequence[Entity],
+        *,
+        content_by_entity_id: Mapping[int, str],
+    ) -> None:
         """Refresh a group of entity search rows through one batch entry point.
 
         Index writes stay sequential because local SQLite connections cannot
         safely run these mutations concurrently. Callers still avoid reopening
         repository sessions and dispatching one indexing API call per entity.
+        Accepted content bypasses the disk read while its Markdown projection
+        remains pending.
         """
         for entity in entities:
-            await self.index_entity_data(entity)
+            await self.index_entity_data(
+                entity,
+                content=content_by_entity_id.get(entity.id),
+            )
 
     async def index_entity_data(
         self,

--- a/tests/index/test_local_project_index.py
+++ b/tests/index/test_local_project_index.py
@@ -60,7 +60,10 @@ from basic_memory.indexing.relation_resolution import (
 )
 from basic_memory.models import Entity, Project, Relation
 from basic_memory.repository import EntityRepository
-from basic_memory.repository.note_content_repository import NoteContentRepository
+from basic_memory.repository.note_content_repository import (
+    AcceptedNoteContentWrite,
+    NoteContentRepository,
+)
 from basic_memory.repository.relation_repository import (
     ResolvedRelationWrite,
     ResolvedRelationWriteResult,
@@ -1712,6 +1715,110 @@ permalink: concept/entity-c
     assert {row.to_id for row in relation_search_rows} == {entity_a.id, entity_b.id, entity_c.id}
 
 
+async def test_local_relation_resolution_refreshes_pending_source_without_markdown_file(
+    test_project: Project,
+    project_config,
+    entity_repository,
+    session_maker: async_sessionmaker[AsyncSession],
+    search_service,
+    config_manager,
+    monkeypatch,
+) -> None:
+    """Accepted content keeps relation repair independent of async file materialization."""
+    del config_manager
+
+    source_path = project_config.home / "pending-source.md"
+    source_path.write_text(
+        "# Pending Source\n\n- relates_to [[Pending Target]]\n",
+        encoding="utf-8",
+    )
+    initial = await run_local_project_index_for_project(
+        test_project,
+        runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+        force_full=True,
+    )
+    assert initial.enqueued_files == 1
+
+    accepted_markdown = (
+        source_path.read_text(encoding="utf-8")
+        + "\nAccepted search content before materialization.\n"
+    )
+    accepted_checksum = sha256(accepted_markdown.encode("utf-8")).hexdigest()
+    accepted_at = datetime.now(timezone.utc)
+    note_content_repository = NoteContentRepository(test_project.id)
+
+    async with db.scoped_session(session_maker) as session:
+        source = await entity_repository.get_by_file_path(session, "pending-source.md")
+        assert source is not None
+        current_note_content = await note_content_repository.get_by_entity_id(
+            session,
+            source.id,
+        )
+        assert current_note_content is not None
+
+        target = await entity_repository.add(
+            session,
+            Entity(
+                permalink=f"{test_project.permalink}/pending-target",
+                title="Pending Target",
+                note_type="note",
+                file_path="pending-target.md",
+                checksum="target-checksum",
+                content_type="text/markdown",
+                created_at=accepted_at,
+                updated_at=accepted_at,
+            ),
+        )
+        await entity_repository.update(
+            session,
+            source.id,
+            {
+                "checksum": accepted_checksum,
+                "updated_at": accepted_at,
+            },
+        )
+        await note_content_repository.accept_write(
+            session,
+            AcceptedNoteContentWrite(
+                entity_id=source.id,
+                markdown_content=accepted_markdown,
+                db_version=current_note_content.db_version + 1,
+                db_checksum=accepted_checksum,
+                last_source="test",
+                updated_at=accepted_at,
+            ),
+        )
+        source_id = source.id
+        target_id = target.id
+
+    # The accepted database state is durable, but its Markdown projection is
+    # intentionally absent when relation resolution refreshes the source.
+    source_path.unlink()
+    runtime = await LocalProjectIndexRuntimeFactory().runtime_for_project(test_project)
+    assert isinstance(runtime.completion_relation_runtime, RepositoryRelationResolutionRuntime)
+
+    affected = await runtime.completion_relation_runtime.resolve_relations()
+
+    assert affected == {source_id}
+    search_results = await search_service.search(
+        SearchQuery(text="Accepted search content before materialization")
+    )
+    assert [result.entity_id for result in search_results] == [source_id]
+
+    async with db.scoped_session(session_maker) as session:
+        resolved_source = await entity_repository.find_by_id(session, source_id)
+        relation_search_rows = await search_service.repository.search(
+            search_item_types=[SearchItemType.RELATION],
+            session=session,
+        )
+
+    assert resolved_source is not None
+    assert [relation.to_id for relation in resolved_source.outgoing_relations] == [target_id]
+    source_relation_rows = [row for row in relation_search_rows if row.entity_id == source_id]
+    assert len(source_relation_rows) == 1
+    assert source_relation_rows[0].to_id == target_id
+
+
 async def test_local_project_index_deduplicates_relations_by_type(
     test_project: Project,
     project_config,
@@ -2449,7 +2556,12 @@ class RuntimeFactorySearchIndex:
     async def index_entity(self, entity: Entity) -> None:
         return None
 
-    async def index_entities(self, entities: Sequence[Entity]) -> None:
+    async def index_entities(
+        self,
+        entities: Sequence[Entity],
+        *,
+        content_by_entity_id: Mapping[int, str],
+    ) -> None:
         return None
 
     async def sync_entity_vectors_batch(

--- a/tests/indexing/test_relation_resolution.py
+++ b/tests/indexing/test_relation_resolution.py
@@ -1,6 +1,6 @@
 """Tests for portable relation resolution orchestration."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import FrozenInstanceError, dataclass
 from datetime import timedelta
 from typing import cast
@@ -152,6 +152,30 @@ class StubEntityRepository:
         return [self.entities[entity_id] for entity_id in ids if entity_id in self.entities]
 
 
+@dataclass(slots=True)
+class FakeNoteContent:
+    entity_id: int
+    markdown_content: str
+    file_write_status: str
+
+
+class StubNoteContentRepository:
+    def __init__(self, note_contents: Sequence[FakeNoteContent]) -> None:
+        self.note_contents = {
+            note_content.entity_id: note_content for note_content in note_contents
+        }
+
+    async def find_by_ids(
+        self,
+        session: AsyncSession,
+        ids: list[int],
+    ) -> list[FakeNoteContent]:
+        assert isinstance(session, FakeSession)
+        return [
+            self.note_contents[entity_id] for entity_id in ids if entity_id in self.note_contents
+        ]
+
+
 class StubLinkResolver:
     def __init__(self, targets: dict[str, FakeResolvedEntity]) -> None:
         self.targets = targets
@@ -173,24 +197,53 @@ class StubEntityIndexer:
     def __init__(self) -> None:
         self.indexed_entities: list[Entity] = []
         self.indexed_batches: list[tuple[Entity, ...]] = []
+        self.indexed_content_batches: list[dict[int, str]] = []
 
     async def index_entity(self, entity: Entity) -> None:
         self.indexed_entities.append(entity)
 
-    async def index_entities(self, entities: Sequence[Entity]) -> None:
+    async def index_entities(
+        self,
+        entities: Sequence[Entity],
+        *,
+        content_by_entity_id: Mapping[int, str],
+    ) -> None:
         self.indexed_batches.append(tuple(entities))
+        self.indexed_content_batches.append(dict(content_by_entity_id))
         self.indexed_entities.extend(entities)
+
+
+class MissingFileEntityIndexer(StubEntityIndexer):
+    """Model SearchService's disk fallback for entities without accepted content."""
+
+    async def index_entities(
+        self,
+        entities: Sequence[Entity],
+        *,
+        content_by_entity_id: Mapping[int, str],
+    ) -> None:
+        missing_entity_ids = [
+            entity.id for entity in entities if entity.id not in content_by_entity_id
+        ]
+        if missing_entity_ids:
+            raise FileNotFoundError(f"Missing Markdown for entities {missing_entity_ids}")
+        await super().index_entities(
+            entities,
+            content_by_entity_id=content_by_entity_id,
+        )
 
 
 def build_repository_runtime(
     relation_repository: StubRelationRepository,
     link_resolver: StubLinkResolver,
     entity_indexer: StubEntityIndexer,
+    note_contents: Sequence[FakeNoteContent] = (),
 ) -> RepositoryRelationResolutionRuntime:
     return RepositoryRelationResolutionRuntime(
         session_maker=cast(async_sessionmaker[AsyncSession], FakeSession),
         relation_repository=relation_repository,
         entity_repository=StubEntityRepository(),
+        note_content_repository=StubNoteContentRepository(note_contents),
         link_resolver=link_resolver,
         entity_indexer=entity_indexer,
     )
@@ -495,6 +548,53 @@ async def test_repository_runtime_batches_resolution_and_entity_refresh_sessions
         )
     ]
     assert FakeSession.created_count == 2
+
+
+@pytest.mark.asyncio
+async def test_repository_runtime_refreshes_pending_source_from_accepted_content() -> None:
+    repo = StubRelationRepository([[FakeRelation(id=1, from_id=10, to_name="Target A")]])
+    entity_indexer = MissingFileEntityIndexer()
+    runtime = build_repository_runtime(
+        relation_repository=repo,
+        link_resolver=StubLinkResolver({"Target A": FakeResolvedEntity(id=20, title="Target A")}),
+        entity_indexer=entity_indexer,
+        note_contents=[
+            FakeNoteContent(
+                entity_id=10,
+                markdown_content=(
+                    "---\ntitle: Source A\n---\n\n# Source A\n\nAccepted before materialization."
+                ),
+                file_write_status="pending",
+            )
+        ],
+    )
+
+    affected = await runtime.resolve_relations()
+
+    assert affected == {10}
+    assert entity_indexer.indexed_content_batches == [
+        {10: "# Source A\n\nAccepted before materialization."}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_repository_runtime_preserves_missing_file_error_for_synced_source() -> None:
+    repo = StubRelationRepository([[FakeRelation(id=1, from_id=10, to_name="Target A")]])
+    runtime = build_repository_runtime(
+        relation_repository=repo,
+        link_resolver=StubLinkResolver({"Target A": FakeResolvedEntity(id=20, title="Target A")}),
+        entity_indexer=MissingFileEntityIndexer(),
+        note_contents=[
+            FakeNoteContent(
+                entity_id=10,
+                markdown_content="# Source A\n\nAlready materialized.",
+                file_write_status="synced",
+            )
+        ],
+    )
+
+    with pytest.raises(FileNotFoundError, match=r"entities \[10\]"):
+        await runtime.resolve_relations()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

An accepted `write_note` can schedule relation resolution before its Markdown
projection has been materialized. Relation resolution then refreshes affected
source search rows through a disk-backed path and raises `FileNotFoundError`
during a valid accepted-but-pending state.

This fixes #1159 without moving materialization back onto the request path, so
durable write acceptance keeps its current performance characteristics.

## What Changed

- Load accepted `NoteContent` alongside source entities after relation targets
  are resolved.
- Refresh non-synchronized sources from their accepted Markdown content.
- Keep synchronized and legacy sources on the existing disk-backed refresh
  path so genuine missing-file inconsistencies still surface.
- Wire project-scoped `NoteContentRepository` instances into every shared and
  local relation-resolution composition root.
- Add unit and end-to-end SQLite regressions for both sides of the state
  boundary.

## Implementation Details

`RepositoryRelationResolutionRuntime` performs one additional batch
`NoteContent` lookup only when relation resolution changed source entities.
Rows whose `file_write_status` is not `synced` are converted through
`accepted_search_content_from_markdown()` and passed to
`SearchService.index_entities()` as an explicit per-entity content mapping.

An entity absent from that mapping keeps the existing `content=None` behavior,
which reads the Markdown projection from disk. This avoids broadly swallowing
`FileNotFoundError` and preserves detection of real projection inconsistencies.
Materialization remains asynchronous and off the acceptance path.

## Testing

### Automated

- `source .venv/bin/activate && just fast-check`: passed; reported nine existing
  Python 3.14 asyncio deprecation warnings.
- `source .venv/bin/activate && BASIC_MEMORY_ENV=test LOGFIRE_IGNORE_NO_CONFIG=1 pytest -q tests/index/test_local_project_index.py`:
  44 passed.
- `source .venv/bin/activate && BASIC_MEMORY_ENV=test LOGFIRE_IGNORE_NO_CONFIG=1 pytest -q tests/indexing/test_relation_resolution.py tests/services/test_project_service_composition.py tests/index/test_local_schedulers.py`:
  30 passed.
- `just doctor`: passed the end-to-end file, database, and search loop.
- `git diff --check`: passed.

### Manual

- Reproduced the pre-fix interleaving with an accepted source whose Markdown
  file did not yet exist.
- Verified the regression refreshes accepted searchable content and resolved
  relation metadata while preserving the synchronized-source missing-file
  failure.

## Risks / Follow-ups

- The refresh adds one project-scoped batch `NoteContent` read only when
  relations changed.
- Basic Memory Cloud should consume the fixed Core revision and add hosted
  lifecycle coverage; it does not need duplicate production policy.
- The full 4,985-test suite was not completed locally; CI provides the broader
  SQLite/Postgres matrix.
