### PR TITLE
refactor(core): simplify v0.23 runtime protocols

### DIFF
--- a/.codex/basic-memory.json
+++ b/.codex/basic-memory.json
@@ -1,0 +1,6 @@
+{
+  "basicMemory": {
+    "sessionProfile": "coding",
+    "repository": "basicmachines-co/basic-memory"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ ENV/
 *.swp
 *.swo
 
+# Codex project metadata; all runtime state and nested worktrees stay local.
+/.codex/*
+!/.codex/basic-memory.json
+
 # macOS
 .DS_Store
 .coverage.*

--- a/src/basic_memory/cli/commands/cloud/rclone_commands.py
+++ b/src/basic_memory/cli/commands/cloud/rclone_commands.py
@@ -42,9 +42,14 @@ TIGRIS_CONSISTENCY_HEADERS = [
 
 
 class RunResult(Protocol):
-    returncode: int
-    stdout: str
-    stderr: str
+    @property
+    def returncode(self) -> int: ...
+
+    @property
+    def stdout(self) -> str: ...
+
+    @property
+    def stderr(self) -> str: ...
 
 
 RunFunc = Callable[..., RunResult]

--- a/src/basic_memory/index/local_dependencies.py
+++ b/src/basic_memory/index/local_dependencies.py
@@ -16,7 +16,6 @@ from basic_memory import db
 from basic_memory.config import BasicMemoryConfig, ConfigManager
 from basic_memory.file_utils import FileMetadata, ParseError, compute_checksum, remove_frontmatter
 from basic_memory.indexing.batch_indexer import BatchIndexer
-from basic_memory.indexing.embedding_index_planning import EmbeddingIndexBatchSummary
 from basic_memory.indexing.file_batch_runner import IndexFileBatchIndexer
 from basic_memory.indexing.file_index_checking import (
     IndexedFileChecksumRepository,
@@ -70,6 +69,7 @@ from basic_memory.repository.accepted_note_vector_cleanup import (
 )
 from basic_memory.repository.search_repository import create_search_repository
 from basic_memory.runtime.storage import ProjectId, RuntimeFilePath
+from basic_memory.runtime.vector_sync import VectorSyncBatchResult
 from basic_memory.services import EntityService, FileService
 from basic_memory.services.exceptions import FileOperationError
 from basic_memory.services.link_resolver import LinkResolver
@@ -123,7 +123,8 @@ class LocalIndexEntityRepository(
 ):
     """Entity repository capabilities needed by local event/project indexing."""
 
-    project_id: ProjectId | None
+    @property
+    def project_id(self) -> ProjectId | None: ...
 
     def select(self, *entities: Any) -> Select:
         """Project-scoped SELECT builder used for stat-only watermark scans."""
@@ -180,13 +181,14 @@ class LocalIndexSearchService(
     async def sync_entity_vectors_batch(
         self,
         entity_ids: list[int],
-    ) -> EmbeddingIndexBatchSummary: ...
+    ) -> VectorSyncBatchResult: ...
 
 
 class LocalIndexEntityService(Protocol):
     """Entity service capabilities needed by local index maintenance adapters."""
 
-    app_config: BasicMemoryConfig | None
+    @property
+    def app_config(self) -> BasicMemoryConfig | None: ...
 
     async def resolve_permalink(
         self,

--- a/src/basic_memory/index/local_notes.py
+++ b/src/basic_memory/index/local_notes.py
@@ -92,8 +92,11 @@ LocalAcceptedNoteRepositories = AcceptedNoteRepositories
 class LocalCurrentNoteEntity(Protocol):
     """Entity fields needed to refresh current markdown before route mutation."""
 
-    file_path: str
-    content_type: str
+    @property
+    def file_path(self) -> str: ...
+
+    @property
+    def content_type(self) -> str: ...
 
 
 class LocalCurrentNoteEntityRepository(Protocol):

--- a/src/basic_memory/index/local_project.py
+++ b/src/basic_memory/index/local_project.py
@@ -47,7 +47,6 @@ from basic_memory.indexing.file_index_checking import (
     RepositoryIndexedFileChecksumSource,
     RepositoryMovedEntitySource,
     RepositoryMoveVacateSource,
-    StorageCurrentFileChecksumSource,
 )
 from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
 from basic_memory.indexing.models import (
@@ -463,13 +462,7 @@ LocalProjectIndexObservation = ProjectIndexObservation
 
 
 class LocalProjectIndexRuntimeProvider(Protocol):
-    """Minimal factory shape needed to run a local project-index request.
-
-    A structural seam so callers in higher layers (e.g. services/initialization,
-    which declares its own matching InitialProjectIndexRuntimeFactory Protocol)
-    can supply a runtime factory without importing the concrete
-    LocalProjectIndexRuntimeFactory from this module.
-    """
+    """Minimal factory shape needed to run a local project-index request."""
 
     async def runtime_for_project(self, project: Project) -> LocalProjectIndexRuntime: ...
 
@@ -589,9 +582,7 @@ class LocalProjectIndexRuntimeFactory:
                 session_maker=dependencies.session_maker,
                 entity_repository=dependencies.entity_repository,
             ),
-            current_checksum_source=StorageCurrentFileChecksumSource(
-                metadata_source=metadata_source,
-            ),
+            current_checksum_source=metadata_source,
             moved_entity_source=RepositoryMovedEntitySource(
                 session_maker=dependencies.session_maker,
                 entity_repository=dependencies.entity_repository,

--- a/src/basic_memory/index/local_runtime.py
+++ b/src/basic_memory/index/local_runtime.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from loguru import logger
 
+from basic_memory.file_utils import FileError
 from basic_memory.index.inline_operations import (
     InlineStorageEventIndexRuntime,
     InlineStorageEventOperationProcessor,
@@ -32,7 +33,6 @@ from basic_memory.indexing.file_index_checking import (
     RepositoryIndexedFileChecksumSource,
     RepositoryMovedEntitySource,
     RepositoryMoveVacateSource,
-    StorageCurrentFileChecksumSource,
 )
 from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
 from basic_memory.indexing.index_file_runner import (
@@ -66,6 +66,7 @@ from basic_memory.runtime.storage import (
     RuntimeStorageEventOperation,
 )
 from basic_memory.services import FileService
+from basic_memory.services.exceptions import FileOperationError
 
 
 @dataclass(frozen=True, slots=True)
@@ -102,7 +103,16 @@ class LocalStorageFileMetadataSource:
         self,
         file_path: RuntimeFilePath,
     ) -> RuntimeFileChecksum | None:
-        current_metadata = await self.load_current_file_metadata(file_path)
+        try:
+            current_metadata = await self.load_current_file_metadata(file_path)
+        except (FileError, FileOperationError) as exc:
+            # The file can vanish between exists() and checksum. Only that concrete
+            # disappearance is a missing target; permission and transient I/O failures
+            # must fail indexing instead of silently leaving stale derived state.
+            cause = exc.__cause__ if exc.__cause__ is not None else exc.__context__
+            if isinstance(cause, FileNotFoundError):
+                return None
+            raise
         return current_metadata.checksum if current_metadata is not None else None
 
 
@@ -262,9 +272,7 @@ class LocalWatchEventIndexRuntimeFactory:
                 session_maker=dependencies.session_maker,
                 entity_repository=dependencies.entity_repository,
             ),
-            current_checksum_source=StorageCurrentFileChecksumSource(
-                metadata_source=metadata_source,
-            ),
+            current_checksum_source=metadata_source,
             moved_entity_source=RepositoryMovedEntitySource(
                 session_maker=dependencies.session_maker,
                 entity_repository=dependencies.entity_repository,

--- a/src/basic_memory/index/local_schedulers.py
+++ b/src/basic_memory/index/local_schedulers.py
@@ -15,14 +15,12 @@ from typing import Any, Coroutine
 from loguru import logger
 
 from basic_memory.index.project_indexing import ProjectIndexRunner
-from basic_memory.index.schedulers import (
-    EntityVectorSyncSearchService,
-    SearchReindexService,
-)
+from basic_memory.index.schedulers import SearchReindexService
 from basic_memory.indexing.relation_resolution import (
     RelationResolutionRuntime,
     resolve_project_relations,
 )
+from basic_memory.runtime.vector_sync import EntityVectorSync
 
 # --- Background Task Machinery ---
 
@@ -88,7 +86,7 @@ async def drain_background_tasks() -> None:
 
 @dataclass(frozen=True, slots=True)
 class LocalEntityVectorSyncScheduler:
-    search_service: EntityVectorSyncSearchService
+    search_service: EntityVectorSync
     test_mode: bool
 
     def schedule_entity_vector_sync(self, *, entity_id: int, project_id: int) -> None:

--- a/src/basic_memory/index/note_content_materialization.py
+++ b/src/basic_memory/index/note_content_materialization.py
@@ -6,12 +6,13 @@ import asyncio
 from collections.abc import Coroutine, Mapping
 from contextlib import suppress
 from dataclasses import dataclass, replace
-from typing import Any, Protocol
+from typing import Any
 
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory import db, file_utils
+from basic_memory.index.schedulers import RelationResolutionScheduler
 from basic_memory.indexing.index_file_runner import IndexFileExecutor
 from basic_memory.indexing.note_file_delete_runner import (
     MoveVacateClearer,
@@ -564,12 +565,6 @@ class InlineNoteFileDeleteEnqueuer:
         )
 
 
-class RelationResolutionScheduling(Protocol):
-    """Capability to back-resolve forward references after a write is indexed."""
-
-    def schedule_relation_resolution(self, *, project_id: int) -> None: ...
-
-
 @dataclass(frozen=True, slots=True)
 class LocalNoteContentMaterializationProvider:
     """Run accepted-note materialization inline for the local runtime."""
@@ -579,7 +574,7 @@ class LocalNoteContentMaterializationProvider:
     file_indexer: IndexFileExecutor | None = None
     test_mode: bool = False
     materialization_workers: int = 4
-    relation_resolution_scheduler: RelationResolutionScheduling | None = None
+    relation_resolution_scheduler: RelationResolutionScheduler | None = None
 
     async def materialize_write_change(
         self,

--- a/src/basic_memory/index/schedulers.py
+++ b/src/basic_memory/index/schedulers.py
@@ -15,9 +15,5 @@ class RelationResolutionScheduler(Protocol):
     def schedule_relation_resolution(self, *, project_id: int) -> None: ...
 
 
-class EntityVectorSyncSearchService(Protocol):
-    async def sync_entity_vectors(self, entity_id: int) -> object: ...
-
-
 class SearchReindexService(Protocol):
     async def reindex_all(self) -> object: ...

--- a/src/basic_memory/indexing/accepted_note_enqueue_runner.py
+++ b/src/basic_memory/indexing/accepted_note_enqueue_runner.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, replace
 from typing import Protocol
 
 from basic_memory.runtime.cleanup import (
-    RuntimeNoteFileDeleteJobRequest,
+    RuntimeNoteFileDeleteEnqueuer,
     plan_note_file_delete_job_request,
 )
 from basic_memory.runtime.note_content import (
@@ -37,12 +37,6 @@ class AcceptedNoteMaterializationEnqueuer(Protocol):
         self,
         request: RuntimeNoteMaterializationJobRequest,
     ) -> None: ...
-
-
-class AcceptedNoteFileDeleteEnqueuer(Protocol):
-    """Capability that enqueues materialized-note file cleanup."""
-
-    async def enqueue_note_file_delete(self, request: RuntimeNoteFileDeleteJobRequest) -> None: ...
 
 
 class AcceptedNoteMaterializationFailureMarker(Protocol):
@@ -94,7 +88,7 @@ async def enqueue_accepted_note_write_jobs(
     *,
     materialization_enqueuer: AcceptedNoteMaterializationEnqueuer,
     failure_marker: AcceptedNoteMaterializationFailureMarker,
-    file_delete_enqueuer: AcceptedNoteFileDeleteEnqueuer,
+    file_delete_enqueuer: RuntimeNoteFileDeleteEnqueuer,
 ) -> AcceptedNoteEnqueueResult:
     """Queue writeback and any separate delete cleanup for an accepted note write."""
     result = await enqueue_accepted_note_materialization(
@@ -116,7 +110,7 @@ async def enqueue_accepted_note_write_jobs(
 async def enqueue_accepted_note_file_delete(
     accepted: RuntimeAcceptedNoteChange[RuntimeNoteContentResponsePayload],
     *,
-    file_delete_enqueuer: AcceptedNoteFileDeleteEnqueuer,
+    file_delete_enqueuer: RuntimeNoteFileDeleteEnqueuer,
 ) -> AcceptedNoteEnqueueResult:
     """Queue file cleanup for an already-committed accepted note delete."""
     return await enqueue_accepted_note_file_delete_request(
@@ -132,7 +126,7 @@ async def enqueue_accepted_note_file_delete_request(
     status_code: int,
     payload: RuntimeNoteContentResponsePayload,
     file_delete: RuntimePendingNoteFileDelete,
-    file_delete_enqueuer: AcceptedNoteFileDeleteEnqueuer,
+    file_delete_enqueuer: RuntimeNoteFileDeleteEnqueuer,
 ) -> AcceptedNoteEnqueueResult:
     """Queue one accepted note file cleanup request and update response state on failure."""
     try:

--- a/src/basic_memory/indexing/change_detector.py
+++ b/src/basic_memory/indexing/change_detector.py
@@ -50,8 +50,11 @@ class ChangeDetectionStore(Protocol):
 class ChangeDetectionMoveCandidate(Protocol):
     """Indexed entity shape needed to prove a storage object was moved."""
 
-    file_path: FileIndexPath
-    checksum: FileIndexChecksum | None
+    @property
+    def file_path(self) -> FileIndexPath: ...
+
+    @property
+    def checksum(self) -> FileIndexChecksum | None: ...
 
 
 class ChangeDetectionEntityRepository(IndexedFileChecksumRepository, Protocol):

--- a/src/basic_memory/indexing/embedding_index_planning.py
+++ b/src/basic_memory/indexing/embedding_index_planning.py
@@ -13,12 +13,12 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory.indexing.progress import (
-    VectorSyncBatchSummary,
     VectorSyncProgress,
     apply_vector_sync_batch_result,
     initialize_vector_sync_progress,
 )
 from basic_memory.runtime.storage import ProjectId
+from basic_memory.runtime.vector_sync import EntityVectorSync, VectorSyncBatchResult
 
 if TYPE_CHECKING:  # pragma: no cover
     from loguru import Logger
@@ -49,7 +49,7 @@ class VectorSyncExecutor(Protocol):
         self,
         entity_ids: list[EntityId],
         progress_callback: VectorSyncBatchProgressCallback | None = None,
-    ) -> VectorSyncBatchSummary:
+    ) -> VectorSyncBatchResult:
         """Refresh vector chunks for one batch of entities."""
 
 
@@ -220,28 +220,13 @@ class EmbeddingIndexPlan:
         return len(self.entity_ids)
 
 
-class EmbeddingIndexBatchSummary(Protocol):
-    """Vector sync counts produced by the concrete search backend."""
-
-    entities_synced: int
-    entities_skipped: int
-    entities_failed: int
-    entities_deferred: int
-
-
-class EmbeddingVectorSync(Protocol):
-    """Capability that refreshes vectors for one entity."""
-
-    async def sync_entity_vectors(self, entity_id: int) -> object: ...
-
-
 class EmbeddingBatchVectorSync(Protocol):
     """Capability that refreshes vectors for a batch of entities."""
 
     async def sync_entity_vectors_batch(
         self,
         entity_ids: list[int],
-    ) -> EmbeddingIndexBatchSummary: ...
+    ) -> VectorSyncBatchResult: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -346,7 +331,7 @@ def plan_embedding_index_batch_jobs(
 async def run_embedding_index(
     request: EmbeddingIndexJobRequest,
     *,
-    vector_sync: EmbeddingVectorSync,
+    vector_sync: EntityVectorSync,
 ) -> EmbeddingIndexResult:
     """Run one embedding index request through a concrete vector sync backend."""
     await vector_sync.sync_entity_vectors(request.entity_id)
@@ -374,7 +359,7 @@ async def run_embedding_index_batch(
 
 def summarize_embedding_index_batch_result(
     plan: EmbeddingIndexPlan,
-    batch_result: EmbeddingIndexBatchSummary,
+    batch_result: VectorSyncBatchResult,
 ) -> EmbeddingIndexBatchResult:
     """Combine a deduped embedding plan with backend vector sync counts."""
     return EmbeddingIndexBatchResult(

--- a/src/basic_memory/indexing/external_file_delete_runner.py
+++ b/src/basic_memory/indexing/external_file_delete_runner.py
@@ -37,7 +37,8 @@ class ExternalFileDeleteEntities(Protocol):
 class ExternalFileDeleteEntityRepository(Protocol):
     """Repository capability used by storage-event external delete adapters."""
 
-    project_id: ProjectId | None
+    @property
+    def project_id(self) -> ProjectId | None: ...
 
     async def get_by_file_path(
         self,

--- a/src/basic_memory/indexing/file_index_checking.py
+++ b/src/basic_memory/indexing/file_index_checking.py
@@ -8,7 +8,6 @@ from typing import Protocol
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from basic_memory.file_utils import FileError
 from basic_memory.indexing.file_index_planning import (
     FileIndexChecksum,
     FileIndexDecision,
@@ -22,7 +21,6 @@ from basic_memory.indexing.file_index_planning import (
     plan_file_index_target_from_observed,
     plan_legacy_file_index_targets,
 )
-from basic_memory.services.exceptions import FileOperationError
 
 
 class IndexedFileChecksumSource(Protocol):
@@ -61,24 +59,6 @@ class IndexedFileChecksumRepository(Protocol):
         file_paths: Sequence[FileIndexPath],
     ) -> Sequence[IndexedFileChecksumRow]:
         """Return rows whose first two fields are file path and checksum."""
-
-
-class CurrentFileMetadata(Protocol):
-    """Storage metadata shape needed for file-index current checksum checks."""
-
-    @property
-    def checksum(self) -> FileIndexChecksum:
-        """Return the current storage checksum."""
-
-
-class CurrentFileMetadataSource(Protocol):
-    """Capability that loads current storage metadata for one file path."""
-
-    async def load_current_file_metadata(
-        self,
-        file_path: FileIndexPath,
-    ) -> CurrentFileMetadata | None:
-        """Return current storage metadata for one file, or None when missing."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -198,31 +178,6 @@ class RepositoryIndexedFileChecksumSource:
         async with self.session_maker() as session:
             rows = await self.entity_repository.get_by_file_paths(session, file_paths)
         return {str(row[0]): None if row[1] is None else str(row[1]) for row in rows}
-
-
-@dataclass(frozen=True, slots=True)
-class StorageCurrentFileChecksumSource:
-    """Load current file checksums from storage metadata."""
-
-    metadata_source: CurrentFileMetadataSource
-
-    async def load_current_file_checksum(
-        self,
-        file_path: FileIndexPath,
-    ) -> FileIndexChecksum | None:
-        """Return the current storage checksum for one file."""
-        try:
-            current_metadata = await self.metadata_source.load_current_file_metadata(file_path)
-        except (FileError, FileOperationError) as exc:
-            # A local checksum read wraps the race where a file vanishes after exists() as
-            # FileError. Only that concrete disappearance is a missing target; permission and
-            # transient I/O failures must fail the indexing job instead of silently leaving stale
-            # database/search state.
-            cause = exc.__cause__ if exc.__cause__ is not None else exc.__context__
-            if isinstance(cause, FileNotFoundError):
-                return None
-            raise
-        return current_metadata.checksum if current_metadata is not None else None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/basic_memory/indexing/models.py
+++ b/src/basic_memory/indexing/models.py
@@ -96,7 +96,7 @@ class IndexFrontmatterUpdate:
     metadata: dict[str, Any]
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class IndexFrontmatterWriteResult:
     """Typed result for a frontmatter write performed during indexing."""
 
@@ -825,8 +825,11 @@ class IndexFileWriter(Protocol):
 class IndexFrontmatterStorageResult(Protocol):
     """Storage write result shape needed by the indexing writer adapter."""
 
-    checksum: str
-    content: str
+    @property
+    def checksum(self) -> str: ...
+
+    @property
+    def content(self) -> str: ...
 
 
 class IndexFrontmatterStorage(Protocol):

--- a/src/basic_memory/indexing/note_content_batch_reconciliation.py
+++ b/src/basic_memory/indexing/note_content_batch_reconciliation.py
@@ -22,7 +22,8 @@ from basic_memory.indexing.note_content_reconciler import NoteContentReconcileFi
 class IndexedNoteContentEntity(Protocol):
     """Minimal entity identity needed after a batch index write."""
 
-    id: int
+    @property
+    def id(self) -> int: ...
 
 
 class IndexedNoteContentFileInfo(Protocol):

--- a/src/basic_memory/indexing/note_materialization_runner.py
+++ b/src/basic_memory/indexing/note_materialization_runner.py
@@ -29,7 +29,7 @@ from basic_memory.indexing.note_content_reconciliation import (
     plan_note_content_materialization_status,
 )
 from basic_memory.runtime.cleanup import (
-    RuntimeNoteFileDeleteJobRequest,
+    RuntimeNoteFileDeleteEnqueuer,
     plan_note_file_delete_job_request,
 )
 from basic_memory.runtime.note_content import (
@@ -197,12 +197,6 @@ class NoteMaterializationStatusPublisher(Protocol):
         request: RuntimeNoteMaterializationJobRequest,
         publication: NoteMaterializationStatusPublication,
     ) -> None: ...
-
-
-class NoteFileDeleteEnqueuer(Protocol):
-    """Capability that enqueues cleanup for old materialized note files."""
-
-    async def enqueue_note_file_delete(self, request: RuntimeNoteFileDeleteJobRequest) -> None: ...
 
 
 class NoteMaterializationSessionLock(Protocol):
@@ -572,7 +566,7 @@ async def run_note_materialization(
     writer: NoteMaterializationFileWriter,
     publisher: NoteMaterializationPublisher,
     status_publisher: NoteMaterializationStatusPublisher,
-    cleanup_enqueuer: NoteFileDeleteEnqueuer,
+    cleanup_enqueuer: RuntimeNoteFileDeleteEnqueuer,
 ) -> RuntimeNoteMaterializationResult:
     """Run one queue-neutral materialized-note write."""
     preflight_result = await preflight.prepare_note_materialization(request)
@@ -686,7 +680,7 @@ def cleanup_file_for_orphaned_write(
 
 
 async def enqueue_cleanup_file(
-    cleanup_enqueuer: NoteFileDeleteEnqueuer,
+    cleanup_enqueuer: RuntimeNoteFileDeleteEnqueuer,
     *,
     cleanup_file: RuntimePendingNoteFileDelete | None,
 ) -> bool:

--- a/src/basic_memory/indexing/orphan_cleanup.py
+++ b/src/basic_memory/indexing/orphan_cleanup.py
@@ -14,7 +14,8 @@ from basic_memory.runtime.storage import RuntimeFilePath
 class OrphanIndexedEntity(Protocol):
     """Minimal entity shape needed when removing stale indexed files."""
 
-    id: int
+    @property
+    def id(self) -> int: ...
 
 
 class OrphanEntityRepository[EntityT: OrphanIndexedEntity](Protocol):

--- a/src/basic_memory/indexing/progress.py
+++ b/src/basic_memory/indexing/progress.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Protocol, cast
+from typing import cast
 
 from pydantic import (
     BaseModel,
@@ -15,18 +15,9 @@ from pydantic import (
     model_validator,
 )
 
+from basic_memory.runtime.vector_sync import VectorSyncBatchResult
+
 type EntityId = int
-
-
-class VectorSyncBatchSummary(Protocol):
-    """Fields needed to fold one vector sync batch into durable progress."""
-
-    entities_synced: int
-    entities_failed: int
-    failed_entity_ids: list[EntityId]
-    embedding_jobs_total: int
-    embed_seconds_total: float
-    write_seconds_total: float
 
 
 class CheckpointModel(BaseModel):
@@ -161,7 +152,7 @@ def initialize_vector_sync_progress(
 
 def apply_vector_sync_batch_result(
     progress_state: VectorSyncProgress,
-    batch_result: VectorSyncBatchSummary,
+    batch_result: VectorSyncBatchResult,
     *,
     next_index: int,
     elapsed_seconds: float,

--- a/src/basic_memory/indexing/project_index_coordinator.py
+++ b/src/basic_memory/indexing/project_index_coordinator.py
@@ -37,14 +37,29 @@ from basic_memory.runtime.storage import (
 class ProjectIndexRequestSource(Protocol):
     """Minimal source shape for project-index requests."""
 
-    project_id: ProjectId
-    project_external_id: ProjectExternalId
-    project_name: ProjectName | None
-    project_permalink: ProjectPermalink | None
-    project_path: ProjectPath
-    force_full: bool
-    search: bool
-    embeddings: bool
+    @property
+    def project_id(self) -> ProjectId: ...
+
+    @property
+    def project_external_id(self) -> ProjectExternalId: ...
+
+    @property
+    def project_name(self) -> ProjectName | None: ...
+
+    @property
+    def project_permalink(self) -> ProjectPermalink | None: ...
+
+    @property
+    def project_path(self) -> ProjectPath: ...
+
+    @property
+    def force_full(self) -> bool: ...
+
+    @property
+    def search(self) -> bool: ...
+
+    @property
+    def embeddings(self) -> bool: ...
 
 
 class ProjectIndexObservedFileSource(Protocol):

--- a/src/basic_memory/indexing/relation_resolution.py
+++ b/src/basic_memory/indexing/relation_resolution.py
@@ -39,17 +39,27 @@ class RelationResolutionRuntime(Protocol):
 class UnresolvedRelation(Protocol):
     """Unresolved relation fields required by the resolver."""
 
-    id: int
-    from_id: int
-    to_name: str
-    relation_type: str
+    @property
+    def id(self) -> int: ...
+
+    @property
+    def from_id(self) -> int: ...
+
+    @property
+    def to_name(self) -> str: ...
+
+    @property
+    def relation_type(self) -> str: ...
 
 
 class ResolvedRelationTarget(Protocol):
     """Entity fields needed to complete an unresolved relation."""
 
-    id: int
-    title: str
+    @property
+    def id(self) -> int: ...
+
+    @property
+    def title(self) -> str: ...
 
 
 class RelationResolutionRelationRepository(Protocol):
@@ -97,9 +107,14 @@ class BatchRelationResolutionEntityRepository(Protocol):
 class RelationResolutionNoteContent(Protocol):
     """Accepted note-content fields needed for a state-aware search refresh."""
 
-    entity_id: EntityId
-    markdown_content: str
-    file_write_status: str
+    @property
+    def entity_id(self) -> EntityId: ...
+
+    @property
+    def markdown_content(self) -> str: ...
+
+    @property
+    def file_write_status(self) -> str: ...
 
 
 class BatchRelationResolutionNoteContentRepository(Protocol):

--- a/src/basic_memory/repository/embedding_provider.py
+++ b/src/basic_memory/repository/embedding_provider.py
@@ -6,8 +6,11 @@ from typing import Any, Protocol, runtime_checkable
 class EmbeddingProvider(Protocol):
     """Contract for semantic embedding providers."""
 
-    model_name: str
-    dimensions: int
+    @property
+    def model_name(self) -> str: ...
+
+    @property
+    def dimensions(self) -> int: ...
 
     async def embed_query(self, text: str) -> list[float]:
         """Embed a single query string."""

--- a/src/basic_memory/repository/fastembed_provider.py
+++ b/src/basic_memory/repository/fastembed_provider.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from basic_memory.repository.embedding_provider import EmbeddingProvider
 from basic_memory.repository.semantic_errors import SemanticDependenciesMissingError
 
 if TYPE_CHECKING:
@@ -35,7 +34,7 @@ _MISSING_ARTIFACT_ERROR_MARKERS = (
 )
 
 
-class FastEmbedEmbeddingProvider(EmbeddingProvider):
+class FastEmbedEmbeddingProvider:
     """Local ONNX embedding provider backed by FastEmbed."""
 
     _MODEL_ALIASES = {

--- a/src/basic_memory/repository/fastembed_rerank_provider.py
+++ b/src/basic_memory/repository/fastembed_rerank_provider.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 from requests import exceptions as requests_exceptions
 
-from basic_memory.repository.rerank_provider import RerankProvider, validate_rerank_scores
+from basic_memory.repository.rerank_provider import validate_rerank_scores
 from basic_memory.repository.semantic_errors import (
     RerankProviderContractError,
     RerankTransientError,
@@ -59,7 +59,7 @@ def _is_transient_model_load_error(
     return not offline_mode
 
 
-class FastEmbedRerankProvider(RerankProvider):
+class FastEmbedRerankProvider:
     """Local ONNX cross-encoder reranker backed by FastEmbed.
 
     Shares the FastEmbed model cache with the embedding provider — reranker

--- a/src/basic_memory/repository/litellm_provider.py
+++ b/src/basic_memory/repository/litellm_provider.py
@@ -18,7 +18,6 @@ import math
 import os
 from typing import Any
 
-from basic_memory.repository.embedding_provider import EmbeddingProvider
 from basic_memory.repository.semantic_errors import SemanticDependenciesMissingError
 
 
@@ -104,7 +103,7 @@ def _import_litellm() -> Any:
     return litellm
 
 
-class LiteLLMEmbeddingProvider(EmbeddingProvider):
+class LiteLLMEmbeddingProvider:
     """Embedding provider backed by the litellm SDK."""
 
     def __init__(

--- a/src/basic_memory/repository/litellm_rerank_provider.py
+++ b/src/basic_memory/repository/litellm_rerank_provider.py
@@ -15,14 +15,14 @@ from typing import Any
 from pydantic import ValidationError
 
 from basic_memory.repository.litellm_provider import _import_litellm
-from basic_memory.repository.rerank_provider import RerankProvider, validate_rerank_scores
+from basic_memory.repository.rerank_provider import validate_rerank_scores
 from basic_memory.repository.semantic_errors import (
     RerankProviderContractError,
     RerankTransientError,
 )
 
 
-class LiteLLMRerankProvider(RerankProvider):
+class LiteLLMRerankProvider:
     """Reranker provider backed by the litellm SDK."""
 
     def __init__(

--- a/src/basic_memory/repository/milvus_index.py
+++ b/src/basic_memory/repository/milvus_index.py
@@ -14,8 +14,6 @@ from basic_memory.repository.milvus_repository import (
     create_repository,
 )
 from basic_memory.repository.semantic_vector_index import (
-    SemanticVectorIndex,
-    SemanticVectorIndexReconciler,
     VectorDeletion,
     VectorIndexScope,
     VectorKey,
@@ -46,7 +44,7 @@ def _normalize_cosine_score(score: float) -> float:
     return max(0.0, min(1.0, score))
 
 
-class MilvusVectorIndex(SemanticVectorIndex, SemanticVectorIndexReconciler):
+class MilvusVectorIndex:
     """Persist and query one Basic Memory project's vectors in Milvus."""
 
     def __init__(

--- a/src/basic_memory/repository/openai_provider.py
+++ b/src/basic_memory/repository/openai_provider.py
@@ -6,11 +6,10 @@ import asyncio
 import os
 from typing import Any
 
-from basic_memory.repository.embedding_provider import EmbeddingProvider
 from basic_memory.repository.semantic_errors import SemanticDependenciesMissingError
 
 
-class OpenAIEmbeddingProvider(EmbeddingProvider):
+class OpenAIEmbeddingProvider:
     """Embedding provider backed by OpenAI's embeddings API."""
 
     def __init__(

--- a/src/basic_memory/repository/pgvector_index.py
+++ b/src/basic_memory/repository/pgvector_index.py
@@ -12,7 +12,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from basic_memory import db
 from basic_memory.repository.semantic_errors import SemanticDependenciesMissingError
 from basic_memory.repository.semantic_vector_index import (
-    SemanticVectorIndex,
     VectorDeletion,
     VectorIndexScope,
     VectorKey,
@@ -23,7 +22,7 @@ from basic_memory.repository.semantic_vector_index import (
 )
 
 
-class PgVectorIndex(SemanticVectorIndex):
+class PgVectorIndex:
     """Persist and query semantic vectors in PostgreSQL with pgvector."""
 
     def __init__(

--- a/src/basic_memory/repository/prefixing_provider.py
+++ b/src/basic_memory/repository/prefixing_provider.py
@@ -41,7 +41,7 @@ def prefixing_embedding_identity(
     )
 
 
-class PrefixingEmbeddingProvider(EmbeddingProvider):
+class PrefixingEmbeddingProvider:
     """Apply document/query text prefixes before delegating to an embedding provider."""
 
     def __init__(

--- a/src/basic_memory/repository/rerank_provider.py
+++ b/src/basic_memory/repository/rerank_provider.py
@@ -68,7 +68,8 @@ def validate_rerank_scores(scores: Sequence[float | str], expected_count: int) -
 class RerankProvider(Protocol):
     """Contract for cross-encoder reranking providers."""
 
-    model_name: str
+    @property
+    def model_name(self) -> str: ...
 
     async def rerank(self, query: str, documents: list[str]) -> list[float]:
         """Return a relevance score in ``[0, 1]`` per document, aligned to input order.

--- a/src/basic_memory/repository/search_repository.py
+++ b/src/basic_memory/repository/search_repository.py
@@ -18,11 +18,11 @@ from basic_memory.repository.embedding_provider_factory import create_embedding_
 from basic_memory.repository.rerank_provider_factory import create_rerank_provider
 from basic_memory.repository.postgres_search_repository import PostgresSearchRepository
 from basic_memory.repository.search_index_row import SearchIndexRow
-from basic_memory.repository.search_repository_base import VectorSyncBatchResult
 from basic_memory.repository.semantic_vector_index_factory import (
     create_semantic_vector_index,
     resolve_semantic_vector_index_name,
 )
+from basic_memory.runtime.vector_sync import VectorSyncBatchResult
 from basic_memory.repository.sqlite_search_repository import SQLiteSearchRepository
 from basic_memory.schemas.search import SearchItemType, SearchRetrievalMode
 
@@ -33,7 +33,8 @@ class SearchRepository(Protocol):
     Both SQLite and Postgres implementations must satisfy this protocol.
     """
 
-    project_id: int
+    @property
+    def project_id(self) -> int: ...
 
     async def init_search_index(self) -> None:
         """Initialize the search index schema."""

--- a/src/basic_memory/repository/search_repository_base.py
+++ b/src/basic_memory/repository/search_repository_base.py
@@ -54,8 +54,8 @@ from basic_memory.repository.semantic_vector_sync import (
     PreparedEntityVectorSync as _PreparedEntityVectorSync,
     StagedVectorDeletion as _StagedVectorDeletion,
     VectorChunkState,
-    VectorSyncBatchResult,
 )
+from basic_memory.runtime.vector_sync import VectorSyncBatchResult
 from basic_memory.schemas.search import SearchItemType, SearchRetrievalMode
 
 # --- Semantic search constants ---

--- a/src/basic_memory/repository/semantic_chunking.py
+++ b/src/basic_memory/repository/semantic_chunking.py
@@ -19,13 +19,26 @@ _BULLET_PATTERN = re.compile(r"^[\-\*]\s+")
 class SemanticSourceRow(Protocol):
     """Search row fields needed to build semantic chunks."""
 
-    id: int
-    type: str
-    title: str | None
-    permalink: str | None
-    content_snippet: str | None
-    category: str | None
-    relation_type: str | None
+    @property
+    def id(self) -> int: ...
+
+    @property
+    def type(self) -> str: ...
+
+    @property
+    def title(self) -> str | None: ...
+
+    @property
+    def permalink(self) -> str | None: ...
+
+    @property
+    def content_snippet(self) -> str | None: ...
+
+    @property
+    def category(self) -> str | None: ...
+
+    @property
+    def relation_type(self) -> str | None: ...
 
 
 class VectorChunkRecord(TypedDict):

--- a/src/basic_memory/repository/semantic_vector_index.py
+++ b/src/basic_memory/repository/semantic_vector_index.py
@@ -64,7 +64,8 @@ class SemanticVectorIndex(Protocol):
     implementations own only vector persistence and nearest-neighbour lookup.
     """
 
-    scope: VectorIndexScope
+    @property
+    def scope(self) -> VectorIndexScope: ...
 
     async def initialize(self) -> None:
         """Create or validate backend storage for the configured scope."""
@@ -96,7 +97,8 @@ class SemanticVectorIndex(Protocol):
 class SemanticVectorIndexReconciler(Protocol):
     """Optional cleanup capability for removing vectors absent from the live manifest."""
 
-    scope: VectorIndexScope
+    @property
+    def scope(self) -> VectorIndexScope: ...
 
     async def delete_orphans(self, live_keys: Sequence[VectorKey]) -> None:
         """Delete scoped vectors whose stable keys are not in ``live_keys``."""

--- a/src/basic_memory/repository/semantic_vector_sync.py
+++ b/src/basic_memory/repository/semantic_vector_sync.py
@@ -14,6 +14,7 @@ from sqlalchemy import text
 
 from basic_memory import db
 from basic_memory.repository.semantic_chunking import VectorChunkRecord
+from basic_memory.runtime.vector_sync import VectorSyncBatchResult
 from basic_memory.schemas.search import SearchItemType
 
 if TYPE_CHECKING:  # pragma: no cover - import cycle exists only for static analysis
@@ -25,16 +26,11 @@ OVERSIZED_ENTITY_VECTOR_SHARD_SIZE = 256
 SQLITE_MAX_PREPARE_WINDOW = 8
 
 
-@dataclass
-class VectorSyncBatchResult:
-    """Aggregate result for batched semantic vector sync runs."""
+@dataclass(slots=True)
+class _VectorSyncBatchAccumulator:
+    """Mutable counters collected before publishing an immutable batch result."""
 
-    entities_total: int
-    entities_synced: int
-    entities_failed: int
-    entities_deferred: int = 0
     entities_skipped: int = 0
-    failed_entity_ids: list[int] = field(default_factory=list)
     chunks_total: int = 0
     chunks_skipped: int = 0
     embedding_jobs_total: int = 0
@@ -42,6 +38,31 @@ class VectorSyncBatchResult:
     queue_wait_seconds_total: float = 0.0
     embed_seconds_total: float = 0.0
     write_seconds_total: float = 0.0
+
+    def freeze(
+        self,
+        *,
+        entities_total: int,
+        synced_entity_ids: set[int],
+        deferred_entity_ids: set[int],
+        failed_entity_ids: set[int],
+    ) -> VectorSyncBatchResult:
+        """Return the immutable result after entity terminal states settle."""
+        return VectorSyncBatchResult(
+            entities_total=entities_total,
+            entities_synced=len(synced_entity_ids),
+            entities_failed=len(failed_entity_ids),
+            entities_deferred=len(deferred_entity_ids),
+            entities_skipped=self.entities_skipped,
+            failed_entity_ids=tuple(sorted(failed_entity_ids)),
+            chunks_total=self.chunks_total,
+            chunks_skipped=self.chunks_skipped,
+            embedding_jobs_total=self.embedding_jobs_total,
+            prepare_seconds_total=self.prepare_seconds_total,
+            queue_wait_seconds_total=self.queue_wait_seconds_total,
+            embed_seconds_total=self.embed_seconds_total,
+            write_seconds_total=self.write_seconds_total,
+        )
 
 
 @dataclass
@@ -242,15 +263,15 @@ async def sync_entity_vectors_internal(
     assert repository._embedding_provider is not None
 
     total_entities = len(entity_ids)
-    result = VectorSyncBatchResult(
-        entities_total=total_entities,
-        entities_synced=0,
-        entities_failed=0,
-    )
     if total_entities == 0:
-        return result
+        return VectorSyncBatchResult(
+            entities_total=0,
+            entities_synced=0,
+            entities_failed=0,
+        )
     batch_start = time.perf_counter()
     backend_name = type(repository).__name__.removesuffix("SearchRepository").lower()
+    batch_counters = _VectorSyncBatchAccumulator()
 
     repository._log_vector_sync_runtime_settings(
         backend_name=backend_name, entities_total=total_entities
@@ -315,12 +336,12 @@ async def sync_entity_vectors_internal(
                     continue
 
                 embedding_jobs_count = len(prepared.embedding_jobs)
-                result.chunks_total += prepared.chunks_total
-                result.chunks_skipped += prepared.chunks_skipped
+                batch_counters.chunks_total += prepared.chunks_total
+                batch_counters.chunks_skipped += prepared.chunks_skipped
                 if prepared.entity_skipped:
-                    result.entities_skipped += 1
-                result.embedding_jobs_total += embedding_jobs_count
-                result.prepare_seconds_total += prepared.prepare_seconds
+                    batch_counters.entities_skipped += 1
+                batch_counters.embedding_jobs_total += embedding_jobs_count
+                batch_counters.prepare_seconds_total += prepared.prepare_seconds
 
                 if embedding_jobs_count == 0:
                     if prepared.entity_complete:
@@ -393,9 +414,9 @@ async def sync_entity_vectors_internal(
                             entity_runtime=entity_runtime,
                             synced_entity_ids=synced_entity_ids,
                         )
-                        result.embed_seconds_total += embed_seconds
-                        result.write_seconds_total += write_seconds
-                        result.queue_wait_seconds_total += (
+                        batch_counters.embed_seconds_total += embed_seconds
+                        batch_counters.write_seconds_total += write_seconds
+                        batch_counters.queue_wait_seconds_total += (
                             repository._finalize_completed_entity_syncs(
                                 entity_runtime=entity_runtime,
                                 synced_entity_ids=synced_entity_ids,
@@ -433,13 +454,15 @@ async def sync_entity_vectors_internal(
                     entity_runtime=entity_runtime,
                     synced_entity_ids=synced_entity_ids,
                 )
-                result.embed_seconds_total += embed_seconds
-                result.write_seconds_total += write_seconds
-                result.queue_wait_seconds_total += repository._finalize_completed_entity_syncs(
-                    entity_runtime=entity_runtime,
-                    synced_entity_ids=synced_entity_ids,
-                    deferred_entity_ids=deferred_entity_ids,
-                    progress_callback=emit_progress,
+                batch_counters.embed_seconds_total += embed_seconds
+                batch_counters.write_seconds_total += write_seconds
+                batch_counters.queue_wait_seconds_total += (
+                    repository._finalize_completed_entity_syncs(
+                        entity_runtime=entity_runtime,
+                        synced_entity_ids=synced_entity_ids,
+                        deferred_entity_ids=deferred_entity_ids,
+                        progress_callback=emit_progress,
+                    )
                 )
             except Exception as exc:
                 if not continue_on_error:
@@ -482,10 +505,12 @@ async def sync_entity_vectors_internal(
         synced_entity_ids.difference_update(failed_entity_ids)
         deferred_entity_ids.difference_update(failed_entity_ids)
         deferred_entity_ids.difference_update(synced_entity_ids)
-        result.failed_entity_ids = sorted(failed_entity_ids)
-        result.entities_failed = len(result.failed_entity_ids)
-        result.entities_deferred = len(deferred_entity_ids)
-        result.entities_synced = len(synced_entity_ids)
+        result = batch_counters.freeze(
+            entities_total=total_entities,
+            synced_entity_ids=synced_entity_ids,
+            deferred_entity_ids=deferred_entity_ids,
+            failed_entity_ids=failed_entity_ids,
+        )
 
         logger.info(
             "Vector batch sync complete: project_id={project_id} entities_total={entities_total} "

--- a/src/basic_memory/repository/sqlite_vec_index.py
+++ b/src/basic_memory/repository/sqlite_vec_index.py
@@ -15,7 +15,6 @@ from basic_memory import db
 from basic_memory.models.search import create_sqlite_search_vector_embeddings
 from basic_memory.repository.semantic_errors import SemanticDependenciesMissingError
 from basic_memory.repository.semantic_vector_index import (
-    SemanticVectorIndex,
     VectorDeletion,
     VectorIndexScope,
     VectorKey,
@@ -29,7 +28,7 @@ from basic_memory.repository.semantic_vector_index import (
 SQLITE_VEC_MAX_K = 4096
 
 
-class SQLiteVecIndex(SemanticVectorIndex):
+class SQLiteVecIndex:
     """Persist and query semantic vectors in SQLite with sqlite-vec."""
 
     def __init__(

--- a/src/basic_memory/runtime/cleanup.py
+++ b/src/basic_memory/runtime/cleanup.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
-from typing import Self
+from typing import Protocol, Self
 
 from basic_memory.runtime.note_content import (
     RuntimeDeletedNoteEntityDeleteSource,
@@ -213,6 +213,12 @@ class RuntimeNoteFileDeleteJobRequest:
         routing_headers = dict(headers or {})
         routing_headers["project_id"] = str(self.project_id)
         return routing_headers
+
+
+class RuntimeNoteFileDeleteEnqueuer(Protocol):
+    """Capability that enqueues materialized-note file cleanup."""
+
+    async def enqueue_note_file_delete(self, request: RuntimeNoteFileDeleteJobRequest) -> None: ...
 
 
 def plan_note_file_delete_job_request(

--- a/src/basic_memory/runtime/vector_sync.py
+++ b/src/basic_memory/runtime/vector_sync.py
@@ -1,0 +1,31 @@
+"""Portable semantic-vector synchronization contracts."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+type EntityId = int
+
+
+@dataclass(frozen=True, slots=True)
+class VectorSyncBatchResult:
+    """Aggregate result for one batched semantic-vector sync run."""
+
+    entities_total: int
+    entities_synced: int
+    entities_failed: int
+    entities_deferred: int = 0
+    entities_skipped: int = 0
+    failed_entity_ids: tuple[EntityId, ...] = ()
+    chunks_total: int = 0
+    chunks_skipped: int = 0
+    embedding_jobs_total: int = 0
+    prepare_seconds_total: float = 0.0
+    queue_wait_seconds_total: float = 0.0
+    embed_seconds_total: float = 0.0
+    write_seconds_total: float = 0.0
+
+
+class EntityVectorSync(Protocol):
+    """Capability that refreshes semantic vectors for one entity."""
+
+    async def sync_entity_vectors(self, entity_id: EntityId) -> None: ...

--- a/src/basic_memory/services/directory_deletes.py
+++ b/src/basic_memory/services/directory_deletes.py
@@ -6,9 +6,6 @@ enqueuer. The core service owns request acceptance and response shaping.
 
 from __future__ import annotations
 
-from contextlib import AbstractAsyncContextManager
-from typing import Protocol
-
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory import db
@@ -22,12 +19,6 @@ from basic_memory.indexing.directory_delete_runner import (
     finish_directory_delete_acceptance,
     normalize_directory_delete_path,
 )
-
-
-class DirectoryDeleteSessionMaker(Protocol):
-    """Session factory capability needed by directory-delete acceptance."""
-
-    def __call__(self) -> AbstractAsyncContextManager[AsyncSession]: ...
 
 
 class DirectoryDeleteServiceError(Exception):

--- a/src/basic_memory/services/file_service.py
+++ b/src/basic_memory/services/file_service.py
@@ -27,7 +27,7 @@ from basic_memory.utils import FilePath
 from loguru import logger
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class FrontmatterUpdateResult:
     """Final content emitted by a frontmatter rewrite without a follow-up reread."""
 

--- a/src/basic_memory/services/initialization.py
+++ b/src/basic_memory/services/initialization.py
@@ -8,7 +8,7 @@ import asyncio
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING
 
 
 from loguru import logger
@@ -23,19 +23,13 @@ from basic_memory.repository import (
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-    from basic_memory.index.local_project import LocalProjectIndexRuntime
-
-
-class InitialProjectIndexRuntimeFactory(Protocol):
-    """Build local project-index runtime dependencies for startup indexing."""
-
-    async def runtime_for_project(self, project: Project) -> "LocalProjectIndexRuntime": ...
+    from basic_memory.index.local_project import LocalProjectIndexRuntimeProvider
 
 
 async def run_initial_project_index(
     project: Project,
     *,
-    runtime_factory: InitialProjectIndexRuntimeFactory,
+    runtime_factory: "LocalProjectIndexRuntimeProvider",
 ) -> None:
     """Run startup project indexing through the local project-index fanout runtime."""
     from basic_memory.index.local_project import run_local_project_index_for_project

--- a/src/basic_memory/services/search_service.py
+++ b/src/basic_memory/services/search_service.py
@@ -22,10 +22,10 @@ from basic_memory.repository import EntityRepository
 from basic_memory.repository.search_repository import (
     SearchIndexRow,
     SearchRepository,
-    VectorSyncBatchResult,
 )
 from basic_memory.repository.search_query import relaxed_query_words
 from basic_memory.schemas.search import SearchQuery, SearchItemType, SearchRetrievalMode
+from basic_memory.runtime.vector_sync import VectorSyncBatchResult
 from basic_memory.services import FileService
 
 # Maximum size for content_stems field to stay under Postgres's 8KB index row limit.
@@ -539,11 +539,11 @@ class SearchService:
                 + sum(result.entities_skipped for result in repository_results)
                 - len(unknown_ids)
             ),
-            failed_entity_ids=[
+            failed_entity_ids=tuple(
                 failed_entity_id
                 for result in repository_results
                 for failed_entity_id in result.failed_entity_ids
-            ],
+            ),
             chunks_total=sum(result.chunks_total for result in repository_results),
             chunks_skipped=sum(result.chunks_skipped for result in repository_results),
             embedding_jobs_total=sum(result.embedding_jobs_total for result in repository_results),

--- a/tests/api/v2/test_knowledge_router.py
+++ b/tests/api/v2/test_knowledge_router.py
@@ -20,7 +20,7 @@ from basic_memory.models import Entity as EntityModel, Project
 from basic_memory.repository.entity_repository import EntityRepository
 from basic_memory.repository.note_content_repository import NoteContentRepository
 from basic_memory.repository.project_repository import ProjectRepository
-from basic_memory.repository.search_repository_base import VectorSyncBatchResult
+from basic_memory.runtime.vector_sync import VectorSyncBatchResult
 from basic_memory.runtime.note_content import NOTE_CONTENT_BASE_CHECKSUM_HEADER
 from basic_memory.schemas import DeleteEntitiesResponse
 from basic_memory.schemas.response import DirectoryMoveResult, DirectoryDeleteResult
@@ -136,9 +136,7 @@ async def test_resolve_identifier_not_found(client: AsyncClient, v2_project_url)
 
 
 @pytest.mark.asyncio
-async def test_resolve_identifier_ambiguous_title_returns_409(
-    client: AsyncClient, v2_project_url
-):
+async def test_resolve_identifier_ambiguous_title_returns_409(client: AsyncClient, v2_project_url):
     """A strict resolve of a title shared by multiple notes returns 409 (#1148).
 
     Covers the router's AmbiguousIdentifierError -> 409 transport contract: the resolver raising

--- a/tests/index/test_inline_storage_event_processor.py
+++ b/tests/index/test_inline_storage_event_processor.py
@@ -83,7 +83,7 @@ class ReadEverythingChecker:
         )
 
 
-class CurrentFileMetadataSource:
+class RecordingIndexFileMetadataSource:
     def __init__(self) -> None:
         self.paths: list[str] = []
 
@@ -195,7 +195,7 @@ class RecordingInlineResultRecorder:
 def inline_runtime(
     *,
     checker: ReadEverythingChecker | None = None,
-    metadata_source: CurrentFileMetadataSource | None = None,
+    metadata_source: RecordingIndexFileMetadataSource | None = None,
     file_indexer: RecordingFileIndexer | None = None,
     delete_entities: RecordingDeleteEntities | None = None,
     delete_objects: RecordingDeleteObjects | None = None,
@@ -204,7 +204,7 @@ def inline_runtime(
     return InlineStorageEventIndexRuntime(
         project=project_reference(),
         checker=checker or ReadEverythingChecker(),
-        metadata_source=metadata_source or CurrentFileMetadataSource(),
+        metadata_source=metadata_source or RecordingIndexFileMetadataSource(),
         materialized_note_source=EmptyMaterializedNoteSource(),
         file_indexer=file_indexer or RecordingFileIndexer(),
         delete_entities=delete_entities or RecordingDeleteEntities(None),
@@ -215,7 +215,7 @@ def inline_runtime(
 
 async def test_inline_processor_indexes_storage_event_with_index_file_runner() -> None:
     checker = ReadEverythingChecker()
-    metadata_source = CurrentFileMetadataSource()
+    metadata_source = RecordingIndexFileMetadataSource()
     file_indexer = RecordingFileIndexer()
     recorder = RecordingInlineResultRecorder()
     processor = InlineStorageEventOperationProcessor(

--- a/tests/index/test_local_project_index.py
+++ b/tests/index/test_local_project_index.py
@@ -74,6 +74,7 @@ from basic_memory.runtime.jobs import (
     RuntimeProjectIndexJobRequest,
 )
 from basic_memory.runtime.projects import ProjectRuntimeReference
+from basic_memory.runtime.vector_sync import VectorSyncBatchResult
 from basic_memory.schemas.search import SearchItemType, SearchQuery
 from basic_memory.services import FileService
 from basic_memory.services.exceptions import FileOperationError
@@ -2567,17 +2568,12 @@ class RuntimeFactorySearchIndex:
     async def sync_entity_vectors_batch(
         self,
         entity_ids: list[int],
-    ) -> "RuntimeFactoryVectorBatchResult":
-        return RuntimeFactoryVectorBatchResult(entities_synced=len(entity_ids))
-
-
-# Not frozen: EmbeddingIndexBatchSummary declares plain (writable) attribute members.
-@dataclass(slots=True)
-class RuntimeFactoryVectorBatchResult:
-    entities_synced: int
-    entities_skipped: int = 0
-    entities_failed: int = 0
-    entities_deferred: int = 0
+    ) -> VectorSyncBatchResult:
+        return VectorSyncBatchResult(
+            entities_total=len(entity_ids),
+            entities_synced=len(entity_ids),
+            entities_failed=0,
+        )
 
 
 class RuntimeFactoryRelationRepository:

--- a/tests/index/test_local_runtime.py
+++ b/tests/index/test_local_runtime.py
@@ -1,0 +1,75 @@
+"""Tests for local filesystem runtime adapters."""
+
+from dataclasses import dataclass, field
+from typing import cast
+
+import pytest
+
+from basic_memory.file_utils import FileError
+from basic_memory.index.local_runtime import LocalStorageFileMetadataSource
+from basic_memory.services import FileService
+from basic_memory.services.exceptions import FileOperationError
+
+
+@dataclass(slots=True)
+class StubFileService:
+    checksums: dict[str, str]
+    failures: dict[str, str] = field(default_factory=dict)
+    calls: list[tuple[str, str]] = field(default_factory=list)
+
+    async def exists(self, file_path: str) -> bool:
+        self.calls.append(("exists", file_path))
+        return file_path in self.checksums or file_path in self.failures
+
+    async def compute_checksum(self, file_path: str) -> str:
+        self.calls.append(("checksum", file_path))
+        failure = self.failures.get(file_path)
+        if failure == "operation-missing":
+            raise FileOperationError(f"file vanished: {file_path}") from FileNotFoundError(
+                file_path
+            )
+        if failure == "checksum-missing":
+            raise FileError(f"checksum target vanished: {file_path}") from FileNotFoundError(
+                file_path
+            )
+        if failure == "permission":
+            raise FileError(f"permission denied: {file_path}") from PermissionError(file_path)
+        return self.checksums[file_path]
+
+
+def metadata_source(file_service: StubFileService) -> LocalStorageFileMetadataSource:
+    return LocalStorageFileMetadataSource(cast(FileService, file_service))
+
+
+@pytest.mark.asyncio
+async def test_local_storage_checksum_source_loads_current_checksum() -> None:
+    file_service = StubFileService(checksums={"note.md": "checksum-current"})
+    source = metadata_source(file_service)
+
+    assert await source.load_current_file_checksum("note.md") == "checksum-current"
+    assert await source.load_current_file_checksum("missing.md") is None
+    assert file_service.calls == [
+        ("exists", "note.md"),
+        ("checksum", "note.md"),
+        ("exists", "missing.md"),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["operation-missing", "checksum-missing"])
+async def test_local_storage_checksum_source_treats_file_disappearance_as_missing(
+    failure: str,
+) -> None:
+    source = metadata_source(StubFileService(checksums={}, failures={"vanished.md": failure}))
+
+    assert await source.load_current_file_checksum("vanished.md") is None
+
+
+@pytest.mark.asyncio
+async def test_local_storage_checksum_source_propagates_non_missing_failures() -> None:
+    source = metadata_source(
+        StubFileService(checksums={}, failures={"unreadable.md": "permission"})
+    )
+
+    with pytest.raises(FileError, match="permission denied"):
+        await source.load_current_file_checksum("unreadable.md")

--- a/tests/indexing/test_embedding_index_planning.py
+++ b/tests/indexing/test_embedding_index_planning.py
@@ -19,13 +19,7 @@ from basic_memory.indexing.embedding_index_planning import (
     summarize_embedding_index_batch_result,
     vector_sync_perf_counter,
 )
-
-
-class BatchResult:
-    entities_synced = 2
-    entities_skipped = 1
-    entities_failed = 0
-    entities_deferred = 1
+from basic_memory.runtime.vector_sync import VectorSyncBatchResult
 
 
 class SingleVectorSync:
@@ -40,9 +34,15 @@ class BatchVectorSync:
     def __init__(self) -> None:
         self.synced_entity_ids: list[list[int]] = []
 
-    async def sync_entity_vectors_batch(self, entity_ids: list[int]) -> BatchResult:
+    async def sync_entity_vectors_batch(self, entity_ids: list[int]) -> VectorSyncBatchResult:
         self.synced_entity_ids.append(entity_ids)
-        return BatchResult()
+        return VectorSyncBatchResult(
+            entities_total=2,
+            entities_synced=2,
+            entities_failed=0,
+            entities_skipped=1,
+            entities_deferred=1,
+        )
 
 
 def test_embedding_index_job_request_matches_project_queue_identity() -> None:
@@ -191,7 +191,15 @@ def test_embedding_index_batch_result_summarizes_plan_and_sync_counts() -> None:
         ]
     )
 
-    assert summarize_embedding_index_batch_result(plan, BatchResult()) == (
+    batch_result = VectorSyncBatchResult(
+        entities_total=2,
+        entities_synced=2,
+        entities_failed=0,
+        entities_skipped=1,
+        entities_deferred=1,
+    )
+
+    assert summarize_embedding_index_batch_result(plan, batch_result) == (
         EmbeddingIndexBatchResult(
             total_entities=3,
             unique_entities=2,
@@ -202,6 +210,8 @@ def test_embedding_index_batch_result_summarizes_plan_and_sync_counts() -> None:
             reason="entity embedding batch indexed: 2 entities",
         )
     )
+    with pytest.raises(FrozenInstanceError):
+        setattr(batch_result, "entities_synced", 3)
 
 
 def test_embedding_index_batch_result_handles_empty_batches() -> None:

--- a/tests/indexing/test_file_index_checking.py
+++ b/tests/indexing/test_file_index_checking.py
@@ -7,38 +7,15 @@ from typing import cast
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from basic_memory.file_utils import FileError
 from basic_memory.indexing.file_index_checking import (
-    CurrentFileMetadataSource,
     FileIndexChecker,
     MoveVacateMarker,
     MovedEntityFacts,
     RepositoryIndexedFileChecksumSource,
     RepositoryMoveVacateSource,
     RepositoryMovedEntitySource,
-    StorageCurrentFileChecksumSource,
 )
 from basic_memory.indexing.file_index_planning import FileIndexDecisionStatus, FileIndexTarget
-from basic_memory.services.exceptions import FileOperationError
-
-
-@dataclass(frozen=True, slots=True)
-class StubCurrentMetadata:
-    checksum: str
-
-
-@dataclass(slots=True)
-class StubCurrentMetadataSource:
-    calls: list[str] = field(default_factory=list)
-
-    async def load_current_file_metadata(
-        self,
-        file_path: str,
-    ) -> StubCurrentMetadata | None:
-        self.calls.append(file_path)
-        if file_path == "missing.md":
-            return None
-        return StubCurrentMetadata(checksum="etag-current")
 
 
 @dataclass(slots=True)
@@ -293,55 +270,6 @@ async def test_repository_indexed_file_checksum_source_maps_repository_rows() ->
         "notes/b.md": None,
     }
     assert repository.calls == [(session, ("notes/a.md", "notes/b.md"))]
-
-
-@pytest.mark.asyncio
-async def test_storage_current_file_checksum_source_loads_metadata_checksum() -> None:
-    stub_source = StubCurrentMetadataSource()
-    metadata_source: CurrentFileMetadataSource = stub_source
-    source = StorageCurrentFileChecksumSource(metadata_source=metadata_source)
-
-    assert await source.load_current_file_checksum("note.md") == "etag-current"
-    assert await source.load_current_file_checksum("missing.md") is None
-    assert stub_source.calls == ["note.md", "missing.md"]
-
-
-@pytest.mark.asyncio
-async def test_storage_current_file_checksum_source_treats_file_errors_as_missing() -> None:
-    class VanishingMetadataSource:
-        async def load_current_file_metadata(self, file_path: str) -> StubCurrentMetadata | None:
-            raise FileOperationError(f"file vanished: {file_path}") from FileNotFoundError(
-                file_path
-            )
-
-    source = StorageCurrentFileChecksumSource(metadata_source=VanishingMetadataSource())
-
-    assert await source.load_current_file_checksum("vanished.md") is None
-
-
-@pytest.mark.asyncio
-async def test_storage_current_file_checksum_source_treats_checksum_race_as_missing() -> None:
-    class VanishingMetadataSource:
-        async def load_current_file_metadata(self, file_path: str) -> StubCurrentMetadata | None:
-            raise FileError(f"checksum target vanished: {file_path}") from FileNotFoundError(
-                file_path
-            )
-
-    source = StorageCurrentFileChecksumSource(metadata_source=VanishingMetadataSource())
-
-    assert await source.load_current_file_checksum("vanished.md") is None
-
-
-@pytest.mark.asyncio
-async def test_storage_current_file_checksum_source_propagates_non_missing_failures() -> None:
-    class UnreadableMetadataSource:
-        async def load_current_file_metadata(self, file_path: str) -> StubCurrentMetadata | None:
-            raise FileError(f"permission denied: {file_path}") from PermissionError(file_path)
-
-    source = StorageCurrentFileChecksumSource(metadata_source=UnreadableMetadataSource())
-
-    with pytest.raises(FileError, match="permission denied"):
-        await source.load_current_file_checksum("unreadable.md")
 
 
 def _orphan_checker(

--- a/tests/indexing/test_forward_reference_resolution.py
+++ b/tests/indexing/test_forward_reference_resolution.py
@@ -25,8 +25,7 @@ from basic_memory.indexing.forward_reference_resolution import (
 from basic_memory.models import Entity
 
 
-# Not frozen: UnresolvedRelation declares plain (writable) attribute members.
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class StubUnresolvedRelation:
     id: int
     from_id: int

--- a/tests/indexing/test_index_batch_runtime.py
+++ b/tests/indexing/test_index_batch_runtime.py
@@ -61,8 +61,7 @@ class RecordingFrontmatterStorage:
         raise AssertionError("construction test should not write frontmatter")
 
 
-# Not frozen: IndexedNoteContentEntity declares plain (writable) attribute members.
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class FakeEntity:
     id: int
 

--- a/tests/indexing/test_orphan_cleanup.py
+++ b/tests/indexing/test_orphan_cleanup.py
@@ -28,8 +28,7 @@ def capture_logs() -> Iterator[list[Record]]:
         logger.remove(sink_id)
 
 
-# Not frozen: OrphanIndexedEntity declares plain (writable) attribute members.
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class FakeEntity:
     id: int
 

--- a/tests/indexing/test_progress_models.py
+++ b/tests/indexing/test_progress_models.py
@@ -1,7 +1,5 @@
 """Tests for portable indexing progress checkpoint models."""
 
-from dataclasses import dataclass, field
-
 import pytest
 from pydantic import ValidationError
 
@@ -11,19 +9,7 @@ from basic_memory.indexing.progress import (
     apply_vector_sync_batch_result,
     initialize_vector_sync_progress,
 )
-
-
-# Not frozen: VectorSyncBatchSummary declares plain (writable) attribute members.
-@dataclass(slots=True)
-class BatchSummary:
-    """Small fake proving progress updates only need a narrow batch protocol."""
-
-    entities_synced: int
-    entities_failed: int
-    failed_entity_ids: list[int] = field(default_factory=list)
-    embedding_jobs_total: int = 0
-    embed_seconds_total: float = 0.0
-    write_seconds_total: float = 0.0
+from basic_memory.runtime.vector_sync import VectorSyncBatchResult
 
 
 def test_vector_sync_progress_checkpoint_state_shape_is_stable() -> None:
@@ -115,7 +101,11 @@ def test_vector_sync_progress_checkpoint_write_reruns_dedupe_and_clamp() -> None
     progress = VectorSyncProgress(entity_ids=[11, 22], next_index=1)
     apply_vector_sync_batch_result(
         progress,
-        BatchSummary(entities_synced=1, entities_failed=0),
+        VectorSyncBatchResult(
+            entities_total=1,
+            entities_synced=1,
+            entities_failed=0,
+        ),
         next_index=5,
         elapsed_seconds=1.0,
     )
@@ -190,10 +180,11 @@ def test_apply_vector_sync_batch_result_updates_progress_and_reports_new_failure
 
     new_failed_entity_ids = apply_vector_sync_batch_result(
         progress,
-        BatchSummary(
+        VectorSyncBatchResult(
+            entities_total=4,
             entities_synced=2,
             entities_failed=2,
-            failed_entity_ids=[22, 33],
+            failed_entity_ids=(22, 33),
             embedding_jobs_total=6,
             embed_seconds_total=2.0,
             write_seconds_total=0.75,

--- a/tests/indexing/test_project_index_coordinator.py
+++ b/tests/indexing/test_project_index_coordinator.py
@@ -28,10 +28,10 @@ from basic_memory.runtime.jobs import (
     RuntimeProjectIndexJobRequest,
 )
 from basic_memory.runtime.projects import ProjectRuntimeReference
+from basic_memory.runtime.vector_sync import VectorSyncBatchResult
 
 
-# Not frozen: ProjectIndexRequestSource declares plain (writable) attribute members.
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class ProjectIndexSource:
     project_id: int
     project_external_id: str
@@ -111,15 +111,6 @@ class StaticProjectIndexBatchEnqueuer:
         return self.result
 
 
-# Not frozen: EmbeddingIndexBatchSummary declares plain (writable) attribute members.
-@dataclass(slots=True)
-class RecordingEmbeddingBatchSummary:
-    entities_synced: int
-    entities_skipped: int = 0
-    entities_failed: int = 0
-    entities_deferred: int = 0
-
-
 @dataclass(slots=True)
 class RecordingEmbeddingVectorSync:
     entity_batches: list[list[int]] = field(default_factory=list)
@@ -127,9 +118,13 @@ class RecordingEmbeddingVectorSync:
     async def sync_entity_vectors_batch(
         self,
         entity_ids: list[int],
-    ) -> RecordingEmbeddingBatchSummary:
+    ) -> VectorSyncBatchResult:
         self.entity_batches.append(entity_ids)
-        return RecordingEmbeddingBatchSummary(entities_synced=len(entity_ids))
+        return VectorSyncBatchResult(
+            entities_total=len(entity_ids),
+            entities_synced=len(entity_ids),
+            entities_failed=0,
+        )
 
 
 def test_project_index_request_serializes_existing_payload_metadata() -> None:

--- a/tests/indexing/test_project_index_runtime.py
+++ b/tests/indexing/test_project_index_runtime.py
@@ -33,8 +33,7 @@ from basic_memory.indexing.forward_reference_resolution import (
 )
 
 
-# Not frozen: UnresolvedRelation declares plain (writable) attribute members.
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class StubUnresolvedRelation:
     id: int
     from_id: int

--- a/tests/indexing/test_project_index_workflow.py
+++ b/tests/indexing/test_project_index_workflow.py
@@ -33,8 +33,7 @@ from basic_memory.indexing.project_index_workflow import (
 )
 
 
-# Not frozen: ProjectIndexRequestSource declares plain (writable) attribute members.
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class ProjectIndexSource:
     project_id: int
     project_external_id: str

--- a/tests/indexing/test_relation_resolution.py
+++ b/tests/indexing/test_relation_resolution.py
@@ -67,8 +67,7 @@ class FakeSession:
         pass
 
 
-# Not frozen: UnresolvedRelation declares plain (writable) attribute members.
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class FakeRelation:
     id: int
     from_id: int
@@ -76,8 +75,7 @@ class FakeRelation:
     relation_type: str = "related_to"
 
 
-# Not frozen: ResolvedRelationTarget declares plain (writable) attribute members.
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class FakeResolvedEntity:
     id: int
     title: str
@@ -626,9 +624,7 @@ async def test_resolve_relations_skips_ambiguous_target_without_aborting_pass() 
             assert isinstance(session, FakeSession)
             self.calls.append((link_text, strict))
             if link_text in self.ambiguous:
-                raise AmbiguousIdentifierError(
-                    link_text, [("dup-a", "a.md"), ("dup-b", "b.md")]
-                )
+                raise AmbiguousIdentifierError(link_text, [("dup-a", "a.md"), ("dup-b", "b.md")])
             return self.targets.get(link_text)
 
     repo = StubRelationRepository(

--- a/tests/indexing/test_vector_sync_planning.py
+++ b/tests/indexing/test_vector_sync_planning.py
@@ -18,6 +18,7 @@ from basic_memory.indexing.embedding_index_planning import (
     VectorSyncBatchProgressCallback,
     run_vector_sync,
 )
+from basic_memory.runtime.vector_sync import VectorSyncBatchResult
 
 if TYPE_CHECKING:
     from loguru import Record
@@ -35,22 +36,10 @@ def capture_logs() -> Iterator[list[Record]]:
 
 
 @dataclass(slots=True)
-class BatchSummary:
-    """Minimal batch result for exercising portable vector-sync execution."""
-
-    entities_synced: int
-    entities_failed: int = 0
-    failed_entity_ids: list[int] = field(default_factory=list)
-    embedding_jobs_total: int = 0
-    embed_seconds_total: float = 0.0
-    write_seconds_total: float = 0.0
-
-
-@dataclass(slots=True)
 class RecordingVectorSync:
     """Fake vector sync adapter that records chunk calls."""
 
-    results: list[BatchSummary]
+    results: list[VectorSyncBatchResult]
     progress_events: list[tuple[int, int, int]] = field(default_factory=list)
     calls: list[list[int]] = field(default_factory=list)
 
@@ -58,7 +47,7 @@ class RecordingVectorSync:
         self,
         entity_ids: list[int],
         progress_callback: VectorSyncBatchProgressCallback | None = None,
-    ) -> BatchSummary:
+    ) -> VectorSyncBatchResult:
         self.calls.append(list(entity_ids))
         if progress_callback is not None:
             for entity_id, index, total_count in self.progress_events:
@@ -253,10 +242,11 @@ async def test_run_vector_sync_resumes_from_chunk_boundary_and_reports_progress(
 ) -> None:
     vector_sync = RecordingVectorSync(
         results=[
-            BatchSummary(
+            VectorSyncBatchResult(
+                entities_total=25,
                 entities_synced=25,
                 entities_failed=1,
-                failed_entity_ids=[125],
+                failed_entity_ids=(125,),
                 embedding_jobs_total=50,
                 embed_seconds_total=3.0,
                 write_seconds_total=1.0,
@@ -322,7 +312,13 @@ async def test_run_vector_sync_logs_periodic_batch_progress(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     vector_sync = RecordingVectorSync(
-        results=[BatchSummary(entities_synced=3)],
+        results=[
+            VectorSyncBatchResult(
+                entities_total=3,
+                entities_synced=3,
+                entities_failed=0,
+            )
+        ],
         progress_events=[(1, 1, 3)],
     )
     monkeypatch.setattr(

--- a/tests/repository/test_semantic_search_base.py
+++ b/tests/repository/test_semantic_search_base.py
@@ -961,7 +961,7 @@ async def test_sync_entity_vectors_batch_flushes_at_configured_threshold(monkeyp
     assert result.entities_total == 3
     assert result.entities_synced == 3
     assert result.entities_failed == 0
-    assert result.failed_entity_ids == []
+    assert result.failed_entity_ids == ()
     assert result.embedding_jobs_total == 3
     assert result.prepare_seconds_total == pytest.approx(0.0)
     assert result.queue_wait_seconds_total == pytest.approx(0.0)
@@ -1085,7 +1085,7 @@ async def test_sync_entity_vectors_batch_continue_on_error(monkeypatch):
     assert result.entities_total == 3
     assert result.entities_synced == 1
     assert result.entities_failed == 2
-    assert result.failed_entity_ids == [2, 3]
+    assert result.failed_entity_ids == (2, 3)
 
 
 @pytest.mark.asyncio

--- a/tests/repository/test_semantic_vector_sync.py
+++ b/tests/repository/test_semantic_vector_sync.py
@@ -211,7 +211,7 @@ async def test_vector_sync_handles_final_flush_errors_and_orphan_runtime(
         continue_on_error=True,
     )
 
-    assert failed_result.failed_entity_ids == [1]
+    assert failed_result.failed_entity_ids == (1,)
 
     strict_repository = _batch_repository(
         monkeypatch,
@@ -242,7 +242,7 @@ async def test_vector_sync_handles_final_flush_errors_and_orphan_runtime(
         continue_on_error=True,
     )
 
-    assert orphan_result.failed_entity_ids == [1]
+    assert orphan_result.failed_entity_ids == (1,)
 
 
 def test_vector_shard_planning_and_logging_edges(monkeypatch) -> None:

--- a/tests/services/test_file_service.py
+++ b/tests/services/test_file_service.py
@@ -1,6 +1,7 @@
 """Tests for file operations service."""
 
 import os
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 
 import pytest
@@ -195,6 +196,8 @@ async def test_update_frontmatter_checksum_matches_windows_crlf_persisted_bytes(
     )
 
     assert result.checksum == await file_service.compute_checksum(test_path)
+    with pytest.raises(FrozenInstanceError):
+        setattr(result, "checksum", "changed")
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_search_service.py
+++ b/tests/services/test_search_service.py
@@ -1467,7 +1467,7 @@ async def test_index_entity_markdown_strips_nul_bytes(search_service, session_ma
 async def test_reindex_vectors(search_service, session_maker, test_project, monkeypatch):
     """Test that reindex_vectors processes all entities and reports stats."""
     from basic_memory.repository import EntityRepository
-    from basic_memory.repository.search_repository_base import VectorSyncBatchResult
+    from basic_memory.runtime.vector_sync import VectorSyncBatchResult
     from datetime import datetime
 
     entity_repo = EntityRepository(project_id=test_project.id)
@@ -1517,7 +1517,7 @@ async def test_reindex_vectors(search_service, session_maker, test_project, monk
             entities_total=len(entity_ids),
             entities_synced=len(entity_ids),
             entities_failed=0,
-            failed_entity_ids=[],
+            failed_entity_ids=(),
             embedding_jobs_total=9,
             embed_seconds_total=1.2,
             write_seconds_total=0.4,
@@ -1555,7 +1555,7 @@ async def test_reindex_vectors_no_callback(
 ):
     """Test reindex_vectors works without a progress callback."""
     from basic_memory.repository import EntityRepository
-    from basic_memory.repository.search_repository_base import VectorSyncBatchResult
+    from basic_memory.runtime.vector_sync import VectorSyncBatchResult
     from datetime import datetime
 
     entity_repo = EntityRepository(project_id=test_project.id)
@@ -1598,7 +1598,7 @@ async def test_reindex_vectors_no_callback(
             entities_total=len(entity_ids),
             entities_synced=len(entity_ids),
             entities_failed=0,
-            failed_entity_ids=[],
+            failed_entity_ids=(),
             embedding_jobs_total=3,
             embed_seconds_total=0.5,
             write_seconds_total=0.1,

--- a/tests/services/test_semantic_search.py
+++ b/tests/services/test_semantic_search.py
@@ -9,7 +9,7 @@ from sqlalchemy import text
 
 from basic_memory import db
 from basic_memory.repository import EntityRepository
-from basic_memory.repository.search_repository_base import VectorSyncBatchResult
+from basic_memory.runtime.vector_sync import VectorSyncBatchResult
 from basic_memory.repository.semantic_errors import (
     SemanticDependenciesMissingError,
     SemanticSearchDisabledError,


### PR DESCRIPTION
## Why

The v0.23 indexing and semantic-search work added a large Protocol surface so the
portable runtime could serve both Basic Memory and Basic Memory Cloud. A
cross-repository audit found a smaller set of contracts that were unused,
duplicated, mutable despite representing results, or hiding ownership behind an
extra adapter.

This cleanup removes those vestiges before the release without removing any
feature or weakening a capability that Cloud consumes.

## What Changed

- Removed unused or duplicate Protocols for directory deletion, initial project
  indexing, relation scheduling, note-file cleanup, and vector synchronization.
- Added one shared, frozen `VectorSyncBatchResult` and kept mutable batch
  accounting private to the semantic-vector repository operation.
- Made structural data members read-only so frozen dataclasses and ORM-backed
  values can satisfy the same narrow contracts.
- Removed unnecessary nominal Protocol inheritance from concrete embedding,
  reranking, SQLite, pgvector, and Milvus implementations.
- Moved local missing-file race handling into the local storage metadata adapter
  and removed the wrapper that previously obscured that responsibility.
- Made local frontmatter result values frozen and slotted.
- Ignored all repository-local `.codex` runtime state and nested worktrees while
  allowlisting a minimal shared `.codex/basic-memory.json`.

There are no user-visible feature removals.

## Implementation Details

`src/basic_memory/runtime/vector_sync.py` is now the single portable home for
the vector-sync capability and its immutable batch result. The repository
implementation uses a private accumulator and freezes counts, timings, and
failed entity IDs at the public boundary.

Property-only Protocol members are now read-only properties. Concrete providers
remain structurally compatible, but no longer inherit those Protocols
nominally; this avoids inherited property descriptors conflicting with normal
instance initialization.

`LocalStorageFileMetadataSource` now owns checksum lookup semantics directly. A
wrapped `FileNotFoundError` still means the file vanished between existence and
checksum checks, while permission and transient I/O errors continue to
propagate.

The shared Codex config contains only the coding profile and canonical
repository identifier. User project mappings and all `.codex/worktrees` state
remain machine-local.

## Testing

### Automated

- `just fast-check`: passed (Ruff fix/format and `ty` type checking; nine
  existing Python 3.14 event-loop deprecation warnings).
- `BASIC_MEMORY_ENV=test LOGFIRE_IGNORE_NO_CONFIG=1 uv run pytest -q --no-cov tests/index/test_local_schedulers.py tests/index/test_inline_storage_event_processor.py tests/indexing/test_embedding_index_planning.py tests/indexing/test_vector_sync_planning.py tests/repository/test_semantic_vector_sync.py`:
  51 passed.
- Expanded provider/vector regression suite: 294 passed.
- `just doctor`: passed the isolated file, database, indexing, vector, search,
  and status flow.
- `just fast-test`: 4,969 passed and 33 skipped. The only failure was the live
  `postgres-openai` semantic-quality benchmark, which reached OpenAI and
  received HTTP 429 `insufficient_quota`.
- AST Protocol audit: no writable Protocol attributes remain.
- Retired-contract name scan and `git diff --check`: passed.

## Risks / Follow-ups

- The live OpenAI benchmark remains dependent on account quota; its failure did
  not exercise a changed local code path.
- A broad `SearchRepository` split and complete cross-repository frontmatter
  result unification are intentionally deferred until after v0.23. They would
  expand release risk without simplifying this patch.
