### PR TITLE
fix(core): keep relation search refresh retryable

### DIFF
--- a/src/basic_memory/alembic/versions/q0l1m2n3o4p5_add_relation_search_refresh_table.py
+++ b/src/basic_memory/alembic/versions/q0l1m2n3o4p5_add_relation_search_refresh_table.py
@@ -1,0 +1,57 @@
+"""Add durable relation search refresh work.
+
+Revision ID: q0l1m2n3o4p5
+Revises: p9k0l1m2n3o4
+Create Date: 2026-07-27 18:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "q0l1m2n3o4p5"
+down_revision: Union[str, None] = "p9k0l1m2n3o4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create durable work items for relation-derived search refreshes."""
+    op.create_table(
+        "relation_search_refresh",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("project_id", sa.Integer(), nullable=False),
+        sa.Column("entity_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["project.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_relation_search_refresh_project_id",
+        "relation_search_refresh",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_relation_search_refresh_entity_id",
+        "relation_search_refresh",
+        ["entity_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop durable relation-search refresh work."""
+    op.drop_index(
+        "ix_relation_search_refresh_entity_id",
+        table_name="relation_search_refresh",
+    )
+    op.drop_index(
+        "ix_relation_search_refresh_project_id",
+        table_name="relation_search_refresh",
+    )
+    op.drop_table("relation_search_refresh")

--- a/src/basic_memory/indexing/relation_resolution.py
+++ b/src/basic_memory/indexing/relation_resolution.py
@@ -16,6 +16,7 @@ from basic_memory.indexing.accepted_note_search import accepted_search_content_f
 from basic_memory.indexing.models import IndexFileJobStatus
 from basic_memory.models import Entity
 from basic_memory.repository.relation_repository import (
+    PendingRelationSearchRefresh,
     ResolvedRelationWrite,
     ResolvedRelationWriteResult,
 )
@@ -84,6 +85,21 @@ class RelationResolutionRelationRepository(Protocol):
         writes: Sequence[ResolvedRelationWrite],
     ) -> ResolvedRelationWriteResult:
         """Apply canonical targets and remove duplicate edges as one batch."""
+
+    async def list_pending_search_refreshes(
+        self,
+        session: AsyncSession,
+        *,
+        entity_id: EntityId | None = None,
+    ) -> Sequence[PendingRelationSearchRefresh]:
+        """Return durable relation-search refresh work."""
+
+    async def clear_pending_search_refreshes(
+        self,
+        session: AsyncSession,
+        refresh_ids: Sequence[int],
+    ) -> None:
+        """Retire successfully completed relation-search refresh work."""
 
 
 class RelationResolutionEntityRepository(Protocol):
@@ -256,7 +272,6 @@ class RepositoryRelationResolutionRuntime:
                 )
             write_result = await self.relation_repository.apply_resolved_targets(session, writes)
 
-        affected_entity_ids: AffectedEntityIds = set(write_result.affected_entity_ids)
         if write_result.duplicate_relation_ids:
             with logfire.span(
                 "indexing.relation.resolve_conflicts",
@@ -268,9 +283,16 @@ class RepositoryRelationResolutionRuntime:
                     relation_ids=write_result.duplicate_relation_ids,
                 )
 
-        if affected_entity_ids:
-            sorted_affected_entity_ids = sorted(affected_entity_ids)
-            async with db.scoped_session(self.session_maker) as session:
+        async with db.scoped_session(self.session_maker) as session:
+            pending_refreshes = await self.relation_repository.list_pending_search_refreshes(
+                session,
+                entity_id=entity_id,
+            )
+            affected_entity_ids: AffectedEntityIds = {
+                refresh.entity_id for refresh in pending_refreshes
+            }
+            if affected_entity_ids:
+                sorted_affected_entity_ids = sorted(affected_entity_ids)
                 source_entities = await self.entity_repository.find_by_ids(
                     session,
                     sorted_affected_entity_ids,
@@ -280,6 +302,7 @@ class RepositoryRelationResolutionRuntime:
                     sorted_affected_entity_ids,
                 )
 
+        if affected_entity_ids:
             # Trigger: an accepted note has not reached a synchronized Markdown projection.
             # Why: relation repair must refresh its search row without racing the async file
             # materializer, while synchronized notes still need missing files to surface.
@@ -289,6 +312,11 @@ class RepositoryRelationResolutionRuntime:
                 sorted(source_entities, key=lambda entity: entity.id),
                 content_by_entity_id=content_by_entity_id,
             )
+            async with db.scoped_session(self.session_maker) as session:
+                await self.relation_repository.clear_pending_search_refreshes(
+                    session,
+                    [refresh.id for refresh in pending_refreshes],
+                )
 
         return affected_entity_ids
 

--- a/src/basic_memory/models/__init__.py
+++ b/src/basic_memory/models/__init__.py
@@ -10,6 +10,7 @@ from basic_memory.models.knowledge import (
     Relation,
 )
 from basic_memory.models.project import Project
+from basic_memory.models.relation_search_refresh import RelationSearchRefresh
 
 __all__ = [
     "Base",
@@ -18,6 +19,7 @@ __all__ = [
     "NoteFileVacate",
     "Observation",
     "Relation",
+    "RelationSearchRefresh",
     "Project",
     "basic_memory",
 ]

--- a/src/basic_memory/models/relation_search_refresh.py
+++ b/src/basic_memory/models/relation_search_refresh.py
@@ -1,0 +1,39 @@
+"""Durable reconciliation work for relation-derived search projections."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer
+from sqlalchemy.orm import Mapped, mapped_column
+
+from basic_memory.models.base import Base
+
+
+class RelationSearchRefresh(Base):
+    """A committed relation change whose source search projection must be refreshed.
+
+    Rows are append-only until a successful refresh retires the exact work items
+    it observed. Multiple rows for one entity are intentional: a relation change
+    committed during an in-flight refresh must remain visible to a later pass.
+    """
+
+    __tablename__ = "relation_search_refresh"
+    __table_args__ = (
+        Index("ix_relation_search_refresh_project_id", "project_id"),
+        Index("ix_relation_search_refresh_entity_id", "entity_id"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("project.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    entity_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("entity.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now().astimezone(),
+    )

--- a/src/basic_memory/repository/relation_repository.py
+++ b/src/basic_memory/repository/relation_repository.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload, aliased
 from sqlalchemy.orm.interfaces import LoaderOption
 
-from basic_memory.models import Relation, Entity
+from basic_memory.models import Entity, Relation, RelationSearchRefresh
 from basic_memory.repository.repository import Repository
 
 
@@ -48,6 +48,14 @@ class ResolvedRelationWriteResult:
 
     affected_entity_ids: frozenset[int]
     duplicate_relation_ids: tuple[int, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PendingRelationSearchRefresh:
+    """One durable relation-search reconciliation item."""
+
+    id: int
+    entity_id: int
 
 
 class RelationRepository(Repository[Relation]):
@@ -133,6 +141,39 @@ class RelationRepository(Repository[Relation]):
         query = self.select().filter(Relation.from_id == entity_id, Relation.to_id.is_(None))
         result = await self.execute_query(session, query)
         return result.scalars().all()
+
+    async def list_pending_search_refreshes(
+        self,
+        session: AsyncSession,
+        *,
+        entity_id: int | None = None,
+    ) -> list[PendingRelationSearchRefresh]:
+        """Return committed relation changes whose source projection needs refresh."""
+        query = (
+            select(RelationSearchRefresh.id, RelationSearchRefresh.entity_id)
+            .where(RelationSearchRefresh.project_id == self.project_id)
+            .order_by(RelationSearchRefresh.id)
+        )
+        if entity_id is not None:
+            query = query.where(RelationSearchRefresh.entity_id == entity_id)
+        result = await session.execute(query)
+        return [
+            PendingRelationSearchRefresh(id=refresh_id, entity_id=refresh_entity_id)
+            for refresh_id, refresh_entity_id in result.tuples().all()
+        ]
+
+    async def clear_pending_search_refreshes(
+        self,
+        session: AsyncSession,
+        refresh_ids: Sequence[int],
+    ) -> None:
+        """Retire only refresh work completed by the caller's successful pass."""
+        await session.execute(
+            delete(RelationSearchRefresh).where(
+                RelationSearchRefresh.project_id == self.project_id,
+                RelationSearchRefresh.id.in_(refresh_ids),
+            )
+        )
 
     async def apply_resolved_targets(
         self,
@@ -242,6 +283,19 @@ class RelationRepository(Repository[Relation]):
                 )
                 .execution_options(synchronize_session=False)
             )
+
+        # Trigger: relation targets changed or duplicate edges were removed.
+        # Why: a later storage/search failure must not consume the only evidence
+        # that each source projection still needs reconciliation.
+        # Outcome: the relation mutation and its retryable refresh work commit
+        # atomically, while concurrent later changes receive separate markers.
+        session.add_all(
+            RelationSearchRefresh(
+                project_id=self.project_id,
+                entity_id=entity_id,
+            )
+            for entity_id in sorted(source_entity_ids)
+        )
 
         return ResolvedRelationWriteResult(
             affected_entity_ids=frozenset(source_entity_ids),

--- a/src/basic_memory/services/search_service.py
+++ b/src/basic_memory/services/search_service.py
@@ -429,10 +429,17 @@ class SearchService:
         )
         try:
             with logfire.span("search.index_entity_data", entity_id=entity.id):
+                replacement_content = content
+                if entity.is_markdown and replacement_content is None:
+                    # Trigger: synchronized and legacy notes source search text from storage.
+                    # Why: a transient read failure must preserve the last valid projection.
+                    # Outcome: storage errors remain visible before any search rows are deleted.
+                    replacement_content = await self.file_service.read_entity_content(entity)
+
                 await self.repository.delete_by_entity_id(entity_id=entity.id)
 
                 if entity.is_markdown:
-                    await self.index_entity_markdown(entity, content)
+                    await self.index_entity_markdown(entity, replacement_content)
                 else:
                     await self.index_entity_file(entity)
 

--- a/tests/index/test_local_project_index.py
+++ b/tests/index/test_local_project_index.py
@@ -65,6 +65,7 @@ from basic_memory.repository.note_content_repository import (
     NoteContentRepository,
 )
 from basic_memory.repository.relation_repository import (
+    PendingRelationSearchRefresh,
     ResolvedRelationWrite,
     ResolvedRelationWriteResult,
 )
@@ -2610,6 +2611,21 @@ class RuntimeFactoryRelationRepository:
             affected_entity_ids=frozenset(write.from_id for write in writes),
             duplicate_relation_ids=(),
         )
+
+    async def list_pending_search_refreshes(
+        self,
+        session: AsyncSession,
+        *,
+        entity_id: int | None = None,
+    ) -> Sequence[PendingRelationSearchRefresh]:
+        return ()
+
+    async def clear_pending_search_refreshes(
+        self,
+        session: AsyncSession,
+        refresh_ids: Sequence[int],
+    ) -> None:
+        return None
 
 
 class RuntimeFactoryLinkResolver:

--- a/tests/indexing/test_relation_resolution.py
+++ b/tests/indexing/test_relation_resolution.py
@@ -23,6 +23,7 @@ from basic_memory.indexing.relation_resolution import (
 from basic_memory.indexing.models import IndexFileJobStatus
 from basic_memory.models import Entity
 from basic_memory.repository.relation_repository import (
+    PendingRelationSearchRefresh,
     ResolvedRelationWrite,
     ResolvedRelationWriteResult,
 )
@@ -91,6 +92,8 @@ class StubRelationRepository:
         self._unresolved_per_call = unresolved_per_call
         self.calls = 0
         self.write_batches: list[tuple[ResolvedRelationWrite, ...]] = []
+        self.pending_search_refreshes: list[PendingRelationSearchRefresh] = []
+        self._next_refresh_id = 1
 
     async def find_unresolved_relations(
         self,
@@ -120,10 +123,43 @@ class StubRelationRepository:
     ) -> ResolvedRelationWriteResult:
         assert isinstance(session, FakeSession)
         self.write_batches.append(tuple(writes))
+        affected_entity_ids = frozenset(write.from_id for write in writes)
+        for entity_id in sorted(affected_entity_ids):
+            self.pending_search_refreshes.append(
+                PendingRelationSearchRefresh(
+                    id=self._next_refresh_id,
+                    entity_id=entity_id,
+                )
+            )
+            self._next_refresh_id += 1
         return ResolvedRelationWriteResult(
-            affected_entity_ids=frozenset(write.from_id for write in writes),
+            affected_entity_ids=affected_entity_ids,
             duplicate_relation_ids=(),
         )
+
+    async def list_pending_search_refreshes(
+        self,
+        session: AsyncSession,
+        *,
+        entity_id: int | None = None,
+    ) -> list[PendingRelationSearchRefresh]:
+        assert isinstance(session, FakeSession)
+        return [
+            refresh
+            for refresh in self.pending_search_refreshes
+            if entity_id is None or refresh.entity_id == entity_id
+        ]
+
+    async def clear_pending_search_refreshes(
+        self,
+        session: AsyncSession,
+        refresh_ids: Sequence[int],
+    ) -> None:
+        assert isinstance(session, FakeSession)
+        completed_ids = set(refresh_ids)
+        self.pending_search_refreshes = [
+            refresh for refresh in self.pending_search_refreshes if refresh.id not in completed_ids
+        ]
 
 
 class StubEntityRepository:
@@ -545,7 +581,7 @@ async def test_repository_runtime_batches_resolution_and_entity_refresh_sessions
             FakeResolvedEntity(id=11, title="Source B"),
         )
     ]
-    assert FakeSession.created_count == 2
+    assert FakeSession.created_count == 3
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_relation_search_refresh_retry.py
+++ b/tests/indexing/test_relation_search_refresh_retry.py
@@ -1,0 +1,202 @@
+"""Integration coverage for retryable relation-derived search refreshes."""
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from basic_memory import db
+from basic_memory.indexing.relation_resolution import RepositoryRelationResolutionRuntime
+from basic_memory.models import Entity, Relation, RelationSearchRefresh
+from basic_memory.repository.entity_repository import EntityRepository
+from basic_memory.repository.note_content_repository import NoteContentRepository
+from basic_memory.repository.relation_repository import RelationRepository
+from basic_memory.schemas.search import SearchItemType
+
+
+class StaticLinkResolver:
+    """Resolve only the explicit targets provided by the test."""
+
+    def __init__(self, targets: Mapping[str, Entity]) -> None:
+        self.targets = targets
+        self.calls = 0
+
+    async def resolve_link(
+        self,
+        link_text: str,
+        *,
+        strict: bool,
+        session: AsyncSession,
+    ) -> Entity | None:
+        del strict, session
+        self.calls += 1
+        return self.targets.get(link_text)
+
+
+@pytest.mark.asyncio
+async def test_clearing_observed_refresh_preserves_newer_work(
+    relation_repository: RelationRepository,
+    sample_entity: Entity,
+    session_maker,
+    test_project,
+) -> None:
+    """A refresh committed during indexing survives retirement of the observed batch."""
+    async with db.scoped_session(session_maker) as session:
+        session.add(
+            RelationSearchRefresh(
+                project_id=test_project.id,
+                entity_id=sample_entity.id,
+            )
+        )
+
+    async with db.scoped_session(session_maker) as session:
+        observed = await relation_repository.list_pending_search_refreshes(session)
+
+    async with db.scoped_session(session_maker) as session:
+        session.add(
+            RelationSearchRefresh(
+                project_id=test_project.id,
+                entity_id=sample_entity.id,
+            )
+        )
+
+    async with db.scoped_session(session_maker) as session:
+        await relation_repository.clear_pending_search_refreshes(
+            session,
+            [refresh.id for refresh in observed],
+        )
+
+    async with db.scoped_session(session_maker) as session:
+        remaining = await relation_repository.list_pending_search_refreshes(session)
+
+    assert len(observed) == 1
+    assert len(remaining) == 1
+    assert remaining[0].id > observed[0].id
+
+
+@pytest.mark.asyncio
+async def test_relation_refresh_retries_after_storage_read_failure_and_runtime_restart(
+    entity_repository: EntityRepository,
+    relation_repository: RelationRepository,
+    search_service,
+    session_maker,
+    test_project,
+    monkeypatch,
+) -> None:
+    """Committed relation work survives a failed refresh and a new runtime instance."""
+    now = datetime.now(timezone.utc)
+    source = Entity(
+        project_id=test_project.id,
+        title="Retry Source",
+        note_type="note",
+        permalink="retry-source",
+        file_path="retry-source.md",
+        content_type="text/markdown",
+        created_at=now,
+        updated_at=now,
+    )
+    target = Entity(
+        project_id=test_project.id,
+        title="Retry Target",
+        note_type="note",
+        permalink="retry-target",
+        file_path="retry-target.md",
+        content_type="text/markdown",
+        created_at=now,
+        updated_at=now,
+    )
+    async with db.scoped_session(session_maker) as session:
+        session.add_all([source, target])
+        await session.flush()
+        session.add(
+            Relation(
+                project_id=test_project.id,
+                from_id=source.id,
+                to_id=None,
+                to_name=target.title,
+                relation_type="relates_to",
+            )
+        )
+        await session.flush()
+        source_id = source.id
+        target_id = target.id
+
+    async with db.scoped_session(session_maker) as session:
+        indexed_source = await entity_repository.find_by_id(session, source_id)
+    assert indexed_source is not None
+    source_content = "# Retry Source\n\nThe last valid search projection."
+    await search_service.index_entity_data(indexed_source, content=source_content)
+
+    read_attempts = 0
+
+    async def fail_once_read(entity: Entity) -> str:
+        nonlocal read_attempts
+        assert entity.id == source_id
+        read_attempts += 1
+        if read_attempts == 1:
+            raise OSError("transient object-storage read failure")
+        return source_content
+
+    monkeypatch.setattr(search_service.file_service, "read_entity_content", fail_once_read)
+    first_resolver = StaticLinkResolver({target.title: target})
+    first_runtime = RepositoryRelationResolutionRuntime(
+        session_maker=session_maker,
+        relation_repository=relation_repository,
+        entity_repository=entity_repository,
+        note_content_repository=NoteContentRepository(project_id=test_project.id),
+        link_resolver=first_resolver,
+        entity_indexer=search_service,
+    )
+
+    with pytest.raises(OSError, match="transient object-storage read failure"):
+        await first_runtime.resolve_relations()
+
+    async with db.scoped_session(session_maker) as session:
+        resolved_relations = await relation_repository.find_by_type(session, "relates_to")
+        pending_refreshes = await relation_repository.list_pending_search_refreshes(session)
+        filtered_refreshes = await relation_repository.list_pending_search_refreshes(
+            session,
+            entity_id=source_id,
+        )
+    assert [(relation.from_id, relation.to_id) for relation in resolved_relations] == [
+        (source_id, target_id)
+    ]
+    assert [refresh.entity_id for refresh in pending_refreshes] == [source_id]
+    assert filtered_refreshes == pending_refreshes
+
+    rows_after_failure = await search_service.repository.search(
+        search_item_types=[SearchItemType.ENTITY],
+    )
+    assert any(
+        row.entity_id == source_id and row.content_snippet == source_content
+        for row in rows_after_failure
+    )
+
+    # A fresh runtime has no in-memory knowledge of the first attempt. It must
+    # discover the committed refresh marker even though no relation is unresolved.
+    retry_resolver = StaticLinkResolver({})
+    retry_runtime = RepositoryRelationResolutionRuntime(
+        session_maker=session_maker,
+        relation_repository=RelationRepository(project_id=test_project.id),
+        entity_repository=EntityRepository(project_id=test_project.id),
+        note_content_repository=NoteContentRepository(project_id=test_project.id),
+        link_resolver=retry_resolver,
+        entity_indexer=search_service,
+    )
+
+    affected = await retry_runtime.resolve_relations()
+
+    assert affected == {source_id}
+    assert retry_resolver.calls == 0
+    assert read_attempts == 2
+    async with db.scoped_session(session_maker) as session:
+        remaining_refreshes = await relation_repository.list_pending_search_refreshes(session)
+    assert remaining_refreshes == []
+
+    relation_rows = await search_service.repository.search(
+        search_item_types=[SearchItemType.RELATION],
+    )
+    source_relation_rows = [row for row in relation_rows if row.entity_id == source_id]
+    assert len(source_relation_rows) == 1
+    assert source_relation_rows[0].to_id == target_id

--- a/tests/test_semantic_vector_index_migration.py
+++ b/tests/test_semantic_vector_index_migration.py
@@ -192,7 +192,7 @@ def test_upgrade_repairs_sqlite_state_from_duplicate_vector_revision(
         "created_at",
     }
     assert "ix_note_file_vacate_project_id" in indexes
-    assert version == ("p9k0l1m2n3o4",)
+    assert version == ("q0l1m2n3o4p5",)
 
 
 def test_downgrade_removes_manifest_state(monkeypatch) -> None:


### PR DESCRIPTION
## Why

Relation resolution committed a newly resolved target before refreshing the source note's
search projection. If reading synchronized Markdown then failed, the retry no longer found an
unresolved relation and could report success without repairing the stale projection.

This change makes the projection refresh durable across worker/runtime restarts and preserves
the last valid search rows until replacement content is available.

Fixes #1163.

## What Changed

- Added durable, append-only relation search refresh work rows and an Alembic migration.
- Recorded refresh work atomically with resolved-relation mutations.
- Made relation-resolution passes discover and retry committed refresh work even when no
  unresolved relations remain.
- Preserved refresh work after failed indexing and cleared only the exact observed rows after a
  successful refresh.
- Loaded synchronized or legacy Markdown before deleting existing search rows.
- Added regression coverage for restart recovery and concurrent marker creation.

## Implementation Details

- `RelationRepository.apply_resolved_targets()` writes one marker per affected source in the
  same transaction as target resolution and duplicate-edge cleanup.
- Multiple markers for one entity are intentional. A relation change committed while an older
  refresh is running receives a newer row, and exact-ID cleanup cannot erase it.
- `RepositoryRelationResolutionRuntime` queries markers after committing relation changes, so a
  fresh runtime can retry projection work without relying on in-memory affected IDs.
- Marker rows cascade with project/entity deletion and otherwise remain until indexing succeeds.
- `SearchService.index_entity_data()` preloads Markdown only when the caller did not provide
  accepted content. Pending accepted `NoteContent` therefore keeps bypassing file storage.

## Testing

### Automated

- `just fast-check`: passed; type checking reported nine existing Python 3.14 asyncio
  deprecation warnings.
- `BASIC_MEMORY_ENV=test LOGFIRE_IGNORE_NO_CONFIG=1 .venv/bin/pytest -p pytest_mock --no-cov -q tests/indexing/test_relation_resolution.py tests/indexing/test_relation_search_refresh_retry.py tests/repository/test_relation_repository.py`:
  40 passed.
- `BASIC_MEMORY_ENV=test LOGFIRE_IGNORE_NO_CONFIG=1 .venv/bin/pytest -p pytest_mock --no-cov -q tests/services/test_search_service.py`:
  60 passed.
- `BASIC_MEMORY_ENV=test LOGFIRE_IGNORE_NO_CONFIG=1 .venv/bin/pytest -p pytest_mock --no-cov -q tests/index/test_local_project_index.py -k 'relation or runtime_factory_composes'`:
  6 passed, 38 deselected.
- `BASIC_MEMORY_ENV=test BASIC_MEMORY_TEST_POSTGRES=1 LOGFIRE_IGNORE_NO_CONFIG=1 .venv/bin/pytest -p pytest_mock --no-cov -q tests/indexing/test_relation_search_refresh_retry.py`:
  2 passed.
- `BASIC_MEMORY_ENV=test LOGFIRE_IGNORE_NO_CONFIG=1 .venv/bin/pytest -p pytest_mock --no-cov -q tests/test_semantic_vector_index_migration.py tests/test_migration_loop.py tests/test_note_content_migration.py tests/test_alembic_env.py`:
  15 passed with two unrelated deprecation warnings.
- `BASIC_MEMORY_ENV=test BASIC_MEMORY_TEST_POSTGRES=1 LOGFIRE_IGNORE_NO_CONFIG=1 .venv/bin/pytest -p pytest_mock --no-cov -q tests/test_semantic_vector_index_migration.py`:
  7 passed.
- `just doctor`: passed, including migration, file-to-database, relation-resolution, and search
  checks.

A cold `just fast-test` run had no shared testmon baseline and selected all 5,003 tests. It was
stopped after 402 passes; the two observed failures were sandbox-only attempts to change
permissions under `~/.basic-memory`. That interrupted run is not claimed as a passing gate.

## Risks / Follow-ups

- The migration adds a small durable work table. Rows can accumulate while storage/search
  remains unavailable; that backlog is deliberate and is retired after recovery.
- SQLite migration upgrade/downgrade and both SQLite/PostgreSQL repository behavior were
  exercised locally. The normal PR CI matrix remains the final broad gate.
