### PR TITLE
fix(core): guard note-file cleanup delete against a check→delete TOCTOU

### DIFF
--- a/src/basic_memory/index/local_notes.py
+++ b/src/basic_memory/index/local_notes.py
@@ -182,8 +182,21 @@ class LocalNoteFileDeleteStorage:
     async def compute_checksum(self, path: RuntimeFilePath) -> RuntimeFileChecksum:
         return await self.file_service.compute_checksum(path)
 
-    async def delete_file(self, path: RuntimeFilePath) -> None:
+    async def delete_file_if_unchanged(
+        self,
+        path: RuntimeFilePath,
+        *,
+        expected_checksum: RuntimeFileChecksum,
+    ) -> bool:
+        # The local filesystem has no atomic compare-and-delete, so re-verify the checksum
+        # immediately before deleting. A local race is negligible, but this keeps the runner's
+        # guarantee portable: never delete an object that no longer matches (basic-memory-cloud#1618).
+        if not await self.file_service.exists(path):
+            return False
+        if await self.file_service.compute_checksum(path) != expected_checksum:
+            return False
         await self.file_service.delete_file(path)
+        return True
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/basic_memory/index/note_content_materialization.py
+++ b/src/basic_memory/index/note_content_materialization.py
@@ -522,6 +522,22 @@ class LocalNoteContentStorage:
     async def delete_file(self, path: RuntimeFilePath) -> None:
         await self.file_service.delete_file(path)
 
+    async def delete_file_if_unchanged(
+        self,
+        path: RuntimeFilePath,
+        *,
+        expected_checksum: RuntimeFileChecksum,
+    ) -> bool:
+        # Re-verify the checksum immediately before deleting so a replacement written into the
+        # freshness-read → delete gap is never removed (basic-memory-cloud#1618). Local has no
+        # atomic precondition; the race is negligible on a filesystem.
+        if not await self.file_service.exists(path):
+            return False
+        if await self.file_service.compute_checksum(path) != expected_checksum:
+            return False
+        await self.file_service.delete_file(path)
+        return True
+
 
 @dataclass(frozen=True, slots=True)
 class InlineNoteFileDeleteEnqueuer:

--- a/src/basic_memory/indexing/note_file_delete_runner.py
+++ b/src/basic_memory/indexing/note_file_delete_runner.py
@@ -19,13 +19,27 @@ from basic_memory.runtime.storage import ProjectId, RuntimeFileChecksum, Runtime
 
 
 class NoteFileDeleteStorage(Protocol):
-    """Capability that reads and deletes one materialized note file."""
+    """Capability that reads and conditionally deletes one materialized note file."""
 
     async def exists(self, path: RuntimeFilePath) -> bool: ...
 
     async def compute_checksum(self, path: RuntimeFilePath) -> RuntimeFileChecksum: ...
 
-    async def delete_file(self, path: RuntimeFilePath) -> None: ...
+    async def delete_file_if_unchanged(
+        self,
+        path: RuntimeFilePath,
+        *,
+        expected_checksum: RuntimeFileChecksum,
+    ) -> bool:
+        """Delete the object only if it still matches ``expected_checksum``.
+
+        Return ``True`` when the matching object was deleted, ``False`` when it no longer matched
+        (a different object now occupies the path, or it vanished). Closing this compare-and-delete
+        atomically is what prevents deleting a replacement written into the gap between the freshness
+        read and the delete (basic-memory-cloud#1618). Backends without a native precondition
+        (local filesystem) re-verify the checksum immediately before deleting; storage with a
+        conditional delete (S3 If-Match) enforces it server-side.
+        """
 
 
 class MoveVacateClearer(Protocol):
@@ -83,8 +97,21 @@ async def run_note_file_delete(
         accepted_checksum=request.file_checksum,
         actual_checksum=actual_checksum,
     )
+    result = delete_plan.result
     if delete_plan.should_delete_file:
-        await storage.delete_file(request.file_path)
+        # The freshness read above proved the object matched, but a writer can replace it in the
+        # window before the delete. The delete is therefore conditional on the same checksum; if it
+        # no longer matches, we deleted nothing and report `changed` rather than claiming a delete
+        # of a replacement object (basic-memory-cloud#1618).
+        deleted = await storage.delete_file_if_unchanged(
+            request.file_path,
+            expected_checksum=request.file_checksum,
+        )
+        if not deleted:
+            result = RuntimeFileDeleteResult.changed_before_delete(
+                entity_id=request.entity_id,
+                file_path=request.file_path,
+            )
     # Every guarded outcome proves the moved source object is no longer pending: it was deleted,
     # was already missing, or was replaced by different content. Retire only the marker for this
     # accepted checksum; a newer move that refreshed the path marker remains protected.
@@ -94,4 +121,4 @@ async def run_note_file_delete(
             file_path=request.file_path,
             file_checksum=request.file_checksum,
         )
-    return delete_plan.result
+    return result

--- a/tests/indexing/test_note_file_delete_runner.py
+++ b/tests/indexing/test_note_file_delete_runner.py
@@ -14,6 +14,9 @@ from basic_memory.services.exceptions import FileOperationError
 class FakeNoteFileStorage:
     def __init__(self, checksum: str | None = "file-sum") -> None:
         self.checksum = checksum
+        # Checksum seen by the guarded delete; defaults to the freshness-read value. Set it apart
+        # from `checksum` to simulate a TOCTOU: matches at plan time, differs at delete time.
+        self.checksum_at_delete: str | None = checksum
         self.exists_calls: list[str] = []
         self.compute_checksum_calls: list[str] = []
         self.delete_calls: list[str] = []
@@ -29,10 +32,13 @@ class FakeNoteFileStorage:
             raise AssertionError("compute_checksum should not be called for absent files")
         return self.checksum
 
-    async def delete_file(self, path: str) -> None:
+    async def delete_file_if_unchanged(self, path: str, *, expected_checksum: str) -> bool:
         self.delete_calls.append(path)
         if self.delete_error is not None:
             raise self.delete_error
+        if self.checksum_at_delete != expected_checksum:
+            return False
+        return True
 
 
 def delete_request(file_checksum: str | None = "file-sum") -> RuntimeNoteFileDeleteJobRequest:
@@ -94,6 +100,25 @@ async def test_run_note_file_delete_skips_changed_object() -> None:
     assert result.status == RuntimeDeleteStatus.skipped
     assert result.reason == "file changed before delete: notes/a.md"
     assert storage.delete_calls == []
+
+
+@pytest.mark.asyncio
+async def test_run_note_file_delete_skips_when_object_changes_before_delete() -> None:
+    """TOCTOU guard: an object matching at read time but replaced before the delete is not removed.
+
+    The guarded delete sees a different checksum and deletes nothing; the runner reports `changed`
+    instead of claiming it deleted the replacement (basic-memory-cloud#1618).
+    """
+    storage = FakeNoteFileStorage(checksum="file-sum")
+    # A writer replaces the object between the freshness read and the delete.
+    storage.checksum_at_delete = "replacement-sum"
+
+    result = await run_note_file_delete(delete_request(), storage=storage)
+
+    assert result.status == RuntimeDeleteStatus.skipped
+    assert result.reason == "file changed before delete: notes/a.md"
+    # The guarded delete was attempted (and declined) — not skipped at plan time.
+    assert storage.delete_calls == ["notes/a.md"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Core half of basicmachines-co/basic-memory-cloud#1618.

## Problem
`run_note_file_delete` read the object's checksum, then called `storage.delete_file(path)` **unconditionally**. A writer that replaced the object at that path between the read and the delete would have its replacement removed. This is the shared cleanup path behind both the move-cleanup delete job and the periodic reconcile sweep, so the sweep re-running it over old markers amplifies exposure.

## Fix
Make the delete conditional. `NoteFileDeleteStorage` now exposes:

```python
async def delete_file_if_unchanged(self, path, *, expected_checksum) -> bool
```

a compare-and-delete that removes the object only while it still matches `expected_checksum`, returning `False` if a different object now occupies the path (or it vanished). The runner calls it instead of the unconditional delete and maps `False` to the existing `changed_before_delete` result — so it never claims to have deleted a replacement.

- Storage with a native precondition (cloud S3 `If-Match`) enforces this server-side.
- The local file-service adapters (`LocalNoteFileDeleteStorage`, `LocalNoteContentStorage`) re-verify the checksum immediately before deleting; a local filesystem race is negligible, and this keeps the runner's guarantee portable.

Marker-clear behavior is unchanged: every guarded outcome (deleted / missing / changed) still retires the accepted-checksum move-vacate marker.

## Follow-up (cloud)
`S3FileService.delete_file_if_unchanged` will conform to this protocol (reusing its existing guarded `If-Match` delete), then cloud re-pins `basic_memory`. Tracked in basic-memory-cloud#1618.

## Testing
`ty` clean on the changed files; `ruff` clean. New TOCTOU regression test (object matches at read time, replaced before delete → `skipped`, replacement not deleted). Existing delete / missing / changed / marker-clear cases updated to the guarded method. 550 tests pass across `tests/indexing` + `tests/runtime`; `tests/index` 142 passed / 1 deselected (the deselected one is the pre-existing `@pytest.mark.semantic` env test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)