### PR TITLE
fix(core): stop frontmatter merge from stacking a second block on parse failure

### DIFF
--- a/src/basic_memory/services/file_service.py
+++ b/src/basic_memory/services/file_service.py
@@ -481,15 +481,21 @@ class FileService:
             if file_utils.has_frontmatter(content):
                 try:
                     current_fm = file_utils.parse_frontmatter(content)
-                    content = file_utils.remove_frontmatter(content)
-                except (ParseError, yaml.YAMLError) as e:  # pragma: no cover
-                    # Log warning and treat as plain markdown without frontmatter
-                    logger.warning(  # pragma: no cover
+                except (ParseError, yaml.YAMLError) as e:
+                    # Malformed YAML in the existing block: fall through and replace
+                    # it below rather than merging into it.
+                    logger.warning(
                         f"Failed to parse YAML frontmatter in {full_path}: {e}. "
-                        "Treating file as plain markdown without frontmatter."
+                        "Replacing malformed frontmatter instead of merging into it."
                     )
-                    # Keep full content, treat as having no frontmatter
-                    current_fm = {}  # pragma: no cover
+                    current_fm = {}
+                # Trigger: an existing frontmatter block was detected, whether or not
+                # it parsed as valid YAML.
+                # Why: the writer must never emit a second `---` block ahead of the
+                # existing one — that silently shadows every field in it (issue #1171).
+                # Outcome: always strip the detected block from the body so the new
+                # block replaces it in place instead of stacking on top of it.
+                content = file_utils.remove_frontmatter(content)
 
             # Update frontmatter
             new_fm = {**current_fm, **updates}

--- a/tests/services/test_file_service.py
+++ b/tests/services/test_file_service.py
@@ -201,6 +201,30 @@ async def test_update_frontmatter_checksum_matches_windows_crlf_persisted_bytes(
 
 
 @pytest.mark.asyncio
+async def test_update_frontmatter_replaces_malformed_block_instead_of_stacking(
+    tmp_path: Path, file_service: FileService
+):
+    """A frontmatter block that fails to parse as YAML must be replaced, never
+    left in place with a second block prepended ahead of it (issue #1171)."""
+    test_path = tmp_path / "note.md"
+    # Colon inside an unquoted scalar makes this block detectable via fences
+    # (has_frontmatter -> True) but invalid YAML (parse_frontmatter -> raises).
+    test_path.write_text(
+        "---\ndescription: bad: value: shape\n---\n\n# Note\nBody\n",
+        encoding="utf-8",
+    )
+
+    result = await file_service.update_frontmatter_with_result(
+        test_path,
+        {"permalink": "test/note"},
+    )
+
+    assert result.content.count("---\n") == 2
+    assert "permalink: test/note" in result.content
+    assert "# Note\nBody" in result.content
+
+
+@pytest.mark.asyncio
 async def test_read_file_content(tmp_path: Path, file_service: FileService):
     """Test read_file_content returns just the content without checksum."""
     test_path = tmp_path / "test.md"


### PR DESCRIPTION
Fixes #1171.

## Summary
- `FileService.update_frontmatter_with_result` only stripped the existing frontmatter block when YAML parsing of it succeeded. If the block had valid fences but invalid YAML inside (e.g. an unescaped special character in an older-style note), the original block was left in place and a new merge-only block was prepended ahead of it, silently shadowing `name`/`description`/etc. from any first-block frontmatter parser.
- The fix always strips the detected block once fences are found, regardless of parse success, so a malformed block is replaced in place instead of duplicated.
- Added a regression test reproducing the exact failure mode.

## Test plan
- `uv run pytest tests/services/test_file_service.py tests/indexing/test_batch_indexer.py` — all pass
- `ruff check` / `ruff format --check` on changed files — clean
- `ty check` on changed files — clean

Generated with [Claude Code](https://claude.ai/code)