### PR TITLE
fix(core): load existing Milvus collections after restart

### DIFF
--- a/src/basic_memory/repository/milvus_index.py
+++ b/src/basic_memory/repository/milvus_index.py
@@ -85,6 +85,10 @@ class MilvusVectorIndex:
                         "a concurrent create operation."
                     )
             if dimensions == self.scope.dimensions:
+                # Milvus Lite releases persisted collections when the owning process exits.
+                # Load only after the scope check so migrations do not load incompatible
+                # remote collections before Basic Memory refuses to use them.
+                repository.load_collection(self._collection_name)
                 return
 
             # Trigger: an existing project collection uses another embedding dimension.

--- a/src/basic_memory/repository/milvus_repository.py
+++ b/src/basic_memory/repository/milvus_repository.py
@@ -59,6 +59,8 @@ class MilvusRepository(Protocol):
 
     def collection_dimensions(self, collection_name: str) -> int | None: ...
 
+    def load_collection(self, collection_name: str) -> None: ...
+
     def create_collection(self, collection_name: str, dimensions: int) -> bool: ...
 
     def upsert(self, collection_name: str, records: Sequence[MilvusStoredRecord]) -> None: ...
@@ -239,14 +241,13 @@ class PyMilvusRepository:
             raise RuntimeError(
                 f"Milvus collection '{collection_name}' requires a COSINE index on 'embedding'."
             )
-        # Milvus Lite releases persisted collections when the owning process exits.
-        # Fresh CLI processes must load a compatible existing collection before any
-        # search, query, or orphan-reconciliation operation can use it.
+        return dimensions
+
+    def load_collection(self, collection_name: str) -> None:
         self._client.load_collection(
             collection_name=collection_name,
             timeout=self._timeout,
         )
-        return dimensions
 
     def create_collection(self, collection_name: str, dimensions: int) -> bool:
         """Return whether this client created the collection."""

--- a/src/basic_memory/repository/milvus_repository.py
+++ b/src/basic_memory/repository/milvus_repository.py
@@ -239,6 +239,13 @@ class PyMilvusRepository:
             raise RuntimeError(
                 f"Milvus collection '{collection_name}' requires a COSINE index on 'embedding'."
             )
+        # Milvus Lite releases persisted collections when the owning process exits.
+        # Fresh CLI processes must load a compatible existing collection before any
+        # search, query, or orphan-reconciliation operation can use it.
+        self._client.load_collection(
+            collection_name=collection_name,
+            timeout=self._timeout,
+        )
         return dimensions
 
     def create_collection(self, collection_name: str, dimensions: int) -> bool:

--- a/test-int/semantic/test_milvus_lite.py
+++ b/test-int/semantic/test_milvus_lite.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 
 import pytest
@@ -21,6 +22,61 @@ pytestmark = [
     pytest.mark.semantic,
     pytest.mark.skipif(sys.platform == "win32", reason="Milvus Lite does not support Windows"),
 ]
+
+
+_RESTART_SCRIPT = """
+import asyncio
+import sys
+
+from basic_memory.repository.milvus_config import MilvusSettings
+from basic_memory.repository.milvus_index import MilvusVectorIndex
+from basic_memory.repository.semantic_vector_index import (
+    VectorIndexScope,
+    VectorKey,
+    VectorRecord,
+)
+
+
+async def main() -> None:
+    phase, database_path = sys.argv[1:]
+    scope = VectorIndexScope(
+        namespace="restart-database",
+        project_id=7,
+        embedding_identity="Stub:model",
+        dimensions=3,
+    )
+    key = VectorKey(entity_id=1, chunk_key="summary:0")
+    index = MilvusVectorIndex(scope, MilvusSettings(uri=database_path))
+
+    if phase == "write":
+        await index.upsert(
+            [
+                VectorRecord(
+                    key=key,
+                    source_hash="auth-v1",
+                    values=(1.0, 0.0, 0.0),
+                )
+            ]
+        )
+        return
+
+    await index.delete_orphans([key])
+    matches = await index.search((1.0, 0.0, 0.0), limit=1)
+    assert [match.key for match in matches] == [key]
+
+
+asyncio.run(main())
+"""
+
+
+def _run_restart_phase(phase: str, database_path: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _RESTART_SCRIPT, phase, database_path],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.asyncio
@@ -64,3 +120,10 @@ async def test_milvus_lite_vector_lifecycle(tmp_path) -> None:
 
     await index.delete_orphans([])
     assert await index.search((1.0, 0.0, 0.0), limit=2) == []
+
+
+def test_milvus_lite_reloads_collection_after_process_restart(tmp_path) -> None:
+    database_path = str(tmp_path / "restart-vectors.db")
+
+    _run_restart_phase("write", database_path)
+    _run_restart_phase("read", database_path)

--- a/tests/repository/test_milvus_index.py
+++ b/tests/repository/test_milvus_index.py
@@ -50,6 +50,7 @@ class FakeRepository:
         self.create_result = create_result
         self.race_dimensions = race_dimensions
         self.created: list[tuple[str, int]] = []
+        self.loaded: list[str] = []
         self.upserts: list[tuple[str, list[MilvusStoredRecord]]] = []
         self.record_deletes: list[tuple[str, list[tuple[str, str]]]] = []
         self.entity_deletes: list[tuple[str, int]] = []
@@ -62,6 +63,9 @@ class FakeRepository:
     def collection_dimensions(self, collection_name: str) -> int | None:
         assert collection_name
         return self.dimensions
+
+    def load_collection(self, collection_name: str) -> None:
+        self.loaded.append(collection_name)
 
     def create_collection(self, collection_name: str, dimensions: int) -> bool:
         self.created.append((collection_name, dimensions))
@@ -239,6 +243,7 @@ async def test_initialize_accepts_compatible_collection_create_race(
 
     assert repository.created == [(collection_name(settings, scope), scope.dimensions)]
     assert repository.dimensions == scope.dimensions
+    assert repository.loaded == [collection_name(settings, scope)]
 
 
 @pytest.mark.asyncio
@@ -252,6 +257,7 @@ async def test_initialize_rejects_incompatible_collection_create_race(
         await _index(scope, settings, repository).initialize()
 
     assert repository.dimensions == 99
+    assert repository.loaded == []
 
 
 @pytest.mark.asyncio
@@ -278,6 +284,7 @@ async def test_initialize_preserves_collection_on_dimension_mismatch(
 
     assert repository.created == []
     assert repository.dimensions == 99
+    assert repository.loaded == []
 
 
 @pytest.mark.asyncio
@@ -290,6 +297,7 @@ async def test_initialize_accepts_matching_collection(
     await _index(scope, settings, repository).initialize()
 
     assert repository.created == []
+    assert repository.loaded == [collection_name(settings, scope)]
 
 
 @pytest.mark.asyncio

--- a/tests/repository/test_milvus_repository.py
+++ b/tests/repository/test_milvus_repository.py
@@ -104,6 +104,7 @@ class FakeClient:
         self.index_params = FakeIndexParams()
         self.created: list[dict[str, object]] = []
         self.create_exception: MilvusException | None = None
+        self.loaded: list[dict[str, object]] = []
         self.upserts: list[dict[str, object]] = []
         self.deletes: list[dict[str, object]] = []
         self.iterator = FakeIterator([[{"id": "one"}, {"id": "two"}], []])
@@ -165,6 +166,15 @@ class FakeClient:
         self.created.append(kwargs)
         if self.create_exception is not None:
             raise self.create_exception
+
+    def load_collection(self, *, collection_name: str, timeout: float) -> None:
+        self._record_timeout("load_collection", timeout)
+        self.loaded.append(
+            {
+                "collection_name": collection_name,
+                "timeout": timeout,
+            }
+        )
 
     def upsert(self, **kwargs: object) -> None:
         self._record_kwargs_timeout("upsert", kwargs)
@@ -248,6 +258,7 @@ def test_repository_applies_finite_deadline_to_every_remote_operation(
         "describe_index",
         "has_collection",
         "list_indexes",
+        "load_collection",
         "query_iterator",
         "search",
         "upsert",
@@ -258,7 +269,7 @@ def test_repository_applies_finite_deadline_to_every_remote_operation(
     assert client.searches[0]["consistency_level"] == "Strong"
 
 
-def test_collection_dimensions_reports_missing_and_valid_collection(
+def test_collection_dimensions_reports_missing_and_loads_valid_collection(
     repository: PyMilvusRepository,
     client: FakeClient,
 ) -> None:
@@ -266,6 +277,7 @@ def test_collection_dimensions_reports_missing_and_valid_collection(
 
     client.has_collection_result = True
     assert repository.collection_dimensions("vectors") == 4
+    assert client.loaded == [{"collection_name": "vectors", "timeout": 12.5}]
 
 
 @pytest.mark.parametrize(

--- a/tests/repository/test_milvus_repository.py
+++ b/tests/repository/test_milvus_repository.py
@@ -231,6 +231,7 @@ def test_repository_applies_finite_deadline_to_every_remote_operation(
     client.has_collection_result = True
 
     assert repository.collection_dimensions("vectors") == 4
+    repository.load_collection("vectors")
     assert repository.create_collection("vectors", 4)
     repository.upsert(
         "vectors",
@@ -269,7 +270,7 @@ def test_repository_applies_finite_deadline_to_every_remote_operation(
     assert client.searches[0]["consistency_level"] == "Strong"
 
 
-def test_collection_dimensions_reports_missing_and_loads_valid_collection(
+def test_collection_dimensions_reports_missing_and_valid_collection(
     repository: PyMilvusRepository,
     client: FakeClient,
 ) -> None:
@@ -277,6 +278,10 @@ def test_collection_dimensions_reports_missing_and_loads_valid_collection(
 
     client.has_collection_result = True
     assert repository.collection_dimensions("vectors") == 4
+    assert client.loaded == []
+
+    repository.load_collection("vectors")
+
     assert client.loaded == [{"collection_name": "vectors", "timeout": 12.5}]
 
 


### PR DESCRIPTION
## Why

Milvus Lite persists collection data when a process exits, but releases the collection itself.
A fresh Basic Memory process can therefore validate the persisted collection and then fail its
first query, search, or orphan reconciliation because the collection has not been loaded.

This PR carries forward Cheney Zhang's contribution from #1174 with authorship and sign-off
preserved, then addresses the current-head review finding that an incompatible remote collection
must not be loaded before Basic Memory rejects its embedding dimensions.

## What Changed

- Load compatible existing Milvus collections during vector-index initialization.
- Keep collection schema inspection separate from the collection-loading side effect.
- Refuse incompatible dimensions without loading the preserved remote collection.
- Extend the real Milvus Lite integration suite with a two-process restart regression covering
  orphan reconciliation and search.

## Implementation Details

- `MilvusRepository` now exposes `load_collection()` as an explicit lifecycle capability.
- `MilvusVectorIndex` invokes it only after schema, COSINE index, and embedding-dimension checks
  all succeed. Newly created collections remain on PyMilvus's existing create-and-load path.
- Compatible winners of a concurrent collection-creation race are loaded after being re-read;
  incompatible winners retain the existing fail-fast migration behavior without being loaded.
- Contributor commit `3b2450f5` is preserved on this branch as author-attributed commit
  `f72420f7`; the compatibility correction is a separate signed follow-up commit.

## Testing

### Automated

- `uv run pytest -q tests/repository/test_milvus_config.py tests/repository/test_milvus_index.py tests/repository/test_milvus_repository.py tests/repository/test_semantic_vector_index.py test-int/semantic/test_milvus_lite.py --no-cov`: 85 passed.
- `just fast-check`: passed Ruff fixes/checks, formatting, and `ty check src tests test-int`.
- `git diff --check origin/main...HEAD`: passed.

The existing `test-milvus` GitHub Actions job installs `.[dev,milvus]` and runs the Milvus unit
and Lite integration suites on Linux/Python 3.12, macOS/Python 3.13, and Windows/Python 3.12.
Milvus Lite tests are skipped on Windows because Milvus Lite does not support that platform.

### Manual

- Ran the two-process Milvus Lite restart regression locally with loopback binding enabled; the
  persisted collection was loaded in the second process and remained searchable.

## Risks / Follow-ups

- Local and CI integration coverage use Milvus Lite; this change has not been exercised against
  a live remote Milvus or Zilliz deployment.
- Dimension or schema migrations remain an explicit operator action. This PR deliberately does
  not load or replace incompatible collections automatically.
