### PR TITLE
fix(core): preserve malformed frontmatter during sync

### DIFF
--- a/src/basic_memory/services/file_service.py
+++ b/src/basic_memory/services/file_service.py
@@ -465,7 +465,6 @@ class FileService:
 
         Raises:
             FileOperationError: If file operations fail
-            ParseError: If frontmatter parsing fails
         """
         # Convert string to Path if needed
         path_obj = self.base_path / path if isinstance(path, str) else path
@@ -481,15 +480,15 @@ class FileService:
             if file_utils.has_frontmatter(content):
                 try:
                     current_fm = file_utils.parse_frontmatter(content)
-                    content = file_utils.remove_frontmatter(content)
-                except (ParseError, yaml.YAMLError) as e:  # pragma: no cover
-                    # Log warning and treat as plain markdown without frontmatter
-                    logger.warning(  # pragma: no cover
-                        f"Failed to parse YAML frontmatter in {full_path}: {e}. "
-                        "Treating file as plain markdown without frontmatter."
-                    )
-                    # Keep full content, treat as having no frontmatter
-                    current_fm = {}  # pragma: no cover
+                except ParseError as e:
+                    # Trigger: a fenced frontmatter block cannot be parsed safely.
+                    # Why: Markdown is authoritative, and a partial update cannot know
+                    # which malformed metadata fields the user intended to preserve.
+                    # Outcome: reject the rewrite before any bytes are changed.
+                    raise FileOperationError(
+                        f"Refusing to update malformed frontmatter in {full_path}: {e}"
+                    ) from e
+                content = file_utils.remove_frontmatter(content)
 
             # Update frontmatter
             new_fm = {**current_fm, **updates}
@@ -522,14 +521,14 @@ class FileService:
                 content=content_for_checksum,
             )
 
+        except FileOperationError:
+            raise
         except Exception as e:  # pragma: no cover
-            # Only log real errors (not YAML parsing, which is handled above)
-            if not isinstance(e, (ParseError, yaml.YAMLError)):
-                logger.error(
-                    "Failed to update frontmatter",
-                    path=str(full_path),
-                    error=str(e),
-                )
+            logger.error(
+                "Failed to update frontmatter",
+                path=str(full_path),
+                error=str(e),
+            )
             raise FileOperationError(f"Failed to update frontmatter: {e}")
 
     async def update_frontmatter(self, path: FilePath, updates: Dict[str, Any]) -> str:

--- a/tests/indexing/test_batch_indexer.py
+++ b/tests/indexing/test_batch_indexer.py
@@ -656,6 +656,58 @@ async def test_batch_indexer_uses_parsed_markdown_body_for_malformed_frontmatter
 
 
 @pytest.mark.asyncio
+async def test_batch_indexer_reports_malformed_yaml_without_rewriting_source(
+    app_config,
+    entity_service,
+    entity_repository,
+    relation_repository,
+    search_service,
+    file_service,
+    project_config,
+):
+    path = "notes/malformed-yaml.md"
+    original_content = dedent(
+        """\
+        ---
+        title: Important
+        description: Agent context: urgent: keep
+        tags: [critical]
+        ---
+
+        # Important
+
+        The source file must remain authoritative.
+        """
+    )
+    await _create_file(project_config.home / path, original_content)
+    batch_indexer = _make_batch_indexer(
+        app_config,
+        entity_service,
+        entity_repository,
+        relation_repository,
+        search_service,
+        file_service,
+    )
+
+    result = await batch_indexer.index_files(
+        {path: await _load_input(file_service, path)},
+        max_concurrent=1,
+        parse_max_concurrent=1,
+    )
+
+    assert result.indexed == []
+    assert len(result.errors) == 1
+    error_path, error = result.errors[0]
+    assert error_path == path
+    assert "Refusing to update malformed frontmatter" in error
+    assert (project_config.home / path).read_text(encoding="utf-8") == original_content
+
+    async with db.scoped_session(search_service.session_maker) as session:
+        entity = await entity_repository.get_by_file_path(session, path)
+    assert entity is None
+
+
+@pytest.mark.asyncio
 async def test_batch_indexer_re_raises_fatal_sync_errors(
     app_config,
     entity_service,

--- a/tests/services/test_file_service.py
+++ b/tests/services/test_file_service.py
@@ -201,6 +201,32 @@ async def test_update_frontmatter_checksum_matches_windows_crlf_persisted_bytes(
 
 
 @pytest.mark.asyncio
+async def test_update_frontmatter_rejects_malformed_yaml_without_changing_file(
+    tmp_path: Path, file_service: FileService
+):
+    """A partial metadata update must not replace malformed user frontmatter."""
+    test_path = tmp_path / "note.md"
+    original_content = (
+        "---\n"
+        "title: Important\n"
+        "description: Agent context: urgent: keep\n"
+        "tags: [critical]\n"
+        "---\n\n"
+        "# Note\n"
+        "Body\n"
+    )
+    test_path.write_text(original_content, encoding="utf-8")
+
+    with pytest.raises(FileOperationError, match="Refusing to update malformed frontmatter"):
+        await file_service.update_frontmatter_with_result(
+            test_path,
+            {"permalink": "notes/important"},
+        )
+
+    assert test_path.read_text(encoding="utf-8") == original_content
+
+
+@pytest.mark.asyncio
 async def test_read_file_content(tmp_path: Path, file_service: FileService):
     """Test read_file_content returns just the content without checksum."""
     test_path = tmp_path / "test.md"


### PR DESCRIPTION
## Why

Fixes #1171. Supersedes #1173.

When sync adds or updates a permalink, `FileService.update_frontmatter_with_result()` currently
treats an unparseable fenced YAML block as ordinary Markdown and prepends a new frontmatter block.
That creates the double-frontmatter state reported in #1171.

#1173 found this writer path, but its proposed repair strips the malformed block and writes only
the requested fields. A permalink-only sync can therefore delete the note's title, description,
tags, timestamps, and other user metadata. This replacement keeps the root-cause fix while
preserving Markdown as the authoritative user-owned representation.

## What Changed

- Reject a frontmatter update when the existing fenced YAML cannot be parsed safely.
- Leave the source file byte-for-byte unchanged instead of stacking or replacing metadata.
- Report malformed files through the batch-indexing error result without creating derived entity
  or search state from a partial rewrite.
- Add service-level and batch-indexing regressions for the destructive case identified during the
  review of #1173.

## Implementation Details

`FileService` now parses an existing frontmatter block before removing or rewriting any bytes. A
`ParseError` becomes a specific `FileOperationError`, and the existing outer error boundary
preserves that error instead of wrapping it a second time.

Valid frontmatter merges and frontmatter creation are unchanged. The deliberate tradeoff is that
a malformed note must be repaired by its owner before Basic Memory can normalize its permalink;
the system will not guess how to reconstruct invalid YAML or discard fields it cannot understand.

The batch-indexing regression exercises the real storage writer and database path. It proves that
the file is reported as an error, remains unchanged, and produces no entity projection.

## Testing

### Automated

- `BASIC_MEMORY_ENV=test LOGFIRE_IGNORE_NO_CONFIG=1 uv run pytest -q tests/services/test_file_service.py tests/indexing/test_batch_indexer.py --no-cov`: **38 passed**.
- `just fast-check`: Ruff fix/check, formatting, and `ty check src tests test-int` passed.
- `git diff --check origin/main...HEAD`: passed.
- `BASIC_MEMORY_ENV=test LOGFIRE_IGNORE_NO_CONFIG=1 just fast-test`: testmon selected 4,172 tests because its cache was cold/mismatched; the run was stopped manually after **1,488 passed, 25 skipped, and no failures**. This interrupted run is not counted as a passing gate.

### Manual

- Reproduced #1173's proposed behavior against malformed frontmatter containing `title`,
  `description`, and `tags`; a permalink-only update deleted all three fields. The regression now
  asserts that the same update raises and preserves the original bytes.

## Risks / Follow-ups

- Malformed fenced YAML is now visible as a sync/indexing error and remains unindexed until the
  user repairs it. This is intentional: preserving the canonical Markdown is safer than silently
  producing partial metadata.
- We consider #1171 fixed by making this writer unable to emit a second block. If the reported
  symptom is reproduced through another write path, reopen the issue with that new evidence.
