### PR TITLE
fix(core): remove regular-file permalink lookup

### DIFF
--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -52,6 +52,9 @@ which graph and search projections attach.
 - `permalink` is the human/agent-facing semantic address for Markdown content. It is
   project-scoped, may be absent when permalinks are disabled or inapplicable, and changes only
   according to the configured move and permalink policies.
+- Non-Markdown entities always have `permalink=None`. `external_id` is their stable API identity,
+  and `file_path` locates the stored resource; a database-only permalink would not round-trip
+  through the source file.
 - `title` is mutable display metadata, not identity.
 - For Markdown notes, `created_at` and `updated_at` project the canonical `created` and `modified`
   frontmatter values. Missing values fall back independently to file ctime and mtime for legacy

--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -438,7 +438,8 @@ class BatchIndexer:
         is_new_entity = existing is None
 
         if existing is None:
-            await self.entity_service.resolve_permalink(file.path, skip_conflict_check=True)
+            # Non-Markdown resources cannot persist a semantic address back to source bytes.
+            # Their stable API identity is external_id; file_path locates the stored resource.
             entity = Entity(
                 note_type="file",
                 file_path=file.path,

--- a/tests/indexing/test_batch_indexer.py
+++ b/tests/indexing/test_batch_indexer.py
@@ -347,6 +347,7 @@ async def test_batch_indexer_indexes_non_markdown_files(
     search_service,
     file_service,
     project_config,
+    monkeypatch,
 ):
     pdf_path = "assets/doc.pdf"
     image_path = "assets/image.png"
@@ -357,6 +358,10 @@ async def test_batch_indexer_indexes_non_markdown_files(
         pdf_path: await _load_input(file_service, pdf_path),
         image_path: await _load_input(file_service, image_path),
     }
+    resolve_permalink = AsyncMock(
+        side_effect=AssertionError("non-Markdown files must not resolve permalinks")
+    )
+    monkeypatch.setattr(entity_service, "resolve_permalink", resolve_permalink)
     batch_indexer = _make_batch_indexer(
         app_config,
         entity_service,
@@ -380,8 +385,11 @@ async def test_batch_indexer_indexes_non_markdown_files(
         image_entity = await entity_repository.get_by_file_path(session, image_path)
     assert pdf_entity is not None
     assert pdf_entity.content_type == "application/pdf"
+    assert pdf_entity.permalink is None
     assert image_entity is not None
     assert image_entity.content_type == "image/png"
+    assert image_entity.permalink is None
+    resolve_permalink.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Remove the discarded permalink lookup from regular-file indexing and make the existing non-Markdown identity contract explicit.

Non-Markdown resources continue to be addressed by their stable `external_id` and project-relative `file_path`. They continue to persist with `permalink=None`.

Fixes #1182.

## Problem

`BatchIndexer._upsert_regular_file()` called `EntityService.resolve_permalink()` when creating a PDF, image, or other non-Markdown entity, then discarded the returned value and created the entity without a permalink.

That call was dead work, but it also obscured an important domain invariant: permalinks are semantic addresses for Markdown notes because they can round-trip through frontmatter. A generated database-only permalink for arbitrary resource bytes would introduce a second identity that the source cannot represent.

## Implementation

- Remove the unused `resolve_permalink()` call from the regular-file creation path.
- Document that non-Markdown entities always have `permalink=None`.
- Document the intended identities:
  - `external_id` is the stable API identity.
  - `file_path` locates the resource in project storage.
- Strengthen the existing batch-indexer regression so PDF and image indexing:
  - fails immediately if permalink resolution is attempted;
  - asserts both entities persist with no permalink.

## Scope

This is contract cleanup only. It does not:

- add or backfill non-Markdown permalinks;
- change routing, search, relation resolution, or wikilinks;
- change regular-file move/update/delete behavior;
- change Markdown permalink behavior.

## Verification

- `uv run pytest -q --no-cov tests/indexing/test_batch_indexer.py::test_batch_indexer_indexes_non_markdown_files tests/index/test_local_project_index.py::test_local_project_index_indexes_regular_files tests/index/test_local_project_index.py::test_local_project_index_updates_regular_file_checksum tests/index/test_local_project_index.py::test_local_project_index_moves_and_deletes_regular_file_entities tests/index/test_local_project_index.py::test_local_project_index_resolves_regular_file_relations tests/index/test_local_watch_regular_file_parity.py`
  - 8 passed
- `just fast-check`
  - Ruff check/fix passed
  - Ruff formatting passed
  - ty type checking passed
- `git diff --check`
  - passed