### PR TITLE
fix(core): enforce materialization lock order

### DIFF
--- a/src/basic_memory/indexing/note_materialization_runner.py
+++ b/src/basic_memory/indexing/note_materialization_runner.py
@@ -9,6 +9,7 @@ from typing import Protocol, Self
 
 from loguru import logger
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory import db
@@ -426,6 +427,17 @@ class RepositoryNoteMaterializationPublisher:
                 entity_id=request.entity_id,
             )
 
+            # Materialization publishes NoteContent and Entity in one transaction.
+            # Lock Entity before reading the publish state so an Entity-first move
+            # cannot change the destination path while this publisher waits.
+            entity = await session.scalar(
+                select(Entity)
+                .where(
+                    Entity.id == request.entity_id,
+                    Entity.project_id == request.project_id,
+                )
+                .with_for_update()
+            )
             note_content = await session.get(NoteContent, request.entity_id)
             publish_plan = plan_written_note_materialization_publish(
                 request=request,
@@ -436,7 +448,13 @@ class RepositoryNoteMaterializationPublisher:
                     if note_content is not None
                     else None
                 ),
-                current_file_path=note_content.file_path if note_content is not None else None,
+                current_file_path=(
+                    entity.file_path
+                    if entity is not None
+                    else note_content.file_path
+                    if note_content is not None
+                    else None
+                ),
             )
             if note_content is None:
                 return publish_plan.result
@@ -466,7 +484,6 @@ class RepositoryNoteMaterializationPublisher:
                     f"Unhandled note materialization publish action: {publish_plan.action}"
                 )
 
-            entity = await session.get(Entity, request.entity_id)
             if entity is None:
                 return RuntimeNoteMaterializationResult(
                     entity_id=request.entity_id,

--- a/src/basic_memory/repository/note_content_repository.py
+++ b/src/basic_memory/repository/note_content_repository.py
@@ -76,9 +76,18 @@ class NoteContentRepository(Repository[NoteContent]):
 
         return NoteContent(**model_data), set(model_data)
 
-    async def _load_entity_identity(self, session: AsyncSession, entity_id: int) -> Entity:
+    async def _load_entity_identity(
+        self,
+        session: AsyncSession,
+        entity_id: int,
+        *,
+        lock_for_update: bool = False,
+    ) -> Entity:
         """Load the owning entity so duplicated identity fields stay aligned."""
-        result = await session.execute(select(Entity).where(Entity.id == entity_id))
+        query = select(Entity).where(Entity.id == entity_id)
+        if lock_for_update:
+            query = query.with_for_update()
+        result = await session.execute(query)
         entity = result.scalar_one_or_none()
         if entity is None:
             raise ValueError(f"Entity {entity_id} does not exist")
@@ -295,7 +304,14 @@ class NoteContentRepository(Repository[NoteContent]):
             # from the entity (rather than mutating the ORM row) so the whole
             # write is the single conditional UPDATE whose rowcount decides the
             # race, portably across SQLite and Postgres.
-            entity = await self._load_entity_identity(session, entity_id)
+            # Materialization publishes NoteContent state and then updates Entity
+            # file metadata in the same transaction. Lock Entity first so that
+            # path cannot invert an Entity -> NoteContent indexing transaction.
+            entity = await self._load_entity_identity(
+                session,
+                entity_id,
+                lock_for_update=True,
+            )
             result = cast(
                 CursorResult[Any],
                 await session.execute(

--- a/test-int/test_note_materialization_lock_order.py
+++ b/test-int/test_note_materialization_lock_order.py
@@ -1,0 +1,202 @@
+"""Postgres regression coverage for Entity-NoteContent materialization lock order."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from datetime import UTC, datetime
+from typing import Any, override
+
+import pytest
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from basic_memory import db
+from basic_memory.indexing.note_materialization_runner import (
+    NoteMaterializationSessionLock,
+    RepositoryNoteMaterializationPublisher,
+)
+from basic_memory.models import Entity, NoteContent, Project
+from basic_memory.repository.note_content_repository import NoteContentRepository
+from basic_memory.runtime.note_content import (
+    RuntimeNoteMaterializationJobRequest,
+    RuntimeNoteMaterializationStatus,
+)
+from basic_memory.runtime.note_materialization import (
+    RuntimeWrittenFileState,
+    plan_prepared_note_write,
+)
+
+
+class StartedMaterializationLock(NoteMaterializationSessionLock):
+    """Expose that the publisher entered its transaction without adding a DB lock."""
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+
+    @override
+    async def lock_note_materialization(
+        self,
+        session: AsyncSession,
+        *,
+        project_id: int,
+        entity_id: int,
+    ) -> None:
+        self.started.set()
+
+
+class PausingNoteContentRepository(NoteContentRepository):
+    """Hold the materializer after NoteContent is updated but before Entity flush."""
+
+    def __init__(self, project_id: int) -> None:
+        super().__init__(project_id)
+        self.update_applied = asyncio.Event()
+        self.release_update = asyncio.Event()
+
+    @override
+    async def update_state_fields(
+        self,
+        session: AsyncSession,
+        entity_id: int,
+        *,
+        expected_db_version: int | None = None,
+        **updates: Any,
+    ) -> NoteContent | None:
+        note_content = await super().update_state_fields(
+            session,
+            entity_id,
+            expected_db_version=expected_db_version,
+            **updates,
+        )
+        self.update_applied.set()
+        await self.release_update.wait()
+        return note_content
+
+
+@pytest.mark.asyncio
+async def test_materialization_waits_for_entity_before_updating_note_content(
+    engine_factory,
+    test_project: Project,
+) -> None:
+    """An Entity-first reconciliation transaction must not deadlock materialization.
+
+    Before the fix, the publisher reaches ``update_applied`` while this test owns
+    the Entity row. An Entity-first reconciliation update would then wait on the
+    publisher's NoteContent lock while the publisher waits on Entity: the exact
+    deadlock cycle reported in #1187.
+    """
+    engine, session_maker = engine_factory
+    if engine.dialect.name != "postgresql":
+        pytest.skip("row-lock ordering requires PostgreSQL")
+
+    file_path = "notes/lock-order.md"
+    markdown = "# Lock order\n"
+    db_checksum = "accepted-checksum"
+    async with db.scoped_session(session_maker) as session:
+        entity = Entity(
+            project_id=test_project.id,
+            title="Lock order",
+            note_type="note",
+            content_type="text/markdown",
+            file_path=file_path,
+            checksum="previous-file-checksum",
+        )
+        session.add(entity)
+        await session.flush()
+        entity_id = entity.id
+        await NoteContentRepository(project_id=test_project.id).create(
+            session,
+            NoteContent(
+                entity_id=entity_id,
+                markdown_content=markdown,
+                db_version=1,
+                db_checksum=db_checksum,
+                file_version=None,
+                file_checksum="previous-file-checksum",
+                file_write_status="writing",
+            ),
+        )
+
+    request = RuntimeNoteMaterializationJobRequest(
+        project_id=test_project.id,
+        entity_id=entity_id,
+        db_version=1,
+        db_checksum=db_checksum,
+        source="api",
+    )
+    attempted_at = datetime(2026, 8, 5, 1, 0, tzinfo=UTC)
+    prepared_write = plan_prepared_note_write(
+        request=request,
+        file_path=file_path,
+        markdown_content=markdown,
+        previous_file_checksum="previous-file-checksum",
+        attempted_at=attempted_at,
+    )
+    written_file = RuntimeWrittenFileState(
+        file_path=file_path,
+        file_checksum="materialized-checksum",
+        file_updated_at=datetime(2026, 8, 5, 1, 1, tzinfo=UTC),
+    )
+    session_lock = StartedMaterializationLock()
+    note_content_repository = PausingNoteContentRepository(test_project.id)
+    publisher = RepositoryNoteMaterializationPublisher(
+        session_maker=session_maker,
+        session_lock=session_lock,
+        note_content_store=lambda _project_id: note_content_repository,
+    )
+
+    publish_task: asyncio.Task[Any] | None = None
+    async with session_maker() as reconciliation_session:
+        await reconciliation_session.begin()
+        try:
+            locked_entity = await reconciliation_session.scalar(
+                select(Entity).where(Entity.id == entity_id).with_for_update()
+            )
+            assert locked_entity is not None
+
+            publish_task = asyncio.create_task(
+                publisher.publish_written_file_state(
+                    request,
+                    prepared_write,
+                    written_file,
+                )
+            )
+            await asyncio.wait_for(session_lock.started.wait(), timeout=2)
+
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(
+                    note_content_repository.update_applied.wait(),
+                    timeout=0.5,
+                )
+
+            await reconciliation_session.execute(
+                update(NoteContent)
+                .where(NoteContent.entity_id == entity_id)
+                .values(last_materialization_error="entity-first reconciliation")
+            )
+            await reconciliation_session.commit()
+
+            note_content_repository.release_update.set()
+            result = await asyncio.wait_for(publish_task, timeout=2)
+        finally:
+            note_content_repository.release_update.set()
+            if reconciliation_session.in_transaction():
+                await reconciliation_session.rollback()
+            if publish_task is not None and not publish_task.done():
+                publish_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await publish_task
+
+    assert result.status is RuntimeNoteMaterializationStatus.written
+
+    async with session_maker() as verification_session:
+        note_content = await verification_session.get(NoteContent, entity_id)
+        entity = await verification_session.get(Entity, entity_id)
+
+    assert note_content is not None
+    assert note_content.file_version == 1
+    assert note_content.file_checksum == "materialized-checksum"
+    assert note_content.file_write_status == "synced"
+    assert entity is not None
+    assert entity.mtime == written_file.file_updated_at.timestamp()
+    assert entity.size == len(markdown.encode("utf-8"))

--- a/test-int/test_note_materialization_lock_order.py
+++ b/test-int/test_note_materialization_lock_order.py
@@ -74,9 +74,11 @@ class PausingNoteContentRepository(NoteContentRepository):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("move_during_wait", [False, True], ids=["stable-path", "moved-path"])
 async def test_materialization_waits_for_entity_before_updating_note_content(
     engine_factory,
     test_project: Project,
+    move_during_wait: bool,
 ) -> None:
     """An Entity-first reconciliation transaction must not deadlock materialization.
 
@@ -169,11 +171,19 @@ async def test_materialization_waits_for_entity_before_updating_note_content(
                     timeout=0.5,
                 )
 
-            await reconciliation_session.execute(
-                update(NoteContent)
-                .where(NoteContent.entity_id == entity_id)
-                .values(last_materialization_error="entity-first reconciliation")
-            )
+            if move_during_wait:
+                locked_entity.file_path = "notes/moved-during-materialization.md"
+                await reconciliation_session.execute(
+                    update(NoteContent)
+                    .where(NoteContent.entity_id == entity_id)
+                    .values(file_path=locked_entity.file_path)
+                )
+            else:
+                await reconciliation_session.execute(
+                    update(NoteContent)
+                    .where(NoteContent.entity_id == entity_id)
+                    .values(last_materialization_error="entity-first reconciliation")
+                )
             await reconciliation_session.commit()
 
             note_content_repository.release_update.set()
@@ -187,16 +197,24 @@ async def test_materialization_waits_for_entity_before_updating_note_content(
                 with suppress(asyncio.CancelledError):
                     await publish_task
 
-    assert result.status is RuntimeNoteMaterializationStatus.written
-
     async with session_maker() as verification_session:
         note_content = await verification_session.get(NoteContent, entity_id)
         entity = await verification_session.get(Entity, entity_id)
 
     assert note_content is not None
-    assert note_content.file_version == 1
-    assert note_content.file_checksum == "materialized-checksum"
-    assert note_content.file_write_status == "synced"
     assert entity is not None
-    assert entity.mtime == written_file.file_updated_at.timestamp()
-    assert entity.size == len(markdown.encode("utf-8"))
+    if move_during_wait:
+        assert result.status is RuntimeNoteMaterializationStatus.stale
+        assert result.written_file_orphaned
+        assert note_content.file_path == "notes/moved-during-materialization.md"
+        assert note_content.file_version is None
+        assert note_content.file_checksum == "previous-file-checksum"
+        assert entity.file_path == "notes/moved-during-materialization.md"
+        assert entity.mtime != written_file.file_updated_at.timestamp()
+    else:
+        assert result.status is RuntimeNoteMaterializationStatus.written
+        assert note_content.file_version == 1
+        assert note_content.file_checksum == "materialized-checksum"
+        assert note_content.file_write_status == "synced"
+        assert entity.mtime == written_file.file_updated_at.timestamp()
+        assert entity.size == len(markdown.encode("utf-8"))

--- a/tests/indexing/test_note_materialization_runner.py
+++ b/tests/indexing/test_note_materialization_runner.py
@@ -141,6 +141,11 @@ class FakeRepositorySession:
         self.entity = entity
         self.note_content = note_content
         self.flush_count = 0
+        self.scalar_statements: list[object] = []
+
+    async def scalar(self, statement: object) -> object | None:
+        self.scalar_statements.append(statement)
+        return self.entity
 
     async def get(self, model: type[object], identity: int) -> object | None:
         assert identity == 42
@@ -563,6 +568,8 @@ async def test_repository_note_materialization_publisher_updates_current_written
         file_checksum="new-file-sum",
     )
     assert session_lock.calls == [(cast(AsyncSession, session), 7, 42)]
+    assert len(session.scalar_statements) == 1
+    assert "FOR UPDATE" in str(session.scalar_statements[0])
     assert repository.calls == [
         (
             cast(AsyncSession, session),


### PR DESCRIPTION
## Summary

Fixes the Entity/NoteContent lock-order inversion reported from hosted note
materialization. Version-guarded NoteContent state updates now acquire the
owning Entity row lock before updating NoteContent, matching the existing
Entity-first indexing and reconciliation order.

Fixes #1187.

## Problem

The materialization publisher updated NoteContent first and then flushed file
metadata to Entity in the same transaction. Entity-first reconciliation could
hold the Entity row while waiting to update NoteContent. Under concurrency,
those two transactions formed the cycle:

```text
materialization: NoteContent -> Entity
reconciliation:  Entity -> NoteContent
```

Postgres could select either transaction as a deadlock victim. Retrying at the
Cloud job boundary reduced impact but did not remove the Core lock inversion.

## Solution

- Allow `NoteContentRepository._load_entity_identity()` to request a
  `SELECT ... FOR UPDATE` lock.
- Have the publisher acquire the project-scoped Entity row lock before reading
  NoteContent or planning publication, so a same-version move cannot change the
  destination while publication waits.
- Acquire that Entity lock before every version-guarded NoteContent compare-and-set
  update.
- Keep the existing conditional `db_version` update, stale-job skip, checksum
  propagation, and Entity file-metadata flush unchanged.
- Leave the Cloud advisory materialization lock unchanged; this is the
  tenant-neutral Core row-lock invariant.

The ordering is now consistently:

```text
Entity -> NoteContent
```

## Regression coverage

The new real-Postgres integration test orchestrates two transactions:

1. an Entity-first reconciliation transaction locks Entity;
2. the materialization publisher enters its transaction;
3. the test proves materialization cannot update NoteContent while the opposing
   transaction owns Entity;
4. reconciliation either keeps the path stable or moves Entity and NoteContent,
   then commits;
5. materialization either publishes the stable path or marks the old-path write
   stale and orphaned, without deadlock or incorrect file-state advancement.

Before this fix, the publisher reaches the instrumented NoteContent update while
the Entity lock is held, exposing the inversion. The test also verifies the
stable-path file version, checksum, sync status, Entity mtime, and Entity size.
The moved-path case proves the old write is not recorded against the new path.

## Verification

- `BASIC_MEMORY_ENV=test LOGFIRE_IGNORE_NO_CONFIG=1 uv run pytest -q --no-cov tests/repository/test_note_content_repository.py tests/indexing/test_note_materialization_runner.py tests/cloud/test_note_content_materialization.py tests/runtime/test_note_content_store_materialization.py tests/runtime/test_note_materialization_request_matching.py`
  - 69 passed
- `BASIC_MEMORY_ENV=test BASIC_MEMORY_TEST_POSTGRES=1 LOGFIRE_IGNORE_NO_CONFIG=1 uv run pytest -p pytest_mock --no-cov -q tests/repository/test_note_content_repository.py test-int/test_note_materialization_lock_order.py`
  - 23 passed
- `just fast-check`
  - Ruff fix/check, Ruff format, and ty passed
- `git diff --cached --check`
  - passed before commit

## Risk

Version-guarded NoteContent updates now hold the Entity row lock until their
transaction completes. That adds intentional serialization for updates to the
same note, but it removes the conflicting lock order. Updates for different
entities remain independent.
