### PR TITLE
refactor(core): drop the discarded permalink resolution for regular files

### DIFF
--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -438,7 +438,11 @@ class BatchIndexer:
         is_new_entity = existing is None
 
         if existing is None:
-            await self.entity_service.resolve_permalink(file.path, skip_conflict_check=True)
+            # Regular files intentionally carry no permalink. A permalink's durable home is the
+            # markdown frontmatter, and a non-markdown file has nowhere to record one: a DB-only
+            # value could not survive a rebuild from files, and its collision suffix would depend
+            # on indexing order, so links to it would silently rot. file_path and external_id are
+            # the stable addresses for these entities (#1182).
             entity = Entity(
                 note_type="file",
                 file_path=file.path,

--- a/tests/indexing/test_batch_indexer.py
+++ b/tests/indexing/test_batch_indexer.py
@@ -382,6 +382,10 @@ async def test_batch_indexer_indexes_non_markdown_files(
     assert pdf_entity.content_type == "application/pdf"
     assert image_entity is not None
     assert image_entity.content_type == "image/png"
+    # Non-markdown entities carry no permalink: there is no frontmatter to record one in, so a
+    # DB-only value could not survive a rebuild from files (#1182). file_path is their address.
+    assert pdf_entity.permalink is None
+    assert image_entity.permalink is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1182.

## Why
Indexing a regular (non-markdown) file called `resolve_permalink()` and discarded the result. I verified the call is **read-only** — conflict detection plus lookups, returning a string, no persistence side effect — and with `skip_conflict_check=True` it doesn't even emit the conflict warning. So it was a wasted DB round-trip per regular file during indexing, and it misled readers (me included) into thinking the value was meant to be stored.

Per @phernandez's point on the issue, **`permalink IS NULL` for non-markdown files is the intended design, not a defect**: a permalink's durable home is the markdown frontmatter, and a non-markdown file has nowhere to record one. A DB-only value couldn't survive a rebuild from files, and its collision suffix (`-1`, `-1-1`) would depend on indexing order, so the same file could return with a different address and links to it would silently rot. `file_path` and `external_id` are the stable addresses for these entities.

## What changed
- **Removed the discarded `resolve_permalink()` call** in `BatchIndexer._upsert_regular_file`.
- **Documented the invariant where the entity is built** — that's where the discarded call invited the wrong conclusion.
- **Extended the existing non-markdown indexing test** to assert `permalink is None`, locking the invariant on the batch-index path.

## Scope notes (two corrections to the issue as filed)
- **`sync_service` was clean.** The issue suggested auditing it for the same pattern. Every other `resolve_permalink` caller *uses* its return value — `batch_indexer`'s markdown path, `local_moves`, `entity_service.move` — so this was the only site. No sweep needed.
- **The invariant was already partly documented.** `models/knowledge.py` carries "required for markdown files only" on the column, and `test_local_watch_regular_file_parity.py` already asserts `permalink is None` twice for the watch path. The real gap was the batch-index path, which is what this covers. My "undocumented invariant" framing in the issue overstated it.

No behavior change beyond skipping the now-provably-unused lookup: no backfill, no data-shape change, nothing touching permalink-keyed routing, search, or wikilink resolution.

## Testing
- `tests/indexing` + `tests/index`: **602 passed**, 1 deselected (the `@pytest.mark.semantic` env test).
- `ty` and `ruff` clean on the changed files.
- `tests/cli` shows 145 pre-existing failures on this branch **and identically on clean `main`** (145 failed / 531 passed both ways), so they're unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)