### PR TITLE
fix(core): handle legacy pgvector storage status

### DIFF
--- a/src/basic_memory/services/project_service.py
+++ b/src/basic_memory/services/project_service.py
@@ -1094,7 +1094,8 @@ class ProjectService:
         if is_postgres:
             table_check_sql = text(
                 "SELECT table_name FROM information_schema.tables "
-                "WHERE table_name IN ('search_vector_chunks', 'search_vector_embeddings')"
+                "WHERE table_schema = ANY (current_schemas(false)) "
+                "AND table_name IN ('search_vector_chunks', 'search_vector_embeddings')"
             )
         else:
             table_check_sql = text(
@@ -1128,14 +1129,13 @@ class ProjectService:
                 columns_result = await self.repository.execute_query(
                     session,
                     text(
-                        "SELECT column_name FROM information_schema.columns "
-                        "WHERE table_schema = ANY (current_schemas(false)) "
-                        "AND table_name = 'search_vector_embeddings'"
+                        "SELECT 1 FROM pg_attribute "
+                        "WHERE attrelid = 'search_vector_embeddings'::regclass "
+                        "AND attname = 'source_hash'"
                     ),
                     {},
                 )
-                storage_columns = {str(name) for name in columns_result.scalars().all()}
-                storage_schema_current = "source_hash" in storage_columns
+                storage_schema_current = columns_result.scalar_one_or_none() is not None
 
             vector_tables_exist = manifest_exists and (
                 not uses_builtin_vector_storage or (storage_exists and storage_schema_current)

--- a/src/basic_memory/services/project_service.py
+++ b/src/basic_memory/services/project_service.py
@@ -1108,9 +1108,6 @@ class ProjectService:
             existing_vector_tables = {str(name) for name in table_result.scalars().all()}
             manifest_exists = "search_vector_chunks" in existing_vector_tables
             storage_exists = "search_vector_embeddings" in existing_vector_tables
-            vector_tables_exist = manifest_exists and (
-                storage_exists or not uses_builtin_vector_storage
-            )
 
             manifest_schema_current = manifest_exists
             if manifest_exists and not is_postgres:
@@ -1125,6 +1122,23 @@ class ProjectService:
                     "vector_index",
                     "embedding_status",
                 }.issubset(manifest_columns)
+
+            storage_schema_current = storage_exists
+            if storage_exists and is_postgres and vector_index == "pgvector":
+                columns_result = await self.repository.execute_query(
+                    session,
+                    text(
+                        "SELECT column_name FROM information_schema.columns "
+                        "WHERE table_name = 'search_vector_embeddings'"
+                    ),
+                    {},
+                )
+                storage_columns = {str(name) for name in columns_result.scalars().all()}
+                storage_schema_current = "source_hash" in storage_columns
+
+            vector_tables_exist = manifest_exists and (
+                not uses_builtin_vector_storage or (storage_exists and storage_schema_current)
+            )
 
             if not manifest_schema_current or not vector_tables_exist:
                 # Count distinct entities in search index for the recommendation message
@@ -1141,6 +1155,12 @@ class ProjectService:
                 if manifest_exists and not manifest_schema_current:
                     reindex_reason = (
                         "Vector manifest schema is outdated — run: bm reindex --embeddings"
+                    )
+                elif storage_exists and not storage_schema_current:
+                    # Legacy pgvector tables are repaired by index initialization. Status is a
+                    # read path, so it only reports the required rebuild instead of mutating data.
+                    reindex_reason = (
+                        "Vector storage schema is outdated — run: bm reindex --embeddings"
                     )
                 elif manifest_schema_current:
                     reindex_reason = "Vector storage not initialized — run: bm reindex --embeddings"

--- a/src/basic_memory/services/project_service.py
+++ b/src/basic_memory/services/project_service.py
@@ -1129,7 +1129,8 @@ class ProjectService:
                     session,
                     text(
                         "SELECT column_name FROM information_schema.columns "
-                        "WHERE table_name = 'search_vector_embeddings'"
+                        "WHERE table_schema = ANY (current_schemas(false)) "
+                        "AND table_name = 'search_vector_embeddings'"
                     ),
                     {},
                 )

--- a/tests/services/test_project_service_embedding_status.py
+++ b/tests/services/test_project_service_embedding_status.py
@@ -211,6 +211,15 @@ async def test_embedding_status_treats_legacy_pgvector_storage_as_unavailable(
         text("CREATE TABLE search_vector_embeddings (chunk_id INTEGER PRIMARY KEY)"),
         {},
     )
+    await _execute(project_service, text("CREATE SCHEMA embedding_status_shadow"), {})
+    await _execute(
+        project_service,
+        text(
+            "CREATE TABLE embedding_status_shadow.search_vector_embeddings ("
+            "chunk_id INTEGER PRIMARY KEY, source_hash TEXT NOT NULL)"
+        ),
+        {},
+    )
 
     try:
         with patch.object(
@@ -223,6 +232,11 @@ async def test_embedding_status_treats_legacy_pgvector_storage_as_unavailable(
             status = await project_service.get_embedding_status(test_project.id)
     finally:
         await _drop_embeddings_stub(project_service)
+        await _execute(
+            project_service,
+            text("DROP SCHEMA embedding_status_shadow CASCADE"),
+            {},
+        )
 
     assert status.vector_tables_exist is False
     assert status.reindex_recommended is True

--- a/tests/services/test_project_service_embedding_status.py
+++ b/tests/services/test_project_service_embedding_status.py
@@ -205,28 +205,36 @@ async def test_embedding_status_treats_legacy_pgvector_storage_as_unavailable(
     if not _is_postgres():
         pytest.skip("The pgvector physical storage schema only applies to Postgres.")
 
-    await _drop_embeddings_stub(project_service)
-    await _execute(
-        project_service,
-        text("CREATE TABLE search_vector_embeddings (chunk_id INTEGER PRIMARY KEY)"),
-        {},
-    )
+    await _create_embeddings_stub(project_service)
     await _execute(project_service, text("CREATE SCHEMA embedding_status_shadow"), {})
     await _execute(
         project_service,
         text(
             "CREATE TABLE embedding_status_shadow.search_vector_embeddings ("
-            "chunk_id INTEGER PRIMARY KEY, source_hash TEXT NOT NULL)"
+            "chunk_id INTEGER PRIMARY KEY)"
         ),
         {},
     )
 
+    original_execute_query = project_service.repository.execute_query
+
+    async def _execute_with_legacy_storage_first(session, query, params=None):
+        await session.execute(text("SET LOCAL search_path TO embedding_status_shadow, public"))
+        return await original_execute_query(session, query, params or {})
+
     try:
-        with patch.object(
-            type(project_service),
-            "config_manager",
-            new_callable=lambda: property(
-                lambda self: _config_manager_with(semantic_search_enabled=True)
+        with (
+            patch.object(
+                type(project_service),
+                "config_manager",
+                new_callable=lambda: property(
+                    lambda self: _config_manager_with(semantic_search_enabled=True)
+                ),
+            ),
+            patch.object(
+                project_service.repository,
+                "execute_query",
+                side_effect=_execute_with_legacy_storage_first,
             ),
         ):
             status = await project_service.get_embedding_status(test_project.id)

--- a/tests/services/test_project_service_embedding_status.py
+++ b/tests/services/test_project_service_embedding_status.py
@@ -196,6 +196,40 @@ async def test_embedding_status_treats_legacy_sqlite_manifest_as_unavailable(
 
 
 @pytest.mark.asyncio
+async def test_embedding_status_treats_legacy_pgvector_storage_as_unavailable(
+    project_service: ProjectService,
+    test_graph,
+    test_project,
+):
+    """Legacy pgvector storage should recommend rebuild before querying source_hash."""
+    if not _is_postgres():
+        pytest.skip("The pgvector physical storage schema only applies to Postgres.")
+
+    await _drop_embeddings_stub(project_service)
+    await _execute(
+        project_service,
+        text("CREATE TABLE search_vector_embeddings (chunk_id INTEGER PRIMARY KEY)"),
+        {},
+    )
+
+    try:
+        with patch.object(
+            type(project_service),
+            "config_manager",
+            new_callable=lambda: property(
+                lambda self: _config_manager_with(semantic_search_enabled=True)
+            ),
+        ):
+            status = await project_service.get_embedding_status(test_project.id)
+    finally:
+        await _drop_embeddings_stub(project_service)
+
+    assert status.vector_tables_exist is False
+    assert status.reindex_recommended is True
+    assert "Vector storage schema is outdated" in (status.reindex_reason or "")
+
+
+@pytest.mark.asyncio
 async def test_embedding_status_entities_without_chunks(
     project_service: ProjectService, test_graph, test_project
 ):


### PR DESCRIPTION
## Why

Production Logfire issue #2173 shows project-info requests failing with asyncpg `UndefinedColumnError` because a legacy `search_vector_embeddings` table predates the `source_hash` column used by current count queries.

The physical table can exist before `PgVectorIndex.initialize()` has run its existing schema repair. Project status currently treats table existence as schema readiness and executes the invalid join, turning a recoverable reindex state into a customer-visible HTTP 500.

Closes #1195.

## What Changed

- inspect the Postgres pgvector embeddings columns before running physical count queries
- treat storage without `source_hash` as outdated and return the existing reindex recommendation contract
- add a Postgres regression that creates the production-shaped legacy table and proves status does not query the missing column

## Implementation Details

`ProjectService.get_embedding_status()` now distinguishes physical-table existence from schema readiness for the built-in pgvector adapter. When the legacy table is detected, it returns `vector_tables_exist=False` with `Vector storage schema is outdated — run: bm reindex --embeddings`.

The status path remains read-only. It does not drop, migrate, or rebuild the table; `PgVectorIndex.initialize()` remains the single repair owner and will recreate the incompatible physical table when indexing runs. External adapters remain manifest-only, and SQLite behavior is unchanged.

## Testing

### Automated

- `LOGFIRE_IGNORE_NO_CONFIG=1 uv run pytest -p pytest_mock --no-cov -q tests/services/test_project_service_embedding_status.py`: 15 passed, 1 skipped
- `BASIC_MEMORY_TEST_POSTGRES=1 LOGFIRE_IGNORE_NO_CONFIG=1 uv run pytest -p pytest_mock --no-cov -q tests/services/test_project_service_embedding_status.py`: 14 passed, 2 skipped
- `just fast-check`: passed after installing configured optional dependencies with `uv sync --all-extras`
- `git diff --check`: passed

### Manual

- Inspected the production trace and verified the failing SQL joins on the legacy missing column before any pgvector initialization repair runs.

## Risks / Follow-ups

- This change only converts legacy physical storage into an explicit reindex status; it does not perform repair from the read endpoint.
- After this Core PR merges, Basic Memory Cloud must pin the resulting Core commit, deploy it, and observe a non-recurrence window before Logfire #2173 can be closed.

