### PR TITLE
fix(core): lock entity before observation replacement

### DIFF
--- a/src/basic_memory/repository/entity_repository.py
+++ b/src/basic_memory/repository/entity_repository.py
@@ -83,26 +83,43 @@ class EntityRepository(Repository[Entity]):
         return entity
 
     async def get_by_id(
-        self, session: AsyncSession, entity_id: int, *, load_relations: bool = True
+        self,
+        session: AsyncSession,
+        entity_id: int,
+        *,
+        load_relations: bool = True,
+        lock_for_update: bool = False,
     ) -> Optional[Entity]:
         """Get entity by numeric ID.
 
         Args:
             entity_id: Numeric entity ID
+            load_relations: Eager load observations and relations
+            lock_for_update: Lock the entity row for the current transaction
 
         Returns:
             Entity if found, None otherwise
         """
-        if not load_relations:
-            result = await session.execute(self.select().where(Entity.id == entity_id))
-            return result.scalars().one_or_none()
-
-        return await self.select_by_id(session, entity_id)
+        query = self.select().where(Entity.id == entity_id)
+        return await self._find_one_by_query(
+            session,
+            query,
+            load_relations=load_relations,
+            lock_for_update=lock_for_update,
+        )
 
     async def _find_one_by_query(
-        self, session: AsyncSession, query, *, load_relations: bool
+        self,
+        session: AsyncSession,
+        query,
+        *,
+        load_relations: bool,
+        lock_for_update: bool = False,
     ) -> Optional[Entity]:
-        """Return one entity row with optional eager loading."""
+        """Return one entity row with optional eager loading and row locking."""
+        if lock_for_update:
+            query = query.with_for_update()
+
         if load_relations:
             return await self.find_one(session, query)
 
@@ -155,15 +172,27 @@ class EntityRepository(Repository[Entity]):
         return list(result.scalars().all())
 
     async def get_by_file_path(
-        self, session: AsyncSession, file_path: Union[Path, str], *, load_relations: bool = True
+        self,
+        session: AsyncSession,
+        file_path: Union[Path, str],
+        *,
+        load_relations: bool = True,
+        lock_for_update: bool = False,
     ) -> Optional[Entity]:
         """Get entity by file_path.
 
         Args:
             file_path: Path to the entity file (will be converted to string internally)
+            load_relations: Eager load observations and relations
+            lock_for_update: Lock the entity row for the current transaction
         """
         query = self.select().where(Entity.file_path == Path(file_path).as_posix())
-        return await self._find_one_by_query(session, query, load_relations=load_relations)
+        return await self._find_one_by_query(
+            session,
+            query,
+            load_relations=load_relations,
+            lock_for_update=lock_for_update,
+        )
 
     # -------------------------------------------------------------------------
     # Lightweight methods for permalink resolution (no eager loading)

--- a/src/basic_memory/services/entity_service.py
+++ b/src/basic_memory/services/entity_service.py
@@ -607,16 +607,20 @@ class EntityService(BaseService[EntityModel]):
                     active_session,
                     existing_entity.id,
                     load_relations=False,
+                    lock_for_update=True,
                 )
             else:
                 db_entity = await self.repository.get_by_file_path(
                     active_session,
                     file_path.as_posix(),
                     load_relations=False,
+                    lock_for_update=True,
                 )
             if db_entity is None:  # pragma: no cover
                 raise EntityNotFoundError(f"Entity not found for file path: {file_path}")
 
+            # Accepted writes already lock Entity before replacing its graph. Indexing must use
+            # the same order so PostgreSQL cannot deadlock the two paths on Entity/Observation.
             # Observations are owned by the markdown file, so re-indexing replaces the old set.
             # We only need the entity id here; loading the old relationship collection is wasted work.
             await self.observation_repository.delete_by_fields(

--- a/tests/api/v2/test_entity_observation_lock_order.py
+++ b/tests/api/v2/test_entity_observation_lock_order.py
@@ -1,0 +1,189 @@
+"""Entity/Observation lock-order regressions for accepted writes and indexing."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from basic_memory import db
+from basic_memory.markdown.schemas import (
+    EntityFrontmatter,
+    EntityMarkdown,
+    Observation as MarkdownObservation,
+)
+from basic_memory.repository.observation_repository import (
+    AcceptedObservationWrite,
+    ObservationRepository,
+)
+from basic_memory.schemas import Entity as EntitySchema
+from basic_memory.schemas.v2 import EntityResponseV2
+from basic_memory.services.entity_service import EntityService
+
+
+def _indexed_markdown(*, title: str, created: datetime) -> EntityMarkdown:
+    """Build the file snapshot shared by the concurrent indexing regression."""
+    return EntityMarkdown(
+        frontmatter=EntityFrontmatter(metadata={"title": title, "type": "note"}),
+        observations=[
+            MarkdownObservation(content="Initial observation", category="fact"),
+            MarkdownObservation(content="Accepted edit observation", category="fact"),
+        ],
+        relations=[],
+        created=created,
+        modified=datetime.now(tz=UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_indexing_replaces_entity_and_observations_on_both_database_backends(
+    entity_service: EntityService,
+) -> None:
+    """The ordered write preserves file-first entity and graph semantics."""
+    created = await entity_service.create_entity(
+        EntitySchema(
+            title="Lock order semantics",
+            directory="notes",
+            content="# Lock order semantics\n\n- [fact] Initial observation",
+        )
+    )
+
+    markdown = _indexed_markdown(title="Updated lock order semantics", created=created.created_at)
+    updated = await entity_service.update_entity_and_observations(
+        Path(created.file_path),
+        markdown,
+        existing_entity=created,
+    )
+
+    assert updated.title == "Updated lock order semantics"
+    async with db.scoped_session(entity_service.session_maker) as session:
+        observations = await entity_service.observation_repository.find_by_entity(
+            session,
+            updated.id,
+        )
+    assert [observation.content for observation in observations] == [
+        "Initial observation",
+        "Accepted edit observation",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_accepted_edit_and_indexing_lock_entity_before_observations(
+    client: AsyncClient,
+    db_backend: str,
+    entity_service: EntityService,
+    monkeypatch: pytest.MonkeyPatch,
+    v2_project_url: str,
+) -> None:
+    """Concurrent accepted and file-first writes must share Entity -> Observation order."""
+    if db_backend != "postgres":
+        pytest.skip("row-lock ordering requires PostgreSQL")
+
+    create_response = await client.post(
+        f"{v2_project_url}/knowledge/entities",
+        json={
+            "title": "Concurrent lock order",
+            "directory": "notes",
+            "content": "# Concurrent lock order\n\n- [fact] Initial observation",
+        },
+    )
+    assert create_response.status_code == 202
+    created = EntityResponseV2.model_validate(create_response.json())
+    async with db.scoped_session(entity_service.session_maker) as session:
+        existing_entity = await entity_service.repository.get_by_file_path(
+            session,
+            created.file_path,
+            load_relations=False,
+        )
+    assert existing_entity is not None
+
+    accepted_graph_reached = asyncio.Event()
+    release_accepted_graph = asyncio.Event()
+    indexing_observation_write_started = asyncio.Event()
+
+    original_replace = ObservationRepository.replace_accepted_observations
+
+    async def pause_accepted_graph_replace(
+        repository: ObservationRepository,
+        session: AsyncSession,
+        entity_id: int,
+        observations: Sequence[AcceptedObservationWrite],
+    ) -> None:
+        accepted_graph_reached.set()
+        await release_accepted_graph.wait()
+        await original_replace(repository, session, entity_id, observations)
+
+    monkeypatch.setattr(
+        ObservationRepository,
+        "replace_accepted_observations",
+        pause_accepted_graph_replace,
+    )
+
+    original_delete = entity_service.observation_repository.delete_by_fields
+
+    async def observe_indexing_graph_replace(
+        session: AsyncSession,
+        **filters: Any,
+    ) -> bool:
+        indexing_observation_write_started.set()
+        return await original_delete(session, **filters)
+
+    monkeypatch.setattr(
+        entity_service.observation_repository,
+        "delete_by_fields",
+        observe_indexing_graph_replace,
+    )
+
+    edit_task = asyncio.create_task(
+        client.patch(
+            f"{v2_project_url}/knowledge/entities/{created.external_id}",
+            json={
+                "operation": "append",
+                "content": "\n\n- [fact] Accepted edit observation",
+            },
+        )
+    )
+    index_task: asyncio.Task[Any] | None = None
+    try:
+        await asyncio.wait_for(accepted_graph_reached.wait(), timeout=2)
+
+        index_task = asyncio.create_task(
+            entity_service.update_entity_and_observations(
+                Path(created.file_path),
+                _indexed_markdown(
+                    title="Concurrent lock order",
+                    created=created.created_at,
+                ),
+                existing_entity=existing_entity,
+            )
+        )
+
+        # The accepted edit owns the Entity row while paused at its graph phase.
+        # Indexing must wait on that row instead of touching Observations first.
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(indexing_observation_write_started.wait(), timeout=0.5)
+
+        release_accepted_graph.set()
+        edit_response, indexed = await asyncio.wait_for(
+            asyncio.gather(edit_task, index_task),
+            timeout=5,
+        )
+    finally:
+        release_accepted_graph.set()
+        for task in (edit_task, index_task):
+            if task is not None and not task.done():
+                task.cancel()
+        await asyncio.gather(
+            *(task for task in (edit_task, index_task) if task is not None),
+            return_exceptions=True,
+        )
+
+    assert edit_response.status_code == 202
+    assert indexed.id == created.id
+    assert indexing_observation_write_started.is_set()


### PR DESCRIPTION
## Why

Production file-indexing jobs and accepted DB-first note writes can mutate the same Entity and Observation graph concurrently. Indexing previously acquired Observation locks before updating Entity, while accepted writes acquired Entity before Observation. PostgreSQL can deadlock those inverse paths, causing request-side 503 responses and exhausting worker retries.

Closes #1199.

## What Changed

- Added opt-in Entity row locking to the repository's ID and file-path lookups.
- Made file indexing lock the Entity before replacing its Observations, matching the accepted-write invariant.
- Added backend-neutral replacement coverage and a real PostgreSQL concurrency regression.

## Implementation Details

`EntityService.update_entity_and_observations` now loads the existing Entity with `SELECT ... FOR UPDATE` before any Observation delete or insert. The explicit row lock matters even when indexing does not change scalar Entity fields, because an ORM flush alone would not guarantee an UPDATE or lock.

The policy stays in Core, where both mutation paths live. Cloud does not need a parallel ordering override. SQLite treats `FOR UPDATE` as a no-op, so its behavior remains unchanged; PostgreSQL serializes competing graph replacements for the same Entity in the shared `Entity -> Observation` order.

The PostgreSQL test pauses an accepted API edit after its Entity flush and before Observation replacement, then starts the real indexing service. Before the fix, indexing reached Observation deletion while the accepted transaction held Entity. After the fix, indexing waits at the Entity row until the accepted graph write completes.

## Testing

### Automated

- `LOGFIRE_IGNORE_NO_CONFIG=1 uv run pytest -p pytest_mock --no-cov -q tests/api/v2/test_entity_observation_lock_order.py --tb=short`: 1 passed, 1 skipped (PostgreSQL-only case).
- `BASIC_MEMORY_TEST_POSTGRES=1 LOGFIRE_IGNORE_NO_CONFIG=1 uv run pytest -p pytest_mock --no-cov -q tests/api/v2/test_entity_observation_lock_order.py --tb=short`: 2 passed.
- `LOGFIRE_IGNORE_NO_CONFIG=1 uv run pytest -p pytest_mock --no-cov -q tests/repository/test_entity_repository.py tests/services/test_upsert_entity_optimization.py tests/services/test_entity_service.py tests/indexing/test_file_indexer.py tests/indexing/test_note_content_reconciler.py --tb=short`: 156 passed.
- `BASIC_MEMORY_TEST_POSTGRES=1 LOGFIRE_IGNORE_NO_CONFIG=1 uv run pytest -p pytest_mock --no-cov -q test-int/test_note_materialization_lock_order.py --tb=short`: 2 passed.
- `just fast-check`: passed Ruff fixes/checks, formatting, and `ty` type checking.

### Manual

- Ran the PostgreSQL concurrency regression against the unfixed source first; it failed because indexing reached Observation deletion before acquiring Entity, confirming the test reproduces the production inversion.

## Risks / Follow-ups

- Competing graph replacements for one Entity now wait on that Entity's transaction, which is the intended serialization boundary.
- Cloud must consume a Core release containing this fix before the production deadlock fingerprints are expected to stop.
