### PR TITLE
fix(ci): make issue triage labeling deterministic

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -56,7 +56,6 @@ jobs:
                - Enhancement (improvement to existing feature)
                - Documentation (docs improvement)
                - Question/Support (user help)
-               - MCP tool issue (specific to MCP functionality)
 
             2. **Priority Assessment:**
                - Critical: Security issues, data loss, complete breakage
@@ -88,6 +87,8 @@ jobs:
             **Triage Helper Contract:**
             - TYPE must be exactly one of: `bug`, `enhancement`, `documentation`, `question`.
               Map feature requests and improvements to `enhancement`.
+            - MCP identifies a component, not a TYPE. Classify an MCP issue by its behavior using
+              one of the four TYPE values and record the MCP component in prose.
             - COMPONENT must be `cloud` only when the issue directly concerns Cloud behavior;
               otherwise use `none`. Record other components in prose because they do not have
               repository labels.
@@ -96,7 +97,7 @@ jobs:
             - If an issue is a duplicate, link the original in the comment. Do not add a
               `duplicate` label or close the issue.
             - Do not probe labels, try candidate calls, or use the helper for discovery. It is a
-              mutating command. One final call replaces only triage-owned labels and preserves
+              mutating command. One final call updates only triage-owned labels and preserves
               every label outside that owned set.
 
             Read the issue carefully, apply the triage classification, and post a concise comment.

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -7,6 +7,10 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
+concurrency:
+  group: claude-issue-triage-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -45,7 +45,8 @@ jobs:
 
             **Scope Boundary:**
             - Do not implement a fix, edit repository files, run tests, create a branch, commit, or push.
-            - The only permitted write actions are adding issue labels and posting issue comments.
+            - The only permitted write actions are setting triage-owned issue labels and posting
+              issue comments.
             - Even when the issue includes a root cause, suggested fix, or acceptance criteria, stop after triage.
 
             **Issue Analysis:**
@@ -77,22 +78,30 @@ jobs:
                - Complex: Major feature work, architectural changes
 
             **Actions to Take:**
-            1. Add appropriate labels using:
-               `./scripts/edit-issue-labels.sh --add-label label1 --add-label label2`
+            1. After finishing the analysis, call the triage helper exactly once:
+               `./scripts/edit-issue-labels.sh --type TYPE --component COMPONENT`
             2. Check for duplicates using: `gh search issues`
             3. If duplicate found, comment mentioning the original issue
             4. For feature requests, ask clarifying questions if needed
             5. For bugs, request reproduction steps if missing
 
-            **Available Labels:**
-            - Type: bug, enhancement, feature, documentation, question, mcp-tool
-            - Priority: critical, high, medium, low
-            - Component: cli, mcp, database, cloud, docs, testing
-            - Complexity: simple, medium, complex
-            - Status: needs-reproduction, needs-clarification, duplicate
+            **Triage Helper Contract:**
+            - TYPE must be exactly one of: `bug`, `enhancement`, `documentation`, `question`.
+              Map feature requests and improvements to `enhancement`.
+            - COMPONENT must be `cloud` only when the issue directly concerns Cloud behavior;
+              otherwise use `none`. Record other components in prose because they do not have
+              repository labels.
+            - Priority and complexity are prose assessments only. They do not have repository
+              labels.
+            - If an issue is a duplicate, link the original in the comment. Do not add a
+              `duplicate` label or close the issue.
+            - Do not probe labels, try candidate calls, or use the helper for discovery. It is a
+              mutating command. One final call replaces only triage-owned labels and preserves
+              every label outside that owned set.
 
-            Read the issue carefully, apply appropriate labels, post any necessary triage comment,
-            and then stop. Do not begin implementation work.
+            Read the issue carefully, apply the triage classification, and post a concise comment.
+            Do not include tool logs, label-taxonomy discussion, or a task checklist. Then stop;
+            do not begin implementation work.
           claude_args: |
             --permission-mode dontAsk
             --allowedTools "Bash(./scripts/edit-issue-labels.sh:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh search issues:*),Read,Grep,Glob"

--- a/scripts/edit-issue-labels.sh
+++ b/scripts/edit-issue-labels.sh
@@ -73,6 +73,11 @@ labels_url="repos/$repository/issues/$issue_number/labels"
 
 # The triage bot owns only the four type labels and the cloud component label. Preserve every
 # label outside that owned set while replacing prior triage output.
+if ! current_labels=$(gh api "repos/$repository/issues/$issue_number" --jq '.labels[].name'); then
+    echo "Error: unable to read current issue labels" >&2
+    exit 1
+fi
+
 labels=()
 while IFS= read -r label; do
     case "$label" in
@@ -80,7 +85,7 @@ while IFS= read -r label; do
         "") ;;
         *) labels+=("$label") ;;
     esac
-done < <(gh api "repos/$repository/issues/$issue_number" --jq '.labels[].name')
+done <<< "$current_labels"
 
 labels+=("$type_label")
 if [[ "$component" == "cloud" ]]; then

--- a/scripts/edit-issue-labels.sh
+++ b/scripts/edit-issue-labels.sh
@@ -92,10 +92,6 @@ while IFS= read -r label; do
     esac
 done <<< "$current_labels"
 
-for label in "${obsolete_labels[@]}"; do
-    gh api --method DELETE "$labels_url/$label" --silent
-done
-
 desired_labels=("$type_label")
 if [[ "$component" == "cloud" ]]; then
     desired_labels+=("cloud")
@@ -106,5 +102,13 @@ for label in "${desired_labels[@]}"; do
     api_args+=(-f "labels[]=$label")
 done
 
+# Add the desired classification before removing obsolete values. A failed additive request
+# therefore leaves the prior classification intact; a later rerun can converge after a delete
+# failure without losing unrelated labels.
 gh api "${api_args[@]}" --silent
+
+for label in "${obsolete_labels[@]}"; do
+    gh api --method DELETE "$labels_url/$label" --silent
+done
+
 echo "Set triage labels: type=$type_label component=$component"

--- a/scripts/edit-issue-labels.sh
+++ b/scripts/edit-issue-labels.sh
@@ -71,26 +71,12 @@ esac
 repository=${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}
 labels_url="repos/$repository/issues/$issue_number/labels"
 
-# The triage bot owns only the four type labels and the cloud component label. Read current
-# labels only to find obsolete bot-owned values; targeted mutations leave every other label
-# untouched, including labels added concurrently after this read.
-if ! current_labels=$(gh api "repos/$repository/issues/$issue_number" --jq '.labels[].name'); then
+# The triage bot owns only the four type labels and the cloud component label. Verify reads before
+# the first mutation so a permissions or API failure cannot strand the issue in a partial state.
+if ! gh api "repos/$repository/issues/$issue_number" --jq '.labels[].name' >/dev/null; then
     echo "Error: unable to read current issue labels" >&2
     exit 1
 fi
-
-obsolete_labels=()
-while IFS= read -r label; do
-    case "$label" in
-        "$type_label") ;;
-        cloud)
-            if [[ "$component" != "cloud" ]]; then
-                obsolete_labels+=("$label")
-            fi
-            ;;
-        bug|enhancement|documentation|question) obsolete_labels+=("$label") ;;
-    esac
-done <<< "$current_labels"
 
 desired_labels=("$type_label")
 if [[ "$component" == "cloud" ]]; then
@@ -106,6 +92,26 @@ done
 # therefore leaves the prior classification intact; a later rerun can converge after a delete
 # failure without losing unrelated labels.
 gh api "${api_args[@]}" --silent
+
+# A competing triage run can add an owned label after the preflight read. Re-read after the POST
+# so targeted deletes reconcile against the state that includes both additive operations.
+if ! current_labels=$(gh api "repos/$repository/issues/$issue_number" --jq '.labels[].name'); then
+    echo "Error: unable to reconcile current issue labels" >&2
+    exit 1
+fi
+
+obsolete_labels=()
+while IFS= read -r label; do
+    case "$label" in
+        "$type_label") ;;
+        cloud)
+            if [[ "$component" != "cloud" ]]; then
+                obsolete_labels+=("$label")
+            fi
+            ;;
+        bug|enhancement|documentation|question) obsolete_labels+=("$label") ;;
+    esac
+done <<< "$current_labels"
 
 for label in "${obsolete_labels[@]}"; do
     gh api --method DELETE "$labels_url/$label" --silent

--- a/scripts/edit-issue-labels.sh
+++ b/scripts/edit-issue-labels.sh
@@ -71,29 +71,38 @@ esac
 repository=${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}
 labels_url="repos/$repository/issues/$issue_number/labels"
 
-# The triage bot owns only the four type labels and the cloud component label. Preserve every
-# label outside that owned set while replacing prior triage output.
+# The triage bot owns only the four type labels and the cloud component label. Read current
+# labels only to find obsolete bot-owned values; targeted mutations leave every other label
+# untouched, including labels added concurrently after this read.
 if ! current_labels=$(gh api "repos/$repository/issues/$issue_number" --jq '.labels[].name'); then
     echo "Error: unable to read current issue labels" >&2
     exit 1
 fi
 
-labels=()
+obsolete_labels=()
 while IFS= read -r label; do
     case "$label" in
-        bug|enhancement|documentation|question|cloud) ;;
-        "") ;;
-        *) labels+=("$label") ;;
+        "$type_label") ;;
+        cloud)
+            if [[ "$component" != "cloud" ]]; then
+                obsolete_labels+=("$label")
+            fi
+            ;;
+        bug|enhancement|documentation|question) obsolete_labels+=("$label") ;;
     esac
 done <<< "$current_labels"
 
-labels+=("$type_label")
+for label in "${obsolete_labels[@]}"; do
+    gh api --method DELETE "$labels_url/$label" --silent
+done
+
+desired_labels=("$type_label")
 if [[ "$component" == "cloud" ]]; then
-    labels+=("cloud")
+    desired_labels+=("cloud")
 fi
 
-api_args=(--method PUT "$labels_url")
-for label in "${labels[@]}"; do
+api_args=(--method POST "$labels_url")
+for label in "${desired_labels[@]}"; do
     api_args+=(-f "labels[]=$label")
 done
 

--- a/scripts/edit-issue-labels.sh
+++ b/scripts/edit-issue-labels.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Limit automated issue triage to labels on the issue that triggered the workflow.
+# Apply one semantic triage classification to the issue that triggered the workflow.
 set -euo pipefail
 
 issue_number=$(jq -r '.issue.number // empty' "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH not set}")
@@ -9,49 +9,88 @@ if ! [[ "$issue_number" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
-labels=()
+type_label=""
+component=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --add-label)
+        --type)
             if [[ $# -lt 2 ]]; then
-                echo "Error: --add-label requires a label" >&2
+                echo "Error: --type requires a value" >&2
                 exit 1
             fi
-            labels+=("$2")
+            if [[ -n "$type_label" ]]; then
+                echo "Error: --type may be provided only once" >&2
+                exit 1
+            fi
+            type_label="$2"
+            shift 2
+            ;;
+        --component)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --component requires a value" >&2
+                exit 1
+            fi
+            if [[ -n "$component" ]]; then
+                echo "Error: --component may be provided only once" >&2
+                exit 1
+            fi
+            component="$2"
             shift 2
             ;;
         *)
-            echo "Error: only --add-label is accepted" >&2
+            echo "Error: only --type and --component are accepted" >&2
             exit 1
             ;;
     esac
 done
 
-if [[ ${#labels[@]} -eq 0 ]]; then
-    echo "Error: at least one label is required" >&2
-    exit 1
-fi
+case "$type_label" in
+    bug|enhancement|documentation|question) ;;
+    "")
+        echo "Error: --type is required" >&2
+        exit 1
+        ;;
+    *)
+        echo "Error: unsupported triage type: $type_label" >&2
+        exit 1
+        ;;
+esac
 
-valid_labels=$(gh label list --limit 500 --json name --jq '.[].name')
-filtered_labels=()
-for label in "${labels[@]}"; do
-    if grep -qxF "$label" <<<"$valid_labels"; then
-        filtered_labels+=("$label")
-    else
-        echo "Ignoring unknown label: $label" >&2
-    fi
-done
-
-if [[ ${#filtered_labels[@]} -eq 0 ]]; then
-    exit 0
-fi
+case "$component" in
+    cloud|none) ;;
+    "")
+        echo "Error: --component is required" >&2
+        exit 1
+        ;;
+    *)
+        echo "Error: unsupported triage component: $component" >&2
+        exit 1
+        ;;
+esac
 
 repository=${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}
 labels_url="repos/$repository/issues/$issue_number/labels"
-api_args=(--method POST "$labels_url")
-for label in "${filtered_labels[@]}"; do
+
+# The triage bot owns only the four type labels and the cloud component label. Preserve every
+# label outside that owned set while replacing prior triage output.
+labels=()
+while IFS= read -r label; do
+    case "$label" in
+        bug|enhancement|documentation|question|cloud) ;;
+        "") ;;
+        *) labels+=("$label") ;;
+    esac
+done < <(gh api "repos/$repository/issues/$issue_number" --jq '.labels[].name')
+
+labels+=("$type_label")
+if [[ "$component" == "cloud" ]]; then
+    labels+=("cloud")
+fi
+
+api_args=(--method PUT "$labels_url")
+for label in "${labels[@]}"; do
     api_args+=(-f "labels[]=$label")
 done
 
 gh api "${api_args[@]}" --silent
-echo "Added: ${filtered_labels[*]}"
+echo "Set triage labels: type=$type_label component=$component"

--- a/tests/test_claude_issue_triage.py
+++ b/tests/test_claude_issue_triage.py
@@ -35,13 +35,16 @@ def _run_triage_helper(
     tmp_path: Path,
     *arguments: str,
     current_labels: tuple[str, ...] = (),
+    labels_after_add: tuple[str, ...] | None = None,
     fail_label_read: bool = False,
+    fail_label_read_after_add: bool = False,
     fail_label_add: bool = False,
 ) -> tuple[subprocess.CompletedProcess[str], list[list[str]]]:
     event_path = tmp_path / "event.json"
     event_path.write_text(json.dumps({"issue": {"number": 1205}}), encoding="utf-8")
 
     gh_arguments_path = tmp_path / "gh-arguments.txt"
+    label_add_marker_path = tmp_path / "label-add-completed"
     bin_path = tmp_path / "bin"
     bin_path.mkdir()
     gh_path = bin_path / "gh"
@@ -54,10 +57,16 @@ if [[ " $* " == *" --method POST "* ]]; then
     if [[ "${GH_FAIL_LABEL_ADD:-false}" == "true" ]]; then
         exit 1
     fi
+    : > "${GH_LABEL_ADD_MARKER_PATH:?}"
 elif [[ " $* " == *" --method DELETE "* ]]; then
     printf '%s\n' "__CALL__" "$@" >> "${GH_ARGUMENTS_PATH:?}"
 elif [[ "${GH_FAIL_LABEL_READ:-false}" == "true" ]]; then
     exit 1
+elif [[ -f "${GH_LABEL_ADD_MARKER_PATH:?}" ]]; then
+    if [[ "${GH_FAIL_LABEL_READ_AFTER_ADD:-false}" == "true" ]]; then
+        exit 1
+    fi
+    printf '%s\n' "${GH_CURRENT_LABELS_AFTER_ADD:-}"
 else
     printf '%s\n' "${GH_CURRENT_LABELS:-}"
 fi
@@ -72,8 +81,13 @@ fi
         {
             "GH_ARGUMENTS_PATH": gh_arguments_path.as_posix(),
             "GH_CURRENT_LABELS": "\n".join(current_labels),
+            "GH_CURRENT_LABELS_AFTER_ADD": "\n".join(
+                current_labels if labels_after_add is None else labels_after_add
+            ),
             "GH_FAIL_LABEL_ADD": "true" if fail_label_add else "false",
             "GH_FAIL_LABEL_READ": "true" if fail_label_read else "false",
+            "GH_FAIL_LABEL_READ_AFTER_ADD": ("true" if fail_label_read_after_add else "false"),
+            "GH_LABEL_ADD_MARKER_PATH": label_add_marker_path.as_posix(),
             "GITHUB_EVENT_PATH": event_path.as_posix(),
             "GITHUB_REPOSITORY": "basicmachines-co/basic-memory",
             "PATH": f"{bin_path}{os.pathsep}{env['PATH']}",
@@ -195,6 +209,54 @@ def test_triage_helper_keeps_only_one_type_and_cloud_component(tmp_path: Path) -
     ]
 
 
+def test_triage_helper_reconciles_owned_labels_added_after_the_preflight_read(
+    tmp_path: Path,
+) -> None:
+    result, gh_calls = _run_triage_helper(
+        tmp_path,
+        "--type",
+        "enhancement",
+        "--component",
+        "none",
+        current_labels=("bug", "production"),
+        labels_after_add=("bug", "documentation", "cloud", "enhancement", "production"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert gh_calls == [
+        [
+            "api",
+            "--method",
+            "POST",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels",
+            "-f",
+            "labels[]=enhancement",
+            "--silent",
+        ],
+        [
+            "api",
+            "--method",
+            "DELETE",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels/bug",
+            "--silent",
+        ],
+        [
+            "api",
+            "--method",
+            "DELETE",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels/documentation",
+            "--silent",
+        ],
+        [
+            "api",
+            "--method",
+            "DELETE",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels/cloud",
+            "--silent",
+        ],
+    ]
+
+
 def test_triage_helper_does_not_update_labels_when_current_labels_cannot_be_read(
     tmp_path: Path,
 ) -> None:
@@ -211,6 +273,34 @@ def test_triage_helper_does_not_update_labels_when_current_labels_cannot_be_read
     assert result.returncode != 0
     assert "unable to read current issue labels" in result.stderr
     assert gh_calls == []
+
+
+def test_triage_helper_stops_deletes_when_the_reconciliation_read_fails(
+    tmp_path: Path,
+) -> None:
+    result, gh_calls = _run_triage_helper(
+        tmp_path,
+        "--type",
+        "enhancement",
+        "--component",
+        "none",
+        current_labels=("bug", "cloud", "production"),
+        fail_label_read_after_add=True,
+    )
+
+    assert result.returncode != 0
+    assert "unable to reconcile current issue labels" in result.stderr
+    assert gh_calls == [
+        [
+            "api",
+            "--method",
+            "POST",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels",
+            "-f",
+            "labels[]=enhancement",
+            "--silent",
+        ]
+    ]
 
 
 def test_triage_helper_does_not_delete_prior_labels_when_add_fails(tmp_path: Path) -> None:

--- a/tests/test_claude_issue_triage.py
+++ b/tests/test_claude_issue_triage.py
@@ -17,6 +17,7 @@ def _run_triage_helper(
     *arguments: str,
     current_labels: tuple[str, ...] = (),
     fail_label_read: bool = False,
+    fail_label_add: bool = False,
 ) -> tuple[subprocess.CompletedProcess[str], list[list[str]]]:
     event_path = tmp_path / "event.json"
     event_path.write_text(json.dumps({"issue": {"number": 1205}}), encoding="utf-8")
@@ -29,7 +30,12 @@ def _run_triage_helper(
         """#!/usr/bin/env bash
 set -euo pipefail
 
-if [[ " $* " == *" --method DELETE "* || " $* " == *" --method POST "* ]]; then
+if [[ " $* " == *" --method POST "* ]]; then
+    printf '%s\n' "__CALL__" "$@" >> "${GH_ARGUMENTS_PATH:?}"
+    if [[ "${GH_FAIL_LABEL_ADD:-false}" == "true" ]]; then
+        exit 1
+    fi
+elif [[ " $* " == *" --method DELETE "* ]]; then
     printf '%s\n' "__CALL__" "$@" >> "${GH_ARGUMENTS_PATH:?}"
 elif [[ "${GH_FAIL_LABEL_READ:-false}" == "true" ]]; then
     exit 1
@@ -46,6 +52,7 @@ fi
         {
             "GH_ARGUMENTS_PATH": str(gh_arguments_path),
             "GH_CURRENT_LABELS": "\n".join(current_labels),
+            "GH_FAIL_LABEL_ADD": "true" if fail_label_add else "false",
             "GH_FAIL_LABEL_READ": "true" if fail_label_read else "false",
             "GITHUB_EVENT_PATH": str(event_path),
             "GITHUB_REPOSITORY": "basicmachines-co/basic-memory",
@@ -90,6 +97,15 @@ def test_triage_helper_updates_only_owned_labels_without_replacing_other_labels(
         [
             "api",
             "--method",
+            "POST",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels",
+            "-f",
+            "labels[]=enhancement",
+            "--silent",
+        ],
+        [
+            "api",
+            "--method",
             "DELETE",
             "repos/basicmachines-co/basic-memory/issues/1205/labels/bug",
             "--silent",
@@ -99,15 +115,6 @@ def test_triage_helper_updates_only_owned_labels_without_replacing_other_labels(
             "--method",
             "DELETE",
             "repos/basicmachines-co/basic-memory/issues/1205/labels/cloud",
-            "--silent",
-        ],
-        [
-            "api",
-            "--method",
-            "POST",
-            "repos/basicmachines-co/basic-memory/issues/1205/labels",
-            "-f",
-            "labels[]=enhancement",
             "--silent",
         ],
     ]
@@ -135,6 +142,17 @@ def test_triage_helper_keeps_only_one_type_and_cloud_component(tmp_path: Path) -
         [
             "api",
             "--method",
+            "POST",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels",
+            "-f",
+            "labels[]=question",
+            "-f",
+            "labels[]=cloud",
+            "--silent",
+        ],
+        [
+            "api",
+            "--method",
             "DELETE",
             "repos/basicmachines-co/basic-memory/issues/1205/labels/bug",
             "--silent",
@@ -151,17 +169,6 @@ def test_triage_helper_keeps_only_one_type_and_cloud_component(tmp_path: Path) -
             "--method",
             "DELETE",
             "repos/basicmachines-co/basic-memory/issues/1205/labels/documentation",
-            "--silent",
-        ],
-        [
-            "api",
-            "--method",
-            "POST",
-            "repos/basicmachines-co/basic-memory/issues/1205/labels",
-            "-f",
-            "labels[]=question",
-            "-f",
-            "labels[]=cloud",
             "--silent",
         ],
     ]
@@ -183,6 +190,31 @@ def test_triage_helper_does_not_update_labels_when_current_labels_cannot_be_read
     assert result.returncode != 0
     assert "unable to read current issue labels" in result.stderr
     assert gh_calls == []
+
+
+def test_triage_helper_does_not_delete_prior_labels_when_add_fails(tmp_path: Path) -> None:
+    result, gh_calls = _run_triage_helper(
+        tmp_path,
+        "--type",
+        "enhancement",
+        "--component",
+        "none",
+        current_labels=("bug", "cloud", "production"),
+        fail_label_add=True,
+    )
+
+    assert result.returncode != 0
+    assert gh_calls == [
+        [
+            "api",
+            "--method",
+            "POST",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels",
+            "-f",
+            "labels[]=enhancement",
+            "--silent",
+        ]
+    ]
 
 
 @pytest.mark.parametrize(
@@ -222,4 +254,6 @@ def test_triage_workflow_defines_one_semantic_mutation() -> None:
     assert "--type TYPE --component COMPONENT" in prompt
     assert "Do not probe labels" in prompt
     assert "Priority and complexity are prose assessments only" in prompt
+    assert "MCP identifies a component, not a TYPE" in prompt
+    assert "MCP tool issue (specific to MCP functionality)" not in prompt
     assert "--add-label" not in workflow_text

--- a/tests/test_claude_issue_triage.py
+++ b/tests/test_claude_issue_triage.py
@@ -1,0 +1,156 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TRIAGE_SCRIPT = REPO_ROOT / "scripts" / "edit-issue-labels.sh"
+TRIAGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "claude-issue-triage.yml"
+
+
+def _run_triage_helper(
+    tmp_path: Path,
+    *arguments: str,
+    current_labels: tuple[str, ...] = (),
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({"issue": {"number": 1205}}), encoding="utf-8")
+
+    gh_arguments_path = tmp_path / "gh-arguments.txt"
+    bin_path = tmp_path / "bin"
+    bin_path.mkdir()
+    gh_path = bin_path / "gh"
+    gh_path.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ " $* " == *" --method PUT "* ]]; then
+    printf '%s\n' "$@" > "${GH_ARGUMENTS_PATH:?}"
+else
+    printf '%s\n' "${GH_CURRENT_LABELS:-}"
+fi
+""",
+        encoding="utf-8",
+    )
+    gh_path.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "GH_ARGUMENTS_PATH": str(gh_arguments_path),
+            "GH_CURRENT_LABELS": "\n".join(current_labels),
+            "GITHUB_EVENT_PATH": str(event_path),
+            "GITHUB_REPOSITORY": "basicmachines-co/basic-memory",
+            "PATH": f"{bin_path}{os.pathsep}{env['PATH']}",
+        }
+    )
+    result = subprocess.run(
+        [str(TRIAGE_SCRIPT), *arguments],
+        cwd=REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    gh_arguments = (
+        gh_arguments_path.read_text(encoding="utf-8").splitlines()
+        if gh_arguments_path.exists()
+        else []
+    )
+    return result, gh_arguments
+
+
+def test_triage_helper_replaces_owned_labels_and_preserves_other_labels(tmp_path: Path) -> None:
+    result, gh_arguments = _run_triage_helper(
+        tmp_path,
+        "--type",
+        "enhancement",
+        "--component",
+        "none",
+        current_labels=("bug", "cloud", "production", "arch-review"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert gh_arguments == [
+        "api",
+        "--method",
+        "PUT",
+        "repos/basicmachines-co/basic-memory/issues/1205/labels",
+        "-f",
+        "labels[]=production",
+        "-f",
+        "labels[]=arch-review",
+        "-f",
+        "labels[]=enhancement",
+        "--silent",
+    ]
+
+
+def test_triage_helper_keeps_only_one_type_and_cloud_component(tmp_path: Path) -> None:
+    result, gh_arguments = _run_triage_helper(
+        tmp_path,
+        "--type",
+        "question",
+        "--component",
+        "cloud",
+        current_labels=(
+            "bug",
+            "enhancement",
+            "documentation",
+            "question",
+            "cloud",
+            "production",
+        ),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "labels[]=bug" not in gh_arguments
+    assert "labels[]=enhancement" not in gh_arguments
+    assert "labels[]=documentation" not in gh_arguments
+    assert gh_arguments.count("labels[]=question") == 1
+    assert gh_arguments.count("labels[]=cloud") == 1
+    assert "labels[]=production" in gh_arguments
+
+
+@pytest.mark.parametrize(
+    "arguments, expected_error",
+    [
+        (("--add-label", "bug"), "only --type and --component are accepted"),
+        (("--component", "none"), "--type is required"),
+        (("--type", "bug"), "--component is required"),
+        (
+            ("--type", "bug", "--type", "enhancement", "--component", "none"),
+            "--type may be provided only once",
+        ),
+        (("--type", "feature", "--component", "none"), "unsupported triage type"),
+        (("--type", "bug", "--component", "database"), "unsupported triage component"),
+    ],
+)
+def test_triage_helper_rejects_probe_and_unsupported_arguments(
+    tmp_path: Path,
+    arguments: tuple[str, ...],
+    expected_error: str,
+) -> None:
+    result, gh_arguments = _run_triage_helper(tmp_path, *arguments)
+
+    assert result.returncode != 0
+    assert expected_error in result.stderr
+    assert gh_arguments == []
+
+
+def test_triage_workflow_defines_one_semantic_mutation() -> None:
+    workflow_text = TRIAGE_WORKFLOW.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(workflow_text)
+    action_step = workflow["jobs"]["triage"]["steps"][1]
+    prompt = action_step["with"]["prompt"]
+
+    assert action_step["uses"] == "anthropics/claude-code-action@v1"
+    assert "call the triage helper exactly once" in prompt
+    assert "--type TYPE --component COMPONENT" in prompt
+    assert "Do not probe labels" in prompt
+    assert "Priority and complexity are prose assessments only" in prompt
+    assert "--add-label" not in workflow_text

--- a/tests/test_claude_issue_triage.py
+++ b/tests/test_claude_issue_triage.py
@@ -44,6 +44,7 @@ else
 fi
 """,
         encoding="utf-8",
+        newline="\n",
     )
     gh_path.chmod(0o755)
 
@@ -60,7 +61,8 @@ fi
         }
     )
     result = subprocess.run(
-        [str(TRIAGE_SCRIPT), *arguments],
+        # Windows cannot execute a POSIX script directly; hosted runners provide Git Bash.
+        ["bash", str(TRIAGE_SCRIPT), *arguments],
         cwd=REPO_ROOT,
         env=env,
         check=False,

--- a/tests/test_claude_issue_triage.py
+++ b/tests/test_claude_issue_triage.py
@@ -360,6 +360,10 @@ def test_triage_workflow_defines_one_semantic_mutation() -> None:
     action_step = workflow["jobs"]["triage"]["steps"][1]
     prompt = action_step["with"]["prompt"]
 
+    assert workflow["concurrency"] == {
+        "group": "claude-issue-triage-${{ github.event.issue.number }}",
+        "cancel-in-progress": False,
+    }
     assert action_step["uses"] == "anthropics/claude-code-action@v1"
     assert "call the triage helper exactly once" in prompt
     assert "--type TYPE --component COMPONENT" in prompt

--- a/tests/test_claude_issue_triage.py
+++ b/tests/test_claude_issue_triage.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -10,6 +11,24 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[1]
 TRIAGE_SCRIPT = REPO_ROOT / "scripts" / "edit-issue-labels.sh"
 TRIAGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "claude-issue-triage.yml"
+
+
+def _bash_executable() -> str:
+    if os.name != "nt":
+        return "bash"
+
+    git_executable = shutil.which("git")
+    if git_executable is None:
+        raise RuntimeError("Git for Windows is required to run the triage helper tests")
+
+    git_directory = Path(git_executable).parent
+    git_bin_directory = (
+        git_directory if git_directory.name.casefold() == "bin" else git_directory.parent / "bin"
+    )
+    git_bash = git_bin_directory / "bash.exe"
+    if not git_bash.is_file():
+        raise RuntimeError(f"Git Bash was not found at {git_bash}")
+    return str(git_bash)
 
 
 def _run_triage_helper(
@@ -51,18 +70,18 @@ fi
     env = os.environ.copy()
     env.update(
         {
-            "GH_ARGUMENTS_PATH": str(gh_arguments_path),
+            "GH_ARGUMENTS_PATH": gh_arguments_path.as_posix(),
             "GH_CURRENT_LABELS": "\n".join(current_labels),
             "GH_FAIL_LABEL_ADD": "true" if fail_label_add else "false",
             "GH_FAIL_LABEL_READ": "true" if fail_label_read else "false",
-            "GITHUB_EVENT_PATH": str(event_path),
+            "GITHUB_EVENT_PATH": event_path.as_posix(),
             "GITHUB_REPOSITORY": "basicmachines-co/basic-memory",
             "PATH": f"{bin_path}{os.pathsep}{env['PATH']}",
         }
     )
     result = subprocess.run(
-        # Windows cannot execute a POSIX script directly; hosted runners provide Git Bash.
-        ["bash", str(TRIAGE_SCRIPT), *arguments],
+        # Windows' plain bash command launches WSL; select Git Bash for the POSIX helper instead.
+        [_bash_executable(), TRIAGE_SCRIPT.as_posix(), *arguments],
         cwd=REPO_ROOT,
         env=env,
         check=False,

--- a/tests/test_claude_issue_triage.py
+++ b/tests/test_claude_issue_triage.py
@@ -17,7 +17,7 @@ def _run_triage_helper(
     *arguments: str,
     current_labels: tuple[str, ...] = (),
     fail_label_read: bool = False,
-) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+) -> tuple[subprocess.CompletedProcess[str], list[list[str]]]:
     event_path = tmp_path / "event.json"
     event_path.write_text(json.dumps({"issue": {"number": 1205}}), encoding="utf-8")
 
@@ -29,8 +29,8 @@ def _run_triage_helper(
         """#!/usr/bin/env bash
 set -euo pipefail
 
-if [[ " $* " == *" --method PUT "* ]]; then
-    printf '%s\n' "$@" > "${GH_ARGUMENTS_PATH:?}"
+if [[ " $* " == *" --method DELETE "* || " $* " == *" --method POST "* ]]; then
+    printf '%s\n' "__CALL__" "$@" >> "${GH_ARGUMENTS_PATH:?}"
 elif [[ "${GH_FAIL_LABEL_READ:-false}" == "true" ]]; then
     exit 1
 else
@@ -60,16 +60,23 @@ fi
         capture_output=True,
         text=True,
     )
-    gh_arguments = (
+    gh_calls: list[list[str]] = []
+    for line in (
         gh_arguments_path.read_text(encoding="utf-8").splitlines()
         if gh_arguments_path.exists()
         else []
-    )
-    return result, gh_arguments
+    ):
+        if line == "__CALL__":
+            gh_calls.append([])
+        else:
+            gh_calls[-1].append(line)
+    return result, gh_calls
 
 
-def test_triage_helper_replaces_owned_labels_and_preserves_other_labels(tmp_path: Path) -> None:
-    result, gh_arguments = _run_triage_helper(
+def test_triage_helper_updates_only_owned_labels_without_replacing_other_labels(
+    tmp_path: Path,
+) -> None:
+    result, gh_calls = _run_triage_helper(
         tmp_path,
         "--type",
         "enhancement",
@@ -79,23 +86,35 @@ def test_triage_helper_replaces_owned_labels_and_preserves_other_labels(tmp_path
     )
 
     assert result.returncode == 0, result.stderr
-    assert gh_arguments == [
-        "api",
-        "--method",
-        "PUT",
-        "repos/basicmachines-co/basic-memory/issues/1205/labels",
-        "-f",
-        "labels[]=production",
-        "-f",
-        "labels[]=arch-review",
-        "-f",
-        "labels[]=enhancement",
-        "--silent",
+    assert gh_calls == [
+        [
+            "api",
+            "--method",
+            "DELETE",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels/bug",
+            "--silent",
+        ],
+        [
+            "api",
+            "--method",
+            "DELETE",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels/cloud",
+            "--silent",
+        ],
+        [
+            "api",
+            "--method",
+            "POST",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels",
+            "-f",
+            "labels[]=enhancement",
+            "--silent",
+        ],
     ]
 
 
 def test_triage_helper_keeps_only_one_type_and_cloud_component(tmp_path: Path) -> None:
-    result, gh_arguments = _run_triage_helper(
+    result, gh_calls = _run_triage_helper(
         tmp_path,
         "--type",
         "question",
@@ -112,18 +131,46 @@ def test_triage_helper_keeps_only_one_type_and_cloud_component(tmp_path: Path) -
     )
 
     assert result.returncode == 0, result.stderr
-    assert "labels[]=bug" not in gh_arguments
-    assert "labels[]=enhancement" not in gh_arguments
-    assert "labels[]=documentation" not in gh_arguments
-    assert gh_arguments.count("labels[]=question") == 1
-    assert gh_arguments.count("labels[]=cloud") == 1
-    assert "labels[]=production" in gh_arguments
+    assert gh_calls == [
+        [
+            "api",
+            "--method",
+            "DELETE",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels/bug",
+            "--silent",
+        ],
+        [
+            "api",
+            "--method",
+            "DELETE",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels/enhancement",
+            "--silent",
+        ],
+        [
+            "api",
+            "--method",
+            "DELETE",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels/documentation",
+            "--silent",
+        ],
+        [
+            "api",
+            "--method",
+            "POST",
+            "repos/basicmachines-co/basic-memory/issues/1205/labels",
+            "-f",
+            "labels[]=question",
+            "-f",
+            "labels[]=cloud",
+            "--silent",
+        ],
+    ]
 
 
 def test_triage_helper_does_not_update_labels_when_current_labels_cannot_be_read(
     tmp_path: Path,
 ) -> None:
-    result, gh_arguments = _run_triage_helper(
+    result, gh_calls = _run_triage_helper(
         tmp_path,
         "--type",
         "bug",
@@ -135,7 +182,7 @@ def test_triage_helper_does_not_update_labels_when_current_labels_cannot_be_read
 
     assert result.returncode != 0
     assert "unable to read current issue labels" in result.stderr
-    assert gh_arguments == []
+    assert gh_calls == []
 
 
 @pytest.mark.parametrize(
@@ -157,11 +204,11 @@ def test_triage_helper_rejects_probe_and_unsupported_arguments(
     arguments: tuple[str, ...],
     expected_error: str,
 ) -> None:
-    result, gh_arguments = _run_triage_helper(tmp_path, *arguments)
+    result, gh_calls = _run_triage_helper(tmp_path, *arguments)
 
     assert result.returncode != 0
     assert expected_error in result.stderr
-    assert gh_arguments == []
+    assert gh_calls == []
 
 
 def test_triage_workflow_defines_one_semantic_mutation() -> None:

--- a/tests/test_claude_issue_triage.py
+++ b/tests/test_claude_issue_triage.py
@@ -16,6 +16,7 @@ def _run_triage_helper(
     tmp_path: Path,
     *arguments: str,
     current_labels: tuple[str, ...] = (),
+    fail_label_read: bool = False,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     event_path = tmp_path / "event.json"
     event_path.write_text(json.dumps({"issue": {"number": 1205}}), encoding="utf-8")
@@ -30,6 +31,8 @@ set -euo pipefail
 
 if [[ " $* " == *" --method PUT "* ]]; then
     printf '%s\n' "$@" > "${GH_ARGUMENTS_PATH:?}"
+elif [[ "${GH_FAIL_LABEL_READ:-false}" == "true" ]]; then
+    exit 1
 else
     printf '%s\n' "${GH_CURRENT_LABELS:-}"
 fi
@@ -43,6 +46,7 @@ fi
         {
             "GH_ARGUMENTS_PATH": str(gh_arguments_path),
             "GH_CURRENT_LABELS": "\n".join(current_labels),
+            "GH_FAIL_LABEL_READ": "true" if fail_label_read else "false",
             "GITHUB_EVENT_PATH": str(event_path),
             "GITHUB_REPOSITORY": "basicmachines-co/basic-memory",
             "PATH": f"{bin_path}{os.pathsep}{env['PATH']}",
@@ -114,6 +118,24 @@ def test_triage_helper_keeps_only_one_type_and_cloud_component(tmp_path: Path) -
     assert gh_arguments.count("labels[]=question") == 1
     assert gh_arguments.count("labels[]=cloud") == 1
     assert "labels[]=production" in gh_arguments
+
+
+def test_triage_helper_does_not_update_labels_when_current_labels_cannot_be_read(
+    tmp_path: Path,
+) -> None:
+    result, gh_arguments = _run_triage_helper(
+        tmp_path,
+        "--type",
+        "bug",
+        "--component",
+        "none",
+        current_labels=("production",),
+        fail_label_read=True,
+    )
+
+    assert result.returncode != 0
+    assert "unable to read current issue labels" in result.stderr
+    assert gh_arguments == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

The Claude issue-triage workflow advertises priority, component, complexity, and status labels that do not exist in this repository. Its only label tool accepted arbitrary candidate labels, silently ignored unknown names, and immediately added every candidate that happened to exist. Because the tool was add-only, label discovery mutated the live issue and Claude could not undo mistakes.

This has recurred since the helper was introduced on July 16: at least 12 triage comments explicitly report accidental label application. On [issue #1205](https://github.com/basicmachines-co/basic-memory/issues/1205#issuecomment-5205709963), an enhancement tracker ended up labeled as a bug, documentation request, duplicate, good first issue, question, and Cloud issue as well.

## What Changed

- Replace the generic `--add-label` interface with one semantic classification:
  `--type bug|enhancement|documentation|question --component cloud|none`.
- Reject unsupported values, duplicate options, and candidate-probing arguments before any GitHub mutation.
- Remove only obsolete triage-owned labels and add the requested classification without replacing the issue's full label set.
- Abort before mutation if the current labels cannot be read.
- Add the desired classification before removing obsolete labels, so an additive API failure leaves the prior classification intact.
- Re-read labels after the additive update so competing bot-owned labels introduced during the first read/POST window are included in reconciliation.
- Serialize workflow runs by issue number so two triage attempts cannot delete each other's selected type.
- Update the workflow prompt to call the helper exactly once, treat priority and complexity as prose, classify MCP as a component rather than a fifth type, and avoid duplicate/status labels that the bot does not own.
- Require a concise triage comment without tool logs, taxonomy discussion, or task checklists.
- Add regression coverage for targeted mutations, read failures, concurrent conflicting labels, workflow serialization, invalid probes, required arguments, and workflow YAML/prompt syntax.
- Select Git Bash from the installed Git for Windows and use LF-only, Bash-compatible fixture paths so the shell-helper coverage runs on Windows.

## Implementation Details

The helper first verifies that current labels are readable before any mutation. It then uses GitHub's additive labels endpoint to apply the requested type and optional Cloud component. After that POST succeeds, it reads the labels again and deletes obsolete values from the automated triage ownership set (`bug`, `enhancement`, `documentation`, `question`, and `cloud`). The second read includes a competing owned label added during the initial read/POST window, while targeted DELETE requests leave template, maintainer, and unrelated automation labels untouched.

The workflow uses `claude-issue-triage-${{ github.event.issue.number }}` as its concurrency group with `cancel-in-progress: false`. Runs for different issues remain independent, while attempts for the same issue are serialized so one complete classification wins instead of two DELETE loops removing each other's desired labels.

Repeated valid calls converge on one type and one Cloud/non-Cloud component choice. Unsupported attempts and failed preflight reads stop before the first write. A failed additive request leaves the prior classification intact. A failed post-add reconciliation read leaves the desired label added but performs no destructive calls, allowing a later rerun to converge safely. Duplicate detection remains read-only; Claude links the original issue in prose rather than labeling or closing the new issue.

The tests invoke `scripts/edit-issue-labels.sh` with ordinary `bash` on POSIX. On Windows they derive `bash.exe` from the installed Git executable, because the unqualified Windows `bash` command launches WSL rather than Git Bash. Temporary shell fixtures use LF line endings and POSIX-form paths so Git Bash parses them consistently.

## Testing

### Automated

- `uv run pytest -p pytest_mock --no-cov -q tests/test_claude_issue_triage.py`: 13 passed
- `just fast-check`: Ruff checks and formatting passed; ty passed
- `bash -n scripts/edit-issue-labels.sh`: passed
- `uv run ruff check tests/test_claude_issue_triage.py`: passed
- `uv run ruff format --check tests/test_claude_issue_triage.py`: passed
- `git diff --check`: passed

The focused suite parses the edited workflow as YAML and asserts the single semantic helper contract, per-issue non-cancelling concurrency, the four-type/MCP-component taxonomy, exact additive POST/targeted DELETE ordering, preservation of non-triage labels, no mutation after a failed preflight read, no deletion after a failed additive or reconciliation read, and reconciliation of bot-owned labels added during the initial mutation window.

### Manual

- Inspected the live repository label taxonomy and recent Claude triage comments.
- Confirmed at least 12 self-reported accidental-label incidents since July 16.
- No live issue labels were mutated while testing this fix.
- Inspected the original Windows failure and confirmed all 10 helper cases failed before script execution with `WinError 193`.
- Inspected the first portability rerun: direct-script execution was fixed, 25 checks passed, and the Windows job exposed that unqualified `bash` selected the WSL launcher rather than Git Bash.
- Reproduced Codex's concurrent-owned-label scenario in the fake GitHub boundary and verified the fresh reconciliation read removes the competing type and Cloud labels.
- Evaluated the two-simultaneous-run interleaving and placed serialization at the Actions workflow boundary rather than adding locks or retries to the shell helper.

## Risks / Follow-ups

- The workflow itself cannot be exercised end to end without opening a real issue; the first issue opened after merge is the live acceptance check.
- GitHub does not provide an atomic operation for replacing only a label subset. Per-issue workflow serialization prevents competing helper runs, and the post-add read reconciles other owned-label changes observed during the initial mutation window. A distinct external actor can still mutate labels after any final operation; a later valid triage run converges without replacing unrelated labels.
- This PR prevents new label accumulation but intentionally does not clean labels on previously affected issues.
- The pushed head relies on the Windows CI job for platform-specific confirmation of the Git Bash selection and fixture paths.
