### PR TITLE
fix(core): survive a stale Windows log deleted mid-cleanup (#1211)

### DIFF
--- a/src/basic_memory/utils.py
+++ b/src/basic_memory/utils.py
@@ -501,7 +501,15 @@ def _cleanup_windows_log_files(log_dir: Path, current_log_name: str) -> None:
     # Trigger: per-process log filenames avoid Windows rename contention but fragment retention.
     # Why: loguru retention applies per sink, not across the whole basic-memory log directory.
     # Outcome: keep only the newest stale PID logs so repeated CLI/server launches stay bounded.
-    stale_logs.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+    def _mtime(path: Path) -> float:
+        try:
+            return path.stat().st_mtime
+        except OSError:
+            # Another launch pruned it between the glob above and this read. Sorting it last means it lands in
+            # the delete slice, where unlink() is already guarded against the same race.
+            return -1.0
+
+    stale_logs.sort(key=_mtime, reverse=True)
     for stale_log in stale_logs[WINDOWS_LOG_FILE_RETENTION - 1 :]:
         try:
             stale_log.unlink()

--- a/tests/utils/test_setup_logging.py
+++ b/tests/utils/test_setup_logging.py
@@ -84,6 +84,50 @@ def test_setup_logging_trims_stale_windows_pid_logs(monkeypatch, tmp_path) -> No
     ]
 
 
+def test_setup_logging_survives_a_stale_log_deleted_mid_cleanup(monkeypatch, tmp_path) -> None:
+    """Regression guard for #1211: a stale log that disappears mid-cleanup must not kill the process.
+
+    Windows log files are per-PID, so every launch prunes the same shared directory and concurrent launches
+    are the normal case for the Claude Code plugin. The ``unlink`` below is guarded against exactly that race;
+    the ``stat`` in the sort key that precedes it was not, so ``FileNotFoundError`` escaped through
+    ``setup_logging`` and ended the process during logging setup. When that process was the MCP server, the
+    client saw the stdio connection close and the session silently had no basic-memory tools at all.
+    """
+    log_dir = tmp_path / ".basic-memory"
+    log_dir.mkdir()
+
+    for index in range(6):
+        log_path = log_dir / f"basic-memory-{1000 + index}.log"
+        log_path.write_text("old log", encoding="utf-8")
+        mtime = 1_000 + index
+        os.utime(log_path, (mtime, mtime))
+
+    vanishing = log_dir / "basic-memory-1003.log"
+    real_stat = Path.stat
+
+    def stat_with_a_racing_deletion(self: Path, *args: Any, **kwargs: Any) -> Any:
+        # Stand in for another launch pruning the same shared directory between the glob and the stat.
+        if self == vanishing and vanishing.exists():
+            vanishing.unlink()
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setenv("BASIC_MEMORY_ENV", "dev")
+    monkeypatch.delenv("BASIC_MEMORY_CONFIG_DIR", raising=False)
+    monkeypatch.setattr(utils.os, "name", "nt")
+    monkeypatch.setattr(utils.os, "getpid", lambda: 4242)
+    monkeypatch.setattr(utils.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(utils.Path, "stat", stat_with_a_racing_deletion)
+    monkeypatch.setattr(utils.logger, "remove", lambda *args, **kwargs: None)
+    monkeypatch.setattr(utils.logger, "add", lambda *args, **kwargs: None)
+    monkeypatch.setattr(utils.telemetry, "get_logfire_handler", lambda: None)
+
+    utils.setup_logging(log_to_file=True)
+
+    # The point is that logging came up at all; the pruning itself is covered by the test above.
+    remaining = sorted(path.name for path in log_dir.glob("basic-memory-*.log*"))
+    assert "basic-memory-1003.log" not in remaining
+
+
 def test_setup_logging_honors_basic_memory_config_dir(monkeypatch, tmp_path) -> None:
     """Regression guard for #742: log path must follow BASIC_MEMORY_CONFIG_DIR.
 

--- a/tests/utils/test_setup_logging.py
+++ b/tests/utils/test_setup_logging.py
@@ -104,10 +104,15 @@ def test_setup_logging_survives_a_stale_log_deleted_mid_cleanup(monkeypatch, tmp
 
     vanishing = log_dir / "basic-memory-1003.log"
     real_stat = Path.stat
+    already_deleted = False
 
     def stat_with_a_racing_deletion(self: Path, *args: Any, **kwargs: Any) -> Any:
         # Stand in for another launch pruning the same shared directory between the glob and the stat.
-        if self == vanishing and vanishing.exists():
+        # A one-shot flag rather than an existence check: Path.exists() is implemented by calling stat(),
+        # which is the method being patched here, so asking it would recurse.
+        nonlocal already_deleted
+        if self == vanishing and not already_deleted:
+            already_deleted = True
             vanishing.unlink()
         return real_stat(self, *args, **kwargs)
 


### PR DESCRIPTION
`_cleanup_windows_log_files` can kill the process during logging setup.

Windows log files are per-PID, so every launch prunes the same shared directory, and concurrent launches are the normal case with the Claude Code plugin: several editor sessions plus a session-start hook each start a process. The `unlink` is guarded against another launch removing a file first; the `stat` in the sort key that precedes it is not, so `FileNotFoundError` escapes through `setup_logging`. When that process is the MCP server, the client sees the stdio connection close a couple of seconds after launch and the session silently has no basic-memory tools, while the bundled skills and slash commands go on instructing against tools that are not there.

The sort key now treats a file that has already gone as oldest, which puts it in the delete slice where `unlink` already handles the same race. The regression test stands in for the racing launch by deleting the file during the `stat` it is about to be sorted by.

Fixes #1211.

**Tested.** `tests/utils/` passes (166 passed). The full `tests/` run is 2407 passed, 32 skipped, with one failure in `tests/cli/test_ci_commands.py::test_setup_writes_workflow_config_and_prompt`; that one fails identically on a clean checkout of the same commit in my environment (a missing external binary in a slim container) and is unrelated to this change.

Disclosure: prepared with an AI coding assistant, per the collaborative workflow described in CONTRIBUTING.