### PR TITLE
fix: keep customer content out of loguru message formatting during index retries

### DIFF
--- a/src/basic_memory/index/local_dependencies.py
+++ b/src/basic_memory/index/local_dependencies.py
@@ -292,7 +292,7 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
         source: str,
     ) -> FileIndexResult:
         """Read, persist, search-index, and reconcile one markdown file."""
-        logger.info(f"Indexing markdown file: {file_path}")
+        logger.info("Indexing markdown file: {}", file_path)
 
         async with db.scoped_session(self.session_maker) as session:
             existing = await self.entity_repository.get_by_file_path(
@@ -343,7 +343,8 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
             )
 
         logger.info(
-            f"Indexed markdown file: {file_path}",
+            "Indexed markdown file: {}",
+            file_path,
             entity_id=synced.entity.id,
             checksum=synced.checksum,
             operation=operation,
@@ -367,7 +368,7 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
         source: str,
     ) -> FileIndexResult:
         """Read, persist, and search-index one regular file entity."""
-        logger.info(f"Indexing regular file: {file_path}", source=source)
+        logger.info("Indexing regular file: {}", file_path, source=source)
 
         async with db.scoped_session(self.session_maker) as session:
             existing = await self.entity_repository.get_by_file_path(
@@ -411,7 +412,8 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
 
         entity = refreshed_entities[0]
         logger.info(
-            f"Indexed regular file: {file_path}",
+            "Indexed regular file: {}",
+            file_path,
             entity_id=entity.id,
             checksum=indexed.checksum,
             operation=operation,
@@ -436,7 +438,7 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
         refresh_unchanged_derived_state: bool,
     ) -> SyncedMarkdownFile:
         """Index the current local markdown bytes and return canonical file state."""
-        logger.debug(f"Parsing markdown file, path: {path}, new: {new}")
+        logger.debug("Parsing markdown file, path: {}, new: {}", path, new)
 
         try:
             initial_markdown_bytes = await self.file_service.read_file_bytes(path)
@@ -473,8 +475,10 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
                 )
 
             logger.debug(
-                f"Markdown index skipped unchanged file: path={path}, "
-                f"entity_id={existing_entity.id}, checksum={initial_checksum[:8]}"
+                "Markdown index skipped unchanged file: path={}, entity_id={}, checksum={}",
+                path,
+                existing_entity.id,
+                initial_checksum[:8],
             )
             return SyncedMarkdownFile(
                 entity=existing_entity,
@@ -506,8 +510,10 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
     ) -> SyncedMarkdownFile:
         """Refresh derived DB/search state for a markdown file with unchanged bytes."""
         logger.debug(
-            f"Markdown index refreshing unchanged derived state: path={input_file.path}, "
-            f"entity_id={existing_entity.id}, checksum={input_file.checksum[:8] if input_file.checksum else None}"
+            "Markdown index refreshing unchanged derived state: path={}, entity_id={}, checksum={}",
+            input_file.path,
+            existing_entity.id,
+            input_file.checksum[:8] if input_file.checksum else None,
         )
         indexed = await self.batch_indexer.index_markdown_file(
             input_file,
@@ -580,9 +586,13 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
             )
 
         logger.debug(
-            f"Markdown index completed: path={input_file.path}, entity_id={updated_entity.id}, "
-            f"observation_count={len(updated_entity.observations)}, "
-            f"relation_count={len(updated_entity.relations)}, checksum={indexed.checksum[:8]}"
+            "Markdown index completed: path={}, entity_id={}, observation_count={}, "
+            "relation_count={}, checksum={}",
+            input_file.path,
+            updated_entity.id,
+            len(updated_entity.observations),
+            len(updated_entity.relations),
+            indexed.checksum[:8],
         )
         return SyncedMarkdownFile(
             entity=updated_entity,

--- a/src/basic_memory/indexing/file_indexer.py
+++ b/src/basic_memory/indexing/file_indexer.py
@@ -167,7 +167,7 @@ class FileIndexer:
     ) -> FileIndexResult:
         """Read, parse, persist, search-index, and reconcile one markdown file."""
         log = bound_logger or logger
-        log.info(f"Indexing markdown file: {file_path}")
+        log.info("Indexing markdown file: {}", file_path)
 
         async with db.scoped_session(self.markdown_indexer.session_maker) as session:
             existing = await self.markdown_indexer.entity_repository.get_by_file_path(
@@ -219,7 +219,8 @@ class FileIndexer:
             )
 
         log.info(
-            f"Indexed markdown file: {file_path}",
+            "Indexed markdown file: {}",
+            file_path,
             entity_id=synced.entity.id,
             checksum=synced.checksum,
             operation=operation,

--- a/tests/index/test_local_markdown_file_indexer.py
+++ b/tests/index/test_local_markdown_file_indexer.py
@@ -1,0 +1,99 @@
+"""Tests for the local per-file markdown indexer."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import cast
+from unittest.mock import AsyncMock, Mock
+
+from loguru import logger
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from basic_memory.index.local_dependencies import (
+    LocalIndexEntityRepository,
+    LocalMarkdownFileIndexer,
+)
+from basic_memory.indexing.batch_indexer import BatchIndexer
+from basic_memory.indexing.file_indexer import IndexMarkdownNoteContentReconciler
+from basic_memory.indexing.models import IndexEntitySearchWriter, SyncedMarkdownFile
+from basic_memory.services import FileService
+
+
+class _FakeSession:
+    def get_bind(self) -> Mock:
+        return Mock()
+
+    async def commit(self) -> None:
+        pass
+
+    async def rollback(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_local_file_indexer_logs_brace_path_through_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The local retry loop must render customer braces as literal path and title text."""
+    file_path = "notes/{AG} Plan.md"
+    entity = Mock()
+    entity.id = 42
+    entity.external_id = "note-42"
+    entity.title = "{AG} Plan"
+    entity.permalink = "notes/ag-plan"
+    entity.observations = []
+    entity.relations = []
+    synced_file = SyncedMarkdownFile(
+        entity=entity,
+        checksum="abc123",
+        markdown_content="# {AG} Plan\n",
+        file_path=file_path,
+        content_type="text/markdown",
+        updated_at=datetime(2026, 8, 9, tzinfo=UTC),
+        size=12,
+    )
+
+    entity_repository = Mock()
+    entity_repository.get_by_file_path = AsyncMock(return_value=entity)
+    note_content_reconciler = Mock()
+    note_content_reconciler.capture_anchor = AsyncMock(return_value=None)
+    note_content_reconciler.reconcile = AsyncMock(side_effect=["stale", "current"])
+    indexer = LocalMarkdownFileIndexer(
+        file_service=cast(FileService, Mock()),
+        session_maker=cast(async_sessionmaker[AsyncSession], _FakeSession),
+        entity_repository=cast(LocalIndexEntityRepository, entity_repository),
+        batch_indexer=cast(BatchIndexer, Mock()),
+        search_service=cast(IndexEntitySearchWriter, Mock()),
+        note_content_reconciler=cast(
+            IndexMarkdownNoteContentReconciler,
+            note_content_reconciler,
+        ),
+    )
+    monkeypatch.setattr(
+        LocalMarkdownFileIndexer,
+        "index_current_markdown_file",
+        AsyncMock(return_value=synced_file),
+    )
+
+    rendered_messages: list[str] = []
+    sink_id = logger.add(
+        lambda message: rendered_messages.append(str(message).strip()),
+        format="{message}",
+        level="INFO",
+    )
+    try:
+        result = await indexer.index_markdown_file(file_path, source="index")
+    finally:
+        logger.remove(sink_id)
+
+    assert note_content_reconciler.reconcile.await_count == 2
+    assert f"Retrying markdown index after concurrent accepted note write: {file_path}" in (
+        rendered_messages
+    )
+    assert f"Indexed markdown file: {file_path}" in rendered_messages
+    assert result.file_path == file_path
+    assert result.title == "{AG} Plan"

--- a/tests/indexing/test_file_indexer.py
+++ b/tests/indexing/test_file_indexer.py
@@ -7,6 +7,7 @@ from typing import cast
 from unittest.mock import ANY, AsyncMock, Mock
 
 import pytest
+from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory.indexing.file_indexer import (
@@ -231,9 +232,12 @@ async def test_file_indexer_indexes_existing_markdown_file() -> None:
 
 @pytest.mark.asyncio
 async def test_file_indexer_reindexes_current_file_after_anchor_becomes_stale() -> None:
-    """A stale pass must repair derived state from the current file before succeeding."""
+    """A stale pass must retry and log brace-bearing customer identity safely."""
+    file_path = "notes/{AG} Plan.md"
     existing_entity = _entity(entity_id=7, checksum="older-checksum")
+    existing_entity.title = "{AG} Plan"
     current_entity = _entity(entity_id=7, checksum="current-checksum")
+    current_entity.title = "{AG} Plan"
     stale_file = _synced_file(entity=existing_entity)
     current_file = _synced_file(entity=current_entity, checksum="current-checksum")
 
@@ -251,11 +255,26 @@ async def test_file_indexer_reindexes_current_file_after_anchor_becomes_stale() 
     ]
     note_content_reconciler.reconcile.side_effect = ["stale", "current"]
 
-    result = await file_indexer.index_markdown_file("notes/note.md")
+    rendered_messages: list[str] = []
+    sink_id = logger.add(
+        lambda message: rendered_messages.append(str(message).strip()),
+        format="{message}",
+        level="INFO",
+    )
+    try:
+        result = await file_indexer.index_markdown_file(file_path, bound_logger=logger)
+    finally:
+        logger.remove(sink_id)
 
     assert markdown_indexer.index_current_markdown_file.await_count == 2
     assert note_content_reconciler.capture_anchor.await_args_list[0].args == (7,)
     assert note_content_reconciler.capture_anchor.await_args_list[1].args == (7,)
+    assert f"Retrying markdown index after concurrent accepted note write: {file_path}" in (
+        rendered_messages
+    )
+    assert f"Indexed markdown file: {file_path}" in rendered_messages
+    assert result.file_path == file_path
+    assert result.title == "{AG} Plan"
     assert result.checksum == "current-checksum"
 
 
@@ -362,7 +381,7 @@ async def test_file_indexer_reports_refreshed_derived_counts_after_unchanged_rep
 
     assert result.entity_id == refreshed_entity.id
     final_log = bound_logger.info.call_args_list[-1]
-    assert final_log.args == ("Indexed markdown file: notes/note.md",)
+    assert final_log.args == ("Indexed markdown file: {}", "notes/note.md")
     assert final_log.kwargs["observation_count"] == 2
     assert final_log.kwargs["relation_count"] == 1
 


### PR DESCRIPTION
## Why

Index retry jobs can reach Loguru with customer-derived note paths already interpolated into the
message template. When a path contains literal braces such as `{AG}`, Loguru treats the customer
text as a formatting field and raises `KeyError`, preventing the note from indexing across every
identical job attempt.

Closes #1212

## What Changed

- pass customer-derived paths as positional Loguru arguments in both per-file markdown retry loops
- apply the same brace-safe pattern to sibling regular-file and markdown debug log calls in the
  two audited indexing modules
- cover both reachable retry loops with real Loguru rendering and brace-bearing filename/title
  regressions

## Implementation Details

The log messages now use static templates and provide paths as positional arguments, which Loguru
formats once without interpreting braces inside the argument value. Existing structured context
such as entity IDs, checksums, operations, and graph counts remains attached to each record. This
is intentionally a call-site fix rather than a logging wrapper or content sanitizer.

## Testing

### Automated

- `uv run pytest tests/indexing/test_file_indexer.py tests/index/test_local_markdown_file_indexer.py -q`: 12 passed
- `just fast-check`: passed (Ruff fix/format and `ty` typecheck)
- `just fast-test`: 5,116 passed, 41 skipped
- `just doctor`: passed

### Manual

- reproduced the pre-fix distinction directly with Loguru: positional `notes/{AG}.md` rendered,
  while the interpolated success template raised `KeyError: 'AG'`
- audited both changed modules and confirmed no Loguru call still uses an f-string template

## Risks / Follow-ups

The change affects logging argument construction only; indexing control flow and persisted data are
unchanged. Production should be monitored for recurrence of the two Logfire issue cohorts cited in
#1212 after deployment.
