### PR TITLE
test(ci): locate Git Bash from MinGW Git path

### DIFF
--- a/tests/test_claude_issue_triage.py
+++ b/tests/test_claude_issue_triage.py
@@ -13,6 +13,15 @@ TRIAGE_SCRIPT = REPO_ROOT / "scripts" / "edit-issue-labels.sh"
 TRIAGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "claude-issue-triage.yml"
 
 
+def _git_bash_candidates(git_executable: Path) -> tuple[Path, ...]:
+    git_directory = git_executable.parent
+    return (
+        git_directory / "bash.exe",
+        git_directory.parent / "bin" / "bash.exe",
+        git_directory.parent.parent / "bin" / "bash.exe",
+    )
+
+
 def _bash_executable() -> str:
     if os.name != "nt":
         return "bash"
@@ -21,14 +30,10 @@ def _bash_executable() -> str:
     if git_executable is None:
         raise RuntimeError("Git for Windows is required to run the triage helper tests")
 
-    git_directory = Path(git_executable).parent
-    git_bin_directory = (
-        git_directory if git_directory.name.casefold() == "bin" else git_directory.parent / "bin"
-    )
-    git_bash = git_bin_directory / "bash.exe"
-    if not git_bash.is_file():
-        raise RuntimeError(f"Git Bash was not found at {git_bash}")
-    return str(git_bash)
+    for git_bash in _git_bash_candidates(Path(git_executable)):
+        if git_bash.is_file():
+            return str(git_bash)
+    raise RuntimeError(f"Git Bash was not found near {git_executable}")
 
 
 def _run_triage_helper(
@@ -113,6 +118,12 @@ fi
         else:
             gh_calls[-1].append(line)
     return result, gh_calls
+
+
+def test_git_bash_candidates_include_launcher_for_mingw_git() -> None:
+    git_executable = Path("Git") / "mingw64" / "bin" / "git.exe"
+
+    assert Path("Git") / "bin" / "bash.exe" in _git_bash_candidates(git_executable)
 
 
 def test_triage_helper_updates_only_owned_labels_without_replacing_other_labels(


### PR DESCRIPTION
## Summary

- locate the Git Bash launcher when `shutil.which("git")` resolves Git for Windows through `mingw64/bin`
- keep support for the top-level `bin` and `cmd` Git executable layouts
- add a platform-independent regression for the exact path shape reported by the failed Windows job

## Problem

PR #1206 fixed the original direct-`.sh` execution failure and the WSL `bash` collision, but its final Windows SQLite unit job exposed one more Git-for-Windows layout. The test process resolved `git.exe` as `C:\Program Files\Git\mingw64\bin\git.exe`, while the Bash launcher lives at `C:\Program Files\Git\bin\bash.exe`. The locator checked only the directory containing `git.exe`, so all 12 shell-helper cases failed before invoking the script.

This is a test-harness correction only. The merged issue-label reconciliation and per-issue workflow serialization are unchanged.

## Changes

- derive candidate Bash paths for Git executables found under `bin`, `cmd`, or `mingw64/bin`
- select the first existing launcher and retain a clear fail-fast error when Git Bash is unavailable
- assert that a `Git/mingw64/bin/git.exe` executable maps back to `Git/bin/bash.exe`

## Testing

- `uv run pytest -p pytest_mock --no-cov -q tests/test_claude_issue_triage.py` — 14 passed
- `bash -n scripts/edit-issue-labels.sh` — passed
- `git diff --check` — passed
- `just fast-check` — passed

## Evidence

- Follow-up to #1206
- Failed Windows job: https://github.com/basicmachines-co/basic-memory/actions/runs/31333760441/job/93296112463
