### PR TITLE
fix(core): validate schema validation modes

### DIFF
--- a/NOTE-FORMAT.md
+++ b/NOTE-FORMAT.md
@@ -329,7 +329,9 @@ Schema notes are regular notes — they show up in search, can have observations
 |------|----------|
 | `warn` | Warnings in output, doesn't block (default) |
 | `strict` | Errors that block sync, for CI/CD enforcement |
-| `off` | No validation |
+
+`strict` is the canonical enforcing mode. `error` is accepted as a compatibility alias and is
+normalized to `strict`. Any other value is rejected when the schema definition is parsed.
 
 ### Validation Output
 

--- a/docs/NOTE-FORMAT.md
+++ b/docs/NOTE-FORMAT.md
@@ -368,7 +368,6 @@ Schema notes are regular notes — they show up in search, can have observations
 |------|----------|
 | `warn` | Warnings in output, doesn't block (default) |
 | `strict` | Errors that block sync, for CI/CD enforcement |
-| `off` | No validation |
 
 `strict` is the canonical enforcing mode. `error` is accepted as a compatibility alias and is
 normalized to `strict`. Any other value is rejected when the schema definition is parsed.

--- a/docs/NOTE-FORMAT.md
+++ b/docs/NOTE-FORMAT.md
@@ -370,6 +370,9 @@ Schema notes are regular notes — they show up in search, can have observations
 | `strict` | Errors that block sync, for CI/CD enforcement |
 | `off` | No validation |
 
+`strict` is the canonical enforcing mode. `error` is accepted as a compatibility alias and is
+normalized to `strict`. Any other value is rejected when the schema definition is parsed.
+
 ### Validation Output
 
 ```

--- a/docs/specs/SPEC-SCHEMA-IMPL.md
+++ b/docs/specs/SPEC-SCHEMA-IMPL.md
@@ -63,7 +63,7 @@ class SchemaDefinition:
     entity: str                  # The entity type this schema describes
     version: int                 # Schema version
     fields: list[SchemaField]    # Parsed fields
-    validation_mode: str         # "warn" | "strict" | "off"
+    validation_mode: str         # "warn" | "strict"
     frontmatter_fields: list[SchemaField]  # From settings.frontmatter (default: [])
 
 

--- a/docs/specs/SPEC-SCHEMA.md
+++ b/docs/specs/SPEC-SCHEMA.md
@@ -99,7 +99,7 @@ schema:
   works_at?: Organization, employer
   expertise?(array): string, areas of knowledge
 settings:
-  validation: warn    # warn | strict | off
+  validation: warn    # warn | strict
   frontmatter:
     tags?(array): string, note categories
     status?(enum): [draft, review, published]
@@ -211,7 +211,6 @@ Configured in the schema's `settings.validation`:
 
 | Mode | Behavior |
 |------|----------|
-| `off` | No validation |
 | `warn` | Warnings in output, doesn't block (default) |
 | `strict` | Errors that block sync, for CI/CD enforcement |
 

--- a/docs/specs/SPEC-SCHEMA.md
+++ b/docs/specs/SPEC-SCHEMA.md
@@ -215,6 +215,9 @@ Configured in the schema's `settings.validation`:
 | `warn` | Warnings in output, doesn't block (default) |
 | `strict` | Errors that block sync, for CI/CD enforcement |
 
+`strict` is the canonical enforcing mode. `error` remains accepted as a compatibility alias and
+is normalized to `strict`. Schema parsing rejects every other value instead of failing open.
+
 ### Validation Output
 
 For a note missing required fields:

--- a/skills/memory-onboarding/references/schema-guide.md
+++ b/skills/memory-onboarding/references/schema-guide.md
@@ -113,7 +113,7 @@ description. Status moves open → in-progress → done; blocked is a holding st
 
 Key points:
 
-- **`validation: warn`, not `strict`** — the modes are `warn`, `strict`, and `off`. Warn logs findings without blocking anything; `strict` escalates the same findings to errors. Start every schema on warn — a new user fighting rejected writes will abandon the system. Move a schema to `strict` only if something automated consumes the notes and malformed ones break it.
+- **`validation: warn`, not `strict`** — the modes are `warn` and `strict`. Warn logs findings without blocking anything; `strict` escalates the same findings to errors. Start every schema on warn — a new user fighting rejected writes will abandon the system. Move a schema to `strict` only if something automated consumes the notes and malformed ones break it.
 - **Content notes declare their type** via `note_type` matching the schema's entity (e.g. `note_type="task"`).
 - **Scalar, enum, and array fields must appear as observations** in the note body (`- [status] open`) to satisfy validation — frontmatter-only values don't count. Putting them in both places gives you metadata search *and* schema validation. **Entity-reference fields are different**: they're satisfied by a relation, not an observation — a line in `## Relations` whose type matches the field name (`project?: Project` is satisfied by `- project [[Kitchen Renovation]]`).
 - **Version in metadata** — bump on breaking changes (new required field, removed field, type change). Additive optional fields don't need a bump.

--- a/skills/memory-schema/SKILL.md
+++ b/skills/memory-schema/SKILL.md
@@ -83,7 +83,7 @@ Relations create edges in the knowledge graph, linking notes together.
 
 ```yaml
 settings:
-  validation: warn    # warn (log issues), strict (errors), or off
+  validation: warn    # warn (log issues) or strict (errors)
 ```
 
 Use `strict` as the canonical enforcing mode. `error` is accepted only as a compatibility alias.
@@ -186,7 +186,6 @@ Validation reports:
 
 - **`warn` mode**: Review warnings periodically. Fix notes that are clearly wrong; add optional fields to the schema for legitimate new patterns.
 - **`strict` mode**: Use where conformance matters (e.g., automated pipelines consuming notes).
-- **`off` mode**: Disable validation diagnostics for the schema.
 
 ## Detecting Drift
 

--- a/skills/memory-schema/SKILL.md
+++ b/skills/memory-schema/SKILL.md
@@ -83,8 +83,10 @@ Relations create edges in the knowledge graph, linking notes together.
 
 ```yaml
 settings:
-  validation: warn    # warn (log issues) or error (strict)
+  validation: warn    # warn (log issues), strict (errors), or off
 ```
+
+Use `strict` as the canonical enforcing mode. `error` is accepted only as a compatibility alias.
 
 ### Complete Example
 
@@ -183,7 +185,8 @@ Validation reports:
 ### Handling Validation Results
 
 - **`warn` mode**: Review warnings periodically. Fix notes that are clearly wrong; add optional fields to the schema for legitimate new patterns.
-- **`error` mode**: Use for strict schemas where conformance matters (e.g., automated pipelines consuming notes).
+- **`strict` mode**: Use where conformance matters (e.g., automated pipelines consuming notes).
+- **`off` mode**: Disable validation diagnostics for the schema.
 
 ## Detecting Drift
 

--- a/src/basic_memory/api/v2/routers/schema_router.py
+++ b/src/basic_memory/api/v2/routers/schema_router.py
@@ -11,7 +11,7 @@ Flow: Entity loaded with eager observations/relations -> convert to tuples -> co
 from pathlib import Path as FilePath
 
 import frontmatter
-from fastapi import APIRouter, Path, Query
+from fastapi import APIRouter, HTTPException, Path, Query, status
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -33,7 +33,8 @@ from basic_memory.schemas.schema import (
     DriftFieldResponse,
     TypeValidationSummary,
 )
-from basic_memory.picoschema.resolver import resolve_schema
+from basic_memory.picoschema.resolver import SchemaSearchFn, resolve_schema
+from basic_memory.picoschema.parser import SchemaDefinition
 from basic_memory.picoschema.validator import validate_note
 from basic_memory.picoschema.inference import infer_schema, NoteData, ObservationData, RelationData
 from basic_memory.picoschema.diff import diff_schema
@@ -131,6 +132,20 @@ async def _schema_frontmatter_from_file(
 # --- Validation ---
 
 
+async def _resolve_schema_for_api(
+    frontmatter: dict[str, Any],
+    search_fn: SchemaSearchFn,
+) -> SchemaDefinition | None:
+    """Resolve a schema and expose authoring errors as client errors."""
+    try:
+        return await resolve_schema(frontmatter, search_fn)
+    except ValueError as exc:
+        # Trigger: user-authored schema frontmatter contains an invalid definition
+        # Why: the configuration error is actionable by the caller, not a server failure
+        # Outcome: API and MCP clients receive the parser's precise message as HTTP 400
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
 @router.post("/schema/validate", response_model=ValidationReport)
 async def validate_schema(
     entity_repository: EntityRepositoryV2ExternalDep,
@@ -174,7 +189,7 @@ async def validate_schema(
             )
             return [await _schema_frontmatter_from_file(file_service, e) for e in entities]
 
-        schema_def = await resolve_schema(frontmatter, search_fn)
+        schema_def = await _resolve_schema_for_api(frontmatter, search_fn)
         if schema_def:
             result = validate_note(
                 entity.title or entity.permalink or identifier,
@@ -319,7 +334,7 @@ async def diff_schema_endpoint(
     # Resolve schema by note type
     canonical_note_type = normalize_note_type(note_type)
     schema_frontmatter = {"type": canonical_note_type}
-    schema_def = await resolve_schema(schema_frontmatter, search_fn)
+    schema_def = await _resolve_schema_for_api(schema_frontmatter, search_fn)
 
     if not schema_def:
         return DriftReport(note_type=canonical_note_type, schema_found=False)
@@ -385,7 +400,7 @@ async def _validate_note_entities(
             )
             return [await _schema_frontmatter_from_file(file_service, e) for e in found]
 
-        schema_def = await resolve_schema(frontmatter, search_fn)
+        schema_def = await _resolve_schema_for_api(frontmatter, search_fn)
         if schema_def:
             result = validate_note(
                 entity.title or entity.permalink or entity.file_path,

--- a/src/basic_memory/picoschema/parser.py
+++ b/src/basic_memory/picoschema/parser.py
@@ -23,7 +23,7 @@ from typing import Any, Literal
 
 # --- Data Model ---
 
-type ValidationMode = Literal["warn", "strict", "off"]
+type ValidationMode = Literal["warn", "strict"]
 
 
 @dataclass
@@ -76,15 +76,13 @@ def parse_validation_mode(value: object = "warn") -> ValidationMode:
             return "warn"
         case "strict":
             return "strict"
-        case "off":
-            return "off"
         case "error":
             # Compatibility: early schema guidance used "error" for enforcing validation.
             return "strict"
         case _:
             raise ValueError(
                 f"Invalid settings.validation value {value!r}; expected one of: "
-                "'warn', 'strict', 'off', or 'error' (alias for 'strict')"
+                "'warn', 'strict', or 'error' (alias for 'strict')"
             )
 
 
@@ -309,7 +307,7 @@ def parse_schema_note(frontmatter: dict[str, Any]) -> SchemaDefinition:
       - entity: the entity type this schema describes
       - version: schema version number
       - schema: the Picoschema dict
-      - settings.validation: validation mode (warn/strict/off)
+      - settings.validation: validation mode (warn/strict)
 
     Args:
         frontmatter: The complete YAML frontmatter dict from a schema note.

--- a/src/basic_memory/picoschema/parser.py
+++ b/src/basic_memory/picoschema/parser.py
@@ -18,10 +18,12 @@ Syntax reference:
 
 import re
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 
 # --- Data Model ---
+
+type ValidationMode = Literal["warn", "strict", "off"]
 
 
 @dataclass
@@ -52,7 +54,7 @@ class SchemaDefinition:
     entity: str  # The entity type this schema describes
     version: int  # Schema version
     fields: list[SchemaField]  # Parsed fields
-    validation_mode: str  # "warn" | "strict" | "off"
+    validation_mode: ValidationMode
     frontmatter_fields: list[SchemaField] = field(default_factory=list)  # From settings.frontmatter
 
 
@@ -62,6 +64,28 @@ class SchemaDefinition:
 
 SCALAR_TYPES = frozenset({"string", "integer", "number", "boolean", "any"})
 MODIFIER_TYPES = frozenset({"array", "enum", "object"})
+
+
+# --- Validation Mode Parsing ---
+
+
+def parse_validation_mode(value: object = "warn") -> ValidationMode:
+    """Parse a schema validation setting into its canonical closed vocabulary."""
+    match value:
+        case "warn":
+            return "warn"
+        case "strict":
+            return "strict"
+        case "off":
+            return "off"
+        case "error":
+            # Compatibility: early schema guidance used "error" for enforcing validation.
+            return "strict"
+        case _:
+            raise ValueError(
+                f"Invalid settings.validation value {value!r}; expected one of: "
+                "'warn', 'strict', 'off', or 'error' (alias for 'strict')"
+            )
 
 
 # --- Field Name Parsing ---
@@ -306,7 +330,8 @@ def parse_schema_note(frontmatter: dict[str, Any]) -> SchemaDefinition:
 
     version = frontmatter.get("version", 1)
     settings = frontmatter.get("settings", {})
-    validation_mode = settings.get("validation", "warn") if isinstance(settings, dict) else "warn"
+    validation_value = settings.get("validation", "warn") if isinstance(settings, dict) else "warn"
+    validation_mode = parse_validation_mode(validation_value)
 
     fields = parse_picoschema(schema_dict)
 

--- a/src/basic_memory/picoschema/resolver.py
+++ b/src/basic_memory/picoschema/resolver.py
@@ -13,7 +13,12 @@ data access layer.
 
 from collections.abc import Callable, Awaitable
 
-from basic_memory.picoschema.parser import SchemaDefinition, parse_picoschema, parse_schema_note
+from basic_memory.picoschema.parser import (
+    SchemaDefinition,
+    parse_picoschema,
+    parse_schema_note,
+    parse_validation_mode,
+)
 from typing import Any
 
 
@@ -86,7 +91,8 @@ def _schema_from_inline(
     fields = parse_picoschema(schema_dict)
     entity = frontmatter.get("type", "unknown")
     settings = frontmatter.get("settings", {})
-    validation_mode = settings.get("validation", "warn") if isinstance(settings, dict) else "warn"
+    validation_value = settings.get("validation", "warn") if isinstance(settings, dict) else "warn"
+    validation_mode = parse_validation_mode(validation_value)
 
     return SchemaDefinition(
         entity=entity,

--- a/src/basic_memory/picoschema/validator.py
+++ b/src/basic_memory/picoschema/validator.py
@@ -16,10 +16,10 @@ are informational, not errors -- schemas are a subset, not a straitjacket.
 """
 
 from dataclasses import dataclass, field as dataclass_field
+from typing import Any, assert_never
 
 from basic_memory.picoschema.inference import ObservationData, RelationData
-from basic_memory.picoschema.parser import SchemaDefinition, SchemaField
-from typing import Any
+from basic_memory.picoschema.parser import SchemaDefinition, SchemaField, ValidationMode
 
 
 # --- Result Data Model ---
@@ -102,19 +102,11 @@ def validate_note(
         # Outcome: only required missing fields produce diagnostics
         if field_result.status == "missing" and schema_field.required:
             msg = _missing_field_message(schema_field)
-            if schema.validation_mode == "strict":
-                result.errors.append(msg)
-                result.passed = False
-            else:
-                result.warnings.append(msg)
+            _record_validation_issue(result, msg, schema.validation_mode)
 
         elif field_result.status == "enum_mismatch":
             msg = field_result.message or f"Field '{schema_field.name}' has invalid enum value"
-            if schema.validation_mode == "strict":
-                result.errors.append(msg)
-                result.passed = False
-            else:
-                result.warnings.append(msg)
+            _record_validation_issue(result, msg, schema.validation_mode)
 
     # --- Validate frontmatter fields ---
     # Trigger: schema has frontmatter_fields and caller provided frontmatter dict
@@ -127,21 +119,13 @@ def validate_note(
 
             if field_result.status == "missing" and fm_field.required:
                 msg = f"Missing required frontmatter key: {fm_field.name}"
-                if schema.validation_mode == "strict":
-                    result.errors.append(msg)
-                    result.passed = False
-                else:
-                    result.warnings.append(msg)
+                _record_validation_issue(result, msg, schema.validation_mode)
 
             elif field_result.status == "enum_mismatch":
                 msg = field_result.message or (
                     f"Frontmatter key '{fm_field.name}' has invalid enum value"
                 )
-                if schema.validation_mode == "strict":
-                    result.errors.append(msg)
-                    result.passed = False
-                else:
-                    result.warnings.append(msg)
+                _record_validation_issue(result, msg, schema.validation_mode)
 
     # --- Collect unmatched observations ---
     for category, values in obs_by_category.items():
@@ -313,6 +297,24 @@ def _validate_frontmatter_field(
 
 
 # --- Helper Functions ---
+
+
+def _record_validation_issue(
+    result: ValidationResult,
+    message: str,
+    validation_mode: ValidationMode,
+) -> None:
+    """Record a validation finding according to the schema's validated mode."""
+    match validation_mode:
+        case "off":
+            return
+        case "warn":
+            result.warnings.append(message)
+        case "strict":
+            result.errors.append(message)
+            result.passed = False
+        case unreachable:
+            assert_never(unreachable)
 
 
 def _group_observations(observations: list[ObservationData]) -> dict[str, list[str]]:

--- a/src/basic_memory/picoschema/validator.py
+++ b/src/basic_memory/picoschema/validator.py
@@ -306,8 +306,6 @@ def _record_validation_issue(
 ) -> None:
     """Record a validation finding according to the schema's validated mode."""
     match validation_mode:
-        case "off":
-            return
         case "warn":
             result.warnings.append(message)
         case "strict":

--- a/test-int/fixtures/schema/schemas/InvalidOffSchema.md
+++ b/test-int/fixtures/schema/schemas/InvalidOffSchema.md
@@ -1,0 +1,14 @@
+---
+title: InvalidOffSchema
+type: schema
+entity: InvalidOffEntity
+version: 1
+schema:
+  name: string, entity name
+settings:
+  validation: off
+---
+
+# InvalidOffSchema
+
+This fixture proves that validation modes are checked after loading real Markdown frontmatter.

--- a/test-int/test_picoschema/test_parser_integration.py
+++ b/test-int/test_picoschema/test_parser_integration.py
@@ -1,8 +1,11 @@
 """Integration tests for the Picoschema parser using real fixture files."""
 
+from pathlib import Path
+
 import pytest
 
 from basic_memory.picoschema.parser import parse_schema_note
+from test_picoschema.helpers import parse_frontmatter
 
 
 class TestPersonSchemaParsing:
@@ -73,6 +76,15 @@ class TestStrictSchemaParsing:
 
 class TestSchemaParsingErrors:
     """Verify parser raises on invalid frontmatter."""
+
+    def test_bare_off_from_markdown_is_rejected(self, schemas_dir: Path):
+        frontmatter = parse_frontmatter(schemas_dir / "InvalidOffSchema.md")
+
+        # PyYAML follows YAML 1.1 here, so a bare `off` crosses the Markdown
+        # boundary as False. The parser must reject that undocumented mode.
+        assert frontmatter["settings"]["validation"] is False
+        with pytest.raises(ValueError, match="expected one of: 'warn', 'strict', or 'error'"):
+            parse_schema_note(frontmatter)
 
     def test_missing_entity_raises(self):
         with pytest.raises(ValueError, match="entity"):

--- a/tests/api/v2/test_schema_router.py
+++ b/tests/api/v2/test_schema_router.py
@@ -224,6 +224,45 @@ async def test_validate_with_inline_schema(
 
 
 @pytest.mark.asyncio
+async def test_validate_invalid_mode_returns_client_error(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    entity_service,
+    search_service,
+):
+    """Invalid inline schema modes are configuration errors, not HTTP 500s."""
+    entity, _ = await entity_service.create_or_update_entity(
+        EntitySchema(
+            title="Invalid Mode Note",
+            directory="people",
+            note_type="invalid_mode",
+            entity_metadata={
+                "schema": {"name": "string"},
+                "settings": {"validation": "banana"},
+            },
+            content="## Observations\n- [name] Invalid Mode\n",
+        )
+    )
+    await search_service.index_entity(entity)
+
+    responses = [
+        await client.post(
+            f"{v2_project_url}/schema/validate",
+            params={"identifier": entity.permalink},
+        ),
+        await client.post(
+            f"{v2_project_url}/schema/validate",
+            params={"note_type": "invalid_mode"},
+        ),
+    ]
+
+    for response in responses:
+        assert response.status_code == 400
+        assert "Invalid settings.validation value 'banana'" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
 async def test_validate_with_explicit_schema_reference_by_permalink_slug(
     client: AsyncClient,
     test_project: Project,
@@ -908,6 +947,36 @@ async def test_diff_with_schema_note(
     assert isinstance(data["new_fields"], list)
     assert isinstance(data["dropped_fields"], list)
     assert isinstance(data["cardinality_changes"], list)
+
+
+@pytest.mark.asyncio
+async def test_diff_invalid_mode_returns_client_error(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    entity_service,
+    search_service,
+):
+    """Invalid file-backed schema modes return their actionable parser error."""
+    schema_entity, _ = await entity_service.create_or_update_entity(
+        EntitySchema(
+            title="Invalid Diff Schema",
+            directory="schemas",
+            note_type="schema",
+            entity_metadata={
+                "entity": "invalid_diff",
+                "schema": {"name": "string"},
+                "settings": {"validation": "banana"},
+            },
+            content="## Observations\n- [note] Invalid mode fixture\n",
+        )
+    )
+    await search_service.index_entity(schema_entity)
+
+    response = await client.get(f"{v2_project_url}/schema/diff/invalid_diff")
+
+    assert response.status_code == 400
+    assert "Invalid settings.validation value 'banana'" in response.json()["detail"]
 
 
 # --- File-based schema frontmatter tests ---

--- a/tests/picoschema/test_parser.py
+++ b/tests/picoschema/test_parser.py
@@ -409,8 +409,8 @@ class TestParseSchemaNote:
         result = parse_schema_note(frontmatter)
         assert result.validation_mode == "strict"
 
-    @pytest.mark.parametrize("validation_mode", ["banana", 42, None])
-    def test_unknown_validation_mode_raises(self, validation_mode):
+    @pytest.mark.parametrize("validation_mode", ["banana", "off", False, 42, None])
+    def test_unknown_validation_mode_raises(self, validation_mode: object):
         frontmatter = {
             "entity": "Person",
             "schema": {"name": "string"},
@@ -419,7 +419,7 @@ class TestParseSchemaNote:
 
         with pytest.raises(
             ValueError,
-            match="expected one of: 'warn', 'strict', 'off', or 'error'",
+            match="expected one of: 'warn', 'strict', or 'error'",
         ):
             parse_schema_note(frontmatter)
 

--- a/tests/picoschema/test_parser.py
+++ b/tests/picoschema/test_parser.py
@@ -400,6 +400,29 @@ class TestParseSchemaNote:
         result = parse_schema_note(frontmatter)
         assert result.validation_mode == "strict"
 
+    def test_error_validation_mode_aliases_strict(self):
+        frontmatter = {
+            "entity": "Person",
+            "schema": {"name": "string"},
+            "settings": {"validation": "error"},
+        }
+        result = parse_schema_note(frontmatter)
+        assert result.validation_mode == "strict"
+
+    @pytest.mark.parametrize("validation_mode", ["banana", 42, None])
+    def test_unknown_validation_mode_raises(self, validation_mode):
+        frontmatter = {
+            "entity": "Person",
+            "schema": {"name": "string"},
+            "settings": {"validation": validation_mode},
+        }
+
+        with pytest.raises(
+            ValueError,
+            match="expected one of: 'warn', 'strict', 'off', or 'error'",
+        ):
+            parse_schema_note(frontmatter)
+
     def test_missing_entity_raises(self):
         with pytest.raises(ValueError, match="entity"):
             parse_schema_note({"schema": {"name": "string"}})

--- a/tests/picoschema/test_resolver.py
+++ b/tests/picoschema/test_resolver.py
@@ -85,7 +85,7 @@ class TestInlineSchema:
             "settings": {"validation": "banana"},
         }
 
-        with pytest.raises(ValueError, match="warn.*strict.*off.*error"):
+        with pytest.raises(ValueError, match="warn.*strict.*error"):
             await resolve_schema(frontmatter, mock_search_fn)
 
 

--- a/tests/picoschema/test_resolver.py
+++ b/tests/picoschema/test_resolver.py
@@ -66,6 +66,28 @@ class TestInlineSchema:
         assert result is not None
         assert result.validation_mode == "strict"
 
+    @pytest.mark.asyncio
+    async def test_inline_schema_normalizes_error_validation_mode(self, mock_search_fn):
+        frontmatter = {
+            "type": "Test",
+            "schema": {"name": "string"},
+            "settings": {"validation": "error"},
+        }
+        result = await resolve_schema(frontmatter, mock_search_fn)
+        assert result is not None
+        assert result.validation_mode == "strict"
+
+    @pytest.mark.asyncio
+    async def test_inline_schema_rejects_unknown_validation_mode(self, mock_search_fn):
+        frontmatter = {
+            "type": "Test",
+            "schema": {"name": "string"},
+            "settings": {"validation": "banana"},
+        }
+
+        with pytest.raises(ValueError, match="warn.*strict.*off.*error"):
+            await resolve_schema(frontmatter, mock_search_fn)
+
 
 # --- Explicit reference (priority 2) ---
 

--- a/tests/picoschema/test_validator.py
+++ b/tests/picoschema/test_validator.py
@@ -115,14 +115,6 @@ class TestValidateRequiredFields:
         assert len(result.errors) == 1
         assert result.warnings == []
 
-    def test_required_field_missing_off_mode_has_no_diagnostics(self):
-        schema = _make_schema([_scalar_field("name")], validation_mode="off")
-        result = validate_note("test-note", schema, [], [])
-
-        assert result.passed is True
-        assert result.warnings == []
-        assert result.errors == []
-
     def test_invalid_internal_validation_mode_raises(self):
         schema = _make_schema([_scalar_field("name")])
         schema.validation_mode = cast(ValidationMode, "banana")

--- a/tests/picoschema/test_validator.py
+++ b/tests/picoschema/test_validator.py
@@ -1,7 +1,16 @@
 """Tests for basic_memory.picoschema.validator -- note validation against schemas."""
 
+from typing import cast
+
+import pytest
+
 from basic_memory.picoschema.inference import ObservationData, RelationData
-from basic_memory.picoschema.parser import SchemaField, SchemaDefinition
+from basic_memory.picoschema.parser import (
+    SchemaDefinition,
+    SchemaField,
+    ValidationMode,
+    parse_schema_note,
+)
 from basic_memory.picoschema.validator import validate_note
 
 # Short aliases for test readability
@@ -50,7 +59,7 @@ def _enum_field(
 
 def _make_schema(
     fields: list[SchemaField],
-    validation_mode: str = "warn",
+    validation_mode: ValidationMode = "warn",
     entity: str = "TestEntity",
 ) -> SchemaDefinition:
     return SchemaDefinition(
@@ -91,6 +100,35 @@ class TestValidateRequiredFields:
         assert result.passed is False
         assert len(result.errors) == 1
         assert "name" in result.errors[0]
+
+    def test_error_alias_missing_required_field_fails(self):
+        schema = parse_schema_note(
+            {
+                "entity": "TestEntity",
+                "schema": {"name": "string"},
+                "settings": {"validation": "error"},
+            }
+        )
+        result = validate_note("test-note", schema, [], [])
+
+        assert result.passed is False
+        assert len(result.errors) == 1
+        assert result.warnings == []
+
+    def test_required_field_missing_off_mode_has_no_diagnostics(self):
+        schema = _make_schema([_scalar_field("name")], validation_mode="off")
+        result = validate_note("test-note", schema, [], [])
+
+        assert result.passed is True
+        assert result.warnings == []
+        assert result.errors == []
+
+    def test_invalid_internal_validation_mode_raises(self):
+        schema = _make_schema([_scalar_field("name")])
+        schema.validation_mode = cast(ValidationMode, "banana")
+
+        with pytest.raises(AssertionError, match="Expected code to be unreachable"):
+            validate_note("test-note", schema, [], [])
 
 
 # --- Optional field behavior ---
@@ -253,7 +291,7 @@ class TestValidateFrontmatterFields:
     def _make_fm_schema(
         self,
         frontmatter_fields: list[SchemaField],
-        validation_mode: str = "warn",
+        validation_mode: ValidationMode = "warn",
     ) -> SchemaDefinition:
         return SchemaDefinition(
             entity="TestEntity",


### PR DESCRIPTION
## Why

Schema validation accepted arbitrary `settings.validation` values and treated every value except `strict` as warning-only. That made the natural `error` spelling fail open: notes missing required fields still reported `passed: true`.

The public schema contract documents two modes, `warn` and `strict`. The parser also has to enforce that contract after Markdown frontmatter loading, where YAML 1.1 tokens such as bare `off` may already have become non-string values. Invalid schema configuration must also remain actionable at the API boundary instead of surfacing as a generic server error.

Closes #1222.

## What Changed

- Model validation mode as the documented closed `warn | strict` vocabulary.
- Parse modes at schema boundaries for both schema notes and inline schemas.
- Accept `error` as a compatibility alias normalized to canonical `strict`.
- Reject `off`, its YAML-loaded `False` representation, and every other unknown value.
- Handle `warn` and `strict` exhaustively when recording validation findings.
- Translate invalid schema definitions into HTTP 400 responses for single validation, batch validation, and schema diff.
- Align checked-in schema references and shared skills with the public documentation.
- Add unit coverage for the complete accepted/rejected mode matrix.
- Add integration coverage that loads a real Markdown fixture and exercises the PyYAML boundary.
- Add API regression coverage for malformed inline and file-backed schema modes.

## Implementation Details

`parse_validation_mode()` narrows the untrusted YAML value once, so `SchemaDefinition.validation_mode` is always a typed `ValidationMode`. The validator consumes that closed type with an exhaustive match and `assert_never`, preventing a future mode from silently degrading to warnings.

The compatibility alias preserves the spelling already used by the cloud acceptance flow while keeping `strict` as the documented canonical enforcing mode. The integration fixture deliberately uses bare `validation: off`: PyYAML loads it as `False`, and schema parsing now rejects it with the accepted vocabulary instead of bypassing the boundary behavior in hand-built test dictionaries.

The schema router catches parser `ValueError` only around schema resolution and returns HTTP 400 with the actionable parser message. Other failures retain their existing error behavior.

## Testing

### Automated

- `uv run pytest tests/picoschema/test_parser.py tests/picoschema/test_resolver.py tests/picoschema/test_validator.py test-int/test_picoschema/test_parser_integration.py test-int/test_picoschema/test_validator_integration.py -q`: 138 passed
- `uv run pytest tests/api/v2/test_schema_router.py tests/mcp/test_client_schema.py tests/mcp/test_tool_schema.py -q`: 56 passed
- `just fast-check`: passed
- `just package-check`: passed
- `just doctor`: passed
- `git diff --check`: passed

### Manual

- Verified the pushed branch matches local head `91e16b77409e52aefff138f2dcbf6ce3c283dfb7`.
- Verified checked-in Markdown documentation has no remaining supported-`off` guidance; the only bare `off` is the intentional invalid integration fixture.
- Verified malformed modes return HTTP 400 for identifier validation, note-type batch validation, and schema diff.

## Risks / Follow-ups

- Unknown modes, including previously tolerated `off`, now fail at schema parse time instead of degrading to warnings. This is intentional alignment with the public `warn | strict` contract but may expose previously unnoticed invalid schemas.
- The cloud development MCP acceptance schemas phase was not run locally because it requires a deployed build carrying this core change. Rerun that phase after deployment.