### PR TITLE
fix(core): remove entity read locks from materialization publish

### DIFF
--- a/src/basic_memory/indexing/note_materialization_runner.py
+++ b/src/basic_memory/indexing/note_materialization_runner.py
@@ -57,6 +57,7 @@ from basic_memory.runtime.storage import (
     RuntimeFilePath,
 )
 from basic_memory.models import Entity, NoteContent
+from basic_memory.repository.entity_repository import EntityRepository
 from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
 
 type NoteMaterializationPreflightOutcome = (
@@ -427,25 +428,21 @@ class RepositoryNoteMaterializationPublisher:
                 entity_id=request.entity_id,
             )
 
-            # Materialization publishes NoteContent and Entity in one transaction.
-            # The canonical order lives in current_relation_generation_statement:
-            # claim NoteContent before any Entity lock so publication, accepted
-            # mutation, deletion, and materialization cannot form a lock cycle.
+            # These are plain snapshots for planning. This transaction's first row
+            # lock is the NoteContent CAS UPDATE, preserving the canonical order in
+            # current_relation_generation_statement. With no read locks held, the
+            # publisher cannot anchor the lock cycle reported in #1224.
             note_content = await session.scalar(
-                select(NoteContent)
-                .where(
+                select(NoteContent).where(
                     NoteContent.entity_id == request.entity_id,
                     NoteContent.project_id == request.project_id,
                 )
-                .with_for_update()
             )
             entity = await session.scalar(
-                select(Entity)
-                .where(
+                select(Entity).where(
                     Entity.id == request.entity_id,
                     Entity.project_id == request.project_id,
                 )
-                .with_for_update()
             )
             publish_plan = plan_written_note_materialization_publish(
                 request=request,
@@ -509,9 +506,20 @@ class RepositoryNoteMaterializationPublisher:
                 expected_db_version=expected_db_version,
             )
             if not applied:
-                # A newer accepted write (and its own materialization) superseded
-                # this one between our read and write; skip the stale file_version
-                # publish and the entity metadata update rather than reverting them.
+                # Trigger: a move can commit after the plain planning reads but
+                # before the CAS observes the newer NoteContent row.
+                # Why: that observation guarantees this later plain read sees the
+                # move's committed Entity path.
+                # Outcome: clean the just-written vacated path while keeping a
+                # same-path superseded write in place for its newer materialization.
+                current_entity = await session.scalar(
+                    select(Entity)
+                    .where(
+                        Entity.id == request.entity_id,
+                        Entity.project_id == request.project_id,
+                    )
+                    .execution_options(populate_existing=True)
+                )
                 return RuntimeNoteMaterializationResult(
                     entity_id=request.entity_id,
                     status=RuntimeNoteMaterializationStatus.stale,
@@ -519,6 +527,31 @@ class RepositoryNoteMaterializationPublisher:
                         "file written but a newer accepted note superseded it "
                         f"before publish: {request.entity_id}"
                     ),
+                    file_path=written_file.file_path,
+                    file_checksum=written_file.file_checksum,
+                    written_file_orphaned=(
+                        current_entity is None or current_entity.file_path != written_file.file_path
+                    ),
+                )
+
+            updated = await EntityRepository(request.project_id).update_fields(
+                session,
+                request.entity_id,
+                {
+                    "mtime": written_file.file_updated_at.timestamp(),
+                    "size": len(prepared_write.markdown_content.encode("utf-8")),
+                },
+            )
+            if not updated:
+                # Trigger: the guarded Entity update found no row after the CAS.
+                # Why: this is a portable fail-safe; on PostgreSQL the successful
+                # CAS holds NoteContent while every Entity metadata producer crosses
+                # that row first, so the miss is unreachable under row locking.
+                # Outcome: report the missing Entity without clearing its vacate path.
+                return RuntimeNoteMaterializationResult(
+                    entity_id=request.entity_id,
+                    status=RuntimeNoteMaterializationStatus.missing,
+                    reason=f"entity disappeared after file write: {request.entity_id}",
                     file_path=written_file.file_path,
                     file_checksum=written_file.file_checksum,
                 )
@@ -530,9 +563,6 @@ class RepositoryNoteMaterializationPublisher:
                 session,
                 file_path=written_file.file_path,
             )
-            entity.mtime = written_file.file_updated_at.timestamp()
-            entity.size = len(prepared_write.markdown_content.encode("utf-8"))
-            await session.flush()
             return publish_plan.result
 
 

--- a/src/basic_memory/indexing/note_materialization_runner.py
+++ b/src/basic_memory/indexing/note_materialization_runner.py
@@ -432,6 +432,16 @@ class RepositoryNoteMaterializationPublisher:
             # lock is the NoteContent CAS UPDATE, preserving the canonical order in
             # current_relation_generation_statement. With no read locks held, the
             # publisher cannot anchor the lock cycle reported in #1224.
+            #
+            # Everything this publisher writes — the file on disk, Entity
+            # mtime/size, NoteContent file lineage — is derived, eventually
+            # consistent state. A concurrent accepted write or move may
+            # invalidate these snapshots at any point; when it does, the CAS
+            # below no-ops and the newer generation's own publish converges the
+            # projections. Do not "fix" an observed race here by reintroducing
+            # SELECT-time locks: every such lock rebuilds a #1224-class
+            # deadlock, while the drift it would prevent is transient and
+            # repaired by the next write's index pass.
             note_content = await session.scalar(
                 select(NoteContent).where(
                     NoteContent.entity_id == request.entity_id,

--- a/src/basic_memory/repository/note_content_repository.py
+++ b/src/basic_memory/repository/note_content_repository.py
@@ -80,13 +80,9 @@ class NoteContentRepository(Repository[NoteContent]):
         self,
         session: AsyncSession,
         entity_id: int,
-        *,
-        lock_for_update: bool = False,
     ) -> Entity:
         """Load the owning entity so duplicated identity fields stay aligned."""
         query = select(Entity).where(Entity.id == entity_id)
-        if lock_for_update:
-            query = query.with_for_update()
         result = await session.execute(query)
         entity = result.scalar_one_or_none()
         if entity is None:
@@ -304,14 +300,12 @@ class NoteContentRepository(Repository[NoteContent]):
             # from the entity (rather than mutating the ORM row) so the whole
             # write is the single conditional UPDATE whose rowcount decides the
             # race, portably across SQLite and Postgres.
-            # Materialization publishes NoteContent state and then updates Entity
-            # file metadata in the same transaction. Lock Entity first so that
-            # path cannot invert an Entity -> NoteContent indexing transaction.
-            entity = await self._load_entity_identity(
-                session,
-                entity_id,
-                lock_for_update=True,
-            )
+            # This identity read is deliberately unlocked. Reconciler and
+            # materialization callers hold no prior NoteContent claim, so an
+            # Entity lock here would invert the NoteContent-first order documented
+            # by current_relation_generation_statement and recreate the #1224
+            # deadlock. The conditional UPDATE rowcount is the only guard needed.
+            entity = await self._load_entity_identity(session, entity_id)
             result = cast(
                 CursorResult[Any],
                 await session.execute(

--- a/src/basic_memory/repository/note_content_repository.py
+++ b/src/basic_memory/repository/note_content_repository.py
@@ -305,6 +305,12 @@ class NoteContentRepository(Repository[NoteContent]):
             # Entity lock here would invert the NoteContent-first order documented
             # by current_relation_generation_statement and recreate the #1224
             # deadlock. The conditional UPDATE rowcount is the only guard needed.
+            # A project-index move can repoint entity and note_content paths
+            # without advancing db_version, so this copy can lose that race and
+            # go briefly stale. That is accepted: the identity columns are a
+            # denormalized convenience, planning always prefers Entity.file_path,
+            # and every subsequent write refreshes the copy. Serializing here
+            # would trade a self-healing drift for a deadlock class.
             entity = await self._load_entity_identity(session, entity_id)
             result = cast(
                 CursorResult[Any],

--- a/test-int/test_note_materialization_lock_order.py
+++ b/test-int/test_note_materialization_lock_order.py
@@ -1,4 +1,4 @@
-"""Postgres regression coverage for NoteContent-Entity materialization lock order."""
+"""Postgres coverage that materialization publish cannot anchor a row-lock cycle."""
 
 from __future__ import annotations
 
@@ -132,8 +132,9 @@ async def test_materialization_and_accepted_mutation_share_note_content_first_or
                 )
             )
             await asyncio.wait_for(session_lock.started.wait(), timeout=2)
-            # Let PostgreSQL enqueue the materializer's NoteContent lock. With
-            # the old Entity-first order, the next lock request closes a cycle.
+            # The publisher holds no row locks while it waits at its NoteContent
+            # CAS, so this Entity lock probe cannot close a lock cycle. Keep the
+            # timeout as a loud regression if publish-span read locks return.
             await asyncio.sleep(0.1)
 
             locked_entity = await asyncio.wait_for(
@@ -149,7 +150,7 @@ async def test_materialization_and_accepted_mutation_share_note_content_first_or
                 await mutation_session.execute(
                     update(NoteContent)
                     .where(NoteContent.entity_id == entity_id)
-                    .values(file_path=locked_entity.file_path)
+                    .values(file_path=locked_entity.file_path, db_version=2)
                 )
             else:
                 locked_entity.title = "Accepted mutation completed"
@@ -179,6 +180,7 @@ async def test_materialization_and_accepted_mutation_share_note_content_first_or
         assert result.status is RuntimeNoteMaterializationStatus.stale
         assert result.written_file_orphaned
         assert note_content.file_path == "notes/moved-during-materialization.md"
+        assert note_content.db_version == 2
         assert note_content.file_version is None
         assert note_content.file_checksum == "previous-file-checksum"
         assert entity.file_path == "notes/moved-during-materialization.md"
@@ -191,3 +193,127 @@ async def test_materialization_and_accepted_mutation_share_note_content_first_or
         assert note_content.file_write_status == "synced"
         assert entity.mtime == written_file.file_updated_at.timestamp()
         assert entity.size == len(markdown.encode("utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_publish_cas_loss_never_reverts_newer_accepted_write(
+    engine_factory,
+    test_project: Project,
+) -> None:
+    """A publisher blocked at CAS must preserve a newer same-path accepted write."""
+    engine, session_maker = engine_factory
+    if engine.dialect.name != "postgresql":
+        pytest.skip("row-lock ordering requires PostgreSQL")
+
+    file_path = "notes/cas-loss.md"
+    original_markdown = "# Original\n"
+    async with db.scoped_session(session_maker) as session:
+        entity = Entity(
+            project_id=test_project.id,
+            title="CAS loss",
+            note_type="note",
+            content_type="text/markdown",
+            file_path=file_path,
+            checksum="previous-file-checksum",
+        )
+        session.add(entity)
+        await session.flush()
+        entity_id = entity.id
+        original_mtime = entity.mtime
+        original_size = entity.size
+        await NoteContentRepository(project_id=test_project.id).create(
+            session,
+            NoteContent(
+                entity_id=entity_id,
+                markdown_content=original_markdown,
+                db_version=1,
+                db_checksum="original-db-checksum",
+                file_version=None,
+                file_checksum="previous-file-checksum",
+                file_write_status="writing",
+            ),
+        )
+
+    request = RuntimeNoteMaterializationJobRequest(
+        project_id=test_project.id,
+        entity_id=entity_id,
+        db_version=1,
+        db_checksum="original-db-checksum",
+        source="api",
+    )
+    prepared_write = plan_prepared_note_write(
+        request=request,
+        file_path=file_path,
+        markdown_content=original_markdown,
+        previous_file_checksum="previous-file-checksum",
+        attempted_at=datetime(2026, 8, 5, 2, 0, tzinfo=UTC),
+    )
+    written_file = RuntimeWrittenFileState(
+        file_path=file_path,
+        file_checksum="stale-materialized-checksum",
+        file_updated_at=datetime(2026, 8, 5, 2, 1, tzinfo=UTC),
+    )
+    session_lock = StartedMaterializationLock()
+    publisher = RepositoryNoteMaterializationPublisher(
+        session_maker=session_maker,
+        session_lock=session_lock,
+    )
+
+    publish_task: asyncio.Task[Any] | None = None
+    async with session_maker() as mutation_session:
+        await mutation_session.begin()
+        try:
+            await lock_accepted_note_content_for_entity_mutation(
+                mutation_session,
+                project_id=test_project.id,
+                entity_id=entity_id,
+            )
+
+            publish_task = asyncio.create_task(
+                publisher.publish_written_file_state(
+                    request,
+                    prepared_write,
+                    written_file,
+                )
+            )
+            await asyncio.wait_for(session_lock.started.wait(), timeout=2)
+            await asyncio.sleep(0.1)
+            assert not publish_task.done()
+
+            await mutation_session.execute(
+                update(NoteContent)
+                .where(NoteContent.entity_id == entity_id)
+                .values(
+                    db_version=2,
+                    db_checksum="newer-db-checksum",
+                    markdown_content="# Newer accepted write\n",
+                    file_write_status="pending",
+                )
+            )
+            await mutation_session.commit()
+
+            result = await asyncio.wait_for(publish_task, timeout=2)
+        finally:
+            if mutation_session.in_transaction():
+                await mutation_session.rollback()
+            if publish_task is not None and not publish_task.done():
+                publish_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await publish_task
+
+    async with session_maker() as verification_session:
+        note_content = await verification_session.get(NoteContent, entity_id)
+        entity = await verification_session.get(Entity, entity_id)
+
+    assert result.status is RuntimeNoteMaterializationStatus.stale
+    assert result.written_file_orphaned is False
+    assert note_content is not None
+    assert note_content.db_version == 2
+    assert note_content.db_checksum == "newer-db-checksum"
+    assert note_content.markdown_content == "# Newer accepted write\n"
+    assert note_content.file_version is None
+    assert note_content.file_checksum == "previous-file-checksum"
+    assert note_content.file_write_status == "pending"
+    assert entity is not None
+    assert entity.mtime == original_mtime
+    assert entity.size == original_size

--- a/tests/indexing/test_note_materialization_runner.py
+++ b/tests/indexing/test_note_materialization_runner.py
@@ -24,6 +24,7 @@ from basic_memory.indexing.note_materialization_runner import (
 )
 from basic_memory.indexing.note_content_reconciliation import NoteContentState
 from basic_memory.models import Entity, NoteContent
+from basic_memory.repository.entity_repository import EntityRepository
 from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
 from basic_memory.runtime.cleanup import RuntimeNoteFileDeleteJobRequest
 from basic_memory.runtime.note_content import (
@@ -533,6 +534,7 @@ async def test_repository_note_materialization_publisher_updates_current_written
     session = FakeRepositorySession(entity=entity, note_content=note_content)
     session_lock = FakeSessionLock()
     repository = RecordingNoteContentRepository()
+    entity_updates: list[tuple[AsyncSession, int, dict[str, object]]] = []
     cleared_vacate_paths: list[tuple[AsyncSession, str]] = []
     scoped_session = RecordingScopedSession(
         scoped_session=FakeScopedSession(session),
@@ -540,6 +542,16 @@ async def test_repository_note_materialization_publisher_updates_current_written
     )
 
     with pytest.MonkeyPatch.context() as monkeypatch:
+
+        async def record_entity_update_fields(
+            entity_repository: EntityRepository,
+            current_session: AsyncSession,
+            entity_id: int,
+            entity_data: dict[str, object],
+        ) -> bool:
+            assert entity_repository.project_id == 7
+            entity_updates.append((current_session, entity_id, entity_data))
+            return True
 
         async def record_clear_vacate_path(
             vacate_repository: NoteFileVacateRepository,
@@ -553,6 +565,10 @@ async def test_repository_note_materialization_publisher_updates_current_written
         monkeypatch.setattr(
             "basic_memory.indexing.note_materialization_runner.db.scoped_session",
             scoped_session,
+        )
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner.EntityRepository.update_fields",
+            record_entity_update_fields,
         )
         monkeypatch.setattr(
             "basic_memory.indexing.note_materialization_runner."
@@ -576,7 +592,7 @@ async def test_repository_note_materialization_publisher_updates_current_written
     assert len(session.scalar_statements) == 2
     assert "FROM note_content" in str(session.scalar_statements[0])
     assert "FROM entity" in str(session.scalar_statements[1])
-    assert all("FOR UPDATE" in str(statement) for statement in session.scalar_statements)
+    assert all("FOR UPDATE" not in str(statement) for statement in session.scalar_statements)
     assert repository.calls == [
         (
             cast(AsyncSession, session),
@@ -593,9 +609,17 @@ async def test_repository_note_materialization_publisher_updates_current_written
         )
     ]
     assert entity.updated_at == semantic_updated_at
-    assert entity.mtime == written.file_updated_at.timestamp()
-    assert entity.size == len(b"# A note\n")
-    assert session.flush_count == 1
+    assert entity_updates == [
+        (
+            cast(AsyncSession, session),
+            42,
+            {
+                "mtime": written.file_updated_at.timestamp(),
+                "size": len(b"# A note\n"),
+            },
+        )
+    ]
+    assert session.flush_count == 0
     assert cleared_vacate_paths == [(cast(AsyncSession, session), "notes/a.md")]
 
 
@@ -620,9 +644,17 @@ async def test_repository_note_materialization_publisher_records_stale_written_f
     )
 
     with pytest.MonkeyPatch.context() as monkeypatch:
+
+        async def fail_entity_update_fields(*args: object, **kwargs: object) -> bool:
+            raise AssertionError("stale publish must not update Entity")
+
         monkeypatch.setattr(
             "basic_memory.indexing.note_materialization_runner.db.scoped_session",
             scoped_session,
+        )
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner.EntityRepository.update_fields",
+            fail_entity_update_fields,
         )
         result = await RepositoryNoteMaterializationPublisher(
             session_maker=cast(async_sessionmaker[AsyncSession], object()),
@@ -653,6 +685,270 @@ async def test_repository_note_materialization_publisher_records_stale_written_f
         )
     ]
     # The entity metadata update belongs to the newer version's publish.
+    assert session.flush_count == 0
+
+
+@pytest.mark.asyncio
+async def test_repository_note_materialization_publisher_handles_entity_missing_before_cas() -> (
+    None
+):
+    request = materialization_request()
+    prepared = prepared_write(request)
+    written = written_file()
+    note_content = materialization_note_content()
+    session = FakeRepositorySession(entity=None, note_content=note_content)
+    repository = RecordingNoteContentRepository()
+    cleared_vacate_paths: list[str] = []
+    scoped_session = RecordingScopedSession(
+        scoped_session=FakeScopedSession(session),
+        opened_session_makers=[],
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+
+        async def fail_entity_update_fields(*args: object, **kwargs: object) -> bool:
+            raise AssertionError("missing Entity must stop before metadata update")
+
+        async def record_clear_vacate_path(
+            vacate_repository: NoteFileVacateRepository,
+            current_session: AsyncSession,
+            *,
+            file_path: str,
+        ) -> None:
+            cleared_vacate_paths.append(file_path)
+
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner.db.scoped_session",
+            scoped_session,
+        )
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner.EntityRepository.update_fields",
+            fail_entity_update_fields,
+        )
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner."
+            "NoteFileVacateRepository.clear_vacate_path",
+            record_clear_vacate_path,
+        )
+        result = await RepositoryNoteMaterializationPublisher(
+            session_maker=cast(async_sessionmaker[AsyncSession], object()),
+            note_content_store=lambda project_id: repository,
+        ).publish_written_file_state(request, prepared, written)
+
+    assert result == RuntimeNoteMaterializationResult(
+        entity_id=42,
+        status=RuntimeNoteMaterializationStatus.missing,
+        reason="entity disappeared after file write: 42",
+        file_path="notes/a.md",
+        file_checksum="new-file-sum",
+    )
+    assert repository.calls == []
+    assert cleared_vacate_paths == []
+    assert session.flush_count == 0
+
+
+@pytest.mark.asyncio
+async def test_repository_note_materialization_publisher_handles_entity_missing_after_cas() -> None:
+    request = materialization_request()
+    prepared = prepared_write(request)
+    written = written_file()
+    session = FakeRepositorySession(
+        entity=materialization_entity(),
+        note_content=materialization_note_content(),
+    )
+    repository = RecordingNoteContentRepository()
+    entity_updates: list[tuple[AsyncSession, int, dict[str, object]]] = []
+    cleared_vacate_paths: list[str] = []
+    scoped_session = RecordingScopedSession(
+        scoped_session=FakeScopedSession(session),
+        opened_session_makers=[],
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+
+        async def miss_entity_update_fields(
+            entity_repository: EntityRepository,
+            current_session: AsyncSession,
+            entity_id: int,
+            entity_data: dict[str, object],
+        ) -> bool:
+            assert entity_repository.project_id == 7
+            entity_updates.append((current_session, entity_id, entity_data))
+            return False
+
+        async def record_clear_vacate_path(
+            vacate_repository: NoteFileVacateRepository,
+            current_session: AsyncSession,
+            *,
+            file_path: str,
+        ) -> None:
+            cleared_vacate_paths.append(file_path)
+
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner.db.scoped_session",
+            scoped_session,
+        )
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner.EntityRepository.update_fields",
+            miss_entity_update_fields,
+        )
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner."
+            "NoteFileVacateRepository.clear_vacate_path",
+            record_clear_vacate_path,
+        )
+        result = await RepositoryNoteMaterializationPublisher(
+            session_maker=cast(async_sessionmaker[AsyncSession], object()),
+            note_content_store=lambda project_id: repository,
+        ).publish_written_file_state(request, prepared, written)
+
+    assert result == RuntimeNoteMaterializationResult(
+        entity_id=42,
+        status=RuntimeNoteMaterializationStatus.missing,
+        reason="entity disappeared after file write: 42",
+        file_path="notes/a.md",
+        file_checksum="new-file-sum",
+    )
+    assert len(repository.calls) == 1
+    assert entity_updates == [
+        (
+            cast(AsyncSession, session),
+            42,
+            {
+                "mtime": written.file_updated_at.timestamp(),
+                "size": len(b"# A note\n"),
+            },
+        )
+    ]
+    assert cleared_vacate_paths == []
+    assert session.flush_count == 0
+
+
+@pytest.mark.asyncio
+async def test_repository_note_materialization_publisher_cas_loss_same_path_is_not_orphaned() -> (
+    None
+):
+    request = materialization_request()
+    prepared = prepared_write(request)
+    written = written_file()
+    session = FakeRepositorySession(
+        entity=materialization_entity(),
+        note_content=materialization_note_content(),
+    )
+    repository = RecordingNoteContentRepository()
+    lost_cas_calls: list[tuple[AsyncSession, int, dict[str, object]]] = []
+    scoped_session = RecordingScopedSession(
+        scoped_session=FakeScopedSession(session),
+        opened_session_makers=[],
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+
+        async def lose_note_content_cas(
+            current_session: AsyncSession,
+            entity_id: int,
+            **updates: object,
+        ) -> None:
+            lost_cas_calls.append((current_session, entity_id, updates))
+            return None
+
+        async def fail_entity_update_fields(*args: object, **kwargs: object) -> bool:
+            raise AssertionError("lost CAS must not update Entity")
+
+        async def fail_clear_vacate_path(*args: object, **kwargs: object) -> None:
+            raise AssertionError("lost CAS must not clear a vacate path")
+
+        monkeypatch.setattr(repository, "update_state_fields", lose_note_content_cas)
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner.db.scoped_session",
+            scoped_session,
+        )
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner.EntityRepository.update_fields",
+            fail_entity_update_fields,
+        )
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner."
+            "NoteFileVacateRepository.clear_vacate_path",
+            fail_clear_vacate_path,
+        )
+        result = await RepositoryNoteMaterializationPublisher(
+            session_maker=cast(async_sessionmaker[AsyncSession], object()),
+            note_content_store=lambda project_id: repository,
+        ).publish_written_file_state(request, prepared, written)
+
+    assert result.status is RuntimeNoteMaterializationStatus.stale
+    assert (
+        result.reason == "file written but a newer accepted note superseded it before publish: 42"
+    )
+    assert result.written_file_orphaned is False
+    assert len(lost_cas_calls) == 1
+    assert len(session.scalar_statements) == 3
+    assert "FROM entity" in str(session.scalar_statements[2])
+    assert session.flush_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entity_after_cas", ["moved", "missing"])
+async def test_repository_note_materialization_publisher_cas_loss_orphans_vacated_path(
+    entity_after_cas: str,
+) -> None:
+    request = materialization_request()
+    prepared = prepared_write(request)
+    written = written_file()
+    session = FakeRepositorySession(
+        entity=materialization_entity(),
+        note_content=materialization_note_content(),
+    )
+    repository = RecordingNoteContentRepository()
+    scoped_session = RecordingScopedSession(
+        scoped_session=FakeScopedSession(session),
+        opened_session_makers=[],
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+
+        async def lose_note_content_cas(
+            current_session: AsyncSession,
+            entity_id: int,
+            **updates: object,
+        ) -> None:
+            if entity_after_cas == "moved":
+                assert session.entity is not None
+                session.entity.file_path = "notes/moved.md"
+            else:
+                session.entity = None
+            return None
+
+        async def fail_entity_update_fields(*args: object, **kwargs: object) -> bool:
+            raise AssertionError("lost CAS must not update Entity")
+
+        async def fail_clear_vacate_path(*args: object, **kwargs: object) -> None:
+            raise AssertionError("lost CAS must not clear a vacate path")
+
+        monkeypatch.setattr(repository, "update_state_fields", lose_note_content_cas)
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner.db.scoped_session",
+            scoped_session,
+        )
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner.EntityRepository.update_fields",
+            fail_entity_update_fields,
+        )
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner."
+            "NoteFileVacateRepository.clear_vacate_path",
+            fail_clear_vacate_path,
+        )
+        result = await RepositoryNoteMaterializationPublisher(
+            session_maker=cast(async_sessionmaker[AsyncSession], object()),
+            note_content_store=lambda project_id: repository,
+        ).publish_written_file_state(request, prepared, written)
+
+    assert result.status is RuntimeNoteMaterializationStatus.stale
+    assert result.written_file_orphaned is True
+    assert len(session.scalar_statements) == 3
+    assert "FROM entity" in str(session.scalar_statements[2])
     assert session.flush_count == 0
 
 


### PR DESCRIPTION
Closes #1224. Cloud symptom: basicmachines-co/basic-memory-cloud#1727 (Logfire #2384).

## What changed

`publish_written_file_state` no longer takes any SELECT-time row locks. The existing
`expected_db_version` CAS is the only write guard, and the transaction's first row lock is
the CAS UPDATE itself — preserving the canonical NoteContent-first order, so the publisher
can no longer anchor a lock cycle.

- Dropped both `with_for_update()` calls on the NoteContent and Entity planning reads.
- **Also removed the Entity lock inside the CAS path** (`_load_entity_identity(lock_for_update=True)`
  in `update_state_fields`). This lock isn't in the issue text, but dropping only the
  publisher's read locks would have left the publisher acquiring Entity → NoteContent while
  accepted mutations acquire NoteContent → Entity — recreating the deadlock with inverted
  order. The dead `lock_for_update` parameter is deleted.
- Entity `mtime`/`size` writes are now one guarded single-statement UPDATE via the existing
  `Repository.update_fields` (`WHERE id AND project_id`, rowcount-checked). rowcount 0 maps
  to the existing "entity disappeared" missing result and skips the vacate-marker clear. No
  staleness guard is needed: a successful CAS holds the note_content row lock until commit,
  and every producer of newer entity file metadata crosses that row first.
- **CAS-loss orphan re-check** (slightly beyond the issue text — flagging for review): with
  the old locked reads, a concurrent move was visible at plan time and the written file at
  the vacated path got orphan cleanup. With plain reads that move surfaces as a CAS loss, so
  the loss branch now re-reads Entity (`populate_existing=True` to bypass the identity map);
  if the entity is gone or its path moved, the stale result carries
  `written_file_orphaned=True`, restoring exact cleanup parity.

## Issue-text corrections

- `clear_vacate_path` is untouched: it is already a plain project-scoped DELETE with no
  Entity lock. The Entity `with_for_update` in that file is `lock_recoverable_vacate`, which
  belongs to move-recovery and never runs in the publish transaction.

## Verification

- `tests/indexing/test_note_materialization_runner.py` + repo/reconciler suites: 75 passed
  (4 new unit tests: entity missing pre-CAS, entity missing post-CAS, CAS loss same-path not
  orphaned, CAS loss orphans vacated path).
- `test-int/test_note_materialization_lock_order.py` on real Postgres (testcontainers):
  3 passed — the FOR UPDATE deadlock probe is kept as a regression tripwire, the moved-path
  case now models a real move (db_version advances) and asserts the newer path is never
  reverted, and the new `test_publish_cas_loss_never_reverts_newer_accepted_write` pins the
  acceptance criterion (stale publisher reports `stale`, newer write survives untouched).
- `just typecheck`, `just lint`: clean.

Note for release: verify basic-memory-cloud's pgq worker doesn't rely on the publisher
holding Entity row locks (it injects the advisory `session_lock`, which is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPdSXDbYyhyZ1TwgFnpEv8
