### PR TITLE
test(core): add reranker real-model smoke and quality harness

### DIFF
--- a/test-int/semantic/conftest.py
+++ b/test-int/semantic/conftest.py
@@ -26,7 +26,7 @@ from sqlalchemy.pool import NullPool
 from testcontainers.postgres import PostgresContainer
 
 from basic_memory import db
-from basic_memory.config import BasicMemoryConfig, DatabaseBackend
+from basic_memory.config import BasicMemoryConfig, DatabaseBackend, default_fastembed_cache_dir
 from basic_memory.db import DatabaseType, engine_session_factory
 from basic_memory.markdown import EntityParser
 from basic_memory.markdown.markdown_processor import MarkdownProcessor
@@ -220,7 +220,11 @@ async def postgres_engine_factory(postgres_engine):
 def _create_fastembed_provider() -> EmbeddingProvider:
     from basic_memory.repository.fastembed_provider import FastEmbedEmbeddingProvider
 
-    return FastEmbedEmbeddingProvider(model_name="bge-small-en-v1.5", batch_size=64)
+    return FastEmbedEmbeddingProvider(
+        model_name="bge-small-en-v1.5",
+        batch_size=64,
+        cache_dir=default_fastembed_cache_dir(),
+    )
 
 
 def _create_openai_provider() -> EmbeddingProvider:
@@ -237,6 +241,8 @@ async def create_search_service(
     combo: SearchCombo,
     tmp_path: Path,
     embedding_provider: EmbeddingProvider | None = None,
+    *,
+    reranker_enabled: bool = False,
 ) -> SearchService:
     """Build a fully wired SearchService for a given combo."""
     engine, session_maker = engine_factory_result
@@ -264,6 +270,7 @@ async def create_search_service(
         database_backend=combo.backend,
         semantic_search_enabled=semantic_enabled,
         semantic_min_similarity=BENCHMARK_MIN_SIMILARITY,
+        reranker_enabled=reranker_enabled,
     )
 
     # Create search repository (backend-specific)

--- a/test-int/semantic/corpus.py
+++ b/test-int/semantic/corpus.py
@@ -10,9 +10,12 @@ embedding quality actually differentiates providers.
 from __future__ import annotations
 
 import random
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from basic_memory import db
+from basic_memory.models import Entity
+from basic_memory.services.search_service import SearchService
 
 
 # --- Topic vocabulary ---
@@ -260,6 +263,15 @@ class QueryCase:
     expected_topic: str
 
 
+@dataclass(frozen=True)
+class RankingDocument:
+    """A fixed note whose exact identity matters to a ranking assertion."""
+
+    title: str
+    permalink: str
+    content: str
+
+
 # --- Query suites ---
 # Lexical queries use keywords that appear in the content but require
 # disambiguation when topics share vocabulary.
@@ -415,6 +427,32 @@ Related concepts: {keyword_line}.
         if search_service.repository._semantic_enabled:
             await search_service.sync_entity_vectors(entity.id)
 
+        entities.append(entity)
+
+    return entities
+
+
+async def seed_ranking_documents(
+    search_service: SearchService,
+    documents: Sequence[RankingDocument],
+) -> list[Entity]:
+    """Index a small exact-note corpus through the production semantic path."""
+    entities: list[Entity] = []
+    for document in documents:
+        async with db.scoped_session(search_service.session_maker) as session:
+            entity = await search_service.entity_repository.create(
+                session,
+                {
+                    "title": document.title,
+                    "note_type": "benchmark",
+                    "entity_metadata": {"tags": ["benchmark", "ranking"]},
+                    "content_type": "text/markdown",
+                    "permalink": document.permalink,
+                    "file_path": f"{document.permalink}.md",
+                },
+            )
+        await search_service.index_entity_data(entity, content=document.content)
+        await search_service.sync_entity_vectors(entity.id)
         entities.append(entity)
 
     return entities

--- a/test-int/semantic/corpus.py
+++ b/test-int/semantic/corpus.py
@@ -272,6 +272,244 @@ class RankingDocument:
     content: str
 
 
+@dataclass(frozen=True)
+class RankingQuery:
+    """A natural-language query paired with its one expected top note."""
+
+    text: str
+    expected_permalink: str
+
+
+# --- Reranker quality corpus ---
+# Each topic has nearby alternatives that share vocabulary. The expected note is
+# distinguished by the request's full intent, giving the cross-encoder useful
+# query-document interaction instead of a trivial unique-keyword lookup.
+
+GOLDEN_RANKING_DOCUMENTS = (
+    RankingDocument(
+        title="Charge After Annual Plan Cancellation",
+        permalink="ranking/billing-cancelled-renewal",
+        content=(
+            "If an annual plan renews after a cancellation was recorded before the renewal "
+            "deadline, support verifies the cancellation timestamp and refunds the renewal "
+            "charge to the original payment method."
+        ),
+    ),
+    RankingDocument(
+        title="Cancel a Free Trial",
+        permalink="ranking/billing-free-trial",
+        content=(
+            "Cancel a free trial before day fourteen to prevent the first subscription charge. "
+            "Trials that already converted follow the standard subscription refund policy."
+        ),
+    ),
+    RankingDocument(
+        title="Correct Company Invoice Details",
+        permalink="ranking/billing-invoice-details",
+        content=(
+            "Billing administrators can update a legal company name, address, and VAT number on "
+            "future invoices. Invoice detail corrections do not cancel a plan or reverse a charge."
+        ),
+    ),
+    RankingDocument(
+        title="Recover Access Without an Authenticator",
+        permalink="ranking/auth-lost-authenticator",
+        content=(
+            "When a member loses the phone that holds their authenticator, they should use a "
+            "single-use recovery code. Without a recovery code, support performs identity "
+            "verification before resetting two-factor authentication."
+        ),
+    ),
+    RankingDocument(
+        title="Reset a Forgotten Password",
+        permalink="ranking/auth-forgotten-password",
+        content=(
+            "Request a password-reset email from the sign-in page. Completing the link sets a new "
+            "password and invalidates existing sessions without changing two-factor settings."
+        ),
+    ),
+    RankingDocument(
+        title="Respond to a Suspicious Sign-In",
+        permalink="ranking/auth-suspicious-login",
+        content=(
+            "After an unfamiliar sign-in alert, revoke all active sessions, change the password, "
+            "and review connected applications. Keep two-factor authentication enabled."
+        ),
+    ),
+    RankingDocument(
+        title="Choose Columns for a Composite Index",
+        permalink="ranking/database-composite-index",
+        content=(
+            "For queries that filter by tenant and then sort by creation time, create a composite "
+            "index with tenant_id first and created_at second. Confirm the query plan uses it."
+        ),
+    ),
+    RankingDocument(
+        title="Roll Back a Failed Schema Deployment",
+        permalink="ranking/database-migration-rollback",
+        content=(
+            "If a schema migration fails during deployment, stop application writes and run the "
+            "tested downgrade revision. A rollback restores the previous schema, not deleted data."
+        ),
+    ),
+    RankingDocument(
+        title="Restore Data to a Point in Time",
+        permalink="ranking/database-point-in-time-restore",
+        content=(
+            "To recover rows deleted by mistake, restore the latest base backup and replay the "
+            "write-ahead log until just before the deletion timestamp in an isolated database."
+        ),
+    ),
+    RankingDocument(
+        title="Resolve Two Copies of the Same Edited Note",
+        permalink="ranking/sync-edit-conflict",
+        content=(
+            "When local and remote writers edit the same note from one shared base, preserve both "
+            "versions, compare the conflict copy, and merge the intended paragraphs manually."
+        ),
+    ),
+    RankingDocument(
+        title="Recover Changes Missed by the File Watcher",
+        permalink="ranking/sync-watcher-reconcile",
+        content=(
+            "If filesystem events were missed while the watcher was offline, run a reconciliation "
+            "scan. It compares checksums and reindexes files whose current bytes changed."
+        ),
+    ),
+    RankingDocument(
+        title="Pull Shared Notes Without Removing Local Files",
+        permalink="ranking/sync-additive-pull",
+        content=(
+            "Use an additive cloud pull to download new team notes while preserving local-only "
+            "files. A mirror sync is different because it may delete files absent at the source."
+        ),
+    ),
+    RankingDocument(
+        title="Revive a Weak Sourdough Starter",
+        permalink="ranking/kitchen-sourdough-starter",
+        content=(
+            "A starter that barely rises needs regular feedings at a warm temperature. Keep a small "
+            "portion, add equal weights of flour and water, and wait for it to double before baking."
+        ),
+    ),
+    RankingDocument(
+        title="Fix Soup That Tastes Too Salty",
+        permalink="ranking/kitchen-salty-soup",
+        content=(
+            "Dilute an over-salted soup with unsalted stock or water, then add more vegetables or "
+            "grains to spread the seasoning. Do not expect a raw potato to absorb only salt."
+        ),
+    ),
+    RankingDocument(
+        title="Remove Rust From Cast Iron",
+        permalink="ranking/kitchen-cast-iron-rust",
+        content=(
+            "Scrub rust from a cast-iron pan, dry it completely over heat, apply a very thin coat of "
+            "oil, and bake it to rebuild the protective seasoning."
+        ),
+    ),
+    RankingDocument(
+        title="Replace a Lost Passport Abroad",
+        permalink="ranking/travel-lost-passport",
+        content=(
+            "A traveler who loses a passport in another country should contact their embassy or "
+            "consulate, file a police report, and request an emergency travel document."
+        ),
+    ),
+    RankingDocument(
+        title="Rebook After a Missed Connection",
+        permalink="ranking/travel-missed-connection",
+        content=(
+            "When a delay on the first flight causes a missed protected connection, ask the airline "
+            "operating the itinerary to rebook the next available route at no extra fare."
+        ),
+    ),
+    RankingDocument(
+        title="Claim Essentials for Delayed Baggage",
+        permalink="ranking/travel-delayed-baggage",
+        content=(
+            "Report delayed checked baggage before leaving the airport, keep the claim number, and "
+            "save receipts for reasonable replacement toiletries and clothing."
+        ),
+    ),
+)
+
+GOLDEN_RANKING_QUERIES = (
+    RankingQuery(
+        text="I cancelled before the annual renewal deadline but was billed anyway. Can it be refunded?",
+        expected_permalink="ranking/billing-cancelled-renewal",
+    ),
+    RankingQuery(
+        text="How do I stop a fourteen-day trial from turning into my first paid subscription?",
+        expected_permalink="ranking/billing-free-trial",
+    ),
+    RankingQuery(
+        text="Where can our billing admin fix the VAT number and legal address shown on invoices?",
+        expected_permalink="ranking/billing-invoice-details",
+    ),
+    RankingQuery(
+        text="My old phone with the authenticator is gone and I cannot pass two-step verification.",
+        expected_permalink="ranking/auth-lost-authenticator",
+    ),
+    RankingQuery(
+        text="I forgot my password and need an emailed link that also signs out old sessions.",
+        expected_permalink="ranking/auth-forgotten-password",
+    ),
+    RankingQuery(
+        text="An unknown device logged in to my account. What should I revoke and change?",
+        expected_permalink="ranking/auth-suspicious-login",
+    ),
+    RankingQuery(
+        text="Which column order speeds up tenant-filtered rows sorted by creation time?",
+        expected_permalink="ranking/database-composite-index",
+    ),
+    RankingQuery(
+        text="A deployment's schema change failed; how do we return to the previous revision?",
+        expected_permalink="ranking/database-migration-rollback",
+    ),
+    RankingQuery(
+        text="How can we recover accidentally deleted rows to the moment before deletion?",
+        expected_permalink="ranking/database-point-in-time-restore",
+    ),
+    RankingQuery(
+        text="Local and remote edits diverged from the same note. How should I preserve and merge both?",
+        expected_permalink="ranking/sync-edit-conflict",
+    ),
+    RankingQuery(
+        text="The watcher was offline and missed file events. How do I detect changed bytes and reindex?",
+        expected_permalink="ranking/sync-watcher-reconcile",
+    ),
+    RankingQuery(
+        text="How can I download new team notes without deleting files that exist only on my laptop?",
+        expected_permalink="ranking/sync-additive-pull",
+    ),
+    RankingQuery(
+        text="My sourdough culture barely rises. What feeding ratio and readiness sign should I use?",
+        expected_permalink="ranking/kitchen-sourdough-starter",
+    ),
+    RankingQuery(
+        text="I added too much salt to a pot of soup. What should I dilute and bulk it out with?",
+        expected_permalink="ranking/kitchen-salty-soup",
+    ),
+    RankingQuery(
+        text="How do I scrub and reseason a rusty cast-iron skillet?",
+        expected_permalink="ranking/kitchen-cast-iron-rust",
+    ),
+    RankingQuery(
+        text="I am overseas and my passport was stolen. Which authority can issue an emergency document?",
+        expected_permalink="ranking/travel-lost-passport",
+    ),
+    RankingQuery(
+        text="The first leg was delayed and I missed the connecting flight on one itinerary. Who rebooks me?",
+        expected_permalink="ranking/travel-missed-connection",
+    ),
+    RankingQuery(
+        text="My checked suitcase has not arrived. What report and purchase receipts should I keep?",
+        expected_permalink="ranking/travel-delayed-baggage",
+    ),
+)
+
+
 # --- Query suites ---
 # Lexical queries use keywords that appear in the content but require
 # disambiguation when topics share vocabulary.

--- a/test-int/semantic/metrics.py
+++ b/test-int/semantic/metrics.py
@@ -7,6 +7,7 @@ data for performance comparison across backends and providers.
 from __future__ import annotations
 
 import json
+import math
 import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -111,6 +112,38 @@ class QualityMetrics:
         }
 
 
+@dataclass
+class LatencyMetrics:
+    """Warm-search latency samples for one retrieval mode and reranker state."""
+
+    configuration: str
+    mode: str
+    latencies: list[float] = field(default_factory=list)
+
+    @property
+    def p50_ms(self) -> float:
+        return _percentile_ms(self.latencies, 0.50)
+
+    @property
+    def p95_ms(self) -> float:
+        return _percentile_ms(self.latencies, 0.95)
+
+
+def _percentile_ms(samples: list[float], quantile: float) -> float:
+    """Return a linearly interpolated percentile in milliseconds."""
+    if not samples:
+        return 0.0
+    ordered = sorted(samples)
+    position = (len(ordered) - 1) * quantile
+    lower_index = math.floor(position)
+    upper_index = math.ceil(position)
+    if lower_index == upper_index:
+        return ordered[lower_index] * 1000
+    fraction = position - lower_index
+    interpolated = ordered[lower_index] + (ordered[upper_index] - ordered[lower_index]) * fraction
+    return interpolated * 1000
+
+
 # --- Comparison table ---
 
 
@@ -152,6 +185,20 @@ def format_reranker_quality_table(all_metrics: list[QualityMetrics]) -> str:
             f"{'delta':<16} {reranked.hit_at_1 - baseline.hit_at_1:>+7.3f} "
             f"{reranked.hit_at_5 - baseline.hit_at_5:>+7.3f} "
             f"{reranked.mrr_at_10 - baseline.mrr_at_10:>+7.3f}"
+        )
+    lines.append(separator)
+    return "\n".join(lines)
+
+
+def format_latency_table(all_metrics: list[LatencyMetrics]) -> str:
+    """Format P50/P95 search latency for each mode and reranker state."""
+    header = f"{'Configuration':<16} {'Mode':<8} {'N':>4} {'P50 ms':>10} {'P95 ms':>10}"
+    separator = "-" * len(header)
+    lines = [separator, header, separator]
+    for metrics in all_metrics:
+        lines.append(
+            f"{metrics.configuration:<16} {metrics.mode:<8} {len(metrics.latencies):>4} "
+            f"{metrics.p50_ms:>10.2f} {metrics.p95_ms:>10.2f}"
         )
     lines.append(separator)
     return "\n".join(lines)

--- a/test-int/semantic/metrics.py
+++ b/test-int/semantic/metrics.py
@@ -29,6 +29,16 @@ def first_relevant_rank(results: list[SearchIndexRow], expected_topic: str, k: i
     return None
 
 
+def first_permalink_rank(
+    results: list[SearchIndexRow], expected_permalink: str, k: int
+) -> int | None:
+    """Return the 1-based rank of one exact note, or ``None`` when it misses the window."""
+    for rank, row in enumerate(results[:k], start=1):
+        if row.permalink == expected_permalink:
+            return rank
+    return None
+
+
 # --- Metric dataclass ---
 
 
@@ -69,6 +79,11 @@ class QualityMetrics:
     @property
     def recall_at_5(self) -> float:
         return self.hits_at_5 / self.cases if self.cases else 0.0
+
+    @property
+    def hit_at_5(self) -> float:
+        """Return hit@5; one gold note per query makes this equivalent to recall@5."""
+        return self.recall_at_5
 
     @property
     def mrr_at_10(self) -> float:
@@ -115,6 +130,29 @@ def format_comparison_table(all_metrics: list[QualityMetrics]) -> str:
             f"{m.avg_latency_ms:>8.1f} {m.total_time_ms:>9.1f}"
         )
 
+    lines.append(separator)
+    return "\n".join(lines)
+
+
+def format_reranker_quality_table(all_metrics: list[QualityMetrics]) -> str:
+    """Format reranker-off/on quality and deltas using exact-note ranking metrics."""
+    header = f"{'Configuration':<16} {'hit@1':>7} {'hit@5':>7} {'MRR':>7}"
+    separator = "-" * len(header)
+    lines = [separator, header, separator]
+    for metrics in all_metrics:
+        lines.append(
+            f"{metrics.combo:<16} {metrics.hit_at_1:>7.3f} "
+            f"{metrics.hit_at_5:>7.3f} {metrics.mrr_at_10:>7.3f}"
+        )
+
+    if len(all_metrics) == 2:
+        baseline, reranked = all_metrics
+        lines.append(separator)
+        lines.append(
+            f"{'delta':<16} {reranked.hit_at_1 - baseline.hit_at_1:>+7.3f} "
+            f"{reranked.hit_at_5 - baseline.hit_at_5:>+7.3f} "
+            f"{reranked.mrr_at_10 - baseline.mrr_at_10:>+7.3f}"
+        )
     lines.append(separator)
     return "\n".join(lines)
 

--- a/test-int/semantic/test_real_fastembed_reranker.py
+++ b/test-int/semantic/test_real_fastembed_reranker.py
@@ -1,0 +1,122 @@
+"""Real-model smoke coverage for the local FastEmbed reranker."""
+
+from __future__ import annotations
+
+import math
+from typing import cast
+
+import pytest
+
+from basic_memory.config import BasicMemoryConfig, DatabaseBackend
+from basic_memory.repository.fastembed_rerank_provider import FastEmbedRerankProvider
+from basic_memory.repository.rerank_provider_factory import create_rerank_provider
+from basic_memory.repository.sqlite_search_repository import SQLiteSearchRepository
+from basic_memory.schemas.search import SearchItemType, SearchQuery, SearchRetrievalMode
+
+from semantic.conftest import SearchCombo, _create_fastembed_provider, create_search_service
+from semantic.corpus import RankingDocument, seed_ranking_documents
+
+
+SMOKE_QUERY = "How should I fill and heat a moka pot to brew coffee?"
+SMOKE_DOCUMENTS = (
+    RankingDocument(
+        title="Moka Pot Brewing Guide",
+        permalink="rerank-smoke/moka-pot-brewing",
+        content=(
+            "Fill the lower chamber with water just below the safety valve. Add finely ground "
+            "coffee to the filter basket without tamping, assemble the moka pot, and heat it "
+            "gently until brewed coffee reaches the upper chamber."
+        ),
+    ),
+    RankingDocument(
+        title="Moka Pot Gasket Replacement",
+        permalink="rerank-smoke/moka-pot-gasket",
+        content=(
+            "Replace a worn rubber gasket when a moka pot leaks around the middle seam. Remove "
+            "the old seal, clean the threads, and press the new gasket into its groove."
+        ),
+    ),
+    RankingDocument(
+        title="Cold Brew Storage",
+        permalink="rerank-smoke/cold-brew-storage",
+        content=(
+            "Keep concentrated cold brew coffee refrigerated in a sealed glass bottle and "
+            "dilute each serving with water or milk."
+        ),
+    ),
+    RankingDocument(
+        title="Espresso Grinder Calibration",
+        permalink="rerank-smoke/espresso-grinder",
+        content=(
+            "Adjust an espresso grinder one step at a time and purge retained coffee before "
+            "timing the next shot."
+        ),
+    ),
+    RankingDocument(
+        title="Reset a Locked Account",
+        permalink="rerank-smoke/account-reset",
+        content=(
+            "An administrator can unlock a user account after verifying identity and revoke "
+            "old login sessions before issuing a password reset link."
+        ),
+    ),
+    RankingDocument(
+        title="Apply a Database Migration",
+        permalink="rerank-smoke/database-migration",
+        content=(
+            "Back up the database, apply the schema migration in a transaction, and verify the "
+            "new index before serving application traffic."
+        ),
+    ),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.semantic
+async def test_real_fastembed_reranker_scores_and_hybrid_search(
+    sqlite_engine_factory,
+    tmp_path,
+) -> None:
+    """The default cross-encoder should deterministically promote the relevant note."""
+    config = BasicMemoryConfig(
+        env="test",
+        projects={"bench-project": str(tmp_path)},
+        default_project="bench-project",
+        database_backend=DatabaseBackend.SQLITE,
+        semantic_search_enabled=True,
+        reranker_enabled=True,
+    )
+    provider = create_rerank_provider(config)
+    assert isinstance(provider, FastEmbedRerankProvider)
+
+    rerank_documents = [f"{document.content}\n{document.title}" for document in SMOKE_DOCUMENTS]
+    first_scores = await provider.rerank(SMOKE_QUERY, rerank_documents)
+    second_scores = await provider.rerank(SMOKE_QUERY, rerank_documents)
+
+    assert first_scores == second_scores
+    assert all(math.isfinite(score) and 0.0 <= score <= 1.0 for score in first_scores)
+    assert max(range(len(first_scores)), key=first_scores.__getitem__) == 0
+
+    combo = SearchCombo("sqlite-fastembed-rerank", DatabaseBackend.SQLITE, "fastembed", 384)
+    search_service = await create_search_service(
+        sqlite_engine_factory,
+        combo,
+        tmp_path,
+        embedding_provider=_create_fastembed_provider(),
+        reranker_enabled=True,
+    )
+    repository = cast(SQLiteSearchRepository, search_service.repository)
+    assert repository._rerank_provider is provider
+    await seed_ranking_documents(search_service, SMOKE_DOCUMENTS)
+
+    results = await search_service.search(
+        SearchQuery(
+            text=SMOKE_QUERY,
+            retrieval_mode=SearchRetrievalMode.HYBRID,
+            entity_types=[SearchItemType.ENTITY],
+        ),
+        limit=len(SMOKE_DOCUMENTS),
+    )
+
+    assert results
+    assert results[0].permalink == SMOKE_DOCUMENTS[0].permalink

--- a/test-int/semantic/test_reranker_latency.py
+++ b/test-int/semantic/test_reranker_latency.py
@@ -1,0 +1,115 @@
+"""Latency benchmark for vector and hybrid search with the local reranker."""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import cast
+
+import pytest
+
+from basic_memory.config import DatabaseBackend
+from basic_memory.repository.rerank_provider import RerankProvider
+from basic_memory.repository.sqlite_search_repository import SQLiteSearchRepository
+from basic_memory.schemas.search import SearchItemType, SearchQuery, SearchRetrievalMode
+from basic_memory.services.search_service import SearchService
+
+from semantic.conftest import SearchCombo, _create_fastembed_provider, create_search_service
+from semantic.corpus import (
+    GOLDEN_RANKING_DOCUMENTS,
+    GOLDEN_RANKING_QUERIES,
+    seed_ranking_documents,
+)
+from semantic.metrics import LatencyMetrics, format_latency_table
+
+
+LATENCY_ITERATIONS = 20
+CATASTROPHIC_P95_CEILING_MS = 10_000.0
+LATENCY_COMBO = SearchCombo(
+    "sqlite-fastembed-rerank",
+    DatabaseBackend.SQLITE,
+    "fastembed",
+    384,
+)
+
+
+async def _search_once(
+    search_service: SearchService,
+    query_text: str,
+    mode: SearchRetrievalMode,
+) -> None:
+    results = await search_service.search(
+        SearchQuery(
+            text=query_text,
+            retrieval_mode=mode,
+            entity_types=[SearchItemType.ENTITY],
+            min_similarity=0.0,
+        ),
+        limit=10,
+    )
+    assert results
+
+
+async def _measure_latency(
+    search_service: SearchService,
+    repository: SQLiteSearchRepository,
+    rerank_provider: RerankProvider | None,
+    mode: SearchRetrievalMode,
+) -> LatencyMetrics:
+    """Warm one configuration, then collect the fixed twenty-sample window."""
+    repository._rerank_provider = rerank_provider
+    configuration = "reranker-on" if rerank_provider is not None else "reranker-off"
+    metrics = LatencyMetrics(configuration=configuration, mode=mode.value)
+
+    # The warmup owns lazy model construction and ONNX graph initialization, so
+    # the reported samples represent steady-state local search latency.
+    await _search_once(search_service, GOLDEN_RANKING_QUERIES[0].text, mode)
+    for index in range(LATENCY_ITERATIONS):
+        case = GOLDEN_RANKING_QUERIES[index % len(GOLDEN_RANKING_QUERIES)]
+        started = time.perf_counter()
+        await _search_once(search_service, case.text, mode)
+        metrics.latencies.append(time.perf_counter() - started)
+
+    return metrics
+
+
+@pytest.mark.asyncio
+@pytest.mark.semantic
+@pytest.mark.benchmark
+async def test_local_reranker_vector_and_hybrid_latency(
+    sqlite_engine_factory,
+    tmp_path,
+) -> None:
+    """Report steady-state local rerank overhead without a timing-sensitive quality gate."""
+    search_service = await create_search_service(
+        sqlite_engine_factory,
+        LATENCY_COMBO,
+        tmp_path,
+        embedding_provider=_create_fastembed_provider(),
+        reranker_enabled=True,
+    )
+    await seed_ranking_documents(search_service, GOLDEN_RANKING_DOCUMENTS)
+
+    repository = cast(SQLiteSearchRepository, search_service.repository)
+    rerank_provider = repository._rerank_provider
+    assert rerank_provider is not None
+
+    measurements: list[LatencyMetrics] = []
+    for mode in (SearchRetrievalMode.VECTOR, SearchRetrievalMode.HYBRID):
+        measurements.append(await _measure_latency(search_service, repository, None, mode))
+        measurements.append(
+            await _measure_latency(search_service, repository, rerank_provider, mode)
+        )
+
+    print(f"\n{format_latency_table(measurements)}")
+
+    for metrics in measurements:
+        assert len(metrics.latencies) == LATENCY_ITERATIONS
+        assert math.isfinite(metrics.p50_ms)
+        assert math.isfinite(metrics.p95_ms)
+        if metrics.configuration == "reranker-on":
+            assert metrics.p95_ms < CATASTROPHIC_P95_CEILING_MS
+
+    for baseline, reranked in zip(measurements[::2], measurements[1::2], strict=True):
+        assert baseline.mode == reranked.mode
+        assert math.isfinite(reranked.p95_ms - baseline.p95_ms)

--- a/test-int/semantic/test_reranker_quality.py
+++ b/test-int/semantic/test_reranker_quality.py
@@ -1,0 +1,101 @@
+"""Golden-query quality regression coverage for the local reranker."""
+
+from __future__ import annotations
+
+import time
+from typing import cast
+
+import pytest
+
+from basic_memory.config import DatabaseBackend
+from basic_memory.repository.rerank_provider import RerankProvider
+from basic_memory.repository.sqlite_search_repository import SQLiteSearchRepository
+from basic_memory.schemas.search import SearchItemType, SearchRetrievalMode
+
+from semantic.conftest import SearchCombo, _create_fastembed_provider, create_search_service
+from semantic.corpus import (
+    GOLDEN_RANKING_DOCUMENTS,
+    GOLDEN_RANKING_QUERIES,
+    RankingQuery,
+    seed_ranking_documents,
+)
+from semantic.metrics import (
+    QualityMetrics,
+    first_permalink_rank,
+    format_reranker_quality_table,
+    write_benchmark_artifact,
+)
+
+
+QUALITY_COMBO = SearchCombo(
+    "sqlite-fastembed-rerank",
+    DatabaseBackend.SQLITE,
+    "fastembed",
+    384,
+)
+
+
+async def _evaluate_quality(
+    repository: SQLiteSearchRepository,
+    rerank_provider: RerankProvider | None,
+    cases: tuple[RankingQuery, ...],
+) -> QualityMetrics:
+    """Run one fixed retrieval configuration over every golden query."""
+    repository._rerank_provider = rerank_provider
+    configuration = "reranker-on" if rerank_provider is not None else "reranker-off"
+    metrics = QualityMetrics(combo=configuration, suite="golden", mode="hybrid")
+
+    for case in cases:
+        started = time.perf_counter()
+        results = await repository.search(
+            search_text=case.text,
+            retrieval_mode=SearchRetrievalMode.HYBRID,
+            search_item_types=[SearchItemType.ENTITY],
+            min_similarity=0.0,
+            limit=10,
+        )
+        latency = time.perf_counter() - started
+        rank = first_permalink_rank(results, case.expected_permalink, k=10)
+        metrics.record(case.text, case.expected_permalink, rank, latency=latency)
+
+    return metrics
+
+
+@pytest.mark.asyncio
+@pytest.mark.semantic
+async def test_real_reranker_preserves_or_improves_golden_query_quality(
+    sqlite_engine_factory,
+    tmp_path,
+) -> None:
+    """Cross-encoder reranking must improve a case without regressing aggregate quality."""
+    search_service = await create_search_service(
+        sqlite_engine_factory,
+        QUALITY_COMBO,
+        tmp_path,
+        embedding_provider=_create_fastembed_provider(),
+        reranker_enabled=True,
+    )
+    await seed_ranking_documents(search_service, GOLDEN_RANKING_DOCUMENTS)
+
+    repository = cast(SQLiteSearchRepository, search_service.repository)
+    rerank_provider = repository._rerank_provider
+    assert rerank_provider is not None
+
+    baseline = await _evaluate_quality(repository, None, GOLDEN_RANKING_QUERIES)
+    reranked = await _evaluate_quality(repository, rerank_provider, GOLDEN_RANKING_QUERIES)
+    print(f"\n{format_reranker_quality_table([baseline, reranked])}")
+    write_benchmark_artifact([baseline, reranked])
+
+    assert reranked.hit_at_1 >= baseline.hit_at_1
+    assert reranked.mrr_at_10 >= baseline.mrr_at_10
+    assert reranked.hit_at_5 == 1.0
+    assert any(
+        reranked_case["rank"] is not None
+        and baseline_case["rank"] is not None
+        and reranked_case["rank"] < baseline_case["rank"]
+        for baseline_case, reranked_case in zip(
+            baseline.per_query,
+            reranked.per_query,
+            strict=True,
+        )
+    )


### PR DESCRIPTION
Phases 2-3 of #1231 — the remaining automated items. Test-only: six files under
`test-int/semantic/`, zero production changes.

## What's added

- **Real-model smoke** (`test_real_fastembed_reranker.py`, semantic-marked): loads the
  actual `jinaai/jina-reranker-v1-tiny-en` cross-encoder through the production
  provider/factory path (no stubs), asserts the relevant doc wins with calibrated `[0,1]`
  scores and deterministic ordering, plus one end-to-end hybrid search through an indexed
  repository with reranking enabled.
- **Quality regression harness** (`test_reranker_quality.py` + ranking corpus/metrics
  extensions): golden ranking-sensitive queries measured reranker-off vs reranker-on with
  real embeddings + real cross-encoder. Asserts on >= off for hit@1/MRR plus an absolute
  hit@5 floor so a silent rerank no-op cannot pass. Measured on the curated set:

  | Mode | hit@1 | hit@5 | MRR |
  |---|---|---|---|
  | Reranking off | 0.833 | 1.000 | 0.917 |
  | Reranking on | **1.000** | 1.000 | **1.000** |

  No queries needed exclusion; the real tiny model degraded nothing.
- **Latency benchmark** (`test_reranker_latency.py`, semantic+benchmark-marked, report-
  focused with a generous catastrophic-regression ceiling only). Warmed local numbers,
  20 iterations:

  | Search | P50 | P95 |
  |---|---|---|
  | Vector off | 9.5 ms | 10.1 ms |
  | Vector on | 102.5 ms | 238.4 ms |
  | Hybrid off | 13.2 ms | 17.6 ms |
  | Hybrid on | 98.2 ms | 463.8 ms |

  ~90 ms P50 overhead for the local tiny cross-encoder — comfortably inside the latency
  headroom that motivated #950.

## Verification

- The three new test files: pass, run twice for determinism (16s total once models are
  cached).
- `just typecheck`, `just lint`: clean.
- Note: `test_semantic_quality[asyncio-postgres-fastembed]` can exceed the 120s per-test
  timeout on a loaded local machine — reproduced identically on `main`, pre-existing and
  unrelated to this PR.

Ticks the Phase 2 fastembed-smoke and both Phase 3 boxes on #1231. Remaining there: the
deferred live LiteLLM run and the optional live smoke. These numbers also set the baseline
for revisiting #951 (entity boosting) and closing #618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPdSXDbYyhyZ1TwgFnpEv8
