### PR TITLE
fix(core): reject timestamp and checkbox-marker observation categories

### DIFF
--- a/src/basic_memory/markdown/plugins.py
+++ b/src/basic_memory/markdown/plugins.py
@@ -14,10 +14,26 @@ from markdown_it.token import Token
 _TIMESTAMP_CATEGORY = re.compile(r"^\d{1,3}:\d{2}(:\d{2})?([.,]\d{1,3})?$")
 
 
+def _is_task_marker_category(category: str) -> bool:
+    """Recognize checkbox-marker shapes the GFM/Obsidian task family uses.
+
+    `[ ]`, `[x]`, and `[-]` are excluded upstream, but the extended vocabulary
+    (`[/]` in progress, `[>]` deferred, `[?]` question, uppercase `[X]`) shares the
+    bracket shape and would otherwise mint junk one-character categories (#1241).
+    Single-character alphanumeric categories other than x/X keep parsing as today.
+    """
+    if len(category) != 1:
+        return False
+    return category in {"x", "X"} or not category.isalnum()
+
+
 def _observation_category_match(content: str) -> re.Match[str] | None:
-    """Match ``[category] content``, rejecting timestamp-shaped categories."""
+    """Match ``[category] content``, rejecting timestamp and task-marker shapes."""
     match = re.match(r"^\[([^\[\]()]+)\]\s+(.+)", content)
-    if match and _TIMESTAMP_CATEGORY.match(match.group(1).strip()):
+    if not match:
+        return None
+    category = match.group(1).strip()
+    if _TIMESTAMP_CATEGORY.match(category) or _is_task_marker_category(category):
         return None
     return match
 

--- a/src/basic_memory/markdown/plugins.py
+++ b/src/basic_memory/markdown/plugins.py
@@ -1,16 +1,30 @@
 """Markdown-it plugins for Basic Memory markdown parsing."""
 
+import re
 from typing import List, Any, Dict
 
 from basic_memory.utils import normalize_project_reference
 from markdown_it import MarkdownIt
 from markdown_it.token import Token
 
+# Transcript timecodes like [00:00:11] or [1:02:03.500] share the bracket shape of
+# observation categories, so indexed transcripts would mint one junk observation per
+# spoken line. A category that is purely a clock value is never a semantic category;
+# those bracket prefixes stay ordinary content (issue #1219).
+_TIMESTAMP_CATEGORY = re.compile(r"^\d{1,3}:\d{2}(:\d{2})?([.,]\d{1,3})?$")
+
+
+def _observation_category_match(content: str) -> re.Match[str] | None:
+    """Match ``[category] content``, rejecting timestamp-shaped categories."""
+    match = re.match(r"^\[([^\[\]()]+)\]\s+(.+)", content)
+    if match and _TIMESTAMP_CATEGORY.match(match.group(1).strip()):
+        return None
+    return match
+
 
 # Observation handling functions
 def is_observation(token: Token) -> bool:
     """Check if token looks like our observation format."""
-    import re
 
     if token.type != "inline":  # pragma: no cover
         return False
@@ -31,7 +45,7 @@ def is_observation(token: Token) -> bool:
         return False
 
     # Check for proper observation format: [category] content
-    match = re.match(r"^\[([^\[\]()]+)\]\s+(.+)", content)
+    match = _observation_category_match(content)
     # Check for standalone hashtags (words starting with #)
     # This excludes # in HTML attributes like color="#4285F4"
     has_tags = any(part.startswith("#") for part in content.split())
@@ -40,13 +54,13 @@ def is_observation(token: Token) -> bool:
 
 def parse_observation(token: Token) -> Dict[str, Any]:
     """Extract observation parts from token."""
-    import re
 
     # Use token.tag which contains the actual content for test tokens, fallback to content
     content = (token.tag or token.content).strip()
 
-    # Parse [category] with regex
-    match = re.match(r"^\[([^\[\]()]+)\]\s+(.+)", content)
+    # Parse [category] with regex; a timestamp-shaped prefix is not a category, so a
+    # hashtag-promoted transcript line keeps its timecode inside the content instead.
+    match = _observation_category_match(content)
     category = None
     if match:
         category = match.group(1).strip()

--- a/tests/markdown/test_observation_edge_cases.py
+++ b/tests/markdown/test_observation_edge_cases.py
@@ -186,3 +186,34 @@ def test_numeric_but_non_timestamp_categories_still_parse():
         obs = token.meta.get("observation") if token.meta else None
         assert obs is not None, line
         assert obs["category"] == category
+
+
+def test_extended_checkbox_markers_are_not_observation_categories():
+    """Obsidian's extended task markers must not mint observations (issue #1241)."""
+    md = MarkdownIt().use(observation_plugin)
+
+    for line in (
+        "- [/] in progress task",
+        "- [>] deferred task",
+        "- [?] maybe task",
+        "- [!] important task",
+        "- [X] uppercase done task",
+    ):
+        tokens = md.parse(line)
+        assert not any(t.meta and "observation" in t.meta for t in tokens), line
+
+
+def test_single_character_alphanumeric_categories_still_parse():
+    """Only marker shapes are rejected; short real categories keep working."""
+    md = MarkdownIt().use(observation_plugin)
+
+    for line, category in (
+        ("- [a] annotation shorthand", "a"),
+        ("- [1] first point", "1"),
+        ("- [q] question shorthand", "q"),
+    ):
+        tokens = md.parse(line)
+        token = next(t for t in tokens if t.type == "inline")
+        obs = token.meta.get("observation") if token.meta else None
+        assert obs is not None, line
+        assert obs["category"] == category

--- a/tests/markdown/test_observation_edge_cases.py
+++ b/tests/markdown/test_observation_edge_cases.py
@@ -127,3 +127,62 @@ def test_unicode_content():
     observation = Observation.model_validate(obs)
     assert "中文" in observation.content
     assert "👍" in observation.content
+
+
+def test_timestamp_prefixes_are_not_observation_categories():
+    """Transcript timecodes must not mint observations (issue #1219)."""
+    md = MarkdownIt().use(observation_plugin)
+
+    # The issue's repro: list-item and bare transcript lines plus one real observation.
+    tokens = md.parse(
+        "[00:00:11] Speaker: We chose the safer option.\n"
+        "- [00:01:42] Speaker: Follow up next week.\n"
+        "- [decision] Use the safer option.\n"
+    )
+    observations = [t.meta["observation"] for t in tokens if t.meta and "observation" in t.meta]
+    assert len(observations) == 1
+    assert observations[0]["category"] == "decision"
+    assert observations[0]["content"] == "Use the safer option."
+
+
+def test_timestamp_shapes_rejected_across_formats():
+    """MM:SS, HH:MM:SS, and fractional-second timecodes all stay ordinary content."""
+    md = MarkdownIt().use(observation_plugin)
+
+    for line in (
+        "- [1:02] short timecode",
+        "- [00:00:11] plain timecode",
+        "- [1:02:03.500] fractional seconds",
+        "- [100:02:11] long recording hours",
+        "- [12:03,250] comma milliseconds",
+    ):
+        tokens = md.parse(line)
+        assert not any(t.meta and "observation" in t.meta for t in tokens), line
+
+
+def test_hashtag_promoted_timestamp_line_keeps_timecode_in_content():
+    """A tagged transcript line is an observation via its hashtag, never via the timecode."""
+    md = MarkdownIt().use(observation_plugin)
+
+    tokens = md.parse("- [00:00:11] Speaker: decision recorded #meeting")
+    token = next(t for t in tokens if t.type == "inline")
+    obs = parse_observation(token)
+    assert obs["category"] is None
+    assert obs["content"].startswith("[00:00:11] Speaker:")
+    assert obs["tags"] == ["meeting"]
+
+
+def test_numeric_but_non_timestamp_categories_still_parse():
+    """Only pure clock values are rejected; other numeric categories keep working."""
+    md = MarkdownIt().use(observation_plugin)
+
+    for line, category in (
+        ("- [2024] year in review", "2024"),
+        ("- [v1:2] odd but not a clock", "v1:2"),
+        ("- [10:30am] time-of-day words", "10:30am"),
+    ):
+        tokens = md.parse(line)
+        token = next(t for t in tokens if t.type == "inline")
+        obs = token.meta.get("observation") if token.meta else None
+        assert obs is not None, line
+        assert obs["category"] == category


### PR DESCRIPTION
Closes #1219. Closes #1241.

Two sibling false-positive classes in the observation recognizer, one PR: the bracket
regex accepted any `[x] content` line whose bracket text had no brackets or parentheses,
so (a) transcript timecodes and (b) extended checkbox markers both minted junk
observations.

## Commit 1 — timestamp-shaped categories (#1219)

`[00:00:11] Speaker: ...` minted an observation with category `00:00:11` — one junk graph
row per spoken transcript line, which matters more now that harness hook capture writes
transcripts into notes. A shared `_observation_category_match` helper rejects bracket
prefixes that are pure clock values (`MM:SS`, `HH:MM:SS`, optional `.`/`,` fractional
seconds) in both recognition paths:

- `is_observation`: a bare or list-item timecode line is not an observation.
- `parse_observation`: a hashtag-promoted transcript line (`- [00:00:11] ... #meeting`)
  stays an observation via its tag, but keeps the timecode in content with
  `category=None`.

## Commit 2 — extended checkbox markers (#1241)

The task exclusion only knew GFM's `[ ]`/`[x]`/`[-]`, so Obsidian's extended vocabulary
leaked: `- [/] task` → category `/`, `[>]` → `>`, `[?]` → `?`, and GFM-legal `[X]` → `X`.
The helper now also rejects single-character non-alphanumeric bracket prefixes plus
`x`/`X` — the checkbox-marker family — as categories. This is the interim guard until
first-class task extraction (#1242) owns these lines.

Deliberately narrow throughout: `[2024]`, `[10:30am]`, `[v1:2]`, `[a]`, `[1]`, `[q]` all
still parse as categories (each pinned by test). Lineage: #247/#269, #738/#769.

## Verification

- Regression tests for both classes: the #1219 repro, timestamp shapes across formats,
  the hashtag-promotion path, all five extended markers, and single-char alphanumeric
  control cases. `tests/markdown/`: 84 passed.
- Broad sweep `tests/services/` + `tests/repository/`: 1081 passed.
- `just typecheck`, `just lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPdSXDbYyhyZ1TwgFnpEv8
