### PR TITLE
fix(sync): guard project-index deletes against materialization

### DIFF
--- a/docs/ENGINEERING_STYLE.md
+++ b/docs/ENGINEERING_STYLE.md
@@ -100,6 +100,10 @@ For example, prefer separate `Completed(result)` and `Failed(reason)` values joi
 
 ## Database Writes And Concurrency
 
+See [TRANSACTION_ISOLATION.md](TRANSACTION_ISOLATION.md) for the PostgreSQL Read Committed
+semantics, guarded-write patterns, and NoteContent-before-Entity lock protocol that repository
+code may rely on.
+
 - Let the database arbitrate ordinary write contention. Express idempotency and uniqueness with
   constraints plus `INSERT ... ON CONFLICT DO NOTHING` or `DO UPDATE`, and return an explicit
   inserted, existing, or updated outcome when callers need to distinguish them.

--- a/docs/TRANSACTION_ISOLATION.md
+++ b/docs/TRANSACTION_ISOLATION.md
@@ -1,0 +1,107 @@
+# Transaction Isolation And Concurrency
+
+Basic Memory's PostgreSQL code assumes the database's default **Read Committed** isolation level.
+SQLite remains a supported local/test backend, but its single-writer behavior is not evidence that
+a PostgreSQL row-lock protocol is correct. Any design that depends on concurrent row behavior must
+have a PostgreSQL regression test.
+
+This document records the specific guarantees repository code may use. It is not permission to add
+broad locks: optimistic compare-and-swap remains the default, and canonical note safety is the main
+case where a narrow lock is justified.
+
+## Read Committed Statement Model
+
+Under PostgreSQL Read Committed:
+
+- Each command sees rows committed before that command began, plus changes already made by its own
+  transaction. Two commands in one transaction can therefore observe different committed state.
+- `UPDATE`, `DELETE`, and locking `SELECT` statements wait when a target row is concurrently
+  updated, deleted, or locked.
+- After the wait, PostgreSQL applies the operation to the current row version and re-evaluates the
+  command's `WHERE` predicate. If the row was deleted or no longer matches, the command affects no
+  row.
+- Row locks last until transaction end. `FOR UPDATE` conflicts with the weaker `FOR KEY SHARE`
+  lock used to protect referenced keys, which is relevant when a child row is inserted through a
+  foreign key.
+
+The authoritative references are PostgreSQL's
+[Transaction Isolation](https://www.postgresql.org/docs/current/transaction-iso.html) and
+[Explicit Locking](https://www.postgresql.org/docs/current/explicit-locking.html) chapters.
+
+Read Committed is deliberately not a transaction-wide snapshot. Never assume an earlier plain
+`SELECT` still describes the row when a later statement writes it.
+
+## Preferred Guarded-Write Pattern
+
+Put the expected lineage in the write itself and inspect whether it matched:
+
+```sql
+UPDATE note_content
+SET file_write_status = 'writing',
+    last_materialization_attempt_at = :attempted_at
+WHERE project_id = :project_id
+  AND entity_id = :entity_id
+  AND db_version = :db_version
+  AND db_checksum = :db_checksum
+RETURNING markdown_content, file_checksum;
+```
+
+This is a compare-and-swap claim, not a read followed by an ORM flush. If a concurrent delete wins,
+the statement returns no row. If the claim wins, its NoteContent row lock remains held until commit,
+and a later delete must observe the changed materialization lineage. Expected contention is returned
+as a typed missing or stale outcome; it is not an ORM `StaleDataError` control path.
+
+Use this pattern when one statement can name the invariant. Do not add a pre-read lock merely to
+make a later unconditional write appear safe.
+
+## Canonical Lock Order
+
+When a transaction must touch accepted `NoteContent` and then mutate or delete its `Entity` or
+relations, it acquires locks in this order:
+
+1. Lock every relevant `NoteContent` row, sorted by `entity_id`.
+2. Lock the corresponding `Entity` rows, also in stable order, only when the operation needs an
+   explicit entity fence.
+3. Mutate Entity, search, relation, or vector projection rows.
+
+The shared entry point is
+`lock_note_content_before_entity_mutation` in
+`src/basic_memory/repository/relation_repository.py`. Reversing this order can deadlock accepted
+writes, materialization, relation publication, and cascading deletes.
+
+The Entity lock matters for a legacy indexed row with no `NoteContent`. A concurrent accepted write
+can bootstrap that child row. Locking the referenced Entity makes PostgreSQL serialize the foreign
+key insertion; a subsequent Read Committed statement then either sees the committed `NoteContent`
+and preserves it, or the inserter waits until deletion completes and cannot accept content for a
+missing Entity.
+
+## External Storage Is Outside The Transaction
+
+Object storage and the local filesystem cannot participate in the database transaction. Project
+index deletion therefore uses three explicit phases:
+
+1. Snapshot only valid DB delete candidates: storage-owned entities with no `NoteContent`, or notes
+   where status is `synced`, `file_version == db_version`, and
+   `file_checksum == db_checksum`.
+2. Outside a DB transaction, positively verify that each candidate path is still absent from the
+   current storage backend. A scan listing alone is not sufficient.
+3. Lock NoteContent then Entity, reload the exact candidate lineage in a new Read Committed
+   statement, and delete only candidates equal to the snapshot.
+
+The materialization-attempt timestamp is part of a synchronized note candidate. It prevents an ABA
+window where a same-version materialization leaves `synced`, writes the file, and returns to
+`synced` while the storage absence probe is in flight.
+
+Do not hold database locks across the storage probe. Candidate equality bridges the two systems
+without a distributed transaction and keeps transient projection lag eventually consistent.
+
+## Review Checklist
+
+For a concurrency-sensitive persistence change:
+
+- Name the canonical invariant and the exact row(s) that protect it.
+- Prefer a conditional write with row-count or `RETURNING` evidence.
+- If a lock is necessary, preserve NoteContent-before-Entity order and keep the locked set narrow.
+- Do not infer PostgreSQL safety from SQLite.
+- Add a PostgreSQL test for both winner orderings and use timeouts so a lock cycle fails loudly.
+- Keep network and filesystem I/O outside database transactions.

--- a/src/basic_memory/indexing/note_materialization_runner.py
+++ b/src/basic_memory/indexing/note_materialization_runner.py
@@ -9,7 +9,7 @@ from typing import Protocol, Self
 
 from loguru import logger
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory import db
@@ -113,6 +113,14 @@ class NoteMaterializationPreflightResult:
         if self.prepared_write is None:
             raise RuntimeError("terminal note materialization preflight has no prepared write")
         return self.prepared_write
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimedNoteMaterializationContent:
+    """Content returned by an atomic claim of one accepted note version."""
+
+    markdown_content: str
+    previous_file_checksum: RuntimeFileChecksum | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -284,6 +292,66 @@ def plan_note_materialization_preflight(
     )
 
 
+async def claim_note_materialization_content(
+    session: AsyncSession,
+    *,
+    request: RuntimeNoteMaterializationJobRequest,
+    attempted_at: datetime,
+) -> ClaimedNoteMaterializationContent | None:
+    """Atomically claim the queued accepted version and return its file input."""
+    claim_result = await session.execute(
+        update(NoteContent)
+        .where(
+            NoteContent.project_id == request.project_id,
+            NoteContent.entity_id == request.entity_id,
+            NoteContent.db_version == request.db_version,
+            NoteContent.db_checksum == request.db_checksum,
+        )
+        .values(
+            file_write_status="writing",
+            last_materialization_attempt_at=attempted_at,
+        )
+        .returning(
+            NoteContent.markdown_content,
+            NoteContent.file_checksum,
+        )
+        .execution_options(synchronize_session=False)
+    )
+    claimed_row = claim_result.one_or_none()
+    if claimed_row is None:
+        return None
+    return ClaimedNoteMaterializationContent(
+        markdown_content=claimed_row[0],
+        previous_file_checksum=claimed_row[1],
+    )
+
+
+def plan_missed_note_materialization_claim(
+    request: RuntimeNoteMaterializationJobRequest,
+    *,
+    entity: NoteMaterializationEntitySource | None,
+    note_content: NoteMaterializationContentSource | None,
+    attempted_at: datetime,
+) -> NoteMaterializationPreflightResult:
+    """Classify the current state after a guarded materialization claim misses."""
+    current_plan = plan_note_materialization_preflight(
+        request,
+        entity=entity,
+        note_content=note_content,
+        attempted_at=attempted_at,
+    )
+    if current_plan.terminal_result is not None:
+        return current_plan
+    return NoteMaterializationPreflightResult.terminal(
+        RuntimeNoteMaterializationResult(
+            entity_id=request.entity_id,
+            status=RuntimeNoteMaterializationStatus.stale,
+            reason=f"note state changed before file-write claim: {request.entity_id}",
+            file_path=entity.file_path if entity is not None else None,
+        )
+    )
+
+
 def plan_written_note_materialization_publish(
     *,
     request: RuntimeNoteMaterializationJobRequest,
@@ -384,25 +452,45 @@ class RepositoryNoteMaterializationPreflight:
                 entity_id=request.entity_id,
             )
 
-            entity = await session.get(Entity, request.entity_id)
-            note_content = await session.get(NoteContent, request.entity_id)
             attempted_at = note_materialization_utc_now()
-            preflight_result = plan_note_materialization_preflight(
-                request,
-                entity=entity,
-                note_content=note_content,
+            claimed_content = await claim_note_materialization_content(
+                session,
+                request=request,
                 attempted_at=attempted_at,
             )
-            if preflight_result.terminal_result is not None:
-                return preflight_result
+            if claimed_content is None:
+                entity = await session.get(Entity, request.entity_id)
+                note_content = await session.get(NoteContent, request.entity_id)
+                if entity is not None and entity.project_id != request.project_id:
+                    entity = None
+                if note_content is not None and note_content.project_id != request.project_id:
+                    note_content = None
+                return plan_missed_note_materialization_claim(
+                    request,
+                    entity=entity,
+                    note_content=note_content,
+                    attempted_at=attempted_at,
+                )
 
-            if note_content is None:
-                raise RuntimeError("prepared note materialization requires note_content")
-
-            note_content.file_write_status = "writing"
-            note_content.last_materialization_attempt_at = attempted_at
-            await session.flush()
-            return preflight_result
+            entity = await session.get(Entity, request.entity_id)
+            if entity is None or entity.project_id != request.project_id:
+                return NoteMaterializationPreflightResult.terminal(
+                    RuntimeNoteMaterializationResult(
+                        entity_id=request.entity_id,
+                        status=RuntimeNoteMaterializationStatus.missing,
+                        reason=f"note state no longer exists: {request.entity_id}",
+                    ),
+                    cleanup_file=plan_note_materialization_cleanup_file_delete(request),
+                )
+            return NoteMaterializationPreflightResult.prepared(
+                plan_prepared_note_write(
+                    request=request,
+                    file_path=entity.file_path,
+                    markdown_content=claimed_content.markdown_content,
+                    previous_file_checksum=claimed_content.previous_file_checksum,
+                    attempted_at=attempted_at,
+                )
+            )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/basic_memory/indexing/project_index_maintenance.py
+++ b/src/basic_memory/indexing/project_index_maintenance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from datetime import datetime
 from typing import override, Protocol
 
 from loguru import logger
@@ -100,17 +101,147 @@ class ProjectIndexDeletePathVerifier(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class TrustPlannedProjectIndexDeleteVerifier(ProjectIndexDeletePathVerifier):
-    """Confirm every planned delete without re-probing storage.
+    """Confirm deletes already proven by a path-specific storage event.
 
-    Cloud/S3 runtimes treat the scan's storage listing as authoritative and
-    have no cheap per-path existence probe at apply time, so they keep the
-    plan's verdict unchanged. Runtimes with a live filesystem (local) inject
-    a probing verifier instead.
+    This verifier is not safe for project scans: their listing is a stale
+    snapshot by the time a delete batch applies. Scan runtimes must inject a
+    verifier that probes each candidate's current storage state.
     """
 
     @override
     async def confirm_deleted_paths(self, paths: Sequence[str]) -> frozenset[str]:
         return frozenset(paths)
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectIndexDeleteEntity:
+    """Stable entity identity carried through one delete eligibility check."""
+
+    entity_id: int
+    file_path: str
+
+
+@dataclass(frozen=True, slots=True)
+class StorageOwnedProjectIndexDeleteCandidate:
+    """An indexed file with no DB-accepted Markdown content."""
+
+    entity: ProjectIndexDeleteEntity
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializedNoteProjectIndexDeleteCandidate:
+    """A note whose accepted content is fully represented by its file."""
+
+    entity: ProjectIndexDeleteEntity
+    db_version: int
+    db_checksum: str
+    file_version: int
+    file_checksum: str
+    last_materialization_attempt_at: datetime | None
+
+
+type ProjectIndexDeleteCandidate = (
+    StorageOwnedProjectIndexDeleteCandidate | MaterializedNoteProjectIndexDeleteCandidate
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectIndexDeleteCandidateScreen:
+    """Candidate rows plus paths that exist but are not currently deletable."""
+
+    candidates: tuple[ProjectIndexDeleteCandidate, ...]
+    indexed_paths: frozenset[str]
+
+
+class ProjectIndexDeleteCandidateRow(Protocol):
+    """Persistence projection consumed by delete-candidate classification."""
+
+    def __getitem__(self, key: str, /) -> object: ...
+
+
+def _project_index_delete_candidate_from_row(
+    row: ProjectIndexDeleteCandidateRow,
+) -> ProjectIndexDeleteCandidate | None:
+    """Classify one persistence row into the positive delete-eligible domain."""
+    entity_id = row["entity_id"]
+    file_path = row["file_path"]
+    if not isinstance(entity_id, int) or not isinstance(file_path, str):
+        raise TypeError("delete candidate identity must contain an integer id and string path")
+    entity = ProjectIndexDeleteEntity(
+        entity_id=entity_id,
+        file_path=file_path,
+    )
+    if row["note_content_entity_id"] is None:
+        return StorageOwnedProjectIndexDeleteCandidate(entity=entity)
+
+    db_version = row["db_version"]
+    db_checksum = row["db_checksum"]
+    file_version = row["file_version"]
+    file_checksum = row["file_checksum"]
+    if row["file_write_status"] != "synced":
+        return None
+    if (
+        not isinstance(db_version, int)
+        or not isinstance(db_checksum, str)
+        or not isinstance(file_version, int)
+        or not isinstance(file_checksum, str)
+    ):
+        return None
+    if file_version != db_version or file_checksum != db_checksum:
+        return None
+
+    attempted_at = row["last_materialization_attempt_at"]
+    if attempted_at is not None and not isinstance(attempted_at, datetime):
+        raise TypeError("last_materialization_attempt_at must be a datetime")
+    return MaterializedNoteProjectIndexDeleteCandidate(
+        entity=entity,
+        db_version=db_version,
+        db_checksum=db_checksum,
+        file_version=file_version,
+        file_checksum=file_checksum,
+        last_materialization_attempt_at=attempted_at,
+    )
+
+
+async def _load_project_index_delete_candidates(
+    session: AsyncSession,
+    *,
+    project_id: ProjectId,
+    paths: Sequence[str],
+) -> ProjectIndexDeleteCandidateScreen:
+    """Load the exact lineage that permits deletion for the requested paths."""
+    if not paths:
+        return ProjectIndexDeleteCandidateScreen(candidates=(), indexed_paths=frozenset())
+
+    result = await session.execute(
+        select(
+            Entity.id.label("entity_id"),
+            Entity.file_path.label("file_path"),
+            NoteContent.entity_id.label("note_content_entity_id"),
+            NoteContent.db_version.label("db_version"),
+            NoteContent.db_checksum.label("db_checksum"),
+            NoteContent.file_version.label("file_version"),
+            NoteContent.file_checksum.label("file_checksum"),
+            NoteContent.file_write_status.label("file_write_status"),
+            NoteContent.last_materialization_attempt_at.label("last_materialization_attempt_at"),
+        )
+        .outerjoin(NoteContent, NoteContent.entity_id == Entity.id)
+        .where(
+            Entity.project_id == project_id,
+            Entity.file_path.in_(tuple(paths)),
+        )
+        .order_by(Entity.id)
+    )
+    rows = result.mappings().all()
+    candidates = tuple(
+        candidate
+        for row in rows
+        if (candidate := _project_index_delete_candidate_from_row(row)) is not None
+    )
+    return ProjectIndexDeleteCandidateScreen(
+        candidates=candidates,
+        indexed_paths=frozenset(str(row["file_path"]) for row in rows),
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -586,7 +717,7 @@ class RepositoryProjectIndexMaintenanceStore:
     project_id: ProjectId
     external_vector_cleaner: ProjectIndexExternalVectorCleaner | None = None
     move_content_updater: ProjectIndexMoveContentUpdater | None = None
-    delete_path_verifier: ProjectIndexDeletePathVerifier = TrustPlannedProjectIndexDeleteVerifier()
+    delete_path_verifier: ProjectIndexDeletePathVerifier | None = None
     # Trigger: an entity occupies a move destination at apply time.
     # Why: scan change planning only pairs moves with paths that had no DB row
     #      at snapshot time, so a row found there was created concurrently and
@@ -853,53 +984,131 @@ class RepositoryProjectIndexMaintenanceStore:
         if not delete_batch.paths:
             return ProjectIndexDeleteBatchResult(deleted_entities=0)
 
-        # Trigger: a planned delete path exists in storage again at apply time.
-        # Why: the plan compares a storage snapshot against a later DB read, so
-        #      a note accepted and materialized in between is planned as deleted;
-        #      applying it would destroy the accepted entity, search, and vector
-        #      rows with no recovery.
-        # Outcome: only positively re-confirmed absences are deleted; skipped
-        #          paths are reported and the next scan picks the file up as
-        #          modified.
-        confirmed_paths = await self.delete_path_verifier.confirm_deleted_paths(delete_batch.paths)
-        skipped_paths = tuple(
-            deleted_path
-            for deleted_path in delete_batch.paths
-            if deleted_path not in confirmed_paths
+        # --- Snapshot DB eligibility before probing storage ---
+        # Only storage-owned rows and fully synchronized notes can become delete
+        # candidates. Pending, writing, failed, externally changed, and partially
+        # synchronized NoteContent states remain canonical DB work and are skipped.
+        async with db.scoped_session(self.session_maker) as session:
+            initial_screen = await _load_project_index_delete_candidates(
+                session,
+                project_id=self.project_id,
+                paths=delete_batch.paths,
+            )
+
+        initial_candidates_by_path = {
+            candidate.entity.file_path: candidate for candidate in initial_screen.candidates
+        }
+        protected_paths = initial_screen.indexed_paths - initial_candidates_by_path.keys()
+        missing_paths = set(delete_batch.paths) - initial_screen.indexed_paths
+        skipped_paths = set(protected_paths)
+        if protected_paths:
+            logger.warning(
+                "Skipping planned index deletes for unsynchronized note state",
+                paths=tuple(path for path in delete_batch.paths if path in protected_paths),
+            )
+        if not initial_candidates_by_path:
+            return ProjectIndexDeleteBatchResult(
+                deleted_entities=0,
+                missing_paths=tuple(path for path in delete_batch.paths if path in missing_paths),
+                skipped_paths=tuple(path for path in delete_batch.paths if path in skipped_paths),
+            )
+
+        # --- Re-probe external storage outside the DB transaction ---
+        # A project scan's listing is only a snapshot. Refuse to delete when the
+        # runtime cannot positively confirm each candidate is still absent.
+        if self.delete_path_verifier is None:
+            raise RuntimeError("project-index delete requires a live storage path verifier")
+        candidate_paths = tuple(
+            path for path in delete_batch.paths if path in initial_candidates_by_path
         )
-        if skipped_paths:
+        confirmed_paths = await self.delete_path_verifier.confirm_deleted_paths(candidate_paths)
+        storage_present_paths = set(candidate_paths) - confirmed_paths
+        skipped_paths.update(storage_present_paths)
+        if storage_present_paths:
             logger.warning(
                 "Skipping planned index deletes for paths present in storage again",
-                paths=skipped_paths,
+                paths=tuple(path for path in delete_batch.paths if path in storage_present_paths),
             )
         if not confirmed_paths:
             return ProjectIndexDeleteBatchResult(
                 deleted_entities=0,
-                skipped_paths=skipped_paths,
+                missing_paths=tuple(path for path in delete_batch.paths if path in missing_paths),
+                skipped_paths=tuple(path for path in delete_batch.paths if path in skipped_paths),
             )
 
+        # --- Lock and revalidate the exact DB lineage before deletion ---
         async with db.scoped_session(self.session_maker) as session:
-            target_result = await session.execute(
-                select(Entity.id, Entity.file_path).where(
-                    Entity.project_id == self.project_id,
-                    Entity.file_path.in_(tuple(confirmed_paths)),
-                )
+            confirmed_candidates = tuple(
+                initial_candidates_by_path[path]
+                for path in candidate_paths
+                if path in confirmed_paths
             )
-            target_rows = target_result.mappings().all()
-
-            if not target_rows:
+            candidate_entity_ids = tuple(
+                candidate.entity.entity_id for candidate in confirmed_candidates
+            )
+            await lock_note_content_before_entity_mutation(
+                session,
+                project_id=self.project_id,
+                entity_ids=candidate_entity_ids,
+            )
+            # PostgreSQL foreign-key insertion takes a lock on Entity. Taking
+            # these row locks after NoteContent means a concurrent legacy-note
+            # bootstrap either commits before the next statement or waits until
+            # this externally deleted entity is gone.
+            await session.execute(
+                select(Entity.id)
+                .where(
+                    Entity.project_id == self.project_id,
+                    Entity.id.in_(candidate_entity_ids),
+                )
+                .order_by(Entity.id)
+                .with_for_update()
+            )
+            current_screen = await _load_project_index_delete_candidates(
+                session,
+                project_id=self.project_id,
+                paths=tuple(confirmed_paths),
+            )
+            current_candidates_by_path = {
+                candidate.entity.file_path: candidate for candidate in current_screen.candidates
+            }
+            deletable_candidates = tuple(
+                candidate
+                for candidate in confirmed_candidates
+                if current_candidates_by_path.get(candidate.entity.file_path) == candidate
+            )
+            changed_paths = {
+                candidate.entity.file_path
+                for candidate in confirmed_candidates
+                if candidate.entity.file_path in current_screen.indexed_paths
+                and current_candidates_by_path.get(candidate.entity.file_path) != candidate
+            }
+            disappeared_paths = {
+                candidate.entity.file_path
+                for candidate in confirmed_candidates
+                if candidate.entity.file_path not in current_screen.indexed_paths
+            }
+            skipped_paths.update(changed_paths)
+            missing_paths.update(disappeared_paths)
+            if changed_paths:
+                logger.warning(
+                    "Skipping planned index deletes whose canonical lineage changed",
+                    paths=tuple(path for path in delete_batch.paths if path in changed_paths),
+                )
+            if not deletable_candidates:
                 return ProjectIndexDeleteBatchResult(
                     deleted_entities=0,
                     missing_paths=tuple(
-                        deleted_path
-                        for deleted_path in delete_batch.paths
-                        if deleted_path in confirmed_paths
+                        path for path in delete_batch.paths if path in missing_paths
                     ),
-                    skipped_paths=skipped_paths,
+                    skipped_paths=tuple(
+                        path for path in delete_batch.paths if path in skipped_paths
+                    ),
                 )
 
-            deleted_entity_ids = tuple(int(row["id"]) for row in target_rows)
-            deleted_found_paths = frozenset(str(row["file_path"]) for row in target_rows)
+            deleted_entity_ids = tuple(
+                candidate.entity.entity_id for candidate in deletable_candidates
+            )
 
             relation_cleanup_entity_ids = await delete_project_index_entities(
                 session,
@@ -911,12 +1120,8 @@ class RepositoryProjectIndexMaintenanceStore:
         return ProjectIndexDeleteBatchResult(
             deleted_entities=len(deleted_entity_ids),
             relation_cleanup_entity_ids=relation_cleanup_entity_ids,
-            missing_paths=tuple(
-                deleted_path
-                for deleted_path in delete_batch.paths
-                if deleted_path in confirmed_paths and deleted_path not in deleted_found_paths
-            ),
-            skipped_paths=skipped_paths,
+            missing_paths=tuple(path for path in delete_batch.paths if path in missing_paths),
+            skipped_paths=tuple(path for path in delete_batch.paths if path in skipped_paths),
         )
 
 

--- a/src/basic_memory/indexing/project_index_runtime.py
+++ b/src/basic_memory/indexing/project_index_runtime.py
@@ -40,6 +40,7 @@ from basic_memory.indexing.relation_resolution import (
 )
 from basic_memory.indexing.progress import VectorSyncProgress
 from basic_memory.indexing.project_index_maintenance import (
+    ProjectIndexDeletePathVerifier,
     ProjectIndexDeleteRun,
     ProjectIndexMaintenanceRunner,
     ProjectIndexMoveRun,
@@ -172,6 +173,7 @@ def build_default_project_index_runtime(
     vector_sync: VectorSyncExecutor,
     entity_repository: RelationResolutionEntityRepository,
     entity_indexer: RelationResolutionEntityIndexer,
+    delete_path_verifier: ProjectIndexDeletePathVerifier,
     external_vector_cleaner: ProjectIndexExternalVectorCleaner | None = None,
 ) -> ProjectIndexRuntime:
     """Compose the default repository-backed project-index runtime."""
@@ -183,6 +185,7 @@ def build_default_project_index_runtime(
         session_maker=session_maker,
         project_id=project_id,
         external_vector_cleaner=external_vector_cleaner,
+        delete_path_verifier=delete_path_verifier,
     )
     return ProjectIndexRuntime(
         project_id=project_id,

--- a/test-int/test_project_index_delete_materialization_race.py
+++ b/test-int/test_project_index_delete_materialization_race.py
@@ -1,0 +1,242 @@
+"""PostgreSQL coverage for project-index deletion versus note materialization."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import Any, override
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from basic_memory import db
+import basic_memory.indexing.project_index_maintenance as project_index_maintenance_module
+from basic_memory.indexing.note_materialization_runner import (
+    NoteMaterializationSessionLock,
+    RepositoryNoteMaterializationPreflight,
+)
+from basic_memory.indexing.project_index_maintenance import (
+    ProjectIndexDeleteBatch,
+    RepositoryProjectIndexMaintenanceStore,
+)
+from basic_memory.models import Entity, NoteContent, Project
+from basic_memory.repository.note_content_repository import NoteContentRepository
+from basic_memory.runtime.note_content import (
+    RuntimeNoteMaterializationJobRequest,
+    RuntimeNoteMaterializationStatus,
+)
+
+
+@dataclass(slots=True)
+class BlockingAbsentPathVerifier:
+    """Hold the delete between its DB candidate snapshot and live absence verdict."""
+
+    entered: asyncio.Event = field(default_factory=asyncio.Event)
+    release: asyncio.Event = field(default_factory=asyncio.Event)
+
+    async def confirm_deleted_paths(self, paths: Sequence[str]) -> frozenset[str]:
+        self.entered.set()
+        await self.release.wait()
+        return frozenset(paths)
+
+
+@dataclass(slots=True)
+class StartedPreflightLock(NoteMaterializationSessionLock):
+    """Expose that materialization reached its transaction before the guarded claim."""
+
+    started: asyncio.Event = field(default_factory=asyncio.Event)
+
+    @override
+    async def lock_note_materialization(
+        self,
+        session: AsyncSession,
+        *,
+        project_id: int,
+        entity_id: int,
+    ) -> None:
+        del session, project_id, entity_id
+        self.started.set()
+
+
+async def create_synced_note(
+    session_maker,
+    *,
+    project_id: int,
+    file_path: str,
+) -> tuple[int, RuntimeNoteMaterializationJobRequest]:
+    """Create the fully synchronized state that is eligible for external deletion."""
+    db_checksum = "accepted-checksum"
+    async with db.scoped_session(session_maker) as session:
+        entity = Entity(
+            project_id=project_id,
+            title="Delete race",
+            note_type="note",
+            content_type="text/markdown",
+            file_path=file_path,
+            checksum=db_checksum,
+        )
+        session.add(entity)
+        await session.flush()
+        entity_id = entity.id
+        await NoteContentRepository(project_id=project_id).create(
+            session,
+            NoteContent(
+                entity_id=entity_id,
+                markdown_content="# Delete race\n",
+                db_version=1,
+                db_checksum=db_checksum,
+                file_version=1,
+                file_checksum=db_checksum,
+                file_write_status="synced",
+            ),
+        )
+
+    return entity_id, RuntimeNoteMaterializationJobRequest(
+        project_id=project_id,
+        entity_id=entity_id,
+        db_version=1,
+        db_checksum=db_checksum,
+        source="api",
+    )
+
+
+@pytest.mark.asyncio
+async def test_materialization_claim_wins_before_project_index_delete_revalidation(
+    engine_factory,
+    test_project: Project,
+) -> None:
+    """A claim that commits during the storage probe changes lineage and survives."""
+    engine, session_maker = engine_factory
+    if engine.dialect.name != "postgresql":
+        pytest.skip("row-lock revalidation requires PostgreSQL")
+
+    file_path = "notes/materialization-wins.md"
+    entity_id, request = await create_synced_note(
+        session_maker,
+        project_id=test_project.id,
+        file_path=file_path,
+    )
+    verifier = BlockingAbsentPathVerifier()
+    store = RepositoryProjectIndexMaintenanceStore(
+        session_maker=session_maker,
+        project_id=test_project.id,
+        delete_path_verifier=verifier,
+    )
+
+    delete_task = asyncio.create_task(
+        store.apply_project_index_delete_batch(
+            ProjectIndexDeleteBatch(completed_batches=1, paths=(file_path,))
+        )
+    )
+    await asyncio.wait_for(verifier.entered.wait(), timeout=2)
+
+    preflight_result = await asyncio.wait_for(
+        RepositoryNoteMaterializationPreflight(
+            session_maker=session_maker
+        ).prepare_note_materialization(request),
+        timeout=2,
+    )
+    verifier.release.set()
+    delete_result = await asyncio.wait_for(delete_task, timeout=2)
+
+    async with session_maker() as verification_session:
+        entity = await verification_session.get(Entity, entity_id)
+        note_content = await verification_session.get(NoteContent, entity_id)
+
+    assert preflight_result.prepared_write is not None
+    assert delete_result.deleted_entities == 0
+    assert delete_result.skipped_paths == (file_path,)
+    assert entity is not None
+    assert note_content is not None
+    assert note_content.file_write_status == "writing"
+
+
+@pytest.mark.asyncio
+async def test_project_index_delete_wins_before_materialization_claim(
+    engine_factory,
+    test_project: Project,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A claim blocked behind deletion returns missing instead of StaleDataError."""
+    engine, session_maker = engine_factory
+    if engine.dialect.name != "postgresql":
+        pytest.skip("row-lock revalidation requires PostgreSQL")
+
+    file_path = "notes/delete-wins.md"
+    entity_id, request = await create_synced_note(
+        session_maker,
+        project_id=test_project.id,
+        file_path=file_path,
+    )
+    delete_locked = asyncio.Event()
+    release_delete = asyncio.Event()
+    original_lock = project_index_maintenance_module.lock_note_content_before_entity_mutation
+
+    async def pause_after_delete_lock(
+        session: AsyncSession,
+        *,
+        project_id: int,
+        entity_ids,
+    ) -> None:
+        await original_lock(
+            session,
+            project_id=project_id,
+            entity_ids=entity_ids,
+        )
+        if not delete_locked.is_set():
+            delete_locked.set()
+            await release_delete.wait()
+
+    monkeypatch.setattr(
+        project_index_maintenance_module,
+        "lock_note_content_before_entity_mutation",
+        pause_after_delete_lock,
+    )
+    store = RepositoryProjectIndexMaintenanceStore(
+        session_maker=session_maker,
+        project_id=test_project.id,
+        delete_path_verifier=project_index_maintenance_module.TrustPlannedProjectIndexDeleteVerifier(),
+    )
+    preflight_lock = StartedPreflightLock()
+    preflight = RepositoryNoteMaterializationPreflight(
+        session_maker=session_maker,
+        session_lock=preflight_lock,
+    )
+
+    delete_task: asyncio.Task[Any] | None = None
+    preflight_task: asyncio.Task[Any] | None = None
+    try:
+        delete_task = asyncio.create_task(
+            store.apply_project_index_delete_batch(
+                ProjectIndexDeleteBatch(completed_batches=1, paths=(file_path,))
+            )
+        )
+        await asyncio.wait_for(delete_locked.wait(), timeout=2)
+
+        preflight_task = asyncio.create_task(preflight.prepare_note_materialization(request))
+        await asyncio.wait_for(preflight_lock.started.wait(), timeout=2)
+        await asyncio.sleep(0.1)
+        assert not preflight_task.done()
+
+        release_delete.set()
+        delete_result = await asyncio.wait_for(delete_task, timeout=2)
+        preflight_result = await asyncio.wait_for(preflight_task, timeout=2)
+    finally:
+        release_delete.set()
+        for task in (delete_task, preflight_task):
+            if task is not None and not task.done():
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+
+    async with session_maker() as verification_session:
+        entity = await verification_session.get(Entity, entity_id)
+        note_content = await verification_session.get(NoteContent, entity_id)
+
+    assert delete_result.deleted_entities == 1
+    assert preflight_result.terminal_result is not None
+    assert preflight_result.terminal_result.status is RuntimeNoteMaterializationStatus.missing
+    assert entity is None
+    assert note_content is None

--- a/tests/indexing/test_note_materialization_runner.py
+++ b/tests/indexing/test_note_materialization_runner.py
@@ -18,6 +18,7 @@ from basic_memory.indexing.note_materialization_runner import (
     RepositoryNoteMaterializationPreflight,
     RepositoryNoteMaterializationPublisher,
     RepositoryNoteMaterializationStatusPublisher,
+    plan_missed_note_materialization_claim,
     plan_note_materialization_preflight,
     plan_written_note_materialization_publish,
     run_note_materialization,
@@ -137,12 +138,29 @@ class FakeSessionLock:
         self.calls.append((session, project_id, entity_id))
 
 
+@dataclass(frozen=True, slots=True)
+class FakeReturningResult:
+    row: tuple[str, str | None] | None
+
+    def one_or_none(self) -> tuple[str, str | None] | None:
+        return self.row
+
+
 class FakeRepositorySession:
     def __init__(self, *, entity: Entity | None, note_content: NoteContent | None) -> None:
         self.entity = entity
         self.note_content = note_content
         self.flush_count = 0
         self.scalar_statements: list[object] = []
+        self.execute_statements: list[object] = []
+
+    async def execute(self, statement: object) -> FakeReturningResult:
+        self.execute_statements.append(statement)
+        if self.note_content is None:
+            return FakeReturningResult(row=None)
+        return FakeReturningResult(
+            row=(self.note_content.markdown_content, self.note_content.file_checksum)
+        )
 
     async def scalar(self, statement: object) -> object | None:
         self.scalar_statements.append(statement)
@@ -450,6 +468,26 @@ def test_plan_note_materialization_preflight_returns_prepared_write() -> None:
     )
 
 
+def test_plan_missed_note_materialization_claim_returns_typed_stale_result() -> None:
+    request = materialization_request()
+
+    result = plan_missed_note_materialization_claim(
+        request,
+        entity=SimpleNamespace(file_path="notes/a.md"),
+        note_content=materialization_note_content(),
+        attempted_at=datetime(2026, 6, 18, 15, 0, tzinfo=UTC),
+    )
+
+    assert result == NoteMaterializationPreflightResult.terminal(
+        RuntimeNoteMaterializationResult(
+            entity_id=42,
+            status=RuntimeNoteMaterializationStatus.stale,
+            reason="note state changed before file-write claim: 42",
+            file_path="notes/a.md",
+        )
+    )
+
+
 @pytest.mark.asyncio
 async def test_repository_note_materialization_preflight_marks_current_note_writing() -> None:
     request = materialization_request()
@@ -488,9 +526,43 @@ async def test_repository_note_materialization_preflight_marks_current_note_writ
         )
     )
     assert session_lock.calls == [(cast(AsyncSession, session), 7, 42)]
-    assert note_content.file_write_status == "writing"
-    assert note_content.last_materialization_attempt_at == attempted_at
-    assert session.flush_count == 1
+    assert len(session.execute_statements) == 1
+    assert "UPDATE note_content" in str(session.execute_statements[0])
+    assert "RETURNING note_content.markdown_content" in str(session.execute_statements[0])
+    assert session.flush_count == 0
+
+
+@pytest.mark.asyncio
+async def test_repository_note_materialization_preflight_returns_missing_after_claim_miss() -> None:
+    request = materialization_request()
+    session = FakeRepositorySession(entity=None, note_content=None)
+    scoped_session = RecordingScopedSession(
+        scoped_session=FakeScopedSession(session),
+        opened_session_makers=[],
+    )
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_materialization_runner.db.scoped_session",
+            scoped_session,
+        )
+        result = await RepositoryNoteMaterializationPreflight(
+            session_maker=cast(async_sessionmaker[AsyncSession], object()),
+        ).prepare_note_materialization(request)
+
+    assert result == NoteMaterializationPreflightResult.terminal(
+        RuntimeNoteMaterializationResult(
+            entity_id=42,
+            status=RuntimeNoteMaterializationStatus.missing,
+            reason="note state no longer exists: 42",
+        ),
+        cleanup_file=RuntimePendingNoteFileDelete(
+            project_id=7,
+            entity_id=42,
+            file_path="notes/old.md",
+            file_checksum="old-cleanup-sum",
+        ),
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_project_index_maintenance.py
+++ b/tests/indexing/test_project_index_maintenance.py
@@ -3,6 +3,7 @@
 from collections.abc import AsyncIterator, Iterator, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import override, cast
 
@@ -130,6 +131,106 @@ class FakeProjectIndexResult:
 
     def mappings(self) -> FakeProjectIndexMappingResult:
         return FakeProjectIndexMappingResult(self.mapping_rows)
+
+
+def storage_owned_delete_candidate_row(entity_id: int, file_path: str) -> dict[str, object]:
+    """Return the persistence projection for one storage-owned delete candidate."""
+    return {
+        "entity_id": entity_id,
+        "file_path": file_path,
+        "note_content_entity_id": None,
+        "db_version": None,
+        "db_checksum": None,
+        "file_version": None,
+        "file_checksum": None,
+        "file_write_status": None,
+        "last_materialization_attempt_at": None,
+    }
+
+
+def materialized_delete_candidate_row(
+    entity_id: int,
+    file_path: str,
+    *,
+    file_write_status: str = "synced",
+    db_version: int = 3,
+    db_checksum: str = "current-checksum",
+    file_version: int | None = 3,
+    file_checksum: str | None = "current-checksum",
+    last_materialization_attempt_at: object = None,
+) -> dict[str, object]:
+    """Return the persistence projection for one accepted note delete candidate."""
+    return {
+        "entity_id": entity_id,
+        "file_path": file_path,
+        "note_content_entity_id": entity_id,
+        "db_version": db_version,
+        "db_checksum": db_checksum,
+        "file_version": file_version,
+        "file_checksum": file_checksum,
+        "file_write_status": file_write_status,
+        "last_materialization_attempt_at": last_materialization_attempt_at,
+    }
+
+
+def test_project_index_delete_candidate_constructs_fully_materialized_note() -> None:
+    attempted_at = datetime(2026, 8, 14, 12, 0, tzinfo=UTC)
+
+    candidate = project_index_maintenance_module._project_index_delete_candidate_from_row(
+        materialized_delete_candidate_row(
+            10,
+            "notes/a.md",
+            last_materialization_attempt_at=attempted_at,
+        )
+    )
+
+    assert (
+        candidate
+        == project_index_maintenance_module.MaterializedNoteProjectIndexDeleteCandidate(
+            entity=project_index_maintenance_module.ProjectIndexDeleteEntity(
+                entity_id=10,
+                file_path="notes/a.md",
+            ),
+            db_version=3,
+            db_checksum="current-checksum",
+            file_version=3,
+            file_checksum="current-checksum",
+            last_materialization_attempt_at=attempted_at,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides"),
+    [
+        {"file_write_status": "pending"},
+        {"file_write_status": "writing"},
+        {"file_write_status": "failed"},
+        {"file_write_status": "external_change_detected"},
+        {"file_version": 2},
+        {"file_checksum": "older-checksum"},
+    ],
+)
+def test_project_index_delete_candidate_rejects_unsynchronized_note_state(
+    overrides: dict[str, object],
+) -> None:
+    row = materialized_delete_candidate_row(10, "notes/a.md")
+    row.update(overrides)
+
+    candidate = project_index_maintenance_module._project_index_delete_candidate_from_row(row)
+
+    assert candidate is None
+
+
+def test_project_index_delete_candidate_rejects_invalid_attempt_timestamp() -> None:
+    row = materialized_delete_candidate_row(
+        10,
+        "notes/a.md",
+        last_materialization_attempt_at="not-a-datetime",
+    )
+
+    with pytest.raises(TypeError, match="last_materialization_attempt_at must be a datetime"):
+        project_index_maintenance_module._project_index_delete_candidate_from_row(row)
 
 
 @dataclass(slots=True)
@@ -894,6 +995,92 @@ class StaticDeletePathVerifier:
 
 
 @pytest.mark.asyncio
+async def test_repository_project_index_maintenance_store_requires_live_delete_verifier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_maker = cast(async_sessionmaker[AsyncSession], object())
+    session = FakeProjectIndexSession(
+        results=[
+            FakeProjectIndexResult(
+                mapping_rows=[storage_owned_delete_candidate_row(10, "notes/a.md")]
+            )
+        ]
+    )
+
+    @asynccontextmanager
+    async def fake_scoped_session(
+        scoped_session_maker: async_sessionmaker[AsyncSession],
+    ) -> AsyncIterator[FakeProjectIndexSession]:
+        assert scoped_session_maker is session_maker
+        yield session
+
+    monkeypatch.setattr(
+        project_index_maintenance_module.db,
+        "scoped_session",
+        fake_scoped_session,
+    )
+
+    store = RepositoryProjectIndexMaintenanceStore(
+        session_maker=session_maker,
+        project_id=42,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="project-index delete requires a live storage path verifier",
+    ):
+        await store.apply_project_index_delete_batch(
+            ProjectIndexDeleteBatch(completed_batches=1, paths=("notes/a.md",))
+        )
+
+
+@pytest.mark.asyncio
+async def test_repository_project_index_maintenance_store_protects_pending_note_without_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_maker = cast(async_sessionmaker[AsyncSession], object())
+    session = FakeProjectIndexSession(
+        results=[
+            FakeProjectIndexResult(
+                mapping_rows=[
+                    materialized_delete_candidate_row(
+                        10,
+                        "notes/pending.md",
+                        file_write_status="pending",
+                        file_version=None,
+                        file_checksum=None,
+                    )
+                ]
+            )
+        ]
+    )
+
+    @asynccontextmanager
+    async def fake_scoped_session(
+        scoped_session_maker: async_sessionmaker[AsyncSession],
+    ) -> AsyncIterator[FakeProjectIndexSession]:
+        yield session
+
+    monkeypatch.setattr(
+        project_index_maintenance_module.db,
+        "scoped_session",
+        fake_scoped_session,
+    )
+
+    result = await RepositoryProjectIndexMaintenanceStore(
+        session_maker=session_maker,
+        project_id=42,
+    ).apply_project_index_delete_batch(
+        ProjectIndexDeleteBatch(completed_batches=1, paths=("notes/pending.md",))
+    )
+
+    assert result == ProjectIndexDeleteBatchResult(
+        deleted_entities=0,
+        skipped_paths=("notes/pending.md",),
+    )
+
+
+@pytest.mark.asyncio
 async def test_repository_project_index_maintenance_store_skips_deletes_for_reappeared_paths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -903,9 +1090,16 @@ async def test_repository_project_index_maintenance_store_skips_deletes_for_reap
         results=[
             FakeProjectIndexResult(
                 mapping_rows=[
-                    {"id": 10, "file_path": "notes/a.md"},
+                    storage_owned_delete_candidate_row(10, "notes/a.md"),
+                    storage_owned_delete_candidate_row(20, "notes/reappeared.md"),
                 ]
             ),
+            FakeProjectIndexResult(),  # sorted NoteContent lock fence
+            FakeProjectIndexResult(),  # sorted Entity lock fence
+            FakeProjectIndexResult(
+                mapping_rows=[storage_owned_delete_candidate_row(10, "notes/a.md")]
+            ),
+            FakeProjectIndexResult(),  # delete helper NoteContent fence
             FakeProjectIndexResult(scalar_values=[]),
         ]
     )
@@ -950,7 +1144,16 @@ async def test_repository_project_index_maintenance_store_skips_whole_batch_when
 ) -> None:
     """When no planned delete is re-confirmed absent, the database is not touched."""
     session_maker = cast(async_sessionmaker[AsyncSession], object())
-    session = FakeProjectIndexSession(results=[])
+    session = FakeProjectIndexSession(
+        results=[
+            FakeProjectIndexResult(
+                mapping_rows=[
+                    storage_owned_delete_candidate_row(10, "notes/a.md"),
+                    storage_owned_delete_candidate_row(20, "notes/b.md"),
+                ]
+            )
+        ]
+    )
 
     @asynccontextmanager
     async def fake_scoped_session(
@@ -981,7 +1184,7 @@ async def test_repository_project_index_maintenance_store_skips_whole_batch_when
         deleted_entities=0,
         skipped_paths=("notes/a.md", "notes/b.md"),
     )
-    assert session.statements == []
+    assert len(session.statements) == 1
 
 
 @pytest.mark.asyncio
@@ -1178,11 +1381,19 @@ async def test_repository_project_index_maintenance_store_applies_delete_batch(
         results=[
             FakeProjectIndexResult(
                 mapping_rows=[
-                    {"id": 10, "file_path": "notes/a.md"},
-                    {"id": 20, "file_path": "notes/b.md"},
+                    storage_owned_delete_candidate_row(10, "notes/a.md"),
+                    storage_owned_delete_candidate_row(20, "notes/b.md"),
                 ]
             ),
             FakeProjectIndexResult(),  # sorted NoteContent lock fence
+            FakeProjectIndexResult(),  # sorted Entity lock fence
+            FakeProjectIndexResult(
+                mapping_rows=[
+                    storage_owned_delete_candidate_row(10, "notes/a.md"),
+                    storage_owned_delete_candidate_row(20, "notes/b.md"),
+                ]
+            ),
+            FakeProjectIndexResult(),  # delete helper NoteContent fence
             FakeProjectIndexResult(scalar_values=[99]),
         ]
     )
@@ -1203,6 +1414,7 @@ async def test_repository_project_index_maintenance_store_applies_delete_batch(
     store = RepositoryProjectIndexMaintenanceStore(
         session_maker=session_maker,
         project_id=42,
+        delete_path_verifier=project_index_maintenance_module.TrustPlannedProjectIndexDeleteVerifier(),
     )
 
     result = await store.apply_project_index_delete_batch(
@@ -1217,13 +1429,16 @@ async def test_repository_project_index_maintenance_store_applies_delete_batch(
         relation_cleanup_entity_ids=frozenset({99}),
         missing_paths=("notes/missing.md",),
     )
-    assert len(session.statements) == 6
-    assert "SELECT entity.id, entity.file_path" in str(session.statements[0])
+    assert len(session.statements) == 9
+    assert "LEFT OUTER JOIN note_content" in str(session.statements[0])
     assert "ORDER BY note_content.entity_id" in str(session.statements[1])
-    assert "SELECT DISTINCT relation.from_id" in str(session.statements[2])
-    assert "DELETE FROM search_index" in str(session.statements[3])
-    assert "sqlite_master" in str(session.statements[4])
-    assert "DELETE FROM entity" in str(session.statements[5])
+    assert "FOR UPDATE" in str(session.statements[2])
+    assert "LEFT OUTER JOIN note_content" in str(session.statements[3])
+    assert "ORDER BY note_content.entity_id" in str(session.statements[4])
+    assert "SELECT DISTINCT relation.from_id" in str(session.statements[5])
+    assert "DELETE FROM search_index" in str(session.statements[6])
+    assert "sqlite_master" in str(session.statements[7])
+    assert "DELETE FROM entity" in str(session.statements[8])
 
 
 @pytest.mark.asyncio
@@ -1234,9 +1449,12 @@ async def test_repository_project_index_maintenance_store_deletes_vector_embeddi
     session = FakeProjectIndexSession(
         results=[
             FakeProjectIndexResult(
-                mapping_rows=[
-                    {"id": 10, "file_path": "notes/a.md"},
-                ]
+                mapping_rows=[storage_owned_delete_candidate_row(10, "notes/a.md")]
+            ),
+            FakeProjectIndexResult(),
+            FakeProjectIndexResult(),
+            FakeProjectIndexResult(
+                mapping_rows=[storage_owned_delete_candidate_row(10, "notes/a.md")]
             ),
             FakeProjectIndexResult(),
             FakeProjectIndexResult(scalar_values=[]),
@@ -1276,6 +1494,7 @@ async def test_repository_project_index_maintenance_store_deletes_vector_embeddi
     store = RepositoryProjectIndexMaintenanceStore(
         session_maker=session_maker,
         project_id=42,
+        delete_path_verifier=project_index_maintenance_module.TrustPlannedProjectIndexDeleteVerifier(),
     )
 
     result = await store.apply_project_index_delete_batch(
@@ -1309,9 +1528,12 @@ async def test_repository_project_index_maintenance_store_skips_vector_cleanup_w
     session = FakeProjectIndexSession(
         results=[
             FakeProjectIndexResult(
-                mapping_rows=[
-                    {"id": 10, "file_path": "notes/a.md"},
-                ]
+                mapping_rows=[storage_owned_delete_candidate_row(10, "notes/a.md")]
+            ),
+            FakeProjectIndexResult(),
+            FakeProjectIndexResult(),
+            FakeProjectIndexResult(
+                mapping_rows=[storage_owned_delete_candidate_row(10, "notes/a.md")]
             ),
             FakeProjectIndexResult(),
             FakeProjectIndexResult(scalar_values=[]),
@@ -1336,6 +1558,7 @@ async def test_repository_project_index_maintenance_store_skips_vector_cleanup_w
     store = RepositoryProjectIndexMaintenanceStore(
         session_maker=session_maker,
         project_id=42,
+        delete_path_verifier=project_index_maintenance_module.TrustPlannedProjectIndexDeleteVerifier(),
     )
 
     result = await store.apply_project_index_delete_batch(

--- a/tests/indexing/test_project_index_runtime.py
+++ b/tests/indexing/test_project_index_runtime.py
@@ -24,6 +24,7 @@ from basic_memory.indexing.project_index_maintenance import (
     ProjectIndexMoveBatchResult,
     RepositoryProjectIndexMaintenanceStore,
     StoreProjectIndexMaintenanceRunner,
+    TrustPlannedProjectIndexDeleteVerifier,
 )
 from basic_memory.indexing.embedding_index_planning import RepositoryVectorSyncEntitySource
 from basic_memory.indexing.forward_reference_resolution import (
@@ -207,6 +208,7 @@ def test_build_default_project_index_runtime_composes_repository_backed_runtime(
     vector_sync = NoopVectorSync()
     entity_repository = NoopEntityRepository()
     entity_indexer = NoopEntityIndexer()
+    delete_path_verifier = TrustPlannedProjectIndexDeleteVerifier()
 
     runtime = build_default_project_index_runtime(
         project_id=7,
@@ -214,6 +216,7 @@ def test_build_default_project_index_runtime_composes_repository_backed_runtime(
         vector_sync=vector_sync,
         entity_repository=entity_repository,
         entity_indexer=entity_indexer,
+        delete_path_verifier=delete_path_verifier,
     )
 
     assert isinstance(runtime, ProjectIndexRuntime)
@@ -225,6 +228,7 @@ def test_build_default_project_index_runtime_composes_repository_backed_runtime(
     assert isinstance(runtime.maintenance, StoreProjectIndexMaintenanceRunner)
     assert isinstance(runtime.maintenance.move_store, RepositoryProjectIndexMaintenanceStore)
     assert runtime.maintenance.move_store is runtime.maintenance.delete_store
+    assert runtime.maintenance.move_store.delete_path_verifier is delete_path_verifier
     assert isinstance(
         runtime.forward_reference_relation_source,
         RepositoryForwardReferenceRelationSource,


### PR DESCRIPTION
## Why

Project indexing compares a storage listing with database state observed later. A note accepted
after that listing but before delete maintenance could therefore be classified as externally
deleted, even when its canonical `NoteContent` had not yet reached storage. Applying that stale
plan deleted the accepted entity and note content.

This closes #1256 by making destructive project-index maintenance prove both sides of the delete
decision at apply time: the database row must be in a positive delete-eligible state and the path
must still be absent from current storage.

## What Changed

- Model project-index deletion eligibility as typed positive candidates:
  - storage-owned entities without `NoteContent`
  - accepted notes whose file status, version, and checksum are fully synchronized
- Require scan runtimes to inject a live path verifier; project scans now fail closed without one.
- Re-probe candidate paths outside the database transaction, then lock and revalidate the exact
  candidate lineage before deletion.
- Replace materialization's ORM load/mutate/flush preflight with a guarded
  `UPDATE ... RETURNING` claim.
- Add real PostgreSQL regression coverage for both materialization/delete winner orderings.
- Document the repository's PostgreSQL Read Committed assumptions and canonical lock order in
  `docs/TRANSACTION_ISOLATION.md`.

## Implementation Details

Deletion now runs in three phases:

1. Snapshot only valid DB candidates. Pending, writing, failed, externally changed, and partially
   synchronized notes are protected before any storage call.
2. Positively verify current path absence outside a database transaction.
3. Lock `NoteContent` before `Entity`, reload the candidates under Read Committed, and delete only
   rows whose full lineage still matches the snapshot.

The materialization-attempt timestamp participates in candidate equality. That closes the
same-version ABA window where materialization can move from `synced` to `writing`, create the file,
and return to `synced` while the absence probe is in flight.

Materialization claims the queued `(project_id, entity_id, db_version, db_checksum)` in one
conditional update. PostgreSQL waits on a conflicting delete and re-evaluates the predicate against
the current row version, so a delete winner becomes a typed missing result instead of an expected
`StaleDataError`.

Database locks remain narrow and are never held across storage I/O. The existing
`NoteContent`-before-`Entity` order is preserved.

## Testing

### Automated

- `just fast-check`: passed
- `uv run pytest tests/indexing/test_note_materialization_runner.py tests/indexing/test_project_index_maintenance.py tests/indexing/test_project_index_runtime.py -q --no-cov`: 65 passed
- `BASIC_MEMORY_TEST_POSTGRES=1 uv run pytest test-int/test_project_index_delete_materialization_race.py -q --no-cov`: 2 passed
- `just doctor`: passed
- `git diff --check origin/main...HEAD`: passed

### Manual

- Reviewed the concurrency model against the PostgreSQL transaction-isolation and explicit-locking
  documentation linked from `docs/TRANSACTION_ISOLATION.md`.

## Risks / Follow-ups

- Eligible scan-planned deletes now pay for a current per-path storage probe. The probe happens only
  after DB eligibility filtering and outside the transaction.
- Cloud must inject its strongly consistent Tigris HEAD verifier after this Core API lands. That
  companion change is implemented and tested separately, but its dependency pin cannot be updated
  until this commit is available to Cloud.
- No production recovery or deployment is included in this PR.

## Reviewer Guide

1. Review the candidate model and three-phase delete flow in
   `project_index_maintenance.py`.
2. Review the guarded claim in `note_materialization_runner.py`.
3. Read `test_project_index_delete_materialization_race.py` for the two PostgreSQL interleavings.
4. Use `docs/TRANSACTION_ISOLATION.md` as the durable statement of the concurrency contract.
