### PR TITLE
docs(core): fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,11 +689,11 @@ Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Star History
 
-<a href="https://www.star-history.com/#basicmachines-co/basic-memory&Date">
+<a href="https://star-history.dera.page/#basicmachines-co/basic-memory&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=basicmachines-co/basic-memory&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=basicmachines-co/basic-memory&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=basicmachines-co/basic-memory&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=basicmachines-co/basic-memory&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=basicmachines-co/basic-memory&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=basicmachines-co/basic-memory&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart at the bottom of the README is currently broken and shows nothing, which looks bad for the project's main landing page. The chart was served by a service that no longer works, so this PR switches it to the replacement that is already widely used across open source projects.

No other content in the README is changed.