### PR TITLE
feat(mcp): add directory listing sorting

### DIFF
--- a/src/basic_memory/api/v2/routers/directory_router.py
+++ b/src/basic_memory/api/v2/routers/directory_router.py
@@ -32,6 +32,7 @@ from basic_memory.schemas.directory import (
     MAX_DIRECTORY_PAGE_SIZE,
     DirectoryListResponse,
     DirectoryNode,
+    DirectorySortOrder,
 )
 
 router = APIRouter(prefix="/directory", tags=["directory-v2"])
@@ -150,6 +151,13 @@ async def list_directory(
     dir_name: str = Query("/", description="Directory path to list"),
     depth: int = Query(1, ge=1, le=10, description="Recursion depth (1-10)"),
     file_name_glob: str | None = Query(None, description="Glob pattern for filtering file names"),
+    sort: DirectorySortOrder | None = Query(
+        None,
+        description=(
+            "Optional file ordering. Directories are always returned first; omitting sort "
+            "preserves legacy filename ordering."
+        ),
+    ),
     page: int = Query(1, ge=1, description="One-indexed result page"),
     page_size: int = Query(
         DEFAULT_DIRECTORY_PAGE_SIZE,
@@ -166,6 +174,7 @@ async def list_directory(
         dir_name: Directory path to list (default: root "/")
         depth: Recursion depth (1-10, default: 1 for immediate children only)
         file_name_glob: Optional glob pattern for filtering file names (e.g., "*.md", "*meeting*")
+        sort: Optional title or updated-time ordering for files
         page: One-indexed result page
         page_size: Number of nodes per page (1-200)
 
@@ -179,6 +188,7 @@ async def list_directory(
             dir_name,
             str(depth),
             file_name_glob or "",
+            sort or "",
             str(page),
             str(page_size),
         ),
@@ -196,6 +206,7 @@ async def list_directory(
             dir_name=dir_name,
             depth=depth,
             file_name_glob=file_name_glob,
+            sort=sort,
             page=page,
             page_size=page_size,
         )

--- a/src/basic_memory/mcp/clients/directory.py
+++ b/src/basic_memory/mcp/clients/directory.py
@@ -7,7 +7,11 @@ from typing import Any, Optional
 
 from httpx import AsyncClient
 
-from basic_memory.schemas.directory import DEFAULT_DIRECTORY_PAGE_SIZE, DirectoryListResponse
+from basic_memory.schemas.directory import (
+    DEFAULT_DIRECTORY_PAGE_SIZE,
+    DirectoryListResponse,
+    DirectorySortOrder,
+)
 
 # call_* helpers live in basic_memory.mcp.tools.utils; importing that at module
 # level executes the whole tools package (fastmcp + mcp SDK) during CLI startup,
@@ -45,6 +49,7 @@ class DirectoryClient:
         *,
         depth: int = 1,
         file_name_glob: Optional[str] = None,
+        sort: DirectorySortOrder | None = None,
         page: int = 1,
         page_size: int = DEFAULT_DIRECTORY_PAGE_SIZE,
     ) -> DirectoryListResponse:
@@ -54,6 +59,7 @@ class DirectoryClient:
             dir_name: Directory path to list (default: root)
             depth: How deep to traverse (default: 1)
             file_name_glob: Optional glob pattern to filter files
+            sort: Optional title or updated-time ordering for files
             page: One-indexed result page
             page_size: Number of nodes per page
 
@@ -73,6 +79,8 @@ class DirectoryClient:
         }
         if file_name_glob:
             params["file_name_glob"] = file_name_glob
+        if sort is not None:
+            params["sort"] = sort
 
         response = await call_get(
             self.http_client,

--- a/src/basic_memory/mcp/tools/list_directory.py
+++ b/src/basic_memory/mcp/tools/list_directory.py
@@ -11,6 +11,7 @@ from basic_memory.mcp.server import mcp
 from basic_memory.schemas.directory import (
     DEFAULT_DIRECTORY_PAGE_SIZE,
     MAX_DIRECTORY_PAGE_SIZE,
+    DirectorySortOrder,
 )
 
 
@@ -42,6 +43,7 @@ async def list_directory(
             validation_alias=AliasChoices("file_name_glob", "glob", "pattern", "filter"),
         ),
     ] = None,
+    sort: DirectorySortOrder | None = None,
     page: int = 1,
     page_size: Annotated[
         int,
@@ -68,6 +70,8 @@ async def list_directory(
                Higher values show subdirectory contents recursively
         file_name_glob: Optional glob pattern for filtering file names
                        Examples: "*.md", "*meeting*", "project_*"
+        sort: Optional file ordering: "title_asc", "title_desc", "updated_asc",
+              or "updated_desc". Directories remain first.
         page: One-indexed result page (default: 1)
         page_size: Number of nodes per page (default: 10, maximum: 200)
         output_format: "text" for a readable listing or "json" for structured pagination data
@@ -100,6 +104,9 @@ async def list_directory(
         # Continue a large listing
         list_directory(dir_name="/projects", page=2, page_size=10)
 
+        # List folders first, then notes from newest to oldest
+        list_directory(dir_name="/projects", sort="updated_desc")
+
         # Explicit project specification
         list_directory(project="work-docs", dir_name="/projects")
 
@@ -118,7 +125,8 @@ async def list_directory(
         active_project,
     ):
         logger.debug(
-            f"Listing directory '{dir_name}' in project {project} with depth={depth}, glob='{file_name_glob}'"
+            f"Listing directory '{dir_name}' in project {project} with "
+            f"depth={depth}, glob='{file_name_glob}', sort={sort}"
         )
 
         # Import here to avoid circular import
@@ -130,6 +138,7 @@ async def list_directory(
             dir_name,
             depth=depth,
             file_name_glob=file_name_glob,
+            sort=sort,
             page=page,
             page_size=page_size,
         )
@@ -158,16 +167,13 @@ async def list_directory(
         )
         output_lines.append("")
 
-        # Group by type and sort
+        # The API has already applied the requested stable order. Partitioning
+        # preserves that order while retaining the existing text presentation.
         directories = [n for n in nodes if n["type"] == "directory"]
         files = [n for n in nodes if n["type"] == "file"]
 
         if not nodes:
             output_lines.append("No items on this page.")
-
-        # Sort by name
-        directories.sort(key=lambda x: x["name"])
-        files.sort(key=lambda x: x["name"])
 
         # Display directories first
         for node in directories:
@@ -247,6 +253,8 @@ async def list_directory(
             ]
             if file_name_glob:
                 continuation_args.append(f"file_name_glob={file_name_glob!r}")
+            if sort is not None:
+                continuation_args.append(f"sort={sort!r}")
             if project_id:
                 continuation_args.append(f"project_id={project_id!r}")
             elif project:

--- a/src/basic_memory/schemas/directory.py
+++ b/src/basic_memory/schemas/directory.py
@@ -1,12 +1,19 @@
 """Schemas for directory tree operations."""
 
 from datetime import datetime
-from typing import List, Optional, Literal
+from typing import List, Literal, Optional
 
 from pydantic import BaseModel
 
 DEFAULT_DIRECTORY_PAGE_SIZE = 10
 MAX_DIRECTORY_PAGE_SIZE = 200
+
+type DirectorySortOrder = Literal[
+    "title_asc",
+    "title_desc",
+    "updated_asc",
+    "updated_desc",
+]
 
 
 class DirectoryNode(BaseModel):

--- a/src/basic_memory/services/directory_service.py
+++ b/src/basic_memory/services/directory_service.py
@@ -3,8 +3,8 @@
 import fnmatch
 import logging
 import os
-from typing import Dict, List, Optional, Sequence
-
+from datetime import datetime
+from typing import Dict, List, Optional, Sequence, assert_never
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -16,9 +16,26 @@ from basic_memory.schemas.directory import (
     MAX_DIRECTORY_PAGE_SIZE,
     DirectoryListResponse,
     DirectoryNode,
+    DirectorySortOrder,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _required_file_updated_at(node: DirectoryNode) -> datetime:
+    """Return the timestamp required by an explicit updated-time sort."""
+    if node.updated_at is None:
+        raise ValueError(f"File directory node '{node.directory_path}' is missing updated_at")
+    return node.updated_at
+
+
+def _file_identity_key(node: DirectoryNode) -> tuple[str, str, str]:
+    """Order files deterministically by display title, path, then stable identity."""
+    return (
+        (node.title or node.name).casefold(),
+        node.directory_path.casefold(),
+        node.external_id or "",
+    )
 
 
 class DirectoryService:
@@ -155,6 +172,7 @@ class DirectoryService:
         dir_name: str = "/",
         depth: int = 1,
         file_name_glob: Optional[str] = None,
+        sort: DirectorySortOrder | None = None,
         page: int = 1,
         page_size: int = DEFAULT_DIRECTORY_PAGE_SIZE,
     ) -> DirectoryListResponse:
@@ -164,6 +182,7 @@ class DirectoryService:
             dir_name: Directory path to list (default: root "/")
             depth: Recursion depth (1 = immediate children only)
             file_name_glob: Glob pattern for filtering file names
+            sort: Optional title or updated-time ordering for files
             page: One-indexed result page
             page_size: Number of nodes per page
 
@@ -211,19 +230,51 @@ class DirectoryService:
             )
 
         # Collect nodes with depth and glob filtering
-        result = []
+        result: list[DirectoryNode] = []
         self._collect_nodes_recursive(target_node, result, depth, file_name_glob, 0)
 
-        # Stable ordering is required before slicing so repeated page requests
-        # neither skip nor duplicate nodes when repository row order changes.
-        result.sort(
-            key=lambda node: (
-                0 if node.type == "directory" else 1,
-                node.name.casefold(),
-                node.directory_path.casefold(),
-                node.directory_path,
+        if sort is None:
+            # Omitting sort is a compatibility contract: existing callers retain the
+            # historical folders-first filename order.
+            result.sort(
+                key=lambda node: (
+                    0 if node.type == "directory" else 1,
+                    node.name.casefold(),
+                    node.directory_path.casefold(),
+                    node.directory_path,
+                )
             )
-        )
+        else:
+            directories = [node for node in result if node.type == "directory"]
+            files = [node for node in result if node.type == "file"]
+
+            # Directories are implicit projections of file paths, so they have no
+            # canonical updated_at. Title sorting applies the selected direction to
+            # folder names; updated sorting keeps the folder group name-ascending.
+            directories.sort(
+                key=lambda node: (
+                    node.name.casefold(),
+                    node.directory_path.casefold(),
+                    node.directory_path,
+                ),
+                reverse=sort == "title_desc",
+            )
+
+            match sort:
+                case "title_asc" | "title_desc":
+                    files.sort(key=_file_identity_key, reverse=sort == "title_desc")
+                case "updated_asc" | "updated_desc":
+                    # Stable secondary ordering prevents equal timestamps from moving
+                    # between pages when repository row order changes.
+                    files.sort(key=_file_identity_key)
+                    files.sort(
+                        key=_required_file_updated_at,
+                        reverse=sort == "updated_desc",
+                    )
+                case _ as unreachable:  # pragma: no cover - closed type is exhaustive
+                    assert_never(unreachable)
+
+            result = [*directories, *files]
 
         total = len(result)
         start = (page - 1) * page_size

--- a/test-int/read_cache/test_api_read_cache.py
+++ b/test-int/read_cache/test_api_read_cache.py
@@ -471,6 +471,18 @@ async def test_directory_reads_cache_then_project_invalidation_refreshes(
                 updated_at=datetime.now(timezone.utc),
             ),
         )
+        await repository.add(
+            session,
+            Entity(
+                title="Zebra cached directory note",
+                note_type="note",
+                content_type="text/markdown",
+                file_path="cache-surface/second.md",
+                checksum="second-cached-directory-checksum",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            ),
+        )
 
     app.dependency_overrides[get_read_cache] = lambda: redis_cache.cache
     tree_url = f"{project_url}/directory/tree"
@@ -486,16 +498,30 @@ async def test_directory_reads_cache_then_project_invalidation_refreshes(
     first_tree_response = await client.get(tree_url)
     first_structure_response = await client.get(structure_url)
     first_list_response = await client.get(list_url, params=list_params)
+    title_desc_response = await client.get(
+        list_url,
+        params={**list_params, "sort": "title_desc"},
+    )
     assert first_tree_response.status_code == 200
     assert first_structure_response.status_code == 200
     assert first_list_response.status_code == 200
+    assert title_desc_response.status_code == 200
 
     first_tree = DirectoryNode.model_validate(first_tree_response.json())
     first_structure = DirectoryNode.model_validate(first_structure_response.json())
     first_list = DirectoryListResponse.model_validate(first_list_response.json())
+    title_desc_list = DirectoryListResponse.model_validate(title_desc_response.json())
     assert "/cache-surface/after-cache" not in descendant_paths(first_tree)
     assert "/cache-surface/after-cache" not in descendant_paths(first_structure)
     assert "/cache-surface/after-cache" not in {node.directory_path for node in first_list.nodes}
+    assert [node.title for node in first_list.nodes] == [
+        "Existing cached directory note",
+        "Zebra cached directory note",
+    ]
+    assert [node.title for node in title_desc_list.nodes] == [
+        "Zebra cached directory note",
+        "Existing cached directory note",
+    ]
 
     cache_keys = (
         _cache_key(
@@ -512,7 +538,13 @@ async def test_directory_reads_cache_then_project_invalidation_refreshes(
             project_id=project_external_id,
             operation=ReadCacheOperation.directory_list,
             request="/cache-surface",
-            request_context=("2", "", "1", "200"),
+            request_context=("2", "", "", "1", "200"),
+        ),
+        _cache_key(
+            project_id=project_external_id,
+            operation=ReadCacheOperation.directory_list,
+            request="/cache-surface",
+            request_context=("2", "", "title_desc", "1", "200"),
         ),
     )
     for key in cache_keys:
@@ -540,9 +572,14 @@ async def test_directory_reads_cache_then_project_invalidation_refreshes(
     cached_tree_response = await client.get(tree_url)
     cached_structure_response = await client.get(structure_url)
     cached_list_response = await client.get(list_url, params=list_params)
+    cached_title_desc_response = await client.get(
+        list_url,
+        params={**list_params, "sort": "title_desc"},
+    )
     assert cached_tree_response.json() == first_tree_response.json()
     assert cached_structure_response.json() == first_structure_response.json()
     assert cached_list_response.json() == first_list_response.json()
+    assert cached_title_desc_response.json() == title_desc_response.json()
 
     await redis_cache.cache.invalidate_project(project_external_id)
 

--- a/tests/api/v2/test_directory_router.py
+++ b/tests/api/v2/test_directory_router.py
@@ -115,6 +115,39 @@ async def test_list_directory_with_pagination(
 
 
 @pytest.mark.asyncio
+async def test_list_directory_with_sort(
+    client: AsyncClient,
+    test_graph,
+    v2_project_url: str,
+):
+    """The API validates and applies the closed directory sort contract."""
+    response = await client.get(
+        f"{v2_project_url}/directory/list",
+        params={"dir_name": "/test", "sort": "title_desc", "page_size": 200},
+    )
+
+    assert response.status_code == 200
+    listing = DirectoryListResponse.model_validate(response.json())
+    assert [node.name for node in listing.nodes] == [
+        "Root.md",
+        "Deeper Entity.md",
+        "Deep Entity.md",
+        "Connected Entity 2.md",
+        "Connected Entity 1.md",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_directory_rejects_invalid_sort(
+    client: AsyncClient,
+    v2_project_url: str,
+):
+    response = await client.get(f"{v2_project_url}/directory/list?sort=not-supported")
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("query", ["page=0", "page_size=0", "page_size=201"])
 async def test_list_directory_rejects_invalid_pagination(
     client: AsyncClient,

--- a/tests/mcp/clients/test_clients.py
+++ b/tests/mcp/clients/test_clients.py
@@ -445,6 +445,7 @@ class TestDirectoryClient:
                 "page": 2,
                 "page_size": 4,
                 "file_name_glob": "*.md",
+                "sort": "updated_desc",
             }
             return mock_response
 
@@ -452,11 +453,39 @@ class TestDirectoryClient:
 
         mock_http = MagicMock()
         client = DirectoryClient(mock_http, "proj-123")
-        result = await client.list("/", depth=2, file_name_glob="*.md", page=2, page_size=4)
+        result = await client.list(
+            "/",
+            depth=2,
+            file_name_glob="*.md",
+            sort="updated_desc",
+            page=2,
+            page_size=4,
+        )
         assert len(result.nodes) == 1
         assert result.nodes[0].name == "folder"
         assert result.page == 2
         assert result.total == 5
+
+    @pytest.mark.asyncio
+    async def test_list_omits_optional_sort_by_default(self, monkeypatch):
+        """Legacy callers do not acquire an implicit explicit-sort behavior."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "nodes": [],
+            "page": 1,
+            "page_size": 10,
+            "total": 0,
+            "has_more": False,
+        }
+
+        async def mock_call_get(client, url, **kwargs):
+            assert "sort" not in kwargs["params"]
+            return mock_response
+
+        monkeypatch.setattr("basic_memory.mcp.tools.utils.call_get", mock_call_get)
+
+        client = DirectoryClient(MagicMock(), "proj-123")
+        await client.list()
 
 
 class TestResourceClient:

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -53,6 +53,7 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "dir_name",
         "depth",
         "file_name_glob",
+        "sort",
         "page",
         "page_size",
         "output_format",
@@ -274,6 +275,21 @@ async def test_edit_note_operation_schema_exposes_supported_operations():
 
     assert operation_schema["type"] == "string"
     assert operation_schema["enum"] == EXPECTED_EDIT_NOTE_OPERATIONS
+
+
+@pytest.mark.asyncio
+async def test_list_directory_sort_schema_exposes_supported_orders():
+    """Directory sorting is a closed MCP choice set, not a free-form string."""
+    tool_list = await mcp.list_tools()
+    list_directory_tool = next(tool for tool in tool_list if tool.name == "list_directory")
+
+    input_schema = list_directory_tool.to_mcp_tool().input_schema
+    sort_schema = input_schema["properties"]["sort"]
+
+    assert sort_schema["anyOf"][0] == {
+        "enum": ["title_asc", "title_desc", "updated_asc", "updated_desc"],
+        "type": "string",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_tool_list_directory.py
+++ b/tests/mcp/test_tool_list_directory.py
@@ -99,7 +99,12 @@ async def test_list_directory_with_depth_control(client, test_graph, test_projec
     assert "Total: 1 items (1 directory)" in result_depth_1
 
     # Depth 2: should return directory + its files
-    result_depth_2 = await list_directory(project=test_project.name, dir_name="/", depth=2)
+    result_depth_2 = await list_directory(
+        project=test_project.name,
+        dir_name="/",
+        depth=2,
+        sort="title_desc",
+    )
 
     assert isinstance(result_depth_2, str)
     assert "Contents of '/' (depth 2):" in result_depth_2
@@ -110,6 +115,16 @@ async def test_list_directory_with_depth_control(client, test_graph, test_projec
     assert "📄 Deeper Entity.md" in result_depth_2
     assert "📄 Root.md" in result_depth_2
     assert "Total: 6 items (1 directory, 5 files)" in result_depth_2
+    expected_rows = [
+        "📁 test",
+        "📄 Root.md",
+        "📄 Deeper Entity.md",
+        "📄 Deep Entity.md",
+        "📄 Connected Entity 2.md",
+        "📄 Connected Entity 1.md",
+    ]
+    row_positions = [result_depth_2.index(row) for row in expected_rows]
+    assert row_positions == sorted(row_positions)
 
 
 @pytest.mark.asyncio
@@ -275,12 +290,14 @@ async def test_list_directory_continuation_preserves_project_id(
         project_id=test_project.external_id,
         dir_name="/test",
         file_name_glob="*Entity*",
+        sort="updated_desc",
         page=1,
         page_size=2,
     )
 
     assert isinstance(result, str)
     assert "file_name_glob='*Entity*'" in result
+    assert "sort='updated_desc'" in result
     assert f"project_id={test_project.external_id!r}" in result
     assert "project=" not in result
 
@@ -307,7 +324,7 @@ async def test_list_directory_out_of_range_page_reports_pagination(
 
 
 @pytest.mark.asyncio
-async def test_list_directory_json_pagination_preserves_glob_and_depth(
+async def test_list_directory_json_pagination_preserves_glob_depth_and_sort(
     client,
     test_graph,
     test_project,
@@ -317,6 +334,7 @@ async def test_list_directory_json_pagination_preserves_glob_and_depth(
         dir_name="/test",
         depth=2,
         file_name_glob="*Entity*",
+        sort="title_desc",
         page=2,
         page_size=2,
         output_format="json",
@@ -328,8 +346,8 @@ async def test_list_directory_json_pagination_preserves_glob_and_depth(
     assert result["total"] == 4
     assert result["has_more"] is False
     assert [node["name"] for node in result["nodes"]] == [
-        "Deep Entity.md",
-        "Deeper Entity.md",
+        "Connected Entity 2.md",
+        "Connected Entity 1.md",
     ]
 
 

--- a/tests/services/test_directory_service.py
+++ b/tests/services/test_directory_service.py
@@ -1,8 +1,84 @@
 """Tests for directory service."""
 
-import pytest
+from datetime import UTC, datetime
 
-from basic_memory.services.directory_service import DirectoryService
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from basic_memory import db
+from basic_memory.models import Entity
+from basic_memory.repository import EntityRepository
+from basic_memory.schemas.directory import DirectoryNode, DirectorySortOrder
+from basic_memory.services.directory_service import DirectoryService, _required_file_updated_at
+
+
+async def _create_sortable_directory_entries(
+    entity_repository: EntityRepository,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    older = datetime(2026, 1, 1, tzinfo=UTC)
+    newer = datetime(2026, 1, 2, tzinfo=UTC)
+    entries = (
+        Entity(
+            title="Nested alpha",
+            note_type="note",
+            content_type="text/markdown",
+            file_path="alpha-folder/nested.md",
+            checksum="nested-alpha",
+            created_at=older,
+            updated_at=older,
+        ),
+        Entity(
+            title="Nested zulu",
+            note_type="note",
+            content_type="text/markdown",
+            file_path="zulu-folder/nested.md",
+            checksum="nested-zulu",
+            created_at=older,
+            updated_at=older,
+        ),
+        Entity(
+            title="Zulu",
+            note_type="note",
+            content_type="text/markdown",
+            file_path="a-file.md",
+            checksum="root-zulu",
+            created_at=older,
+            updated_at=older,
+        ),
+        Entity(
+            title="Bravo",
+            note_type="note",
+            content_type="text/markdown",
+            file_path="middle-file.md",
+            checksum="root-bravo",
+            created_at=newer,
+            updated_at=newer,
+        ),
+        Entity(
+            title="Alpha",
+            note_type="note",
+            content_type="text/markdown",
+            file_path="z-file.md",
+            checksum="root-alpha",
+            created_at=older,
+            updated_at=older,
+        ),
+    )
+    async with db.scoped_session(session_maker) as session:
+        for entry in entries:
+            await entity_repository.add(session, entry)
+
+
+def test_updated_sort_requires_file_timestamp() -> None:
+    node = DirectoryNode(
+        name="missing-timestamp.md",
+        directory_path="/missing-timestamp.md",
+        type="file",
+    )
+
+    with pytest.raises(ValueError, match="missing updated_at"):
+        _required_file_updated_at(node)
 
 
 @pytest.mark.asyncio
@@ -270,6 +346,56 @@ async def test_list_directory_orders_directories_before_files_across_depth(
         "file",
     ]
     assert result.nodes[0].name == "test"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sort", "expected_names"),
+    [
+        (
+            None,
+            ["alpha-folder", "zulu-folder", "a-file.md", "middle-file.md", "z-file.md"],
+        ),
+        (
+            "title_asc",
+            ["alpha-folder", "zulu-folder", "z-file.md", "middle-file.md", "a-file.md"],
+        ),
+        (
+            "title_desc",
+            ["zulu-folder", "alpha-folder", "a-file.md", "middle-file.md", "z-file.md"],
+        ),
+        (
+            "updated_asc",
+            ["alpha-folder", "zulu-folder", "z-file.md", "a-file.md", "middle-file.md"],
+        ),
+        (
+            "updated_desc",
+            ["alpha-folder", "zulu-folder", "middle-file.md", "z-file.md", "a-file.md"],
+        ),
+    ],
+)
+async def test_list_directory_sort_variants_are_stable_across_pages(
+    directory_service: DirectoryService,
+    entity_repository: EntityRepository,
+    session_maker: async_sessionmaker[AsyncSession],
+    sort: DirectorySortOrder | None,
+    expected_names: list[str],
+) -> None:
+    await _create_sortable_directory_entries(entity_repository, session_maker)
+
+    pages = [
+        await directory_service.list_directory(
+            dir_name="/",
+            sort=sort,
+            page=page,
+            page_size=2,
+        )
+        for page in range(1, 4)
+    ]
+
+    assert [node.name for page in pages for node in page.nodes] == expected_names
+    assert [page.total for page in pages] == [5, 5, 5]
+    assert [page.has_more for page in pages] == [True, True, False]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

The hosted MCP project and folder browser needs one exact-depth directory read that includes both child folders and notes while supporting title and updated-time sorting.

Core previously exposed only its legacy filename ordering, forcing Cloud to use a notes-only fallback for non-default sorts and lose folder cards. This closes #1267 and unblocks the one-read navigation work in [basic-memory-cloud#1764](https://github.com/basicmachines-co/basic-memory-cloud/pull/1764).

## What Changed

- Added the closed `title_asc`, `title_desc`, `updated_asc`, and `updated_desc` sort contract to the directory API and typed MCP client.
- Applied deterministic, folders-first ordering before pagination.
- Exposed sorting through the public `list_directory` MCP tool without re-sorting the API response.
- Included the selected sort mode in semantic read-cache keys.
- Added service, API, client, MCP contract/tool, pagination, and Redis cache regression coverage.

## Implementation Details

- Omitting `sort` preserves the existing filename-based ordering for compatibility.
- Explicit title sorts use note titles, with directory path and external ID as deterministic tie-breakers.
- Explicit updated sorts use the same identity tie-breakers before applying the timestamp as the stable primary key.
- Implicit directory entries do not have canonical update timestamps, so updated-time modes keep directories name-ascending while still placing them before files.
- Missing file timestamps fail fast instead of silently producing an unstable order.

## Testing

### Automated

- `uv run pytest tests/services/test_directory_service.py tests/api/v2/test_directory_router.py tests/mcp/clients/test_clients.py tests/mcp/test_tool_contracts.py tests/mcp/test_tool_list_directory.py -q`: 88 passed
- `uv run pytest tests/services/test_directory_service.py tests/mcp/test_tool_list_directory.py -q`: 47 passed
- `uv run pytest tests/mcp/test_tool_contracts.py -q`: 5 passed
- `uv run pytest test-int/read_cache/test_api_read_cache.py::test_directory_reads_cache_then_project_invalidation_refreshes -q`: 1 passed
- `just fast-check`: passed
- `just typecheck`: passed
- `just doctor`: passed
- `just test-smoke`: 1 passed

### Manual

- Inspected the generated MCP input schema and confirmed the nullable sort field advertises exactly the four supported enum values.
- Verified the staged diff contained only the 11 implementation and regression-test files.

## Risks / Follow-ups

- No schema migration or default behavior change.
- Cloud can remove its notes-only sorting fallback after consuming this Core contract.
