### PR TITLE
fix(core): preserve repeated default project selection

### DIFF
--- a/src/basic_memory/repository/project_repository.py
+++ b/src/basic_memory/repository/project_repository.py
@@ -168,19 +168,24 @@ class ProjectRepository(Repository[Project]):
         Returns:
             The updated project if found, None otherwise
         """
-        # First, clear the default flag for all projects using direct SQL
-        await session.execute(
-            text("UPDATE project SET is_default = NULL WHERE is_default IS NOT NULL")
-        )
-        await session.flush()
-
-        # Set the new default project
         target_project = await self.select_by_id(session, project_id)
-        if target_project:
-            target_project.is_default = True
-            await session.flush()
-            return target_project
-        return None  # pragma: no cover
+        if not target_project:
+            return None  # pragma: no cover
+
+        # Preserve the target row while clearing previous defaults. Clearing an already-default
+        # target through bulk SQL leaves its ORM identity-map value at True, so assigning True
+        # again emits no UPDATE and otherwise persists a database with no default project.
+        await session.execute(
+            text(
+                "UPDATE project SET is_default = NULL "
+                "WHERE id != :project_id AND is_default IS NOT NULL"
+            ),
+            {"project_id": project_id},
+        )
+
+        target_project.is_default = True
+        await session.flush()
+        return target_project
 
     @override
     async def delete(self, session: AsyncSession, entity_id: int) -> bool:

--- a/tests/repository/test_project_repository.py
+++ b/tests/repository/test_project_repository.py
@@ -273,6 +273,27 @@ async def test_set_as_default(
 
 
 @pytest.mark.asyncio
+async def test_set_as_default_keeps_existing_default(
+    project_repository: ProjectRepository, test_project: Project, session_maker
+):
+    """Setting the existing default again must leave it persisted as the default."""
+    async with db.scoped_session(session_maker) as session:
+        existing_default = await project_repository.find_by_id(session, test_project.id)
+        assert existing_default is not None
+        assert existing_default.is_default is True
+
+        updated_default = await project_repository.set_as_default(session, existing_default.id)
+        assert updated_default is not None
+        assert updated_default.is_default is True
+
+    # Verify from a new identity map so the assertion reflects persisted database state.
+    async with db.scoped_session(session_maker) as session:
+        persisted_default = await project_repository.get_default_project(session)
+        assert persisted_default is not None
+        assert persisted_default.id == test_project.id
+
+
+@pytest.mark.asyncio
 async def test_update_project(
     project_repository: ProjectRepository, sample_project: Project, session_maker
 ):


### PR DESCRIPTION
## Why

Repeatedly choosing the project that is already the default can leave a workspace with no default project. The API still returns success, but subsequent project discovery and every project-scoped MCP tool fail because no default can be resolved.

A production read-only investigation found repeated successful set-default requests followed by a database state where every project row had `is_default = NULL`.

## What Changed

- Make `ProjectRepository.set_as_default` idempotent when the selected project is already the default.
- Add a regression test that verifies the committed state from a new database session.

## Implementation Details

- Validate and load the selected project before changing any default flags.
- Clear the default flag only from other project rows.
- Preserve the selected row so SQLAlchemy cannot lose the update when its identity-map value was already `True` before the bulk update.
- Keep the existing repository and API contracts unchanged; no schema migration is required.

## Testing

Automated:

- `uv run pytest -q tests/repository/test_project_repository.py::test_set_as_default_keeps_existing_default` — reproduced the failure before the fix and passes after it.
- `uv run pytest -q tests/repository/test_project_repository.py` — 14 passed with SQLite.
- `BASIC_MEMORY_TEST_POSTGRES=1 uv run pytest -q tests/repository/test_project_repository.py::test_set_as_default_keeps_existing_default` — passed with PostgreSQL.
- `just fast-check` — passed (Ruff formatting/lint and type checking).

Manual:

- Correlated repeated successful set-default requests with the missing-default database state using production read-only telemetry and database inspection.

## Risks / Follow-ups

- The change is limited to default-project metadata and has no migration or public API impact.
- Basic Memory Cloud must update its Core revision after this PR merges before hosted behavior changes.
- Existing affected workspaces require a separate recovery action; this PR does not mutate production data.
