### PR TITLE
fix(integrations): preserve Hermes registration ownership

### DIFF
--- a/integrations/hermes/MONKEYPATCH.md
+++ b/integrations/hermes/MONKEYPATCH.md
@@ -14,11 +14,11 @@ This is a **Hermes Agent-side** compatibility patch, not a Basic Memory plugin r
 |---|---:|---|
 | `v0.13.x` | `v0.3.0` | Plugin `v0.3.0` remains the right runtime release. If `/bm-*` commands are missing, use the Hermes Agent-side monkeypatch below or wait for the upstream Hermes fix. |
 | `v0.14.0` / `v2026.5.16` | `v0.3.1` docs, runtime still equivalent to `v0.3.0` | The plugin runtime still works, but Hermes Agent `v0.14.0` still does **not** include the upstream slash-command discovery fix. Use the v0.14.0-compatible Hermes Agent-side patch below. |
-| Future Hermes release with upstream fix | Latest plugin | Do **not** apply this monkeypatch unless `/bm-*` commands are still absent; the fix should be redundant once Hermes loads active exclusive memory-provider commands during command discovery. |
+| `v0.20.1` / `v2026.8.13` and newer | Latest plugin | The collector delegates command and skill registration. Do not apply its collector portion; only the active-provider startup-load portion remains necessary when `/bm-*` commands are absent. |
 
 Checked against Hermes Agent `v2026.5.16` / `v0.14.0` on 2026-05-16: the upstream Hermes release still does **not** include this fix. After applying the Hermes Agent-side patch below locally, `get_plugin_commands()` returns the expected `/bm-*` commands.
 
-Important nuance: recent `hermes-basic-memory` versions include a best-effort PluginManager reach-in that registers commands when the provider is loaded. That workaround alone is not enough for gateway startup discovery in affected Hermes builds, because `get_plugin_commands()` does not load the active exclusive memory provider. The Hermes Agent-side patch is still needed until upstream command discovery loads the active memory provider and the memory-provider collector delegates command/skill registration.
+Important nuance: on Hermes `v0.20.1` and newer, registration flows through the lifecycle-aware collector and Basic Memory deliberately does not write the same entries through private PluginManager registries. That fixes provider unload cleanup, but gateway startup still needs to load the active exclusive memory provider before command discovery can see `/bm-*` commands.
 
 Release/tagging note for agents: `v0.3.1` is a documentation release that clarifies Hermes Agent `v0.14.0` compatibility instructions. It does not require users on Hermes Agent `v0.13.x` to change plugin runtime behavior, and it should not be interpreted as a Basic Memory data/schema migration.
 

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -106,7 +106,7 @@ Plugin v0.2.0 and later register the commands above, but some Hermes Agent gatew
 - `hermes memory status` shows `Provider: basic-memory` and `Status: available`; but
 - Discord/native slash command pickers do not show `/bm-search`, `/bm-read`, `/bm-context`, and the other `/bm-*` commands after `hermes gateway restart`.
 
-This is a Hermes Agent plugin-discovery issue, not a Basic Memory runtime issue. It is tracked upstream in [NousResearch/hermes-agent#23603](https://github.com/NousResearch/hermes-agent/issues/23603). Updating the Basic Memory plugin alone cannot fix affected gateway startup discovery; Hermes Agent itself must include or receive the compatibility patch. Until the upstream Hermes fix is available in your installed Hermes version, use one of these workarounds:
+This is a Hermes Agent plugin-discovery issue, not a Basic Memory runtime issue. Hermes `v0.20.1` and newer correctly own provider command and skill registration, including unload cleanup, but command discovery can still omit an exclusive memory provider before it is loaded. It is tracked upstream in [NousResearch/hermes-agent#23603](https://github.com/NousResearch/hermes-agent/issues/23603). Until the active-provider startup-load fix is available in your installed Hermes version, use one of these workarounds:
 
 1. apply the Hermes Agent-side patch described in [MONKEYPATCH.md](MONKEYPATCH.md), which includes compatibility notes for Hermes Agent v0.13.x and v0.14.0; or
 2. use the agent tools directly (`bm_search`, `bm_read`, `bm_recent`, etc.) instead of native slash commands.

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -1842,11 +1842,10 @@ def _build_slash_commands(
 # expose working slash-command and skill registries (used by general plugins).
 #
 # The clean fix lives upstream — a ~15-line patch to teach `_ProviderCollector`
-# to delegate to PluginManager. Until that lands, we write to PluginManager's
-# registries ourselves, matching exactly the entry shape and normalization
-# `PluginContext.register_command` / `register_skill` produce. Idempotent with
-# the future upstream fix: both code paths write identical entries to the same
-# dicts.
+# to delegate to PluginManager. Until that is available, we write only the
+# capabilities the supplied context does not support. A modern PluginContext
+# owns the registered objects' lifecycle, so duplicating its registrations in
+# the private registries would replace those lifecycle-owned entries.
 #
 # Recursion is safe: PluginManager.discover_and_load is idempotent
 # (plugins.py:699) and explicitly skips memory-provider plugins at the
@@ -1864,6 +1863,9 @@ _SKILL_DESCRIPTION = (
 def _register_via_plugin_manager(
     provider: "BasicMemoryProvider",
     skill_path: Path | None = None,
+    *,
+    register_commands: bool = True,
+    register_skill: bool = True,
 ) -> None:
     """
     Reach into Hermes's PluginManager to register slash commands and the
@@ -1896,35 +1898,36 @@ def _register_via_plugin_manager(
     except Exception:
         resolve_command = None  # type: ignore[assignment]
 
-    plugin_commands = getattr(mgr, "_plugin_commands", None)
-    if plugin_commands is None:
-        logger.debug(
-            "basic-memory: PluginManager has no _plugin_commands attr; slash commands skipped"
-        )
-    else:
-        for name, handler, description, args_hint in _build_slash_commands(provider):
-            # Mirror Hermes's normalization (plugins.py:426).
-            clean = name.lower().strip().lstrip("/").replace(" ", "-")
-            if not clean:
-                continue
-            if resolve_command is not None:
-                try:
-                    if resolve_command(clean) is not None:
-                        logger.warning(
-                            "basic-memory: skipping /%s — conflicts with a built-in command",
-                            clean,
-                        )
-                        continue
-                except Exception:
-                    pass
-            plugin_commands[clean] = {
-                "handler": handler,
-                "description": description or "Plugin command",
-                "plugin": _PLUGIN_MANIFEST_NAME,
-                "args_hint": (args_hint or "").strip(),
-            }
+    plugin_commands = getattr(mgr, "_plugin_commands", None) if register_commands else None
+    if register_commands:
+        if plugin_commands is None:
+            logger.debug(
+                "basic-memory: PluginManager has no _plugin_commands attr; slash commands skipped"
+            )
+        else:
+            for name, handler, description, args_hint in _build_slash_commands(provider):
+                # Mirror Hermes's normalization (plugins.py:426).
+                clean = name.lower().strip().lstrip("/").replace(" ", "-")
+                if not clean:
+                    continue
+                if resolve_command is not None:
+                    try:
+                        if resolve_command(clean) is not None:
+                            logger.warning(
+                                "basic-memory: skipping /%s — conflicts with a built-in command",
+                                clean,
+                            )
+                            continue
+                    except Exception:
+                        pass
+                plugin_commands[clean] = {
+                    "handler": handler,
+                    "description": description or "Plugin command",
+                    "plugin": _PLUGIN_MANIFEST_NAME,
+                    "args_hint": (args_hint or "").strip(),
+                }
 
-    plugin_skills = getattr(mgr, "_plugin_skills", None)
+    plugin_skills = getattr(mgr, "_plugin_skills", None) if register_skill else None
     if plugin_skills is not None and skill_path is not None and skill_path.exists():
         plugin_skills[f"{_PLUGIN_MANIFEST_NAME}:basic-memory"] = {
             "path": skill_path,
@@ -2023,11 +2026,12 @@ def register(ctx: Any) -> None:
     # `<available_skills>` index. Always-on agent guidance still flows
     # through `system_prompt_block()`.
     skill_path = Path(__file__).resolve().parent / "skill" / "SKILL.md"
-    if skill_path.exists() and hasattr(ctx, "register_skill"):
+    supports_skill_registration = hasattr(ctx, "register_skill")
+    if skill_path.exists() and supports_skill_registration:
         # Forward-compat: if Hermes's memory-provider collector ever delegates
         # register_skill to PluginManager (or another loader passes us a real
         # PluginContext), this lands the skill via the supported path. The
-        # reach-in below covers the current production collector either way.
+        # legacy collectors without this API use the reach-in below.
         try:
             ctx.register_skill(
                 "basic-memory",
@@ -2041,7 +2045,8 @@ def register(ctx: Any) -> None:
     # register_command (PR to NousResearch/hermes-agent pending), this is the
     # right path. Until then, hasattr returns False and we fall through to
     # the reach-in below.
-    if hasattr(ctx, "register_command"):
+    supports_command_registration = hasattr(ctx, "register_command")
+    if supports_command_registration:
         for name, handler, description, args_hint in _build_slash_commands(provider):
             try:
                 ctx.register_command(
@@ -2053,9 +2058,13 @@ def register(ctx: Any) -> None:
             except Exception as e:
                 logger.warning("basic-memory: register_command(%s) failed: %s", name, e)
 
-    # Write directly to PluginManager's registries. This is the production
-    # path today; see _register_via_plugin_manager docstring for the why.
-    _register_via_plugin_manager(
-        provider,
-        skill_path=skill_path if skill_path.exists() else None,
-    )
+    # Legacy Hermes collectors expose only register_memory_provider. Reach
+    # into PluginManager solely for capabilities missing from that context;
+    # modern contexts retain ownership metadata and can clean up registrations.
+    if not supports_command_registration or not supports_skill_registration:
+        _register_via_plugin_manager(
+            provider,
+            skill_path=skill_path if skill_path.exists() else None,
+            register_commands=not supports_command_registration,
+            register_skill=not supports_skill_registration,
+        )

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -1,8 +1,11 @@
 name: basic-memory
 version: 0.22.1
 description: "Basic Memory — persistent knowledge graph backed by the basic-memory MCP server"
-pip_dependencies:
-  - mcp
+manifest_version: 2
+api_version: 1
+kind: exclusive
+python_dependencies:
+  - "mcp>=2,<3"
 hooks:
   - prefetch
   - queue_prefetch

--- a/integrations/hermes/tests/test_commands.py
+++ b/integrations/hermes/tests/test_commands.py
@@ -49,6 +49,56 @@ class _FakePluginManager:
         self._plugin_skills: dict = {}
 
 
+class _LifecycleAwareContext:
+    """Modern PluginContext-shaped collector with lifecycle-owned entries."""
+
+    def __init__(self):
+        self.provider = None
+        self.commands: dict = {}
+        self.skills: dict = {}
+
+    def register_memory_provider(self, provider):
+        self.provider = provider
+
+    def register_command(self, name, handler, description="", args_hint=""):
+        self.commands[name] = {
+            "handler": handler,
+            "description": description,
+            "args_hint": args_hint,
+            "plugin_key": "basic-memory",
+        }
+
+    def register_skill(self, name, path, description=""):
+        self.skills[name] = {
+            "path": path,
+            "description": description,
+            "plugin_key": "basic-memory",
+        }
+
+    def dispose(self):
+        self.commands.clear()
+        self.skills.clear()
+
+
+class _CommandsOnlyContext:
+    """Transitional collector that delegates commands but not skills."""
+
+    def __init__(self):
+        self.provider = None
+        self.commands: dict = {}
+
+    def register_memory_provider(self, provider):
+        self.provider = provider
+
+    def register_command(self, name, handler, description="", args_hint=""):
+        self.commands[name] = {
+            "handler": handler,
+            "description": description,
+            "args_hint": args_hint,
+            "plugin_key": "basic-memory",
+        }
+
+
 def _install_fake_hermes_cli(monkeypatch, *, resolve_returns=None):
     """
     Insert a fake `hermes_cli.plugins` (with `_ensure_plugins_discovered`) and
@@ -119,12 +169,45 @@ def test_register_command_calls_include_description_and_args_hint(bm):
     bm._active_providers.clear()
     bm.register(ctx)
     for call in ctx.register_command.call_args_list:
-        name, handler = call.args[0], call.args[1]
+        _, handler = call.args[0], call.args[1]
         kwargs = call.kwargs
         assert callable(handler)
         assert "description" in kwargs and kwargs["description"]
         assert "args_hint" in kwargs  # may be empty string for no-arg commands
     bm._active_providers.clear()
+
+
+def test_modern_context_keeps_lifecycle_owned_registrations(bm, monkeypatch):
+    """A context that supports registration APIs must not be overwritten through
+    PluginManager's private registries, or Hermes cannot later dispose it."""
+    fake_mgr = _install_fake_hermes_cli(monkeypatch)
+    ctx = _LifecycleAwareContext()
+    bm._active_providers.clear()
+    bm.register(ctx)
+    try:
+        assert set(ctx.commands) == _EXPECTED_COMMANDS
+        assert all(entry["plugin_key"] == "basic-memory" for entry in ctx.commands.values())
+        assert set(ctx.skills) == {"basic-memory"}
+        assert fake_mgr._plugin_commands == {}
+        assert fake_mgr._plugin_skills == {}
+        ctx.dispose()
+        assert ctx.commands == {}
+        assert ctx.skills == {}
+    finally:
+        bm._active_providers.clear()
+
+
+def test_legacy_fallback_is_gated_per_registration_capability(bm, monkeypatch):
+    fake_mgr = _install_fake_hermes_cli(monkeypatch)
+    ctx = _CommandsOnlyContext()
+    bm._active_providers.clear()
+    bm.register(ctx)
+    try:
+        assert set(ctx.commands) == _EXPECTED_COMMANDS
+        assert fake_mgr._plugin_commands == {}
+        assert set(fake_mgr._plugin_skills) == {"basic-memory:basic-memory"}
+    finally:
+        bm._active_providers.clear()
 
 
 def test_register_tolerates_old_hermes_without_register_command(bm):


### PR DESCRIPTION
## Summary
- avoid private PluginManager writes when Hermes provides command or skill registration APIs
- retain capability-gated fallback support for legacy collectors
- update the Hermes manifest and compatibility guidance for the lifecycle-aware collector

## Testing
- Python 3.14 focused: 107 passed
- Python 3.12 Hermes suite: 269 passed, 12 skipped
- Hermes manifest validation, Ruff lint and format checks, and git diff --check passed

## Notes
- just package-check-hermes could not run because just is not installed on this Windows environment; its underlying manifest and Python 3.12 unit-suite checks were run directly.
- ty check integrations/hermes still reports existing external-Hermes import and strict-annotation diagnostics.

Fixes #1257