### PR TITLE
fix: allow subdirectory traversal during glob-filtered direc…

### DIFF
--- a/src/basic_memory/services/directory_service.py
+++ b/src/basic_memory/services/directory_service.py
@@ -391,12 +391,9 @@ class DirectoryService:
             return
 
         for child in node.children:
-            # Apply glob filtering
-            if file_name_glob and not fnmatch.fnmatch(child.name, file_name_glob):
-                continue
-
-            # Add the child to results
-            result.append(child)
+            # Add child to results if it matches the glob filter
+            if not file_name_glob or fnmatch.fnmatch(child.name, file_name_glob):
+                result.append(child)
 
             # Recurse into subdirectories if we haven't reached max depth
             if child.type == "directory" and current_depth < max_depth:

--- a/tests/services/test_directory_service.py
+++ b/tests/services/test_directory_service.py
@@ -233,6 +233,20 @@ async def test_list_directory_with_specific_file_filter(
 
 
 @pytest.mark.asyncio
+async def test_list_directory_with_glob_filter_recursive_depth(
+    directory_service: DirectoryService, test_graph
+):
+    """Test listing directory from root with depth > 1 and glob filter traverses subdirectories."""
+    result = await directory_service.list_directory(dir_name="/", depth=2, file_name_glob="*.md")
+
+    # Should traverse "/test" directory and match the 5 markdown files inside
+    assert len(result.nodes) == 5
+    file_names = {node.name for node in result.nodes}
+    assert "Root.md" in file_names
+
+
+
+@pytest.mark.asyncio
 async def test_list_directory_depth_control(directory_service: DirectoryService, test_graph):
     """Test listing directory with depth control."""
     # Depth 1 should only return immediate children


### PR DESCRIPTION
…tory listing

In DirectoryService._collect_nodes_recursive, if file_name_glob was set and a directory name did not match the glob, the loop executed 'continue', skipping recursion into the directory. As a result, files in subdirectories were never collected when listing with a file glob and depth > 1. Updated the loop to match nodes against the glob for inclusion in results while continuing recursion into subdirectory nodes.