### PR TITLE
fix(core): traverse subdirectories in glob-filtered directory listings

### DIFF
--- a/src/basic_memory/services/directory_service.py
+++ b/src/basic_memory/services/directory_service.py
@@ -391,12 +391,9 @@ class DirectoryService:
             return
 
         for child in node.children:
-            # Apply glob filtering
-            if file_name_glob and not fnmatch.fnmatch(child.name, file_name_glob):
-                continue
-
-            # Add the child to results
-            result.append(child)
+            # Add child to results if it matches the glob filter
+            if not file_name_glob or fnmatch.fnmatch(child.name, file_name_glob):
+                result.append(child)
 
             # Recurse into subdirectories if we haven't reached max depth
             if child.type == "directory" and current_depth < max_depth:

--- a/src/basic_memory/services/directory_service.py
+++ b/src/basic_memory/services/directory_service.py
@@ -391,7 +391,9 @@ class DirectoryService:
             return
 
         for child in node.children:
-            # Add child to results if it matches the glob filter
+            # The glob gates inclusion in the results only. Recursion below must not
+            # be gated by it: directory names rarely match file globs (e.g. "test"
+            # vs "*.md"), and pruning here would hide every file beneath them.
             if not file_name_glob or fnmatch.fnmatch(child.name, file_name_glob):
                 result.append(child)
 

--- a/tests/services/test_directory_service.py
+++ b/tests/services/test_directory_service.py
@@ -233,6 +233,20 @@ async def test_list_directory_with_specific_file_filter(
 
 
 @pytest.mark.asyncio
+async def test_list_directory_with_glob_filter_recursive_depth(
+    directory_service: DirectoryService, test_graph
+):
+    """Test listing directory from root with depth > 1 and glob filter traverses subdirectories."""
+    result = await directory_service.list_directory(dir_name="/", depth=2, file_name_glob="*.md")
+
+    # Should traverse "/test" directory and match the 5 markdown files inside
+    assert len(result.nodes) == 5
+    file_names = {node.name for node in result.nodes}
+    assert "Root.md" in file_names
+
+
+
+@pytest.mark.asyncio
 async def test_list_directory_depth_control(directory_service: DirectoryService, test_graph):
     """Test listing directory with depth control."""
     # Depth 1 should only return immediate children

--- a/tests/services/test_directory_service.py
+++ b/tests/services/test_directory_service.py
@@ -236,14 +236,20 @@ async def test_list_directory_with_specific_file_filter(
 async def test_list_directory_with_glob_filter_recursive_depth(
     directory_service: DirectoryService, test_graph
 ):
-    """Test listing directory from root with depth > 1 and glob filter traverses subdirectories."""
+    """Test that a glob filter excludes non-matching directories without pruning traversal."""
     result = await directory_service.list_directory(dir_name="/", depth=2, file_name_glob="*.md")
 
-    # Should traverse "/test" directory and match the 5 markdown files inside
-    assert len(result.nodes) == 5
+    # The "test" directory does not match "*.md", so it is excluded from the
+    # results themselves but still traversed for the matching files inside it.
     file_names = {node.name for node in result.nodes}
-    assert "Root.md" in file_names
-
+    assert file_names == {
+        "Connected Entity 1.md",
+        "Connected Entity 2.md",
+        "Deep Entity.md",
+        "Deeper Entity.md",
+        "Root.md",
+    }
+    assert all(node.type == "file" for node in result.nodes)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

In `DirectoryService._collect_nodes_recursive`, a child that did not match `file_name_glob` hit `continue`, which skipped both inclusion **and** recursion. Directory names like `test` never match file globs like `*.md`, so `list_directory(dir_name="/", depth=2, file_name_glob="*.md")` returned nothing from subdirectories — the glob accidentally pruned entire subtrees instead of just filtering the results.

## What changed

- The glob now gates inclusion in results only; recursion into directories always proceeds within `max_depth` (matching `find -maxdepth N -name glob` semantics and the `list_directory` MCP tool's documented behavior)
- Regression test pins the full contract: the exact matched file set across the subtree, and the non-matching directory node excluded from results while still traversed

## Credit

This supersedes #1279 by @kdahal7, whose fix and regression test are carried here with authorship preserved (`be6f8131`). Rehomed to an in-repo branch so CI runs (fork PRs skip the test workflows), with a follow-up commit that strengthens the test assertions and fixes formatting.

## Verification

- Red proof: the new test fails against main's `directory_service.py`, passes with the fix
- `tests/services/test_directory_service.py` + `tests/mcp/test_tool_list_directory.py`: 48 passed
- Existing glob/depth tests unaffected (depth=1 output byte-identical); ruff check, ruff format, ty check all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4rbaeHJN3L7CREp5v38J9