### PR TITLE
fix(core): stop minting typed relations from prose tails

### DIFF
--- a/src/basic_memory/markdown/plugins.py
+++ b/src/basic_memory/markdown/plugins.py
@@ -165,7 +165,7 @@ def _parse_explicit_relation(content: str) -> Dict[str, Any] | None:
     if not target:
         return None
 
-    # Trigger: text follows the target that is not a parenthesized context.
+    # Trigger: text follows the target that is not a single parenthesized context.
     # Why: an explicit relation line ends at its target or its (context). A prose
     #   tail means the line is a sentence that happens to contain a wikilink; the
     #   old behavior minted a junk type from the word before the link and silently
@@ -175,12 +175,33 @@ def _parse_explicit_relation(content: str) -> Dict[str, Any] | None:
     #   every wikilink on the line as an edge and the sentence intact as content.
     after = content[end + 2 :].strip()
     context = None
-    if after.startswith("(") and after.endswith(")"):
+    if after:
+        if not _is_single_parenthesized(after):
+            return None
         context = after[1:-1].strip() or None
-    elif after:
-        return None
 
     return {"type": rel_type, "target": target, "context": context}
+
+
+def _is_single_parenthesized(text: str) -> bool:
+    """Whether the text is one balanced ``(...)`` group and nothing more.
+
+    Checking only the first and last characters would accept
+    ``(primary) and [[Beta]] (secondary)`` as a single context and silently
+    drop the Beta link — the corruption class the prose-tail rule exists to
+    prevent — so the opening paren must close exactly at the final character.
+    """
+    if not text.startswith("("):
+        return False
+    depth = 0
+    for position, char in enumerate(text):
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return position == len(text) - 1
+    return False
 
 
 def parse_relation(token: Token) -> Dict[str, Any] | None:

--- a/src/basic_memory/markdown/plugins.py
+++ b/src/basic_memory/markdown/plugins.py
@@ -145,39 +145,49 @@ def is_explicit_relation(token: Token) -> bool:
 
     # Use token.tag which contains the actual content for test tokens, fallback to content
     content = (token.tag or token.content).strip()
-    return "[[" in content and "]]" in content and parse_relation_type(content) is not None
+    if "[[" not in content or "]]" not in content:
+        return False
+    return _parse_explicit_relation(content) is not None
 
 
-def parse_relation(token: Token) -> Dict[str, Any] | None:
-    """Extract relation parts from token."""
-    # Remove bullet point if present
-    # Use token.tag which contains the actual content for test tokens, fallback to content
-    content = (token.tag or token.content).strip()
-
+def _parse_explicit_relation(content: str) -> Dict[str, Any] | None:
+    """Parse ``type [[target]] (context)``, rejecting lines with a prose tail."""
     rel_type = parse_relation_type(content)
     if rel_type is None:
         return None
 
-    # Extract [[target]]
-    target = None
-    context = None
-
     start = content.find("[[")
     end = content.find("]]", start + 2)
+    if start == -1 or end == -1:
+        return None
 
-    if start != -1 and end != -1:
-        # Get target
-        target = normalize_project_reference(content[start + 2 : end].strip())
+    target = normalize_project_reference(content[start + 2 : end].strip())
+    if not target:
+        return None
 
-        # Look for context after
-        after = content[end + 2 :].strip()
-        if after.startswith("(") and after.endswith(")"):
-            context = after[1:-1].strip() or None
-
-    if not target:  # pragma: no cover
+    # Trigger: text follows the target that is not a parenthesized context.
+    # Why: an explicit relation line ends at its target or its (context). A prose
+    #   tail means the line is a sentence that happens to contain a wikilink; the
+    #   old behavior minted a junk type from the word before the link and silently
+    #   dropped the tail — including any further [[links]] in it — from the edge
+    #   (#1260).
+    # Outcome: such lines fall through to inline links_to handling, which keeps
+    #   every wikilink on the line as an edge and the sentence intact as content.
+    after = content[end + 2 :].strip()
+    context = None
+    if after.startswith("(") and after.endswith(")"):
+        context = after[1:-1].strip() or None
+    elif after:
         return None
 
     return {"type": rel_type, "target": target, "context": context}
+
+
+def parse_relation(token: Token) -> Dict[str, Any] | None:
+    """Extract relation parts from token."""
+    # Use token.tag which contains the actual content for test tokens, fallback to content
+    content = (token.tag or token.content).strip()
+    return _parse_explicit_relation(content)
 
 
 def parse_inline_relations(content: str) -> List[Dict[str, Any]]:

--- a/tests/markdown/test_relation_edge_cases.py
+++ b/tests/markdown/test_relation_edge_cases.py
@@ -42,24 +42,24 @@ def test_malformed_links():
     tokens = md.parse("- type ]]Target[[")
     assert not any(t.meta and "relations" in t.meta for t in tokens)
 
-    # Nested brackets
+    # Nested brackets: the tail after the first ]] is not a (context), so the
+    # line is not an explicit relation; inline handling depth-matches the link.
     tokens = md.parse("- type [[Outer [[Inner]] ]]")
     token = next(t for t in tokens if t.type == "inline")
-    rel = parse_relation(token)
-    assert rel is not None
-    assert "Outer" in rel["target"]
+    assert parse_relation(token) is None
+    assert all(r["type"] == "links_to" for r in token.meta["relations"])
 
 
 def test_context_handling():
     """Test handling of contexts."""
     md = MarkdownIt().use(relation_plugin)
 
-    # Unclosed context
+    # Unclosed context is a prose tail, not a context: the line falls back to
+    # an inline link instead of minting a typed edge with the tail dropped.
     tokens = md.parse("- type [[Target]] (unclosed")
     token = next(t for t in tokens if t.type == "inline")
-    rel = parse_relation(token)
-    assert rel is not None
-    assert rel["context"] is None
+    assert parse_relation(token) is None
+    assert token.meta["relations"] == [{"type": "links_to", "target": "Target", "context": None}]
 
     # Multiple parens
     tokens = md.parse("- type [[Target]] (with (nested) parens)")
@@ -96,6 +96,68 @@ def test_inline_relations():
     tokens = md.parse("[[One]] [[Two]] [[Three]]")
     token = next(t for t in tokens if t.type == "inline")
     assert len(token.meta["relations"]) == 3
+
+
+def test_prose_tail_falls_back_to_inline_link():
+    """A sentence containing a wikilink must not mint a typed relation (#1260).
+
+    An explicit relation line ends at its target or its (context); trailing
+    prose means the line is ordinary writing, and the old behavior both minted
+    a junk type from the word before the link and silently dropped the tail.
+    """
+    md = MarkdownIt().use(relation_plugin)
+
+    for src in [
+        "- Added [[Target Note]] to the roster",
+        "- Calls [[Target Note]] every Sunday",
+        '- "multi word type" [[Target Note]] trailing prose',
+        "- type [[Target Note]] (context) and more",
+    ]:
+        tokens = md.parse(src)
+        token = next(t for t in tokens if t.type == "inline")
+        assert parse_relation(token) is None, src
+        assert token.meta["relations"] == [
+            {"type": "links_to", "target": "Target Note", "context": None}
+        ], src
+
+
+def test_prose_tail_keeps_every_wikilink_in_the_tail():
+    """Falling back to inline handling preserves links the old path dropped."""
+    md = MarkdownIt().use(relation_plugin)
+
+    # The old explicit path minted `relates_to -> A` and lost B's edge entirely.
+    tokens = md.parse("- relates_to [[Alpha]] and [[Beta]]")
+    token = next(t for t in tokens if t.type == "inline")
+    assert parse_relation(token) is None
+    assert {r["target"] for r in token.meta["relations"]} == {"Alpha", "Beta"}
+    assert all(r["type"] == "links_to" for r in token.meta["relations"])
+
+    tokens = md.parse("- Links: [[Alpha]], [[Beta]]")
+    token = next(t for t in tokens if t.type == "inline")
+    assert {r["target"] for r in token.meta["relations"]} == {"Alpha", "Beta"}
+
+
+def test_explicit_relation_forms_still_parse():
+    """Hand-authored relation shapes keep their types after the #1260 fix."""
+    md = MarkdownIt().use(relation_plugin)
+
+    expected = {
+        "- spouse_of [[Target Note]]": ("spouse_of", None),
+        "- requires [[Target Note]] (because reasons)": ("requires", "because reasons"),
+        '- "multi word type" [[Target Note]] (context)': ("multi word type", "context"),
+    }
+    for src, (rel_type, context) in expected.items():
+        tokens = md.parse(src)
+        token = next(t for t in tokens if t.type == "inline")
+        rel = parse_relation(token)
+        assert rel == {"type": rel_type, "target": "Target Note", "context": context}, src
+
+    # Known limitation, pinned deliberately: a single capitalized word with no
+    # tail is indistinguishable by shape from a hand-authored type ("Requires"),
+    # so it still mints. The grammar policy for this case is tracked in #1260.
+    tokens = md.parse("- Mother [[Target Note]]")
+    token = next(t for t in tokens if t.type == "inline")
+    assert parse_relation(token) == {"type": "Mother", "target": "Target Note", "context": None}
 
 
 def test_unicode_targets():

--- a/tests/markdown/test_relation_edge_cases.py
+++ b/tests/markdown/test_relation_edge_cases.py
@@ -136,6 +136,15 @@ def test_prose_tail_keeps_every_wikilink_in_the_tail():
     token = next(t for t in tokens if t.type == "inline")
     assert {r["target"] for r in token.meta["relations"]} == {"Alpha", "Beta"}
 
+    # A context-looking tail whose opening paren closes before the end is prose:
+    # accepting `(primary) and [[Beta]] (secondary)` as one context would drop
+    # the Beta link — the corruption class this rule exists to prevent.
+    tokens = md.parse("- relates_to [[Alpha]] (primary) and [[Beta]] (secondary)")
+    token = next(t for t in tokens if t.type == "inline")
+    assert parse_relation(token) is None
+    assert {r["target"] for r in token.meta["relations"]} == {"Alpha", "Beta"}
+    assert all(r["type"] == "links_to" for r in token.meta["relations"])
+
 
 def test_explicit_relation_forms_still_parse():
     """Hand-authored relation shapes keep their types after the #1260 fix."""


### PR DESCRIPTION
## Why

`- Added [[Target Note]] to the roster` minted a typed relation `Added`, and the tail `to the roster` — including any further `[[links]]` in it — was silently dropped from the edge. Measured at 12.3% of typed edges being parse artifacts in a real vault (#1260).

## What changed

Grammar policy (direction 1 from the issue): **an explicit relation line ends at its target or its `(context)`**. Any other trailing text means the line is a sentence, and it falls through to inline `links_to` handling — which also preserves every wikilink in the tail (the old explicit path lost `[[Beta]]` entirely in `- relates_to [[Alpha]] and [[Beta]]`).

Preserved: `- spouse_of [[X]]`, `- requires [[X]] (context)`, quoted multi-word types, `- 使用 [[X]]`. Changed deliberately: unclosed-context and nested-bracket edge cases now fall back to inline links instead of minting a typed edge with a mangled tail.

**Known limitation, pinned in tests**: `- Mother [[Target Note]]` (capitalized single word, no tail) still mints — indistinguishable by shape from a hand-authored `Requires [[X]]`. The policy for that case (lowercase requirement / structural anchoring) stays open for discussion on #1260.

## Verification

- tests/markdown: 88 passed (4 new tests: prose-tail fallback, tail-link preservation, preserved explicit forms, pinned limitation)
- tests/services + tests/mcp: 1316 passed, 2 skipped
- ruff format, ruff check, ty: clean

Refs #1260 (left open for the remaining grammar-policy discussion).

Credit: analysis, repro, and the measured vault impact are @<!-- -->the issue reporter's — see #1260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4rbaeHJN3L7CREp5v38J9