### PR TITLE
ci(core): fix the silently-skipped dev release publish

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -32,6 +32,22 @@ jobs:
       - name: Compute version from git
         id: check_version
         run: |
+          # Trigger: the push of a release PR's bump commit reaches this
+          #   workflow before the release recipe pushes the vX.Y.Z tag.
+          # Why: dunamai would see an untagged commit and emit a dev version,
+          #   publishing the stable release content as a spurious dev artifact
+          #   under the previous release line.
+          # Outcome: release-bump commits are recognized by the recipe's fixed
+          #   commit subject (the same key the recipe itself uses to locate the
+          #   commit after rebase-merge) and skipped; the Release workflow
+          #   publishes them from the tag.
+          SUBJECT=$(git log -1 --pretty=%s)
+          if [[ "$SUBJECT" =~ ^chore:\ update\ version\ to\ .*\ release$ ]]; then
+            echo "is_dev=false" >> $GITHUB_OUTPUT
+            echo "version=" >> $GITHUB_OUTPUT
+            echo "Release bump commit detected ('$SUBJECT'), skipping dev release"
+            exit 0
+          fi
           # The release automation hardcodes the last stable release into
           # basic_memory.__version__, so importing the source tree always
           # reports that release and the old gate skipped every dev publish.

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -29,16 +29,16 @@ jobs:
         run: |
           pip install uv
 
-      - name: Install dependencies and build
-        run: |
-          uv venv
-          uv sync
-          uv build
-
-      - name: Check if this is a dev version
+      - name: Compute version from git
         id: check_version
         run: |
-          VERSION=$(uv run python -c "import basic_memory; print(basic_memory.__version__)")
+          # The release automation hardcodes the last stable release into
+          # basic_memory.__version__, so importing the source tree always
+          # reports that release and the old gate skipped every dev publish.
+          # Derive the version from the VCS state instead, exactly as
+          # uv-dynamic-versioning would. --no-metadata drops the +commit
+          # local segment, which PyPI rejects on upload.
+          VERSION=$(uvx dunamai from git --style pep440 --bump --no-metadata)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           if [[ "$VERSION" == *"dev"* ]]; then
             echo "is_dev=true" >> $GITHUB_OUTPUT
@@ -47,6 +47,13 @@ jobs:
             echo "is_dev=false" >> $GITHUB_OUTPUT
             echo "Release version detected: $VERSION, skipping dev release"
           fi
+
+      - name: Build
+        if: steps.check_version.outputs.is_dev == 'true'
+        run: |
+          # Bypass VCS version computation in the build backend so the
+          # artifact carries the same metadata-free version the gate saw.
+          UV_DYNAMIC_VERSIONING_BYPASS="${{ steps.check_version.outputs.version }}" uv build
 
       - name: Publish dev version to PyPI
         if: steps.check_version.outputs.is_dev == 'true'


### PR DESCRIPTION
## Why

Release-readiness verification for v0.23 (#1288) found the dev-release pipeline has been silently broken since the 0.22.1 version bump — discovered while proving the #1210 plugin-hooks failure mode live.

Two independent breaks:

1. **The gate never fires.** It ran `python -c "import basic_memory; print(basic_memory.__version__)"`, which imports the source tree — where release automation hardcodes `__version__ = "0.22.1"`. Every run since that bump logs `Release version detected: 0.22.1, skipping dev release` while the workflow shows green (verified in run 32334909584). PyPI confirms: the last five uploads are all stable releases; the last dev build ever published was `0.13.8.dev1`.
2. **The artifacts were unpublishable anyway.** `uv build` under the current `[tool.uv-dynamic-versioning]` config produces versions like `0.22.2.dev242+ca5c54a8` — PyPI rejects local version segments.

The CLAUDE.md claim that every commit to main publishes a dev version has therefore been false for a long time. One consequence: marketplace users of the Claude Code plugin get the silent hook no-op (#1210) with no dev channel to point at.

## What changed

- The gate computes the version from the VCS state via `uvx dunamai from git --style pep440 --bump --no-metadata` — the same engine and settings uv-dynamic-versioning uses, minus the local segment PyPI rejects.
- The build runs with `UV_DYNAMIC_VERSIONING_BYPASS` set to that version, so the artifact metadata matches the gate, and only runs when the gate passes (tagged release commits still skip).
- Dropped the now-unused `uv venv`/`uv sync` (they existed only to import the package for the broken gate).

## Verification

- `uvx dunamai from git --style pep440 --bump --no-metadata` → `0.22.2.dev242` (publishable)
- `UV_DYNAMIC_VERSIONING_BYPASS=0.22.2.dev242 uv build` → `basic_memory-0.22.2.dev242.tar.gz` / `.whl`
- On a tag-exact checkout dunamai emits the bare release version, which contains no `dev` → publish skipped, same as intended today

First real proof will be this PR's merge commit publishing `0.22.2.devN` to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4rbaeHJN3L7CREp5v38J9