### PR TITLE
ci(core): publish dev releases via trusted publishing

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -71,9 +71,12 @@ jobs:
           # artifact carries the same metadata-free version the gate saw.
           UV_DYNAMIC_VERSIONING_BYPASS="${{ steps.check_version.outputs.version }}" uv build
 
+      # Publishes via PyPI trusted publishing (OIDC) — the PYPI_TOKEN secret no
+      # longer exists (stable releases attest via the release.yml trusted
+      # publisher). Requires a PyPI trusted-publisher registration for
+      # dev-release.yml on the basic-memory project.
       - name: Publish dev version to PyPI
         if: steps.check_version.outputs.is_dev == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true  # Don't fail if version already exists


### PR DESCRIPTION
## Why

The first live run of the repaired dev-release pipeline (#1292) got past the gate and build — the fix works — but the publish step failed with `invalid-publisher`. Root cause: the `PYPI_TOKEN` secret no longer exists in this repo, so the action fell back to OIDC trusted publishing, and PyPI has **no trusted publisher registered for `dev-release.yml`**.

Stable releases already publish this way: the v0.22.1 Release run generated digital attestations, which is the trusted-publishing path — `release.yml` has a registered publisher, its `password:` line is equally dead but harmless.

## What changed

Drop the dead `password:` input so the OIDC path is explicit, with a comment naming the registration prerequisite.

## Required manual step (PyPI project owner)

PyPI → `basic-memory` project → Settings → Publishing → Add GitHub publisher:
- owner `basicmachines-co`, repository `basic-memory`, workflow `dev-release.yml`, environment: (leave blank)

Until that registration exists, the workflow will keep failing at publish with the same claims (`workflow_ref: ...dev-release.yml@refs/heads/main`, `environment: MISSING`).

## Verification

The next merge to main after the registration should publish `0.22.2.devN` — the first dev build since `0.13.8.dev1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4rbaeHJN3L7CREp5v38J9