### PR TITLE
fix(cli): stop reporting "up to date" when the Homebrew update check fails

### DIFF
--- a/src/basic_memory/cli/auto_update.py
+++ b/src/basic_memory/cli/auto_update.py
@@ -27,6 +27,10 @@ UV_UPGRADE_TIMEOUT_SECONDS = 180
 BREW_UPGRADE_TIMEOUT_SECONDS = 600
 
 
+class HomebrewCheckError(RuntimeError):
+    """Raised when `brew outdated` could not determine whether an update exists."""
+
+
 class InstallSource(str, Enum):
     """How the running CLI appears to have been installed."""
 
@@ -127,19 +131,36 @@ def _version_from_pypi() -> str:
 
 
 def _check_homebrew_update_available(silent: bool) -> tuple[bool, str | None]:
-    """Check whether Homebrew reports an outdated basic-memory formula."""
-    result = _run_subprocess(
-        ["brew", "outdated", "--quiet", PACKAGE_NAME],
-        timeout_seconds=BREW_OUTDATED_TIMEOUT_SECONDS,
-        silent=silent,
-        capture_output=True,
-    )
-    # Trigger: brew outdated exits 1 when the formula IS outdated (with name on stdout).
-    # Why: non-zero exit here means "outdated", not "error".
-    # Outcome: check stdout for the package name to determine outdated status.
+    """Check whether Homebrew reports an outdated basic-memory formula.
+
+    Raises:
+        HomebrewCheckError: brew could not answer the question (brew missing,
+            untrusted or stale tap, network failure, timeout).
+    """
+    try:
+        result = _run_subprocess(
+            ["brew", "outdated", "--quiet", PACKAGE_NAME],
+            timeout_seconds=BREW_OUTDATED_TIMEOUT_SECONDS,
+            silent=silent,
+            capture_output=True,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise HomebrewCheckError(f"could not run `brew outdated`: {exc}") from exc
+
+    # Trigger: brew outdated exits 1 both when the formula IS outdated (name on
+    # stdout) and when the check failed outright (empty stdout, reason on stderr).
+    # Why: reading a failed check as "not outdated" reports a stale install as up
+    # to date, which silently pins the user to an old version.
+    # Outcome: trust an empty stdout only when brew exited cleanly; otherwise the
+    # check is unanswered and the caller must find the answer elsewhere.
     stdout = (result.stdout or "").strip()
-    is_outdated = PACKAGE_NAME in stdout
-    return is_outdated, None
+    if PACKAGE_NAME in stdout:
+        return True, None
+    if result.returncode == 0:
+        return False, None
+
+    stderr = (result.stderr or "").strip()
+    raise HomebrewCheckError(stderr or f"`brew outdated` exited {result.returncode}")
 
 
 def _check_pypi_update_available() -> tuple[bool, str]:
@@ -247,7 +268,16 @@ def run_auto_update(
         # --- Availability check ---
         latest_version: str | None = None
         if source == InstallSource.HOMEBREW:
-            update_available, latest_version = _check_homebrew_update_available(silent=silent)
+            try:
+                update_available, latest_version = _check_homebrew_update_available(silent=silent)
+            except HomebrewCheckError as exc:
+                # Trigger: brew cannot answer (missing/untrusted tap, no brew, network).
+                # Why: an unanswered check must never be reported as up to date.
+                # Outcome: ask PyPI instead. The tap can only lag PyPI, so a PyPI
+                # comparison is a sound answer, and it yields a real latest version.
+                # `source` is unchanged, so remediation still points at `brew upgrade`.
+                logger.warning(f"Homebrew update check failed, falling back to PyPI: {exc}")
+                update_available, latest_version = _check_pypi_update_available()
         else:
             update_available, latest_version = _check_pypi_update_available()
 

--- a/src/basic_memory/cli/auto_update.py
+++ b/src/basic_memory/cli/auto_update.py
@@ -267,15 +267,19 @@ def run_auto_update(
     try:
         # --- Availability check ---
         latest_version: str | None = None
+        homebrew_check_error: str | None = None
         if source == InstallSource.HOMEBREW:
             try:
                 update_available, latest_version = _check_homebrew_update_available(silent=silent)
             except HomebrewCheckError as exc:
                 # Trigger: brew cannot answer (missing/untrusted tap, no brew, network).
-                # Why: an unanswered check must never be reported as up to date.
-                # Outcome: ask PyPI instead. The tap can only lag PyPI, so a PyPI
-                # comparison is a sound answer, and it yields a real latest version.
-                # `source` is unchanged, so remediation still points at `brew upgrade`.
+                # Why: an unanswered check must never be reported as up to date. PyPI is
+                # sound for the negative answer -- the tap can only lag PyPI, so "nothing
+                # newer exists" holds. It is NOT sound for installing: release.yml
+                # publishes to PyPI in `release`, and the homebrew formula job `needs:
+                # release`, so a newer PyPI version may not be installable via brew yet.
+                # Outcome: ask PyPI, but remember the answer came from there.
+                homebrew_check_error = str(exc)
                 logger.warning(f"Homebrew update check failed, falling back to PyPI: {exc}")
                 update_available, latest_version = _check_pypi_update_available()
         else:
@@ -316,6 +320,26 @@ def run_auto_update(
                 latest_version=latest_version,
                 message=(
                     f"Update available (latest: {latest_version or 'unknown'}). "
+                    f"{_manual_update_hint(source)}"
+                ),
+            )
+
+        if homebrew_check_error is not None:
+            # Trigger: availability was inferred from PyPI because brew could not answer.
+            # Why: the tap may not carry this version yet, and whatever hid the brew
+            # answer (untrusted tap, brew missing) will also block `brew upgrade`.
+            # Outcome: report the update and the reason instead of running a doomed
+            # upgrade; the user resolves the brew problem and upgrades deliberately.
+            return AutoUpdateResult(
+                status=AutoUpdateStatus.UPDATE_AVAILABLE,
+                source=source,
+                checked=True,
+                update_available=True,
+                updated=False,
+                latest_version=latest_version,
+                message=(
+                    f"Update available (latest: {latest_version or 'unknown'}), but the "
+                    f"Homebrew check failed: {homebrew_check_error} "
                     f"{_manual_update_hint(source)}"
                 ),
             )

--- a/src/basic_memory/cli/auto_update.py
+++ b/src/basic_memory/cli/auto_update.py
@@ -139,7 +139,7 @@ def _check_homebrew_update_available(silent: bool) -> tuple[bool, str | None]:
     """
     try:
         result = _run_subprocess(
-            ["brew", "outdated", "--quiet", PACKAGE_NAME],
+            ["brew", "outdated", "--json=v2", PACKAGE_NAME],
             timeout_seconds=BREW_OUTDATED_TIMEOUT_SECONDS,
             silent=silent,
             capture_output=True,
@@ -147,19 +147,39 @@ def _check_homebrew_update_available(silent: bool) -> tuple[bool, str | None]:
     except (OSError, subprocess.SubprocessError) as exc:
         raise HomebrewCheckError(f"could not run `brew outdated`: {exc}") from exc
 
-    # Trigger: brew outdated exits 1 both when the formula IS outdated (name on
-    # stdout) and when the check failed outright (empty stdout, reason on stderr).
-    # Why: reading a failed check as "not outdated" reports a stale install as up
-    # to date, which silently pins the user to an old version.
-    # Outcome: trust an empty stdout only when brew exited cleanly; otherwise the
-    # check is unanswered and the caller must find the answer elsewhere.
     stdout = (result.stdout or "").strip()
-    if PACKAGE_NAME in stdout:
-        return True, None
-    if result.returncode == 0:
-        return False, None
-
     stderr = (result.stderr or "").strip()
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise HomebrewCheckError(
+            stderr or f"`brew outdated --json=v2` returned invalid JSON: {exc}"
+        ) from exc
+
+    formulae = payload.get("formulae") if isinstance(payload, dict) else None
+    if not isinstance(formulae, list):
+        raise HomebrewCheckError("`brew outdated --json=v2` omitted the formulae list")
+
+    # Trigger: brew outdated exits 1 both when the formula IS outdated (a JSON
+    # entry is present) and when the check failed outright (non-JSON error text).
+    # Why: JSON supplies Homebrew's actual target version without consulting a
+    # potentially-ahead package registry, while the exit code alone is ambiguous.
+    # Outcome: a matching formula is outdated, an empty successful list is current,
+    # and every other response remains unanswered for the caller's fallback path.
+    for formula in formulae:
+        if not isinstance(formula, dict):
+            raise HomebrewCheckError("`brew outdated --json=v2` returned a malformed formula")
+        name = formula.get("name")
+        if isinstance(name, str) and name.rsplit("/", maxsplit=1)[-1] == PACKAGE_NAME:
+            latest = formula.get("current_version")
+            if not isinstance(latest, str) or not latest:
+                raise HomebrewCheckError(
+                    "`brew outdated --json=v2` omitted the formula current_version"
+                )
+            return True, latest
+
+    if result.returncode == 0 and not formulae:
+        return False, None
     raise HomebrewCheckError(stderr or f"`brew outdated` exited {result.returncode}")
 
 

--- a/tests/cli/test_auto_update.py
+++ b/tests/cli/test_auto_update.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 import urllib.error
@@ -30,6 +31,21 @@ UNTRUSTED_TAP_STDERR = (
     "Error: Refusing to load formula basicmachines-co/basic-memory/basic-memory "
     "from untrusted tap basicmachines-co/basic-memory."
 )
+
+
+def _brew_outdated_payload(current_version: str | None = None) -> str:
+    formulae = []
+    if current_version is not None:
+        formulae.append(
+            {
+                "name": "basicmachines-co/basic-memory/basic-memory",
+                "installed_versions": ["0.22.1"],
+                "current_version": current_version,
+                "pinned": False,
+                "pinned_version": None,
+            }
+        )
+    return json.dumps({"formulae": formulae, "casks": []})
 
 
 class StubConfigManager:
@@ -148,33 +164,71 @@ def test_force_bypasses_auto_update_disabled(monkeypatch, tmp_path):
 def test_check_homebrew_update_available_exit_code_1_means_outdated(monkeypatch):
     """brew outdated exits 1 when the formula is outdated, not on error.
 
-    Exit 1 is shared with the failure case, so stdout is the discriminator: the
-    tap-qualified formula name means outdated. brew also writes progress chatter
-    to stderr on this path, so a non-empty stderr must not be read as an error.
+    Exit 1 is shared with the failure case, so the JSON formula entry is the
+    discriminator. brew may also write progress chatter to stderr on this path,
+    so a non-empty stderr must not be read as an error.
     """
 
     def _fake_run(command, **kwargs):
+        assert command == ["brew", "outdated", "--json=v2", "basic-memory"]
         return subprocess.CompletedProcess(
             command,
             1,
-            stdout="basicmachines-co/basic-memory/basic-memory\n",
+            stdout=_brew_outdated_payload("0.23.0"),
             stderr="==> Downloading Homebrew API data",
         )
 
     monkeypatch.setattr("basic_memory.cli.auto_update._run_subprocess", _fake_run)
-    is_outdated, _ = _check_homebrew_update_available(silent=False)
+    is_outdated, latest_version = _check_homebrew_update_available(silent=False)
     assert is_outdated is True
+    assert latest_version == "0.23.0"
 
 
 def test_check_homebrew_update_available_exit_code_0_means_up_to_date(monkeypatch):
     """brew outdated exits 0 when the formula is up to date."""
 
     def _fake_run(command, **kwargs):
-        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=_brew_outdated_payload(),
+            stderr="",
+        )
 
     monkeypatch.setattr("basic_memory.cli.auto_update._run_subprocess", _fake_run)
     is_outdated, _ = _check_homebrew_update_available(silent=False)
     assert is_outdated is False
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({}, "omitted the formulae list"),
+        ({"formulae": [None]}, "malformed formula"),
+        (
+            {"formulae": [{"name": "basicmachines-co/basic-memory/basic-memory"}]},
+            "omitted the formula current_version",
+        ),
+        (
+            {"formulae": [{"name": "another-formula", "current_version": "1.0.0"}]},
+            "exited 1",
+        ),
+    ],
+)
+def test_check_homebrew_update_available_rejects_malformed_json(
+    monkeypatch,
+    payload,
+    message,
+):
+    """A syntactically valid but incomplete response is still not an answer."""
+
+    def _fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 1, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr("basic_memory.cli.auto_update._run_subprocess", _fake_run)
+
+    with pytest.raises(HomebrewCheckError, match=message):
+        _check_homebrew_update_available(silent=False)
 
 
 def test_check_homebrew_update_available_failed_check_is_not_up_to_date(monkeypatch):
@@ -339,7 +393,7 @@ def test_homebrew_outdated_triggers_upgrade(monkeypatch, tmp_path):
 
     monkeypatch.setattr(
         "basic_memory.cli.auto_update._check_homebrew_update_available",
-        lambda silent: (True, None),
+        lambda silent: (True, "0.23.0"),
     )
     calls: list[list[str]] = []
 
@@ -355,7 +409,29 @@ def test_homebrew_outdated_triggers_upgrade(monkeypatch, tmp_path):
     )
 
     assert result.status == AutoUpdateStatus.UPDATED
+    assert result.latest_version == "0.23.0"
     assert calls == [["brew", "upgrade", "basic-memory"]]
+
+
+def test_homebrew_outdated_check_only_reports_latest_version(monkeypatch, tmp_path):
+    config = _base_config(tmp_path)
+    manager = StubConfigManager(config)
+
+    monkeypatch.setattr(
+        "basic_memory.cli.auto_update._check_homebrew_update_available",
+        lambda silent: (True, "0.23.0"),
+    )
+
+    result = run_auto_update(
+        check_only=True,
+        config_manager=_config_manager(manager),
+        executable="/opt/homebrew/Cellar/basic-memory/0.22.1/bin/python",
+    )
+
+    assert result.status == AutoUpdateStatus.UPDATE_AVAILABLE
+    assert result.latest_version == "0.23.0"
+    assert "latest: 0.23.0" in (result.message or "")
+    assert "unknown" not in (result.message or "")
 
 
 def test_uv_tool_pypi_check_triggers_upgrade(monkeypatch, tmp_path):

--- a/tests/cli/test_auto_update.py
+++ b/tests/cli/test_auto_update.py
@@ -4,15 +4,18 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import urllib.error
 from datetime import datetime, timedelta, timezone
 from io import StringIO
 from typing import Any, cast
 
+import pytest
 from rich.console import Console
 
 from basic_memory.cli.auto_update import (
     AutoUpdateResult,
     AutoUpdateStatus,
+    HomebrewCheckError,
     InstallSource,
     _check_homebrew_update_available,
     _is_interactive_session,
@@ -22,6 +25,11 @@ from basic_memory.cli.auto_update import (
     run_auto_update,
 )
 from basic_memory.config import BasicMemoryConfig
+
+UNTRUSTED_TAP_STDERR = (
+    "Error: Refusing to load formula basicmachines-co/basic-memory/basic-memory "
+    "from untrusted tap basicmachines-co/basic-memory."
+)
 
 
 class StubConfigManager:
@@ -159,6 +167,87 @@ def test_check_homebrew_update_available_exit_code_0_means_up_to_date(monkeypatc
     monkeypatch.setattr("basic_memory.cli.auto_update._run_subprocess", _fake_run)
     is_outdated, _ = _check_homebrew_update_available(silent=False)
     assert is_outdated is False
+
+
+def test_check_homebrew_update_available_failed_check_is_not_up_to_date(monkeypatch):
+    """A failed `brew outdated` exits non-zero with empty stdout -- it is not an answer."""
+
+    def _fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr=UNTRUSTED_TAP_STDERR)
+
+    monkeypatch.setattr("basic_memory.cli.auto_update._run_subprocess", _fake_run)
+
+    with pytest.raises(HomebrewCheckError) as excinfo:
+        _check_homebrew_update_available(silent=False)
+
+    assert "untrusted tap" in str(excinfo.value)
+
+
+def test_check_homebrew_update_available_reports_missing_brew(monkeypatch):
+    """brew not on PATH must surface as an unanswered check, not as up to date."""
+
+    def _raise_not_found(command, **kwargs):
+        raise FileNotFoundError(command[0])
+
+    monkeypatch.setattr("basic_memory.cli.auto_update._run_subprocess", _raise_not_found)
+
+    with pytest.raises(HomebrewCheckError):
+        _check_homebrew_update_available(silent=False)
+
+
+def test_failed_homebrew_check_falls_back_to_pypi(monkeypatch, tmp_path):
+    """Regression: a failed brew check reported the install as up to date.
+
+    The untrusted tap is one trigger; a stale tap, a missing formula, or a network
+    failure produce the same empty-stdout shape.
+    """
+    config = _base_config(tmp_path)
+    manager = StubConfigManager(config)
+
+    def _fake_run(command, **kwargs):
+        assert command[:2] == ["brew", "outdated"]
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr=UNTRUSTED_TAP_STDERR)
+
+    monkeypatch.setattr("basic_memory.cli.auto_update._run_subprocess", _fake_run)
+    monkeypatch.setattr(
+        "basic_memory.cli.auto_update._check_pypi_update_available",
+        lambda: (True, "9.9.9"),
+    )
+
+    result = run_auto_update(
+        check_only=True,
+        config_manager=_config_manager(manager),
+        executable="/opt/homebrew/Cellar/basic-memory/0.18.0/bin/python",
+    )
+
+    assert result.status == AutoUpdateStatus.UPDATE_AVAILABLE
+    assert result.latest_version == "9.9.9"
+    assert "brew upgrade basic-memory" in (result.message or "")
+
+
+def test_failed_homebrew_check_reports_failure_when_pypi_is_unreachable(monkeypatch, tmp_path):
+    """With neither source able to answer, report the failure rather than success."""
+    config = _base_config(tmp_path)
+    manager = StubConfigManager(config)
+
+    def _fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr=UNTRUSTED_TAP_STDERR)
+
+    def _pypi_unreachable():
+        raise urllib.error.URLError("network unreachable")
+
+    monkeypatch.setattr("basic_memory.cli.auto_update._run_subprocess", _fake_run)
+    monkeypatch.setattr(
+        "basic_memory.cli.auto_update._check_pypi_update_available", _pypi_unreachable
+    )
+
+    result = run_auto_update(
+        config_manager=_config_manager(manager),
+        executable="/opt/homebrew/Cellar/basic-memory/0.18.0/bin/python",
+    )
+
+    assert result.status == AutoUpdateStatus.FAILED
+    assert result.update_available is False
 
 
 def test_preload_lazy_console_modules_imports_deferred_modules(monkeypatch):

--- a/tests/cli/test_auto_update.py
+++ b/tests/cli/test_auto_update.py
@@ -146,11 +146,19 @@ def test_force_bypasses_auto_update_disabled(monkeypatch, tmp_path):
 
 
 def test_check_homebrew_update_available_exit_code_1_means_outdated(monkeypatch):
-    """brew outdated exits 1 when the formula is outdated, not on error."""
+    """brew outdated exits 1 when the formula is outdated, not on error.
+
+    Exit 1 is shared with the failure case, so stdout is the discriminator: the
+    tap-qualified formula name means outdated. brew also writes progress chatter
+    to stderr on this path, so a non-empty stderr must not be read as an error.
+    """
 
     def _fake_run(command, **kwargs):
         return subprocess.CompletedProcess(
-            command, 1, stdout="basicmachines-co/basic-memory/basic-memory\n", stderr=""
+            command,
+            1,
+            stdout="basicmachines-co/basic-memory/basic-memory\n",
+            stderr="==> Downloading Homebrew API data",
         )
 
     monkeypatch.setattr("basic_memory.cli.auto_update._run_subprocess", _fake_run)

--- a/tests/cli/test_auto_update.py
+++ b/tests/cli/test_auto_update.py
@@ -233,6 +233,68 @@ def test_failed_homebrew_check_falls_back_to_pypi(monkeypatch, tmp_path):
     assert "brew upgrade basic-memory" in (result.message or "")
 
 
+def test_failed_homebrew_check_does_not_auto_upgrade(monkeypatch, tmp_path):
+    """Availability inferred from PyPI must not trigger an automatic `brew upgrade`.
+
+    release.yml publishes to PyPI in the `release` job and the Homebrew formula job
+    `needs: release`, so PyPI can carry a version the tap cannot install yet. On top
+    of that, whatever hid the brew answer (untrusted tap, missing brew) also blocks
+    the upgrade -- so acting on the PyPI answer runs a doomed command.
+    """
+    config = _base_config(tmp_path)
+    manager = StubConfigManager(config)
+    calls: list[list[str]] = []
+
+    def _fake_run(command, **kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr=UNTRUSTED_TAP_STDERR)
+
+    monkeypatch.setattr("basic_memory.cli.auto_update._run_subprocess", _fake_run)
+    monkeypatch.setattr(
+        "basic_memory.cli.auto_update._check_pypi_update_available",
+        lambda: (True, "9.9.9"),
+    )
+
+    result = run_auto_update(
+        config_manager=_config_manager(manager),
+        executable="/opt/homebrew/Cellar/basic-memory/0.18.0/bin/python",
+    )
+
+    assert result.status == AutoUpdateStatus.UPDATE_AVAILABLE
+    assert result.updated is False
+    assert result.latest_version == "9.9.9"
+    assert ["brew", "upgrade", "basic-memory"] not in calls
+    assert "untrusted tap" in (result.message or "")
+    assert "brew upgrade basic-memory" in (result.message or "")
+
+
+def test_failed_homebrew_check_still_trusts_a_pypi_negative(monkeypatch, tmp_path):
+    """The fallback stays authoritative for "nothing newer exists".
+
+    The tap can only lag PyPI, never lead it, so a PyPI "up to date" is sound even
+    when brew could not answer. Only the positive answer is unsafe to act on.
+    """
+    config = _base_config(tmp_path)
+    manager = StubConfigManager(config)
+
+    def _fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr=UNTRUSTED_TAP_STDERR)
+
+    monkeypatch.setattr("basic_memory.cli.auto_update._run_subprocess", _fake_run)
+    monkeypatch.setattr(
+        "basic_memory.cli.auto_update._check_pypi_update_available",
+        lambda: (False, "0.0.0"),
+    )
+
+    result = run_auto_update(
+        config_manager=_config_manager(manager),
+        executable="/opt/homebrew/Cellar/basic-memory/0.18.0/bin/python",
+    )
+
+    assert result.status == AutoUpdateStatus.UP_TO_DATE
+    assert result.update_available is False
+
+
 def test_failed_homebrew_check_reports_failure_when_pypi_is_unreachable(monkeypatch, tmp_path):
     """With neither source able to answer, report the failure rather than success."""
     config = _base_config(tmp_path)


### PR DESCRIPTION
Closes #1297

## Why

- `brew outdated --quiet` used empty stdout for both an up-to-date result and several real failures, so Basic Memory could report a failed check as `UP_TO_DATE`.
- The quiet output identified an outdated formula but never supplied its target version, producing `Update available (latest: unknown)`.
- The Homebrew tap can temporarily lag PyPI during release publication, so a PyPI-inferred update must not trigger an automatic Homebrew upgrade.

## What Changed

- Distinguishes Homebrew's current, outdated, and unanswered outcomes.
- Falls back to PyPI when Homebrew cannot answer, while preventing an automatic Homebrew upgrade from a PyPI-only positive result.
- Uses `brew outdated --json=v2` to report Homebrew's own `current_version` for a confirmed outdated formula.
- Preserves Homebrew's failure reason and manual upgrade guidance.

## Implementation Details

- Homebrew exits 1 for both an outdated formula and a command failure, so the exit code is not sufficient.
- A populated JSON formula entry is authoritative for an outdated result and includes the target version.
- An empty JSON formula list with exit 0 is authoritative for an up-to-date result.
- Non-JSON output, malformed JSON, missing version metadata, subprocess failures, and timeouts remain unanswered and raise `HomebrewCheckError` for the existing fallback path.
- Tap-qualified names such as `basicmachines-co/basic-memory/basic-memory` are matched by their final formula component.

## Testing

### Automated

- `uv run pytest tests/cli/test_auto_update.py -q`: 31 passed.
- `uv run ruff check src/basic_memory/cli/auto_update.py tests/cli/test_auto_update.py`: passed.
- `just typecheck`: passed.

### Manual

- Confirmed `brew outdated --json=v2 ada-url` exits 1 with a populated formula entry and `current_version`.
- Confirmed `brew outdated --json=v2 cmux` exits 0 with an empty formula list.
- Confirmed the untrusted Basic Memory tap exits 1 with a non-JSON error, preserving the unanswered/fallback path.

## Risks / Follow-ups

- Availability inferred from PyPI after a Homebrew failure is reported but never automatically installed, because the tap may not yet carry that release.
- If both Homebrew and PyPI fail, the update check remains `FAILED`; it is never reported as up to date.
