### PR TITLE
fix(mcp): bound context traversal requests

### DIFF
--- a/src/basic_memory/api/v2/routers/memory_router.py
+++ b/src/basic_memory/api/v2/routers/memory_router.py
@@ -18,7 +18,11 @@ from basic_memory.deps import (
 )
 from basic_memory.schemas.base import TimeFrame, parse_timeframe
 from basic_memory.schemas.memory import (
+    DEFAULT_CONTEXT_PAGE_SIZE,
+    DEFAULT_CONTEXT_RELATED_RESULTS,
     GraphContext,
+    MAX_CONTEXT_PAGE_SIZE,
+    MAX_CONTEXT_RELATED_RESULTS,
     normalize_memory_url,
 )
 from basic_memory.schemas.search import SearchItemType
@@ -125,9 +129,13 @@ async def get_memory_context(
     project_id: str = Path(..., description="Project external UUID"),
     depth: int = 1,
     timeframe: Optional[TimeFrame] = None,
-    page: int = 1,
-    page_size: int = 10,
-    max_related: int = 10,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(DEFAULT_CONTEXT_PAGE_SIZE, ge=1, le=MAX_CONTEXT_PAGE_SIZE),
+    max_related: int = Query(
+        DEFAULT_CONTEXT_RELATED_RESULTS,
+        ge=0,
+        le=MAX_CONTEXT_RELATED_RESULTS,
+    ),
 ) -> GraphContext:
     """Get rich context from memory:// URI.
 
@@ -143,8 +151,8 @@ async def get_memory_context(
         depth: How many levels of related entities to include
         timeframe: Optional time window for filtering related content
         page: Page number for pagination
-        page_size: Number of items per page
-        max_related: Maximum related entities to include
+        page_size: Number of primary items per page
+        max_related: Maximum total related entities to include
 
     Returns:
         GraphContext with the entity and its related context

--- a/src/basic_memory/mcp/clients/memory.py
+++ b/src/basic_memory/mcp/clients/memory.py
@@ -12,7 +12,11 @@ import logfire
 # call_* helpers live in basic_memory.mcp.tools.utils; importing that at module
 # level executes the whole tools package (fastmcp + mcp SDK) during CLI startup,
 # so each method defers the import to call time instead (#886).
-from basic_memory.schemas.memory import GraphContext
+from basic_memory.schemas.memory import (
+    DEFAULT_CONTEXT_PAGE_SIZE,
+    DEFAULT_CONTEXT_RELATED_RESULTS,
+    GraphContext,
+)
 
 
 class MemoryClient:
@@ -47,8 +51,8 @@ class MemoryClient:
         depth: int = 1,
         timeframe: Optional[str] = None,
         page: int = 1,
-        page_size: int = 10,
-        max_related: int = 10,
+        page_size: int = DEFAULT_CONTEXT_PAGE_SIZE,
+        max_related: int = DEFAULT_CONTEXT_RELATED_RESULTS,
     ) -> GraphContext:
         """Build context from a memory path.
 
@@ -57,8 +61,8 @@ class MemoryClient:
             depth: How deep to traverse relations
             timeframe: Time filter (e.g., "7d", "1 week")
             page: Page number (1-indexed)
-            page_size: Results per page
-            max_related: Maximum related items per result
+            page_size: Primary results per page
+            max_related: Maximum total related items across the page
 
         Returns:
             GraphContext with hierarchical results

--- a/src/basic_memory/mcp/tools/build_context.py
+++ b/src/basic_memory/mcp/tools/build_context.py
@@ -17,8 +17,12 @@ from basic_memory.mcp.server import mcp
 from basic_memory.schemas.base import TimeFrame
 from basic_memory.schemas.memory import (
     ContextResult,
+    DEFAULT_CONTEXT_PAGE_SIZE,
+    DEFAULT_CONTEXT_RELATED_RESULTS,
     EntitySummary,
     GraphContext,
+    MAX_CONTEXT_PAGE_SIZE,
+    MAX_CONTEXT_RELATED_RESULTS,
     MemoryUrl,
     ObservationSummary,
     RelationSummary,
@@ -169,12 +173,18 @@ async def build_context(
     ] = 1,
     page_size: Annotated[
         int,
-        Field(default=10, validation_alias=AliasChoices("page_size", "limit", "per_page")),
-    ] = 10,
+        Field(
+            default=DEFAULT_CONTEXT_PAGE_SIZE,
+            validation_alias=AliasChoices("page_size", "limit", "per_page"),
+        ),
+    ] = DEFAULT_CONTEXT_PAGE_SIZE,
     max_related: Annotated[
         int,
-        Field(default=10, validation_alias=AliasChoices("max_related", "max_results")),
-    ] = 10,
+        Field(
+            default=DEFAULT_CONTEXT_RELATED_RESULTS,
+            validation_alias=AliasChoices("max_related", "max_results"),
+        ),
+    ] = DEFAULT_CONTEXT_RELATED_RESULTS,
     output_format: Literal["json", "text"] = "json",
     context: Context | None = None,
 ) -> dict[str, Any] | str:
@@ -199,8 +209,8 @@ async def build_context(
         depth: How many relation hops to traverse (1-3 recommended for performance)
         timeframe: How far back to look. Supports natural language like "2 days ago", "last week"
         page: Page number of results to return (default: 1)
-        page_size: Number of results to return per page (default: 10)
-        max_related: Maximum number of related results to return (default: 10)
+        page_size: Number of primary results to return per page (default: 10, maximum: 50)
+        max_related: Maximum total related results to return (default: 10, maximum: 100)
         output_format: Response format - "json" for structured JSON dict,
             "text" for compact markdown text
         context: Optional FastMCP context for performance caching.
@@ -233,6 +243,24 @@ async def build_context(
         raise ValueError(f"page must be >= 1, got {page}")
     if page_size < 1:
         raise ValueError(f"page_size must be >= 1, got {page_size}")
+    # Trigger: a caller tries to turn context traversal into a bulk vault read.
+    # Why: primary note bodies dominate response size, while broad graph reads also
+    #      increase database work and consume the model context needed for traversal.
+    # Outcome: keep the tool bounded and direct callers toward pagination and links.
+    if page_size > MAX_CONTEXT_PAGE_SIZE:
+        raise ValueError(
+            f"page_size must be <= {MAX_CONTEXT_PAGE_SIZE}, got {page_size}. "
+            "build_context is a bounded traversal starting point; request another "
+            "page or follow the returned memory:// links."
+        )
+    if max_related < 0:
+        raise ValueError(f"max_related must be >= 0, got {max_related}")
+    if max_related > MAX_CONTEXT_RELATED_RESULTS:
+        raise ValueError(
+            f"max_related must be <= {MAX_CONTEXT_RELATED_RESULTS}, got {max_related}. "
+            "build_context is a bounded traversal starting point; follow the returned "
+            "memory:// links for more context."
+        )
 
     # Detect project from memory URL prefix before routing.
     # project_id routes by external UUID, so it bypasses URL discovery entirely.

--- a/src/basic_memory/schemas/memory.py
+++ b/src/basic_memory/schemas/memory.py
@@ -9,6 +9,12 @@ from pydantic import BaseModel, Field, BeforeValidator, TypeAdapter, field_seria
 from basic_memory.schemas.search import SearchItemType
 
 
+DEFAULT_CONTEXT_PAGE_SIZE = 10
+MAX_CONTEXT_PAGE_SIZE = 50
+DEFAULT_CONTEXT_RELATED_RESULTS = 10
+MAX_CONTEXT_RELATED_RESULTS = 100
+
+
 def validate_memory_url_path(path: str) -> bool:
     """Validate that a memory URL path is well-formed.
 

--- a/test-int/bughunt_fixes/test_navigation_pagination_integration.py
+++ b/test-int/bughunt_fixes/test_navigation_pagination_integration.py
@@ -20,6 +20,7 @@ from fastmcp.exceptions import ToolError
 from typer.testing import CliRunner
 
 from basic_memory.cli.main import app as cli_app
+from basic_memory.schemas.memory import MAX_CONTEXT_PAGE_SIZE, MAX_CONTEXT_RELATED_RESULTS
 
 runner = CliRunner()
 
@@ -204,6 +205,45 @@ async def test_build_context_nonpositive_page_size_drops_primary(mcp_server, app
                     "output_format": "json",
                 },
             )
+        with pytest.raises(ToolError, match="max_related"):
+            await client.call_tool(
+                "build_context",
+                {
+                    "project": test_project.name,
+                    "url": "ctx/primary-note",
+                    "max_related": -1,
+                    "output_format": "json",
+                },
+            )
+
+        # The tool is a bounded starting point for traversal, not a bulk vault export.
+        for parameter, value in (
+            ("page_size", MAX_CONTEXT_PAGE_SIZE + 1),
+            ("max_related", MAX_CONTEXT_RELATED_RESULTS + 1),
+        ):
+            with pytest.raises(ToolError, match="bounded traversal starting point"):
+                await client.call_tool(
+                    "build_context",
+                    {
+                        "project": test_project.name,
+                        "url": "ctx/primary-note",
+                        parameter: value,
+                        "output_format": "json",
+                    },
+                )
+
+        # Values at the ceiling remain valid and return the requested primary note.
+        at_limits = await client.call_tool(
+            "build_context",
+            {
+                "project": test_project.name,
+                "url": "ctx/primary-note",
+                "page_size": MAX_CONTEXT_PAGE_SIZE,
+                "max_related": MAX_CONTEXT_RELATED_RESULTS,
+                "output_format": "json",
+            },
+        )
+        assert _parse(at_limits)["metadata"]["primary_count"] == 1
 
 
 # --- Bug #13: recent_activity header shows project name, not raw UUID ---

--- a/tests/api/v2/test_memory_router.py
+++ b/tests/api/v2/test_memory_router.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from basic_memory import db
 from basic_memory.models import Project
+from basic_memory.schemas.memory import MAX_CONTEXT_PAGE_SIZE, MAX_CONTEXT_RELATED_RESULTS
 
 
 async def create_test_entity(
@@ -180,6 +181,36 @@ async def test_get_memory_context_by_permalink(
     assert response.status_code == 200
     data = response.json()
     assert "results" in data
+
+    # Values at the public limits remain valid so callers can request a bounded,
+    # larger traversal without guessing below the advertised ceiling.
+    response_at_limits = await client.get(
+        f"{v2_project_url}/memory/context-test",
+        params={"page_size": MAX_CONTEXT_PAGE_SIZE, "max_related": MAX_CONTEXT_RELATED_RESULTS},
+    )
+    assert response_at_limits.status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"page_size": MAX_CONTEXT_PAGE_SIZE + 1},
+        {"max_related": MAX_CONTEXT_RELATED_RESULTS + 1},
+        {"page": 0},
+        {"page_size": 0},
+        {"max_related": -1},
+    ],
+)
+async def test_get_memory_context_rejects_unbounded_requests(
+    client: AsyncClient,
+    v2_project_url: str,
+    params: dict[str, int],
+):
+    """The API boundary must enforce the same bounds as the MCP tool."""
+    response = await client.get(f"{v2_project_url}/memory/context-test", params=params)
+
+    assert response.status_code == 422
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

- `build_context` accepted arbitrary `page_size` and `max_related` values, allowing callers to turn a traversal tool into a multi-megabyte vault export.
- Large requests increase database work, response serialization, transport size, and model-context consumption.
- Fixes #1296 for the v0.23 release.

## What Changed

- Caps primary context pages at 50 results.
- Caps related context at 100 total results across the page.
- Rejects negative `max_related` values, which otherwise act like an unbounded SQL limit.
- Enforces the contract at both the MCP tool and direct API boundary.
- Clarifies that callers should paginate or follow returned `memory://` links for continued traversal.

## Implementation Details

- Shared limits live with the memory context schemas so the MCP tool, typed client, and API use the same defaults and ceilings.
- The MCP tool returns an actionable error rather than silently truncating a graph.
- The separate `recent_activity` contract remains unchanged.
- These are count guardrails, not a hard byte limit; progressive content loading remains separate follow-up work in #686.

## Testing

### Automated

- `uv run pytest tests/api/v2/test_memory_router.py test-int/bughunt_fixes/test_navigation_pagination_integration.py -q`: 21 passed.
- `uv run ruff check src/basic_memory/schemas/memory.py src/basic_memory/mcp/tools/build_context.py src/basic_memory/api/v2/routers/memory_router.py src/basic_memory/mcp/clients/memory.py tests/api/v2/test_memory_router.py test-int/bughunt_fixes/test_navigation_pagination_integration.py`: passed.
- `just typecheck`: passed.

### Manual

- Reviewed the API and MCP contracts together to confirm oversized values are rejected and values exactly at each ceiling remain valid.

## Risks / Follow-ups

- Individual note bodies can still be large, so the limits do not promise a fixed response byte size.
- #686 remains the appropriate place for progressive content tiers.
