### PR TITLE
docs(core): explain custom FastEmbed models

### DIFF
--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -150,11 +150,21 @@ Basic Memory passes `semantic_embedding_model` to FastEmbed, so you can select a
 embedding model registered by the installed FastEmbed version. Basic Memory does not maintain a
 second model allowlist or add arbitrary Hugging Face models to FastEmbed.
 
-List the models available in your installation:
+List the models available in the same Python environment as Basic Memory. For a `uv tool`
+installation on macOS or Linux:
 
 ```bash
-python -c "from fastembed import TextEmbedding; print(*(m['model'] for m in TextEmbedding.list_supported_models()), sep='\n')"
+"$(uv tool dir)/basic-memory/bin/python" -c "from fastembed import TextEmbedding; print(*(m['model'] for m in TextEmbedding.list_supported_models()), sep='\n')"
 ```
+
+On Windows PowerShell, use the tool environment's `Scripts` directory:
+
+```powershell
+& "$(uv tool dir)\basic-memory\Scripts\python.exe" -c "from fastembed import TextEmbedding; print(*(m['model'] for m in TextEmbedding.list_supported_models()), sep='\n')"
+```
+
+For a virtual-environment or system `pip` installation, run the original installation's
+`python` executable with the same `-c` argument.
 
 Then configure the model and its output dimensions. For example, the FastEmbed version bundled
 with Basic Memory supports the larger mixed Chinese-English Jina model:

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -154,17 +154,19 @@ List the models available in the same Python environment as Basic Memory. For a 
 installation on macOS or Linux:
 
 ```bash
-"$(uv tool dir)/basic-memory/bin/python" -c "from fastembed import TextEmbedding; print(*(m['model'] for m in TextEmbedding.list_supported_models()), sep='\n')"
+"$(uv tool dir)/basic-memory/bin/python" -c \
+  'from fastembed import TextEmbedding; print(*(m["model"] + "\t" + str(m["dim"]) for m in TextEmbedding.list_supported_models()), sep="\n")'
 ```
 
 On Windows PowerShell, use the tool environment's `Scripts` directory:
 
 ```powershell
-& "$(uv tool dir)\basic-memory\Scripts\python.exe" -c "from fastembed import TextEmbedding; print(*(m['model'] for m in TextEmbedding.list_supported_models()), sep='\n')"
+& "$(uv tool dir)\basic-memory\Scripts\python.exe" -c 'from fastembed import TextEmbedding; print(*(m["model"] + "\t" + str(m["dim"]) for m in TextEmbedding.list_supported_models()), sep="\n")'
 ```
 
 For a virtual-environment or system `pip` installation, run the original installation's
-`python` executable with the same `-c` argument.
+`python` executable with the same `-c` command. Each line shows the model identifier followed by
+its output dimensions.
 
 Then configure the model and its output dimensions. For example, the FastEmbed version bundled
 with Basic Memory supports the larger mixed Chinese-English Jina model:

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -116,10 +116,10 @@ All settings are fields on `BasicMemoryConfig` and can be set via environment va
 | `milvus_collection_prefix` | `BASIC_MEMORY_MILVUS_COLLECTION_PREFIX` | `"basic_memory"` | Prefix for deterministic project-isolated Milvus collections. |
 | `milvus_database` | `BASIC_MEMORY_MILVUS_DATABASE` | `"default"` | Milvus database name. |
 | `semantic_embedding_provider` | `BASIC_MEMORY_SEMANTIC_EMBEDDING_PROVIDER` | `"fastembed"` | Embedding provider: `"fastembed"` (local), `"openai"` (API), or `"litellm"` (multi-provider API, **experimental** — advanced users only). |
-| `semantic_embedding_model` | `BASIC_MEMORY_SEMANTIC_EMBEDDING_MODEL` | `"bge-small-en-v1.5"` | Model identifier. Auto-adjusted per provider if left at default. |
+| `semantic_embedding_model` | `BASIC_MEMORY_SEMANTIC_EMBEDDING_MODEL` | `"bge-small-en-v1.5"` | Model identifier. FastEmbed models must exist in the installed FastEmbed catalog. Auto-adjusted per provider if left at default. |
 | `semantic_embedding_api_base` | `BASIC_MEMORY_SEMANTIC_EMBEDDING_API_BASE` | Unset | Optional custom endpoint for the LiteLLM provider, including local or self-hosted OpenAI-compatible servers. |
 | `semantic_embedding_api_key` | `BASIC_MEMORY_SEMANTIC_EMBEDDING_API_KEY` | Unset | Optional API key passed directly to the LiteLLM provider. When unset, LiteLLM continues to read provider credential env vars such as `OPENAI_API_KEY`. |
-| `semantic_embedding_dimensions` | `BASIC_MEMORY_SEMANTIC_EMBEDDING_DIMENSIONS` | Provider default | Vector dimensions. 384 for FastEmbed, 1536 for OpenAI/LiteLLM OpenAI. Required when using a non-default LiteLLM model. |
+| `semantic_embedding_dimensions` | `BASIC_MEMORY_SEMANTIC_EMBEDDING_DIMENSIONS` | Provider default | Vector dimensions. Defaults to 384 for FastEmbed and 1536 for OpenAI/LiteLLM OpenAI. Set this to the model's output size when choosing a non-default FastEmbed or LiteLLM model. |
 | `semantic_embedding_forward_dimensions` | `BASIC_MEMORY_SEMANTIC_EMBEDDING_FORWARD_DIMENSIONS` | Auto | LiteLLM-only override for whether configured dimensions are sent as a provider-side output-size request. |
 | `semantic_embedding_batch_size` | `BASIC_MEMORY_SEMANTIC_EMBEDDING_BATCH_SIZE` | `2` | Number of texts to embed per batch. |
 | `semantic_embedding_document_input_type` | `BASIC_MEMORY_SEMANTIC_EMBEDDING_DOCUMENT_INPUT_TYPE` | Auto for known LiteLLM models | Optional LiteLLM `input_type` for indexed document/passages. |
@@ -143,6 +143,34 @@ FastEmbed runs entirely locally using ONNX models — no API key, no network cal
 pip install basic-memory
 export BASIC_MEMORY_SEMANTIC_SEARCH_ENABLED=true
 ```
+
+#### Choose another local model
+
+Basic Memory passes `semantic_embedding_model` to FastEmbed, so you can select any text
+embedding model registered by the installed FastEmbed version. Basic Memory does not maintain a
+second model allowlist or add arbitrary Hugging Face models to FastEmbed.
+
+List the models available in your installation:
+
+```bash
+python -c "from fastembed import TextEmbedding; print(*(m['model'] for m in TextEmbedding.list_supported_models()), sep='\n')"
+```
+
+Then configure the model and its output dimensions. For example, the FastEmbed version bundled
+with Basic Memory supports the larger mixed Chinese-English Jina model:
+
+```bash
+basic-memory config set semantic_embedding_provider fastembed
+basic-memory config set semantic_embedding_model jinaai/jina-embeddings-v2-base-zh
+basic-memory config set semantic_embedding_dimensions 768
+bm reindex --embeddings
+```
+
+The model downloads on first use. The configured dimensions must match the model's actual output
+size because Basic Memory creates fixed-dimension vector storage before indexing. After changing
+the model or dimensions, rebuild embeddings as shown above. A model name absent from
+`TextEmbedding.list_supported_models()` requires support in FastEmbed itself or a separately
+operated provider such as LiteLLM; setting an arbitrary Hugging Face identifier is not enough.
 
 ### OpenAI
 


### PR DESCRIPTION
## Why

- Users can already choose any text embedding model supported by their installed FastEmbed version, but the semantic-search guide only showed the default model.
- The guide incorrectly implied that explicit dimensions were only needed for non-default LiteLLM models; larger FastEmbed models also need their actual output dimension configured.
- Closes #1295 by documenting the existing local-first configuration boundary instead of adding model-specific plumbing to Basic Memory.

## What Changed

- Documents how to list each model and output dimension registered by the installed FastEmbed version.
- Adds a complete configuration example using `jinaai/jina-embeddings-v2-base-zh` with 768 dimensions.
- Explains that model and dimension changes require an embedding reindex.
- Clarifies that arbitrary Hugging Face identifiers require FastEmbed support or another provider.

## Implementation Details

- Basic Memory continues to pass the configured model identifier directly to FastEmbed.
- The documentation distinguishes Basic Memory configuration from FastEmbed's upstream model catalog.
- No model allowlist, download registry, or provider fallback was added.

## Testing

### Automated

- `uv run python -c "from fastembed import TextEmbedding; models={m['model']: m for m in TextEmbedding.list_supported_models()}; print(models['jinaai/jina-embeddings-v2-base-zh']['dim'])"`: confirmed the documented model is registered with 768 dimensions.
- `"$(uv tool dir)/basic-memory/bin/python" -c 'from fastembed import TextEmbedding; print(*(m["model"] + "\t" + str(m["dim"]) for m in TextEmbedding.list_supported_models()), sep="\n")'`: confirmed the documented catalog query runs inside an installed `uv tool` environment and prints both model identifiers and dimensions.
- `git diff --check`: passed.

### Manual

- Reviewed the configuration commands against the current `BasicMemoryConfig` fields and reindex guidance.

## Risks / Follow-ups

- Available models remain version-dependent because FastEmbed owns the catalog.
- Models not registered by FastEmbed remain outside Basic Memory's local provider contract.
