### PR TITLE
docs(core): document FastEmbed E5 prefixes

### DIFF
--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -184,6 +184,23 @@ the model or dimensions, rebuild embeddings as shown above. A model name absent 
 `TextEmbedding.list_supported_models()` requires support in FastEmbed itself or a separately
 operated provider such as LiteLLM; setting an arbitrary Hugging Face identifier is not enough.
 
+Some FastEmbed models require different literal prefixes for indexed passages and search queries.
+Basic Memory does not infer model-specific prompts for custom models, so configure the prefixes
+required by the selected model. For example, multilingual E5 models require `passage: ` for
+indexed content and `query: ` for queries:
+
+```bash
+basic-memory config set semantic_embedding_provider fastembed
+basic-memory config set semantic_embedding_model intfloat/multilingual-e5-large
+basic-memory config set semantic_embedding_dimensions 1024
+basic-memory config set semantic_embedding_document_prefix "passage: "
+basic-memory config set semantic_embedding_query_prefix "query: "
+bm reindex --embeddings
+```
+
+Rebuild embeddings after changing either prefix so stored document vectors and new query vectors
+use the same model contract.
+
 ### OpenAI
 
 Uses OpenAI's embeddings API for higher-dimensional vectors. Requires an API key.


### PR DESCRIPTION
## Why

- #1264 reports degraded retrieval when a custom multilingual E5 FastEmbed model is used without
  its required query and passage prefixes.
- Basic Memory already exposes provider-agnostic prefix configuration, so the v0.23 fix is to make
  the model contract discoverable instead of adding model-family heuristics to runtime code.

Closes #1264.

## What Changed

- Added a multilingual E5 example to the FastEmbed model-selection documentation.
- Documented the required `passage: ` and `query: ` prefixes, 1024-dimensional model setting, and
  embedding rebuild command.
- Clarified that custom model prompts remain explicit operator configuration.

## Implementation Details

- Updated only `docs/semantic-search.md`.
- Did not implement the automatic model-family defaults proposed by #1284.

## Testing

### Automated

- `git diff --check`: passed.
- Queried `TextEmbedding.list_supported_models()` in the repository environment: confirmed
  `intfloat/multilingual-e5-large` is available, reports 1024 dimensions, and requires
  query/document prefixes.
- `uv run mdformat --check docs/semantic-search.md`: not a usable focused gate because the file on
  `origin/main` already fails the same whole-file formatting check.

### Manual

- Verified the documented `basic-memory config set KEY VALUE` syntax against the CLI help.

## Risks / Follow-ups

- No runtime behavior changes.
- Operators remain responsible for the documented input contract of other custom embedding models.
- #1284 can close as not planned because Basic Memory will not infer model-specific prompts.
