### PR TITLE
docs(integrations): require supported Hermes installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,13 +240,14 @@ the `memory-*` directories from `skills/` into your agent's skills directory.
 
 Hermes keeps its native plugin shape under [`integrations/hermes`](integrations/hermes):
 
-```bash
-hermes plugins install basicmachines-co/basic-memory --path integrations/hermes
-```
+Managed installation requires a Hermes Agent release containing the
+[manifest-v2 installer fix](https://github.com/NousResearch/hermes-agent/pull/85893).
+Hermes Agent v0.20.5 (`v2026.8.19`) and earlier are not supported. If the installer says it only
+supports `manifest_version: 1`, update Hermes to a release containing that fix.
 
-If your Hermes build lacks subpath installs, use the final deprecated
-`basicmachines-co/hermes-basic-memory` pointer release until host support
-lands.
+```bash
+hermes plugins install basicmachines-co/basic-memory/integrations/hermes
+```
 
 ### OpenClaw
 

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -8,8 +8,13 @@ The plugin replaces Hermes's "no external memory provider" with a real graph: se
 
 ## Install
 
+Managed installation requires a Hermes Agent release containing the
+[manifest-v2 installer fix](https://github.com/NousResearch/hermes-agent/pull/85893).
+Hermes Agent v0.20.5 (`v2026.8.19`) and earlier are not supported. If the installer says it only
+supports `manifest_version: 1`, update Hermes to a release containing that fix.
+
 ```bash
-hermes plugins install basicmachines-co/basic-memory --path integrations/hermes
+hermes plugins install basicmachines-co/basic-memory/integrations/hermes
 ```
 
 Then activate it in `~/.hermes/config.yaml`:
@@ -21,13 +26,12 @@ memory:
 
 If you run the gateway, restart it (`hermes gateway restart`). Done.
 
-If your installed Hermes build does not support `--path`, use the final deprecated `basicmachines-co/hermes-basic-memory` pointer release until Hermes subpath installs are available. Ongoing development now lives in [`basic-memory/integrations/hermes`](https://github.com/basicmachines-co/basic-memory/tree/main/integrations/hermes).
-
 The plugin self-installs the `basic-memory` CLI on first init via `uv tool install basic-memory` (one-time ~10s pause if it isn't already present). The bm binary lands at `~/.local/bin/bm` — the same location a manual `uv tool install basic-memory` would produce, so a later manual install or upgrade is a no-op rather than a second install.
 
 ### Prerequisites
 
-- [Hermes Agent](https://github.com/NousResearch/hermes-agent)
+- A supported [Hermes Agent](https://github.com/NousResearch/hermes-agent) release as described
+  above
 - [`uv`](https://docs.astral.sh/uv/) on PATH (used for the bootstrap install)
 - The `mcp` Python package in the Hermes venv. If `hermes plugins install` doesn't auto-install it (it follows `pip_dependencies` in `plugin.yaml`), run:
   ```bash

--- a/scripts/validate_hermes_plugin.py
+++ b/scripts/validate_hermes_plugin.py
@@ -9,6 +9,11 @@ from pathlib import Path
 
 from validate_skills import parse_frontmatter
 
+HERMES_INSTALL_COMMAND = "hermes plugins install basicmachines-co/basic-memory/integrations/hermes"
+UNSUPPORTED_HERMES_INSTALL_COMMAND = (
+    "hermes plugins install basicmachines-co/basic-memory --path integrations/hermes"
+)
+
 
 def parse_plugin_yaml(path: Path) -> dict[str, str]:
     data: dict[str, str] = {}
@@ -23,10 +28,12 @@ def validate_hermes_plugin(plugin_dir: Path) -> None:
     plugin_dir = plugin_dir.resolve()
     plugin_yaml = plugin_dir / "plugin.yaml"
     module = plugin_dir / "__init__.py"
+    readme = plugin_dir / "README.md"
+    root_readme = plugin_dir.parents[1] / "README.md"
     skill = plugin_dir / "skill/SKILL.md"
     tests = plugin_dir / "tests"
 
-    for path in [plugin_yaml, module, skill, tests]:
+    for path in [plugin_yaml, module, readme, root_readme, skill, tests]:
         if not path.exists():
             raise SystemExit(f"Missing Hermes plugin file: {path}")
 
@@ -45,6 +52,13 @@ def validate_hermes_plugin(plugin_dir: Path) -> None:
     frontmatter = parse_frontmatter(skill)
     if frontmatter.get("name") != "basic-memory":
         raise SystemExit(f"{skill}: expected name=basic-memory")
+
+    for documentation in [root_readme, readme]:
+        documentation_text = documentation.read_text()
+        if HERMES_INSTALL_COMMAND not in documentation_text:
+            raise SystemExit(f"{documentation}: missing supported Hermes install command")
+        if UNSUPPORTED_HERMES_INSTALL_COMMAND in documentation_text:
+            raise SystemExit(f"{documentation}: contains unsupported Hermes --path command")
 
     print(f"validated Hermes plugin in {plugin_dir}")
 


### PR DESCRIPTION
## Why

- #1280 identified that the documented `--path integrations/hermes` option does not exist in
  Hermes Agent.
- The maintained plugin uses `manifest_version: 2`, while Hermes Agent v0.20.5 and earlier cap
  managed installation at manifest v1. We support a current Hermes release containing the
  upstream installer fix instead of maintaining compatibility shims for older hosts.

Addresses #1280.

## What Changed

- Replaced the unsupported `--path` syntax with Hermes's supported monorepo-subdirectory
  identifier in the root and integration READMEs.
- Documented the manifest-v2 support floor and explicitly excluded Hermes Agent v0.20.5 and
  earlier from managed installation support.
- Removed the deprecated standalone pointer-repository fallback.
- Extended the Hermes package validator to require the supported command and reject the old one.

## Implementation Details

- The plugin remains `manifest_version: 2`; there is no runtime compatibility shim or manifest
  downgrade.
- The docs link to NousResearch/hermes-agent#85893, the upstream single-source-of-truth fix for
  the installer/runtime manifest-version mismatch.

## Testing

### Automated

- `uv run ruff check scripts/validate_hermes_plugin.py`: passed.
- `uv run ruff format --check scripts/validate_hermes_plugin.py`: passed after formatting.
- `just package-check-hermes`: passed; 269 tests passed and 12 gated integration tests skipped.
- `just package-check`: passed, including all consolidated agent-package checks.
- `git diff --check`: passed.

### Manual

- Verified Hermes Agent v0.20.5's installer still caps manifests at v1 while its runtime loader
  accepts v2.
- Verified the v0.20.5 installer parses `owner/repo/subdirectory` identifiers.

## Risks / Follow-ups

- No currently released Hermes version satisfies this managed-install support floor. The docs say
  so rather than advertising an install command that fails.
- A live latest-Hermes install gate should be added after upstream #85893 lands in a release; it
  cannot pass against v0.20.5.
- Companion documentation and marketing PRs synchronize the public install surfaces named in
  #1280.
