### PR TITLE
fix(core): update benchmark MCP result fields

### DIFF
--- a/benchmarks/scripts/read_load_bench.py
+++ b/benchmarks/scripts/read_load_bench.py
@@ -382,7 +382,7 @@ def write_manifest(
 
 
 def result_payload(result: CallToolResult) -> dict[str, object]:
-    structured = result.structuredContent
+    structured = result.structured_content
     if isinstance(structured, dict):
         wrapped = structured.get("result")
         payload = wrapped if isinstance(wrapped, dict) else structured
@@ -402,7 +402,7 @@ def result_payload(result: CallToolResult) -> dict[str, object]:
 
 def result_text(result: CallToolResult) -> str | None:
     """Return text from a successful text-mode tool response."""
-    if result.isError:
+    if result.is_error:
         return None
     text_parts = [
         text for item in result.content if isinstance((text := getattr(item, "text", None)), str)
@@ -517,7 +517,7 @@ async def write_target(
             "output_format": "json",
         },
     )
-    if result.isError:
+    if result.is_error:
         raise RuntimeError(f"write_note failed while seeding {title}")
     payload = result_payload(result)
     identifier = payload.get("permalink")
@@ -573,7 +573,7 @@ async def searchable_count(session: ClientSession, project: str) -> int:
             "output_format": "json",
         },
     )
-    if result.isError:
+    if result.is_error:
         return 0
     payload = result_payload(result)
     total = payload.get("total")
@@ -742,7 +742,7 @@ async def run(args: argparse.Namespace) -> int:
                 "create_memory_project",
                 {"project_name": project, "project_path": str(project_dir)},
             )
-            if created.isError:
+            if created.is_error:
                 raise RuntimeError("could not create benchmark project")
 
             targets = await seed_corpus(

--- a/tests/test_read_load_bench.py
+++ b/tests/test_read_load_bench.py
@@ -30,11 +30,11 @@ read_load_bench = load_read_load_bench()
 def test_result_helpers_use_current_mcp_python_fields() -> None:
     success = CallToolResult(
         content=[TextContent(type="text", text="plain response")],
-        structuredContent={"result": {"permalink": "notes/example"}},
+        structured_content={"result": {"permalink": "notes/example"}},
     )
     failure = CallToolResult(
         content=[TextContent(type="text", text="failed response")],
-        isError=True,
+        is_error=True,
     )
 
     assert read_load_bench.result_payload(success) == {"permalink": "notes/example"}

--- a/tests/test_read_load_bench.py
+++ b/tests/test_read_load_bench.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from types import ModuleType
 
 import pytest
+from mcp.types import CallToolResult, TextContent
 
 
 def load_read_load_bench() -> ModuleType:
@@ -24,6 +25,21 @@ def load_read_load_bench() -> ModuleType:
 
 
 read_load_bench = load_read_load_bench()
+
+
+def test_result_helpers_use_current_mcp_python_fields() -> None:
+    success = CallToolResult(
+        content=[TextContent(type="text", text="plain response")],
+        structuredContent={"result": {"permalink": "notes/example"}},
+    )
+    failure = CallToolResult(
+        content=[TextContent(type="text", text="failed response")],
+        isError=True,
+    )
+
+    assert read_load_bench.result_payload(success) == {"permalink": "notes/example"}
+    assert read_load_bench.result_text(success) == "plain response"
+    assert read_load_bench.result_text(failure) is None
 
 
 @dataclass


### PR DESCRIPTION
## Why

The read-load benchmark no longer ran against the current MCP SDK because it accessed wire-format aliases (`isError` and `structuredContent`) as Python attributes. This blocked the authoritative-versus-Redis release benchmark before any measurements were produced.

## What Changed

- Use the MCP model's typed Python attributes, `is_error` and `structured_content`, throughout the read-load harness.
- Add a regression test using real `CallToolResult` and `TextContent` models.

## Implementation Details

The MCP SDK still serializes these fields with camel-case wire aliases, but its Python API exposes snake-case model fields. The harness now follows that typed API directly without compatibility fallbacks or dynamic attribute probing.

## Testing

### Automated

- `uv run pytest tests/test_read_load_bench.py -q`: 23 passed
- `just bench-read-check`: Ruff and Pyright passed
- `just typecheck`: passed

### Manual

- `just bench-read-cache redis://127.0.0.1:6379/0 af691b9d-r1`: completed all 24 authoritative/Redis scenarios with 3,072 successful reads and zero content-validation failures.

## Risks / Follow-ups

No product runtime behavior changes. The generated benchmark artifacts remain local and ignored; this PR only repairs the harness contract.
