### PR TITLE
fix(cli): route Team WebDAV transfers to the control-plane base

### DIFF
--- a/src/basic_memory/cli/commands/cloud/webdav_transfer.py
+++ b/src/basic_memory/cli/commands/cloud/webdav_transfer.py
@@ -56,7 +56,7 @@ from basic_memory.cli.commands.cloud.webdav import (
     upload_file,
 )
 from basic_memory.ignore_utils import load_gitignore_patterns, should_ignore_path
-from basic_memory.mcp.async_client import get_cloud_proxy_client
+from basic_memory.mcp.async_client import get_cloud_control_plane_client
 
 console = Console()
 
@@ -123,7 +123,13 @@ async def webdav_project_diff(
     Raises:
         WebdavError: If the project cannot be listed.
     """
-    cm_factory = client_cm_factory or partial(get_cloud_proxy_client, workspace=workspace_id)
+    # The tenant WebDAV surface is mounted at the cloud app root (/webdav),
+    # not behind /proxy: the proxy catch-alls forward to the per-tenant core
+    # instance, which serves no WebDAV routes, so the proxy client 404s on
+    # every listing (cloud#1816).
+    cm_factory = client_cm_factory or partial(
+        get_cloud_control_plane_client, workspace=workspace_id
+    )
     async with cm_factory() as client:
         remote_files = await list_project_files(client, project)
 
@@ -188,7 +194,11 @@ async def webdav_project_transfer(
             console.print(f"  [dim]{transfer.describe()}[/dim]")
         return
 
-    cm_factory = client_cm_factory or partial(get_cloud_proxy_client, workspace=workspace_id)
+    # Root-mounted /webdav needs the control-plane base — see the note in
+    # webdav_project_diff (cloud#1816).
+    cm_factory = client_cm_factory or partial(
+        get_cloud_control_plane_client, workspace=workspace_id
+    )
     async with cm_factory() as client:
         if direction == "push":
             transfers, appeared = await _drop_appeared_on_cloud(client, project, transfers)


### PR DESCRIPTION
## Why

The live Team push/pull smoke (#1288) kept failing after the cloud gateway fix (cloud#1815) deployed — but with a new signature: JSON 404s instead of Starlette's plain-text ones. Second layer of cloud#1816: the tenant WebDAV surface is mounted at the **cloud app root** (`/webdav`, `main.py:716` in the cloud repo), while `/proxy/{path}` forwards to the per-tenant core instance — which serves no WebDAV routes. #1263's transfer module used `get_cloud_proxy_client`, so every listing died no matter what the gateway forwarded.

`bm cloud upload` already uses `get_cloud_control_plane_client` for exactly this reason (its routing tests pin it); the transfer module now matches.

## Live verification against production (Demo workspace, `leitstern`)

- PROPFIND listing: **207 Multi-Status** with ETag/Last-Modified validators
- Baseline `pull`: 10 files transferred, additive
- Create-only `push` of a new file: transferred, verified cloud-side
- Both-sides divergence: `push` **and** `pull` under default `--on-conflict fail` abort and list the file with resolution options
- `push --on-conflict keep-local`: cloud content verified overwritten (GET shows local version + fresh validators)
- `pull --on-conflict keep-cloud`: local file verified overwritten with cloud version
- Existing project files untouched throughout; scratch file deleted after (WebDAV DELETE 204 → GET 404)

## Checks

163 cloud CLI tests pass (transfer tests inject `client_cm_factory`, unaffected); ruff + ty clean.

Refs cloud#1816, #1262, #1288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4rbaeHJN3L7CREp5v38J9