### PR TITLE
docs(core): set the v0.23.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## v0.23.0 (2026-08-XX)
+## v0.23.0 (2026-08-23)
 
 Semantic search grows up and concurrent writes stop deadlocking. Search gains
 opt-in cross-encoder reranking, pluggable vector indexes with a first-party


### PR DESCRIPTION
The release-day edit: `2026-08-XX` → `2026-08-23`. Lands ahead of `just release v0.23.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4rbaeHJN3L7CREp5v38J9