### PR TITLE
ci(core): add an OIDC-authenticated MCP registry publish workflow

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -1,0 +1,36 @@
+name: MCP Registry Publish
+
+# Publishes server.json to the official MCP Registry. GitHub Actions OIDC
+# authenticates this workflow as the repository owner, which grants the
+# io.github.basicmachines-co/* namespace directly — no personal login or
+# public-org-membership derivation involved (the manual `mcp-publisher login
+# github` path proved flaky there; see the v0.23.0 release notes on #1288).
+#
+# Run manually after a release, once the version is live on PyPI.
+
+on:
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/').tar.gz" \
+            | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+
+      - name: Publish server.json
+        run: |
+          mcp-publisher login github-oidc
+          mcp-publisher publish


### PR DESCRIPTION
The v0.23.0 post-release `mcp-publisher publish` step 403s on the personal-login path: the registry grants org namespaces from public GitHub org membership, and it kept deriving `io.github.phernandez/*` only — despite GitHub's API confirming public membership of `basicmachines-co` (204 on the public-members endpoint, fresh device-flow login). Stale server-side derivation, current CLI (1.8.1).

GitHub Actions OIDC sidesteps the whole derivation: the workflow authenticates as the repository owner and gets `io.github.basicmachines-co/*` directly. This also converts the runbook's manual post-release step into `gh workflow run mcp-registry-publish.yml`.

Dispatch after merge publishes the already-bumped `server.json` (0.23.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4rbaeHJN3L7CREp5v38J9