### PR TITLE
fix(core): scope search reindex to the active project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 ## Unreleased
 
+## v0.23.1 (2026-08-25)
+
+Fast-follow patch to v0.23.0 focused on PostgreSQL search parity and a
+search-destroying reindex bug. Postgres now indexes complete note bodies for
+full-text search (previously only titles and capped content stems, unlike
+SQLite), and the per-project search reindex no longer wipes every other
+project's search rows in the same database. Also adds a `#bm:links_to`
+directive for disambiguating prose wiki-links, and hardens `bm update` output
+after in-place upgrades.
+
+### Features
+
+- Added the `#bm:links_to` directive: ending a list item with `#bm:links_to`
+  forces the reference to the implicit `links_to` relation, so a single-token
+  prose prefix (`- Mother [[Alice]] #bm:links_to`) is not parsed as an
+  explicit relation type. The directive stays in the source file but is
+  stripped from indexed observation and relation content.
+
+### Bug Fixes
+
+- PostgreSQL full-text search now covers complete note bodies. Note content is
+  indexed as bounded, overlapping chunks in a new `search_index_fts_chunks`
+  table (a migration backfills existing notes), so deep content matches on
+  Postgres the way it always has on SQLite FTS5. The work includes correct
+  Boolean AND/NOT semantics across chunk boundaries, apostrophe and
+  punctuated-operand handling (`can't`, `v0.13.0b2`, `auth-service`),
+  metadata-filter composition, 100+ operand queries, and candidate
+  preselection so both GIN indexes stay in play.
+- The per-project search reindex (`POST /search/reindex`) no longer drops the
+  shared `search_index` table. Dropping it destroyed every project's search
+  rows in the same database — and on Postgres nothing outside migrations
+  recreates the table, so cloud tenants lost search entirely until manual
+  repair. The rebuild now deletes only the reindexed project's rows (chunk
+  rows cascade), and the chunks migration recreates a missing `search_index`
+  so databases hit by the old behavior migrate cleanly.
+- **#1316**: `bm update` status output no longer crashes after an in-place
+  upgrade removes the running install's files: rich's deferred Unicode width
+  table is preloaded before upgrading, and status lines fall back to plain
+  output instead of failing a completed update.
+- `bm doctor` waits for deferred note materialization before verifying the
+  API-written file, matching the accepted-write contract instead of racing it.
+
 ## v0.23.0 (2026-08-23)
 
 Semantic search grows up and concurrent writes stop deadlocking. Search gains

--- a/src/basic_memory/alembic/versions/7f6a2b8c9d10_index_full_postgres_note_content.py
+++ b/src/basic_memory/alembic/versions/7f6a2b8c9d10_index_full_postgres_note_content.py
@@ -62,6 +62,10 @@ def upgrade() -> None:
             )
         """)
         op.execute("""
+            CREATE INDEX IF NOT EXISTS ix_search_index_project_id
+            ON search_index (project_id)
+        """)
+        op.execute("""
             CREATE INDEX IF NOT EXISTS idx_search_index_fts
             ON search_index USING gin(textsearchable_index_col)
         """)

--- a/src/basic_memory/alembic/versions/7f6a2b8c9d10_index_full_postgres_note_content.py
+++ b/src/basic_memory/alembic/versions/7f6a2b8c9d10_index_full_postgres_note_content.py
@@ -22,6 +22,58 @@ def upgrade() -> None:
     """Index complete note bodies as bounded PostgreSQL FTS chunks."""
     connection = op.get_bind()
     if connection.dialect.name == "postgresql":
+        # --- Repair: recreate search_index if a destructive reindex removed it ---
+        # Trigger: search_index does not exist. Through v0.23.0, the per-project
+        # search reindex ran DROP TABLE IF EXISTS search_index, and on Postgres
+        # nothing outside migrations recreates that table.
+        # Why: the chunk backfill below reads search_index and the chunks table
+        # declares a foreign key to it, so without repair this migration fails
+        # permanently and blocks the database from ever reaching head.
+        # Outcome: healthy databases no-op on IF NOT EXISTS; a repaired database
+        # gets an empty index that the next full reindex repopulates. The DDL
+        # mirrors the current schema in models/search.py.
+        op.execute("""
+            CREATE TABLE IF NOT EXISTS search_index (
+                id INTEGER NOT NULL,
+                project_id INTEGER NOT NULL,
+                title TEXT,
+                content_stems TEXT,
+                content_snippet TEXT,
+                permalink VARCHAR,
+                file_path VARCHAR,
+                type VARCHAR,
+                from_id INTEGER,
+                to_id INTEGER,
+                relation_type VARCHAR,
+                entity_id INTEGER,
+                category VARCHAR,
+                metadata JSONB,
+                created_at TIMESTAMP WITH TIME ZONE,
+                updated_at TIMESTAMP WITH TIME ZONE,
+                textsearchable_index_col tsvector GENERATED ALWAYS AS (
+                    to_tsvector(
+                        'english',
+                        coalesce(title, '') || ' ' ||
+                        coalesce(content_stems, '')
+                    )
+                ) STORED,
+                PRIMARY KEY (id, type, project_id),
+                FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE CASCADE
+            )
+        """)
+        op.execute("""
+            CREATE INDEX IF NOT EXISTS idx_search_index_fts
+            ON search_index USING gin(textsearchable_index_col)
+        """)
+        op.execute("""
+            CREATE INDEX IF NOT EXISTS idx_search_index_metadata_gin
+            ON search_index USING gin(metadata jsonb_path_ops)
+        """)
+        op.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS uix_search_index_permalink_project
+            ON search_index (permalink, project_id)
+            WHERE permalink IS NOT NULL
+        """)
         op.execute("""
             CREATE TABLE search_index_fts_chunks (
                 project_id INTEGER NOT NULL,

--- a/src/basic_memory/repository/search_repository.py
+++ b/src/basic_memory/repository/search_repository.py
@@ -129,6 +129,10 @@ class SearchRepository(Protocol):
         """Delete item by permalink."""
         ...
 
+    async def delete_project_search_rows(self) -> None:
+        """Delete every full-text search row owned by this project."""
+        ...
+
     async def delete_by_entity_id(self, entity_id: int) -> None:
         """Delete items by entity ID."""
         ...

--- a/src/basic_memory/repository/search_repository_base.py
+++ b/src/basic_memory/repository/search_repository_base.py
@@ -1143,6 +1143,21 @@ class SearchRepositoryBase(ABC):
             )
             await session.commit()
 
+    async def delete_project_search_rows(self) -> None:
+        """Delete every full-text search row owned by this repository's project.
+
+        Shared across backends: both store rows in `search_index` keyed by
+        project_id, and a project-scoped DELETE leaves sibling projects in the
+        same database untouched. On Postgres the bounded FTS chunk rows follow
+        via their ON DELETE CASCADE foreign key.
+        """
+        async with db.scoped_session(self.session_maker) as session:
+            await session.execute(
+                text("DELETE FROM search_index WHERE project_id = :project_id"),
+                {"project_id": self.project_id},
+            )
+            await session.commit()
+
     async def execute_query(
         self,
         query: Executable,

--- a/src/basic_memory/services/search_service.py
+++ b/src/basic_memory/services/search_service.py
@@ -11,7 +11,6 @@ from typing import Any, List, Optional, Set, Dict
 from dateparser import parse
 from fastapi import BackgroundTasks
 from loguru import logger
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 import logfire
@@ -152,11 +151,20 @@ class SearchService:
         logger.info("Starting full reindex")
         # Trigger: a full search rebuild removes every derived row.
         # Why: vector storage may live outside SQL, so cleanup must cross the
-        # repository boundary before the full-text table is recreated.
+        # repository boundary before the full-text rows are rebuilt.
         # Outcome: built-in and extension indexes follow the same lifecycle.
         await self.repository.delete_project_vector_rows()
-        await self.repository.execute_query(text("DROP TABLE IF EXISTS search_index"), params={})
+        # Trigger: this service reindexes exactly one project, but search_index
+        # is shared by every project in the database (local SQLite consolidated
+        # into one memory.db; cloud tenants share one Postgres DB across
+        # projects). The historical DROP TABLE here dated from the one-database-
+        # per-project era and destroyed sibling projects' rows — on Postgres it
+        # also left nothing behind, since only migrations recreate the table.
+        # Why: a project-scoped DELETE clears only rows this rebuild will
+        # repopulate, and on Postgres the FTS chunk rows cascade with them.
+        # Outcome: sibling projects keep serving search while this one rebuilds.
         await self.init_search_index()
+        await self.repository.delete_project_search_rows()
 
         # Reindex all entities
         logger.debug("Indexing entities")

--- a/tests/services/test_search_service.py
+++ b/tests/services/test_search_service.py
@@ -7,6 +7,7 @@ from sqlalchemy import text
 
 from basic_memory import db
 from basic_memory.repository.search_index_row import SearchIndexRow
+from basic_memory.repository.search_repository import create_search_repository
 from basic_memory.schemas.search import SearchQuery, SearchItemType, SearchRetrievalMode
 from basic_memory.services.search_service import _strip_nul
 from typing import Any
@@ -1720,3 +1721,76 @@ async def test_reindex_vectors_no_callback(
     stats = await search_service.reindex_vectors()
     assert stats["total_entities"] >= 1
     assert stats["embedded"] + stats["errors"] == stats["total_entities"]
+
+
+@pytest.mark.asyncio
+async def test_reindex_all_preserves_sibling_project_search_rows(
+    search_service,
+    session_maker,
+    project_repository,
+    app_config,
+    tmp_path,
+):
+    """Regression: a per-project reindex must not destroy sibling projects' rows.
+
+    The historical implementation dropped the shared search_index table, wiping
+    every project in the database — and on Postgres nothing outside migrations
+    recreates that table, so search stayed broken until manual repair.
+    """
+    async with db.scoped_session(session_maker) as session:
+        sibling_project = await project_repository.create(
+            session,
+            {
+                "name": "sibling-project",
+                "description": "Second project sharing the same database",
+                "path": str(tmp_path / "sibling"),
+                "is_active": True,
+                "is_default": False,
+            },
+        )
+
+    sibling_repository = create_search_repository(
+        session_maker,
+        project_id=sibling_project.id,
+        app_config=app_config,
+    )
+    now = datetime.now(timezone.utc)
+    await sibling_repository.index_item(
+        SearchIndexRow(
+            project_id=sibling_project.id,
+            id=77001,
+            type="entity",
+            title="Sibling Note",
+            content_stems="sibling searchable content",
+            content_snippet="sibling searchable content",
+            permalink="sibling/sibling-note",
+            file_path="sibling/sibling_note.md",
+            created_at=now,
+            updated_at=now,
+        )
+    )
+
+    # A row in the reindexed project with no backing entity: the rebuild starts
+    # from the entity table, so this row must be gone afterwards.
+    await search_service.repository.index_item(
+        SearchIndexRow(
+            project_id=search_service.repository.project_id,
+            id=77002,
+            type="entity",
+            title="Stale Row",
+            content_stems="stalemarker content",
+            content_snippet="stalemarker content",
+            permalink="test/stale-row",
+            file_path="test/stale_row.md",
+            created_at=now,
+            updated_at=now,
+        )
+    )
+
+    await search_service.reindex_all()
+
+    sibling_results = await sibling_repository.search(search_text="sibling")
+    assert [row.permalink for row in sibling_results] == ["sibling/sibling-note"]
+
+    own_results = await search_service.repository.search(search_text="stalemarker")
+    assert own_results == []

--- a/tests/test_postgres_full_content_search_migration.py
+++ b/tests/test_postgres_full_content_search_migration.py
@@ -26,17 +26,19 @@ def test_upgrade_creates_and_backfills_bounded_postgres_vectors(monkeypatch) -> 
     # reindex is repaired first; healthy databases no-op on IF NOT EXISTS.
     assert "CREATE TABLE IF NOT EXISTS search_index (" in statements[0]
     assert "PRIMARY KEY (id, type, project_id)" in statements[0]
-    assert "CREATE INDEX IF NOT EXISTS idx_search_index_fts" in statements[1]
-    assert "CREATE INDEX IF NOT EXISTS idx_search_index_metadata_gin" in statements[2]
-    assert "CREATE UNIQUE INDEX IF NOT EXISTS uix_search_index_permalink_project" in statements[3]
+    assert "CREATE INDEX IF NOT EXISTS ix_search_index_project_id" in statements[1]
+    assert "ON search_index (project_id)" in statements[1]
+    assert "CREATE INDEX IF NOT EXISTS idx_search_index_fts" in statements[2]
+    assert "CREATE INDEX IF NOT EXISTS idx_search_index_metadata_gin" in statements[3]
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS uix_search_index_permalink_project" in statements[4]
 
-    assert "CREATE TABLE search_index_fts_chunks" in statements[4]
-    assert "to_tsvector('english', chunk_text)" in statements[4]
-    assert "generate_series" in statements[5]
-    assert "FOR 8000" in statements[5]
-    assert "5952" in statements[5]
-    assert "2,048-character overlap" in statements[5]
-    assert "CREATE INDEX idx_search_index_fts_chunks_fts" in statements[6]
+    assert "CREATE TABLE search_index_fts_chunks" in statements[5]
+    assert "to_tsvector('english', chunk_text)" in statements[5]
+    assert "generate_series" in statements[6]
+    assert "FOR 8000" in statements[6]
+    assert "5952" in statements[6]
+    assert "2,048-character overlap" in statements[6]
+    assert "CREATE INDEX idx_search_index_fts_chunks_fts" in statements[7]
 
 
 def test_downgrade_drops_postgres_chunk_table(monkeypatch) -> None:

--- a/tests/test_postgres_full_content_search_migration.py
+++ b/tests/test_postgres_full_content_search_migration.py
@@ -22,13 +22,21 @@ def test_upgrade_creates_and_backfills_bounded_postgres_vectors(monkeypatch) -> 
 
     migration.upgrade()
 
-    assert "CREATE TABLE search_index_fts_chunks" in statements[0]
-    assert "to_tsvector('english', chunk_text)" in statements[0]
-    assert "generate_series" in statements[1]
-    assert "FOR 8000" in statements[1]
-    assert "5952" in statements[1]
-    assert "2,048-character overlap" in statements[1]
-    assert "CREATE INDEX idx_search_index_fts_chunks_fts" in statements[2]
+    # A database whose search_index was removed by the destructive pre-v0.23.1
+    # reindex is repaired first; healthy databases no-op on IF NOT EXISTS.
+    assert "CREATE TABLE IF NOT EXISTS search_index (" in statements[0]
+    assert "PRIMARY KEY (id, type, project_id)" in statements[0]
+    assert "CREATE INDEX IF NOT EXISTS idx_search_index_fts" in statements[1]
+    assert "CREATE INDEX IF NOT EXISTS idx_search_index_metadata_gin" in statements[2]
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS uix_search_index_permalink_project" in statements[3]
+
+    assert "CREATE TABLE search_index_fts_chunks" in statements[4]
+    assert "to_tsvector('english', chunk_text)" in statements[4]
+    assert "generate_series" in statements[5]
+    assert "FOR 8000" in statements[5]
+    assert "5952" in statements[5]
+    assert "2,048-character overlap" in statements[5]
+    assert "CREATE INDEX idx_search_index_fts_chunks_fts" in statements[6]
 
 
 def test_downgrade_drops_postgres_chunk_table(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Blocks v0.23.1. Fixes the search-destroying `reindex_all` path found while reviewing the fast-follow branch, and makes the new FTS chunks migration self-repairing. Also carries the v0.23.1 CHANGELOG entry so the release pre-flight passes.

### The bug

`SearchService.reindex_all` (and cloud's mirror of it) ran `DROP TABLE IF EXISTS search_index` — a leftover from the one-database-per-project era. Today every project shares one database (local `memory.db`, cloud tenant DBs), so the per-project reindex recovery route (`POST /v2/projects/{id}/search/reindex`) wiped **every** project's search rows. Worse, on Postgres only migrations create `search_index`, so a cloud tenant invoking reindex lost search entirely with nothing to recreate the table (`alembic_version` stays at head, so `ensure_migrations` never repairs it). All existing tests of this path were mocked, which is why nothing caught it.

The new `search_index_fts_chunks` FK would have turned that DROP into a hard failure — safe, but the recovery action itself stayed broken.

### The fix

- `reindex_all` now ensures the schema exists, then deletes only its own project's rows via a new shared `SearchRepository.delete_project_search_rows()`; chunk rows cascade via the FK. Sibling projects keep serving search during a rebuild.
- Migration `7f6a2b8c9d10` (unreleased, amended in place per review) recreates a missing `search_index` + indexes with `IF NOT EXISTS` before creating the chunks table, so any database already hit by the destructive reindex migrates cleanly instead of being blocked from head forever.

### Verification

- New regression test: sibling project's rows survive a reindex, reindexed project rebuilds from entities — passes on SQLite and Postgres (testcontainers). The Postgres run also proves the delete works under the chunks FK.
- `tests/repository/test_postgres_search_repository.py` + full `tests/services/test_search_service.py` green on both backends; migration unit test updated; `ruff` + `ty` clean.

The cloud repo's `ReviewSearchWriter.reindex_all` has the same DROP and needs a matching fix to call `delete_project_search_rows()` — separate PR in basic-memory-cloud after re-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4rbaeHJN3L7CREp5v38J9