### PR TITLE
fix(cli): allow disposable doctor project under configured root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ after in-place upgrades.
   upgrade removes the running install's files: rich's deferred Unicode width
   table is preloaded before upgrading, and status lines fall back to plain
   output instead of failing a completed update.
+- **#1323**: `bm doctor` no longer fails when `BASIC_MEMORY_PROJECT_ROOT`
+  points at an existing project's directory. Doctor now asks the server for a
+  disposable `doctor-*` project under the configured root — the only
+  sanctioned exception to the nested-project guard — and cleanup deletes the
+  project's directory along with its registration.
 - `bm doctor` waits for deferred note materialization before verifying the
   API-written file, matching the accepted-write contract instead of racing it.
 

--- a/src/basic_memory/api/v2/routers/project_router.py
+++ b/src/basic_memory/api/v2/routers/project_router.py
@@ -226,7 +226,7 @@ async def add_doctor_project(project_service: ProjectServiceDep) -> ProjectStatu
     """Create a server-generated disposable project for the local doctor check."""
     try:
         new_project = await project_service.add_doctor_project()
-    except ValueError as e:  # pragma: no cover
+    except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
     return ProjectStatusResponse(

--- a/src/basic_memory/api/v2/routers/project_router.py
+++ b/src/basic_memory/api/v2/routers/project_router.py
@@ -221,6 +221,28 @@ async def add_project(
         raise HTTPException(status_code=400, detail=str(e))
 
 
+@router.post("/doctor", response_model=ProjectStatusResponse, status_code=201)
+async def add_doctor_project(project_service: ProjectServiceDep) -> ProjectStatusResponse:
+    """Create a server-generated disposable project for the local doctor check."""
+    try:
+        new_project = await project_service.add_doctor_project()
+    except ValueError as e:  # pragma: no cover
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return ProjectStatusResponse(
+        message=f"Project '{new_project.name}' added successfully",
+        status="success",
+        default=new_project.is_default or False,
+        new_project=ProjectItem(
+            id=new_project.id,
+            external_id=new_project.external_id,
+            name=new_project.name,
+            path=new_project.path,
+            is_default=new_project.is_default or False,
+        ),
+    )
+
+
 @router.post("/config/sync", response_model=ProjectStatusResponse)
 async def synchronize_projects(
     project_service: ProjectServiceDep,

--- a/src/basic_memory/cli/commands/doctor.py
+++ b/src/basic_memory/cli/commands/doctor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import tempfile
 import uuid
 from pathlib import Path
+from typing import Protocol
 
 from loguru import logger
 from rich.console import Console
@@ -21,6 +22,14 @@ from basic_memory.schemas.search import SearchQuery
 from basic_memory.schemas import ProjectIndexRunResponse
 
 console = Console()
+
+
+class DoctorProjectClient(Protocol):
+    """Project-client capability required to clean up doctor state."""
+
+    async def delete_project(
+        self, project_external_id: str, delete_notes: bool = False
+    ) -> object: ...
 
 
 def _is_default_project_delete_error(error: Exception) -> bool:
@@ -61,14 +70,14 @@ async def _delete_doctor_project_locally(project_name: str, project_id: str) -> 
 
 
 async def _delete_doctor_project(
-    project_client: ProjectClient, project_name: str, project_id: str
+    project_client: DoctorProjectClient, project_name: str, project_id: str
 ) -> None:
     """Delete the generated doctor project without weakening the public API guard."""
     # Deferred: ToolError lives in FastMCP's runtime, which must not load at CLI startup (#886).
     from fastmcp.exceptions import ToolError
 
     try:
-        await project_client.delete_project(project_id)
+        await project_client.delete_project(project_id, delete_notes=True)
     except ToolError as exc:
         if not _is_default_project_delete_error(exc):
             raise
@@ -127,9 +136,16 @@ async def run_doctor() -> None:
             project_id: str | None = None
 
             try:
-                status = await project_client.create_project(project_request.model_dump())
+                from basic_memory.config import ConfigManager
+
+                status = (
+                    await project_client.create_doctor_project()
+                    if ConfigManager().config.project_root
+                    else await project_client.create_project(project_request.model_dump())
+                )
                 if not status.new_project:
                     raise ValueError("Failed to create doctor project")
+                project_name = status.new_project.name
                 project_id = status.new_project.external_id
                 # Use the resolved path from the server — when project_root is configured,
                 # the actual project directory differs from the requested temp_path

--- a/src/basic_memory/mcp/clients/project.py
+++ b/src/basic_memory/mcp/clients/project.py
@@ -78,6 +78,13 @@ class ProjectClient:
         )
         return ProjectStatusResponse.model_validate(response.json())
 
+    async def create_doctor_project(self) -> ProjectStatusResponse:
+        """Create the server-generated disposable project used by doctor."""
+        from basic_memory.mcp.tools.utils import call_post
+
+        response = await call_post(self.http_client, "/v2/projects/doctor")
+        return ProjectStatusResponse.model_validate(response.json())
+
     async def delete_project(
         self, project_external_id: str, delete_notes: bool = False
     ) -> ProjectStatusResponse:

--- a/src/basic_memory/services/project_service.py
+++ b/src/basic_memory/services/project_service.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import shutil
+import uuid
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
@@ -190,7 +191,9 @@ class ProjectService:
                 # Not nested in either direction
                 return False
 
-    async def add_project(self, name: str, path: str, set_default: bool = False) -> None:
+    async def add_project(
+        self, name: str, path: str, set_default: bool = False, *, allow_nested: bool = False
+    ) -> None:
         """Add a new project to the configuration and database.
 
         Args:
@@ -242,7 +245,7 @@ class ProjectService:
 
             # Doctor creates a disposable project inside the configured project root.
             # It must be allowed to coexist with the existing root project.
-            if not name.startswith("doctor-"):
+            if not allow_nested:
                 for existing in existing_projects:
                     if self._check_nested_paths(resolved_path, existing.path):
                         p_new = Path(resolved_path).resolve()
@@ -329,6 +332,19 @@ class ProjectService:
                             )
 
         logger.info(f"Project '{name}' added at {resolved_path}")
+
+    async def add_doctor_project(self) -> Project:
+        """Create a server-generated disposable project under the configured root."""
+        project_root = self.config_manager.config.project_root
+        if not project_root:
+            raise ValueError("Doctor projects require BASIC_MEMORY_PROJECT_ROOT")
+
+        project_name = f"doctor-{uuid.uuid4().hex[:8]}"
+        await self.add_project(project_name, project_root, allow_nested=True)
+        project = await self.get_project(project_name)
+        if project is None:  # pragma: no cover
+            raise ValueError("Failed to retrieve doctor project")
+        return project
 
     async def remove_project(self, name: str, delete_notes: bool = False) -> None:
         """Remove a project from configuration and database.

--- a/src/basic_memory/services/project_service.py
+++ b/src/basic_memory/services/project_service.py
@@ -240,27 +240,25 @@ class ProjectService:
                             f"In cloud mode, paths are normalized to lowercase to prevent case-sensitivity issues."
                         )  # pragma: no cover
 
-            # Check for nested paths with existing projects
-            for existing in existing_projects:
-                if self._check_nested_paths(resolved_path, existing.path):
-                    # Determine which path is nested within which for appropriate error message
-                    p_new = Path(resolved_path).resolve()
-                    p_existing = Path(existing.path).resolve()
-
-                    # Check if new path is nested under existing project
-                    if p_new.is_relative_to(p_existing):
-                        raise ValueError(
-                            f"Cannot create project at '{resolved_path}': "
-                            f"path is nested within existing project '{existing.name}' at '{existing.path}'. "
-                            f"Projects cannot share directory trees."
-                        )
-                    else:
-                        # Existing project is nested under new path
-                        raise ValueError(
-                            f"Cannot create project at '{resolved_path}': "
-                            f"existing project '{existing.name}' at '{existing.path}' is nested within this path. "
-                            f"Projects cannot share directory trees."
-                        )
+            # Doctor creates a disposable project inside the configured project root.
+            # It must be allowed to coexist with the existing root project.
+            if not name.startswith("doctor-"):
+                for existing in existing_projects:
+                    if self._check_nested_paths(resolved_path, existing.path):
+                        p_new = Path(resolved_path).resolve()
+                        p_existing = Path(existing.path).resolve()
+                        if p_new.is_relative_to(p_existing):
+                            raise ValueError(
+                                f"Cannot create project at '{resolved_path}': "
+                                f"path is nested within existing project '{existing.name}' at '{existing.path}'. "
+                                f"Projects cannot share directory trees."
+                            )
+                        else:
+                            raise ValueError(
+                                f"Cannot create project at '{resolved_path}': "
+                                f"existing project '{existing.name}' at '{existing.path}' is nested within this path. "
+                                f"Projects cannot share directory trees."
+                            )
 
             # Ensure the project directory exists on disk.
             # Trigger: project_root not set means local filesystem mode (not S3/cloud)

--- a/tests/api/v2/test_project_router.py
+++ b/tests/api/v2/test_project_router.py
@@ -1,5 +1,6 @@
 """Tests for V2 project management API routes (ID-based endpoints)."""
 
+import os
 import tempfile
 from pathlib import Path
 
@@ -629,3 +630,47 @@ async def test_resolve_project_empty_identifier(client: AsyncClient, v2_projects
     response = await client.post(f"{v2_projects_url}/resolve", json=resolve_data)
 
     assert response.status_code == 422  # Validation error
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Project root constraints only tested on POSIX systems")
+@pytest.mark.asyncio
+async def test_add_doctor_project_endpoint(
+    client: AsyncClient,
+    v2_projects_url,
+    monkeypatch,
+    tmp_path,
+):
+    """Regression #1323: the doctor endpoint creates a disposable nested project."""
+    root_path = tmp_path / "app" / "data"
+    root_path.mkdir(parents=True)
+    monkeypatch.setenv("BASIC_MEMORY_PROJECT_ROOT", str(root_path))
+    from basic_memory import config as config_module
+
+    config_module._CONFIG_CACHE = None
+    config_module._CONFIG_MTIME = None
+    config_module._CONFIG_SIZE = None
+    try:
+        response = await client.post(f"{v2_projects_url}/doctor")
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["new_project"]["name"].startswith("doctor-")
+        assert Path(data["new_project"]["path"]).resolve().is_relative_to(root_path.resolve())
+    finally:
+        monkeypatch.delenv("BASIC_MEMORY_PROJECT_ROOT", raising=False)
+        config_module._CONFIG_CACHE = None
+        config_module._CONFIG_MTIME = None
+        config_module._CONFIG_SIZE = None
+
+
+@pytest.mark.asyncio
+async def test_add_doctor_project_endpoint_requires_project_root(
+    client: AsyncClient,
+    v2_projects_url,
+):
+    """Without a configured project root the doctor endpoint refuses cleanly."""
+    response = await client.post(f"{v2_projects_url}/doctor")
+
+    assert response.status_code == 400
+    assert "BASIC_MEMORY_PROJECT_ROOT" in response.json()["detail"]

--- a/tests/cli/test_doctor_command.py
+++ b/tests/cli/test_doctor_command.py
@@ -91,3 +91,20 @@ async def test_doctor_reports_api_note_missing_after_materialization_drain(tmp_p
             tmp_path / "doctor" / "missing.md",
             "doctor/missing.md",
         )
+
+
+@pytest.mark.asyncio
+async def test_doctor_cleanup_deletes_project_notes():
+    """Doctor cleanup removes the disposable project's canonical files."""
+
+    deleted: list[tuple[str, bool]] = []
+
+    class ProjectClient:
+        async def delete_project(
+            self, project_external_id: str, delete_notes: bool = False
+        ) -> None:
+            deleted.append((project_external_id, delete_notes))
+
+    await doctor_cmd._delete_doctor_project(ProjectClient(), "doctor-test", "project-id")
+
+    assert deleted == [("project-id", True)]

--- a/tests/mcp/clients/test_clients.py
+++ b/tests/mcp/clients/test_clients.py
@@ -528,6 +528,36 @@ class TestProjectClient:
         assert client.http_client is mock_http
 
     @pytest.mark.asyncio
+    async def test_create_doctor_project(self, monkeypatch):
+        """Test create_doctor_project posts to the doctor endpoint."""
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "message": "Project 'doctor-abc12345' added successfully",
+            "status": "success",
+            "default": False,
+            "new_project": {
+                "id": 7,
+                "external_id": "uuid-doctor",
+                "name": "doctor-abc12345",
+                "path": "/app/data/doctor-abc12345",
+                "is_default": False,
+            },
+        }
+
+        async def mock_call_post(client, url, **kwargs):
+            assert url == "/v2/projects/doctor"
+            return mock_response
+
+        monkeypatch.setattr("basic_memory.mcp.tools.utils.call_post", mock_call_post)
+
+        mock_http = MagicMock()
+        client = ProjectClient(mock_http)
+        result = await client.create_doctor_project()
+        assert result.new_project is not None
+        assert result.new_project.name == "doctor-abc12345"
+
+    @pytest.mark.asyncio
     async def test_list_projects(self, monkeypatch):
         """Test list_projects calls correct endpoint."""
 

--- a/tests/services/test_project_service.py
+++ b/tests/services/test_project_service.py
@@ -1208,6 +1208,32 @@ async def test_add_project_rejects_nested_child_path(project_service: ProjectSer
 
 
 @pytest.mark.asyncio
+async def test_add_project_rejects_doctor_prefixed_nested_child_path(
+    project_service: ProjectService,
+):
+    """A user-controlled doctor-prefixed name cannot bypass project isolation."""
+    parent_project_name = f"parent-project-{os.urandom(4).hex()}"
+    doctor_project_name = f"doctor-{os.urandom(4).hex()}"
+    with tempfile.TemporaryDirectory() as temp_dir:
+        parent_path = Path(temp_dir) / "parent"
+        parent_path.mkdir()
+
+        try:
+            await project_service.add_project(parent_project_name, parent_path.as_posix())
+
+            with pytest.raises(ValueError, match="nested within existing project"):
+                await project_service.add_project(
+                    doctor_project_name,
+                    (parent_path / "doctor").as_posix(),
+                )
+        finally:
+            if doctor_project_name in project_service.projects:
+                await project_service.remove_project(doctor_project_name)
+            if parent_project_name in project_service.projects:
+                await project_service.remove_project(parent_project_name)
+
+
+@pytest.mark.asyncio
 async def test_add_project_rejects_parent_path_over_existing_child(project_service: ProjectService):
     """Test that adding a parent project over an existing nested project fails."""
     child_project_name = f"child-project-{os.urandom(4).hex()}"

--- a/tests/services/test_project_service.py
+++ b/tests/services/test_project_service.py
@@ -1722,3 +1722,62 @@ async def test_remove_project_rejects_database_default_in_both_modes(
                 project_service.config_manager.remove_project(test_project_name)
             except Exception:
                 pass
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Project root constraints only tested on POSIX systems")
+@pytest.mark.asyncio
+async def test_add_doctor_project_allows_nested_under_configured_root(
+    project_service: ProjectService, config_manager: ConfigManager, monkeypatch
+):
+    """Regression #1323: doctor can create its disposable project under the root.
+
+    When an existing project owns BASIC_MEMORY_PROJECT_ROOT itself, the normal
+    nesting guard rejects any project beneath it. The server-generated doctor
+    project is the sanctioned exception, and cleanup removes its directory.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root_path = Path(temp_dir) / "app" / "data"
+        root_path.mkdir(parents=True, exist_ok=True)
+        owner_name = f"root-owner-{os.urandom(4).hex()}"
+
+        # The owner project claims the root itself, as in the issue's Docker setup
+        # (created before project_root constraints applied to it).
+        await project_service.add_project(owner_name, str(root_path))
+
+        monkeypatch.setenv("BASIC_MEMORY_PROJECT_ROOT", str(root_path))
+        from basic_memory import config as config_module
+
+        config_module._CONFIG_CACHE = None
+        config_module._CONFIG_MTIME = None
+        config_module._CONFIG_SIZE = None
+
+        doctor_name = None
+        try:
+            project = await project_service.add_doctor_project()
+            doctor_name = project.name
+
+            assert doctor_name.startswith("doctor-")
+            doctor_path = Path(project.path).resolve()
+            assert doctor_path.is_relative_to(root_path.resolve())
+            assert doctor_path != root_path.resolve()
+            assert doctor_path.exists()
+
+            await project_service.remove_project(doctor_name, delete_notes=True)
+            doctor_name = None
+            assert not doctor_path.exists()
+        finally:
+            if doctor_name and doctor_name in project_service.projects:
+                await project_service.remove_project(doctor_name, delete_notes=True)
+            monkeypatch.delenv("BASIC_MEMORY_PROJECT_ROOT", raising=False)
+            config_module._CONFIG_CACHE = None
+            config_module._CONFIG_MTIME = None
+            config_module._CONFIG_SIZE = None
+            if owner_name in project_service.projects:
+                await project_service.remove_project(owner_name)
+
+
+@pytest.mark.asyncio
+async def test_add_doctor_project_requires_project_root(project_service: ProjectService):
+    """Without a configured root there is no nesting problem for doctor to solve."""
+    with pytest.raises(ValueError, match="BASIC_MEMORY_PROJECT_ROOT"):
+        await project_service.add_doctor_project()


### PR DESCRIPTION
## Summary

Salvage of #1324 by @mikemikimike (fixes #1323) — cherry-picked onto an in-repo branch so the full CI suite runs (fork PRs skip it), with their commits and authorship preserved, plus a test commit on top.

### The fix (from #1324)

`bm doctor` failed when `BASIC_MEMORY_PROJECT_ROOT` points at an existing project's directory (the Docker setup in #1323): doctor tried to create its temp project inside the root and the nested-project guard rejected it. Now:

- New server endpoint `POST /v2/projects/doctor` → `ProjectService.add_doctor_project()` creates a server-named `doctor-<hex>` project under the configured root via a keyword-only `allow_nested=True` that no public route exposes — a user-supplied `doctor-` name still hits the guard (tested).
- Under `project_root`, `add_project` derives the directory from the sanitized name, so the doctor project always gets its own `<root>/doctor-<hex>` subdirectory — never the root itself.
- Cleanup passes `delete_notes=True` so the doctor directory is removed along with its registration (addresses both Codex P1 findings on #1324).

### Added on top

- Service regression test for the nested-under-root scenario, including directory deletion on cleanup.
- Router tests for the 201 and 400 paths (pragma removed from the now-tested error handler).
- Typed-client test for `create_doctor_project`.
- v0.23.1 changelog entry for #1323.

Verified: 107 tests green across the four affected files; ruff + ty clean.

Closes #1324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4rbaeHJN3L7CREp5v38J9