### PR TITLE
fix(cli): prevent analytics thread from blocking command exit

### DIFF
--- a/src/basic_memory/cli/analytics.py
+++ b/src/basic_memory/cli/analytics.py
@@ -108,7 +108,7 @@ def track(event_name: str, data: Optional[dict[str, Any]] = None) -> None:
         except Exception:
             pass  # Never break the CLI for analytics
 
-    # Non-daemon so the process waits for the request to complete.
-    # The 3s urllib timeout caps the worst-case exit delay.
-    t = threading.Thread(target=_send)
+    # Analytics must never keep a one-shot CLI process alive during interpreter
+    # shutdown. The request is best-effort and already has a bounded timeout.
+    t = threading.Thread(target=_send, daemon=True)
     t.start()

--- a/tests/cli/test_analytics.py
+++ b/tests/cli/test_analytics.py
@@ -68,6 +68,7 @@ class TestTrack:
             mock_thread.return_value = MagicMock()
             track("test-event")
             mock_thread.assert_called_once()
+            assert mock_thread.call_args.kwargs["daemon"] is True
 
     def test_sends_event_when_configured(self, monkeypatch):
         monkeypatch.delenv("BASIC_MEMORY_NO_PROMOS", raising=False)
@@ -76,7 +77,7 @@ class TestTrack:
 
         captured_target = None
 
-        def fake_thread(target):
+        def fake_thread(target, **kwargs):
             nonlocal captured_target
             captured_target = target
             mock = MagicMock()
@@ -103,7 +104,7 @@ class TestTrack:
         with patch("basic_memory.cli.analytics.urllib.request.urlopen", fake_urlopen):
             with patch("basic_memory.cli.analytics.threading.Thread") as mock_thread:
                 # Capture the target function and call it directly
-                def run_target(target):
+                def run_target(target, **kwargs):
                     target()  # Execute synchronously
                     return MagicMock()
 
@@ -130,7 +131,7 @@ class TestTrack:
         with patch("basic_memory.cli.analytics.urllib.request.urlopen", fake_urlopen):
             with patch("basic_memory.cli.analytics.threading.Thread") as mock_thread:
 
-                def run_target(target):
+                def run_target(target, **kwargs):
                     target()  # Should not raise
                     return MagicMock()
 


### PR DESCRIPTION
Fixes #1333

## Summary

The CLI analytics helper starts a background request thread for the cloud promo path. Because the thread was non-daemon, one-shot commands such as `bm schema validate` could finish their work and output while Python interpreter shutdown waited indefinitely for the analytics request.

This change makes the best-effort analytics thread daemonized, so analytics cannot keep the CLI process alive. The existing request timeout and silent failure behavior are unchanged. A regression assertion verifies the thread is created as a daemon.

## Tests

- `uv run --frozen pytest tests/cli/test_analytics.py tests/cli/test_cli_schema.py -q --no-cov` (28 passed)
- `uv run --frozen ruff check src/basic_memory/cli/analytics.py tests/cli/test_analytics.py`
- `uv run --frozen ruff format --check src/basic_memory/cli/analytics.py tests/cli/test_analytics.py`
- `git diff --check`
