### PR TITLE
fix: resolve app config on the event loop so the CLI can exit

### DIFF
--- a/src/basic_memory/deps/config.py
+++ b/src/basic_memory/deps/config.py
@@ -12,12 +12,27 @@ from fastapi import Depends, Request
 from basic_memory.config import BasicMemoryConfig
 
 
-def get_app_config(request: Request) -> BasicMemoryConfig:
+async def get_app_config(request: Request) -> BasicMemoryConfig:
     """Resolve the application configuration from the composition root.
 
     API requests read the container the lifespan stored on ``app.state``.
     Requests served without a lifespan (the CLI/MCP local ASGI flow) fall back
     to the API composition root, which creates a container on demand.
+
+    This provider must stay ``async`` even though it never awaits. FastAPI runs
+    *sync* dependencies in AnyIO's worker-thread pool, and those workers are
+    non-daemon: after the request finishes AnyIO parks the thread on
+    ``queue.Queue.get`` so it can be reused. Every CLI/MCP command drives the app
+    through an in-process ASGI transport under ``asyncio.run``, which returns
+    without joining that pool, so the interpreter reaches
+    ``threading._shutdown`` with a live non-daemon thread that nothing will ever
+    wake -- and the process hangs instead of exiting (observed as
+    ``basic-memory schema validate`` never returning on Python 3.13; 3.14 reaps
+    the stranded worker itself and masks the bug).
+
+    Declaring it ``async`` keeps resolution on the event loop, so no worker
+    thread is dispatched and nothing survives the request. See
+    ``tests/test_app_config_dependency_resolution.py``.
     """
     container = getattr(request.app.state, "container", None)
     if container is not None:

--- a/tests/api/v2/conftest.py
+++ b/tests/api/v2/conftest.py
@@ -22,7 +22,14 @@ async def app(test_config, engine_factory, app_config) -> AsyncGenerator[FastAPI
     from basic_memory.api.app import app
 
     previous_overrides = dict(app.dependency_overrides)
-    app.dependency_overrides[get_app_config] = lambda: app_config
+
+    # Async override, matching the production provider: a sync override would
+    # be dispatched to AnyIO's non-daemon worker pool and leave a parked thread
+    # behind, which is exactly the shutdown hang the async provider avoids.
+    async def _app_config():
+        return app_config
+
+    app.dependency_overrides[get_app_config] = _app_config
     app.dependency_overrides[get_engine_factory] = lambda: engine_factory
     try:
         yield app

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -44,7 +44,14 @@ async def app(
     """Create test FastAPI application."""
     app = fastapi_app
     previous_overrides = dict(app.dependency_overrides)
-    app.dependency_overrides[get_app_config] = lambda: app_config
+
+    # Async override, matching the production provider: a sync override would
+    # be dispatched to AnyIO's non-daemon worker pool and leave a parked thread
+    # behind, which is exactly the shutdown hang the async provider avoids.
+    async def _app_config():
+        return app_config
+
+    app.dependency_overrides[get_app_config] = _app_config
     app.dependency_overrides[get_engine_factory] = lambda: engine_factory
     try:
         yield app

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -53,7 +53,14 @@ def app(
     """Create test FastAPI application."""
     app = fastapi_app
     previous_overrides = dict(app.dependency_overrides)
-    app.dependency_overrides[get_app_config] = lambda: app_config
+
+    # Async override, matching the production provider: a sync override would
+    # be dispatched to AnyIO's non-daemon worker pool and leave a parked thread
+    # behind, which is exactly the shutdown hang the async provider avoids.
+    async def _app_config():
+        return app_config
+
+    app.dependency_overrides[get_app_config] = _app_config
     app.dependency_overrides[get_engine_factory] = lambda: engine_factory
     try:
         yield app

--- a/tests/test_app_config_dependency_resolution.py
+++ b/tests/test_app_config_dependency_resolution.py
@@ -1,0 +1,108 @@
+"""Regression tests for how the app-config dependency is resolved.
+
+Background
+----------
+``basic-memory schema validate`` (and every other CLI command that drives the
+API through an in-process ASGI transport) used to hang on exit instead of
+returning. The cause was not in the CLI at all: ``get_app_config`` was declared
+as a *sync* FastAPI dependency.
+
+FastAPI runs sync dependencies in AnyIO's worker-thread pool. Those worker
+threads are **non-daemon**, and AnyIO keeps them parked on ``queue.Queue.get``
+for reuse after the task finishes. When ``asyncio.run`` returns without the
+surrounding AnyIO portal having joined the pool, the interpreter reaches
+``threading._shutdown`` with a live non-daemon thread that will never be woken,
+and shutdown blocks forever.
+
+Making ``get_app_config`` ``async`` keeps the dependency on the event loop, so
+no worker thread is ever dispatched and nothing survives the request.
+
+Notes for whoever touches this test next
+----------------------------------------
+* Do **not** rewrite this using ``fastapi.testclient.TestClient``. TestClient
+  runs the app inside a blocking AnyIO portal whose teardown joins the worker
+  pool, which hides the leak: the test then passes with *and* without the fix.
+* The interpreter-level hang is Python 3.13 specific. Python 3.14 reaps the
+  stranded worker itself, so a subprocess "does the CLI exit?" test is green on
+  3.14 either way. This test asserts on the surviving thread instead of on
+  process exit, so it is meaningful on both, and it was verified to fail on the
+  unfixed code under Python 3.13.
+"""
+
+import threading
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from basic_memory.api.container import ApiContainer
+from basic_memory.deps import AppConfigDep
+from basic_memory.runtime.mode import resolve_runtime_mode
+
+
+def _anyio_worker_threads() -> list[threading.Thread]:
+    """Return the live, non-daemon threads that belong to AnyIO's worker pool.
+
+    AnyIO names them ``AnyIO worker thread``. Only non-daemon threads can block
+    ``threading._shutdown``, so daemon threads are deliberately excluded.
+    """
+    return [
+        thread
+        for thread in threading.enumerate()
+        if thread.is_alive() and not thread.daemon and "anyio worker" in thread.name.lower()
+    ]
+
+
+def _app_with_config_dependency(app_config) -> FastAPI:
+    app = FastAPI()
+    app.state.container = ApiContainer(
+        config=app_config, mode=resolve_runtime_mode(is_test_env=True)
+    )
+
+    @app.get("/config-name")
+    async def read_config_name(config: AppConfigDep) -> dict[str, str]:
+        return {"default_project": config.default_project}
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_app_config_dependency_strands_no_worker_thread(app_config):
+    """Resolving AppConfigDep must not leave a non-daemon AnyIO worker alive.
+
+    A sync ``get_app_config`` is dispatched to AnyIO's non-daemon worker pool,
+    where the thread stays parked after the request. That parked thread is what
+    made the CLI hang at interpreter shutdown.
+    """
+    app = _app_with_config_dependency(app_config)
+
+    workers_before = _anyio_worker_threads()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/config-name")
+
+    assert response.status_code == 200
+    assert response.json() == {"default_project": app_config.default_project}
+
+    workers_after = _anyio_worker_threads()
+
+    assert len(workers_after) == len(workers_before), (
+        "AppConfigDep left a non-daemon AnyIO worker thread parked in the pool "
+        f"(before={len(workers_before)}, after={len(workers_after)}); "
+        "get_app_config must be `async def` so FastAPI resolves it on the event "
+        "loop instead of dispatching a worker thread that blocks interpreter "
+        "shutdown."
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_app_config_is_a_coroutine_function(app_config):
+    """Guard the property the fix depends on, so a refactor cannot silently undo it."""
+    import inspect
+
+    from basic_memory.deps import get_app_config
+
+    assert inspect.iscoroutinefunction(get_app_config), (
+        "get_app_config must stay `async def`: a sync FastAPI dependency runs in a "
+        "non-daemon AnyIO worker thread and strands interpreter shutdown."
+    )

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -15,21 +15,23 @@ def _request_for(app: FastAPI) -> Request:
     return Request({"type": "http", "app": app})
 
 
-def test_get_app_config_reads_lifespan_container(app_config):
+@pytest.mark.asyncio
+async def test_get_app_config_reads_lifespan_container(app_config):
     """API requests get the config the lifespan stored on app.state."""
     app = FastAPI()
     app.state.container = ApiContainer(
         config=app_config, mode=resolve_runtime_mode(is_test_env=True)
     )
 
-    assert get_app_config(_request_for(app)) is app_config
+    assert await get_app_config(_request_for(app)) is app_config
 
 
-def test_get_app_config_falls_back_to_composition_root(app_config, config_manager):
+@pytest.mark.asyncio
+async def test_get_app_config_falls_back_to_composition_root(app_config, config_manager):
     """Requests without a lifespan (CLI/MCP local ASGI) resolve via the composition root."""
     app = FastAPI()
 
-    resolved = get_app_config(_request_for(app))
+    resolved = await get_app_config(_request_for(app))
 
     # resolve_container() reads the config the config_manager fixture wrote to disk.
     assert resolved.default_project == app_config.default_project


### PR DESCRIPTION
## Problem

`basic-memory schema validate` prints its result and then never exits. The
output is complete and correct; only the exit is stuck. Fixes #1345.

Reproduced on v0.23.2, CPython 3.13.15 (macOS, Apple Silicon), in a clean
isolated environment (fresh `HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`,
`BASIC_MEMORY_CONFIG_DIR`):

```
$ basic-memory schema validate --project brain --json --local
WITHOUT FIX (sync get_app_config):   HUNG after 90s   (result printed, process never exits)
WITH FIX    (async get_app_config):  exit=0 in 8.24s
```

Same environment, same command, one keyword toggled and nothing else.

Note for reviewers: this does **not** reproduce against a warm, default user
environment — there the command exits in ~2.5s either way. A clean isolated
config/home is needed to see it.

## Root cause

`src/basic_memory/deps/config.py` declared `get_app_config` as a **sync**
FastAPI dependency:

```python
def get_app_config(request: Request) -> BasicMemoryConfig: ...
```

FastAPI runs sync dependencies in AnyIO's worker-thread pool. Those worker
threads are **non-daemon**, and AnyIO deliberately keeps them alive after the
task finishes — parked on `queue.Queue.get` — so they can be reused.

The CLI drives the app under `asyncio.run` via `httpx.ASGITransport`, with no
surrounding AnyIO blocking portal to join the pool on the way out. So
`asyncio.run` returns while a non-daemon worker is still parked, the interpreter
reaches `threading._shutdown`, and it blocks forever on a thread that nothing
will ever wake.

`run_with_cleanup` in `cli/commands/command_utils.py` drains pending
materializations, background tasks and the DB, but does not join the AnyIO
worker pool, so it does not cover this case.

The function body does no I/O — it reads `request.app.state.container` or calls
`resolve_container()` — so there is nothing that needs a worker thread.

## Fix

Declare the provider `async def`. Resolution stays on the event loop and no
worker thread is ever dispatched. One-line change; the body is untouched.

## Tests

Adds `tests/test_app_config_dependency_resolution.py`, which builds a minimal
FastAPI app with one route depending on `AppConfigDep`, drives it over
`ASGITransport`, and asserts no AnyIO worker thread survives the request:

```
WITH FIX:    workers before = 0 / status 200 / workers after = 0 []
WITHOUT FIX: workers before = 0 / status 200 / workers after = 1 ['AnyIO worker thread']
```

Verified RED before GREEN — with `deps/config.py` reverted to `def`, the
behavioural test fails with `before=0, after=1`, not merely on the
`iscoroutinefunction` assertion.

The conftest updates (`tests/api/v2/`, `tests/cli/`, `tests/mcp/`, `tests/test_deps.py`)
are the mechanical `await`/async-override follow-through for the now-async provider.

## Full suite

Run against upstream's canonical unit target
(`BASIC_MEMORY_ENV=test pytest -p pytest_mock --no-cov tests`) on CPython 3.13.15:

```
v0.23.2 baseline:  38 failed, 4984 passed, 38 skipped
with this branch:  38 failed, 4986 passed, 38 skipped
```

The failure sets are **identical** — zero regressions; the +2 are the new tests.
The 38 pre-existing failures are present on a clean `v0.23.2` checkout in this
environment (Rich output-width and cloud-credential assertions) and are
unrelated to this change.
