### PR TITLE
fix(core): honor batch metadata concurrency

### DIFF
--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -159,11 +159,14 @@ class BatchIndexer:
         *,
         max_concurrent: int,
         parse_max_concurrent: int | None = None,
+        metadata_update_max_concurrent: int | None = None,
         existing_permalink_by_path: dict[str, str | None] | None = None,
     ) -> IndexingBatchResult:
         """Index one batch of loaded files with bounded concurrency."""
         if max_concurrent <= 0:
             raise ValueError("max_concurrent must be greater than zero")
+        if metadata_update_max_concurrent is not None and metadata_update_max_concurrent <= 0:
+            raise ValueError("metadata_update_max_concurrent must be greater than zero")
 
         ordered_paths = sorted(files)
         if not ordered_paths:
@@ -220,7 +223,11 @@ class BatchIndexer:
 
         refreshed, refresh_errors = await self._run_bounded(
             [path for path in ordered_paths if path in prepared_entities],
-            limit=self.app_config.index_metadata_update_max_concurrent,
+            limit=(
+                self.app_config.index_metadata_update_max_concurrent
+                if metadata_update_max_concurrent is None
+                else metadata_update_max_concurrent
+            ),
             worker=lambda path: self._refresh_search_index(
                 prepared_entities[path],
                 entities_by_id[prepared_entities[path].entity_id],

--- a/src/basic_memory/indexing/index_batch_runtime.py
+++ b/src/basic_memory/indexing/index_batch_runtime.py
@@ -56,6 +56,7 @@ class IndexInputBatchExecutor(Protocol):
         *,
         max_concurrent: int,
         parse_max_concurrent: int | None = None,
+        metadata_update_max_concurrent: int | None = None,
     ) -> IndexingBatchResult:
         """Index one batch of storage-neutral input files."""
 
@@ -105,6 +106,7 @@ class IndexBatchRuntime[EntityT: IndexedNoteContentEntity, FileInfoT: LoadedInde
             input_files,
             max_concurrent=max_concurrent,
             parse_max_concurrent=parse_max_concurrent,
+            metadata_update_max_concurrent=metadata_update_max_concurrent,
         )
         reconciliation = await reconcile_indexed_note_content_batch(
             result.indexed,

--- a/tests/indexing/test_batch_indexer.py
+++ b/tests/indexing/test_batch_indexer.py
@@ -193,6 +193,58 @@ async def test_batch_indexer_parses_markdown_with_parallel_path(
 
 
 @pytest.mark.asyncio
+async def test_batch_indexer_honors_explicit_search_refresh_concurrency(
+    app_config,
+    entity_service,
+    entity_repository,
+    relation_repository,
+    search_service,
+    file_service,
+    project_config,
+    monkeypatch,
+):
+    paths = ("notes/one.md", "notes/two.md")
+    for path in paths:
+        await _create_file(project_config.home / path, f"# {Path(path).stem}\n")
+
+    files = {path: await _load_input(file_service, path) for path in paths}
+    batch_indexer = _make_batch_indexer(
+        app_config,
+        entity_service,
+        entity_repository,
+        relation_repository,
+        search_service,
+        file_service,
+    )
+    original_index_entity_data = search_service.index_entity_data
+    in_flight = 0
+    max_in_flight = 0
+
+    async def spy_index_entity_data(*args, **kwargs):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.05)
+        try:
+            return await original_index_entity_data(*args, **kwargs)
+        finally:
+            in_flight -= 1
+
+    monkeypatch.setattr(search_service, "index_entity_data", spy_index_entity_data)
+
+    result = await batch_indexer.index_files(
+        files,
+        max_concurrent=2,
+        parse_max_concurrent=2,
+        metadata_update_max_concurrent=1,
+    )
+
+    assert result.errors == []
+    assert len(result.indexed) == 2
+    assert max_in_flight == 1
+
+
+@pytest.mark.asyncio
 async def test_batch_indexer_creates_entities_with_real_db_session(
     app_config,
     entity_service,

--- a/tests/indexing/test_index_batch_runtime.py
+++ b/tests/indexing/test_index_batch_runtime.py
@@ -90,6 +90,7 @@ class RecordingBatchIndexer:
     calls: list[dict[str, IndexInputFile]] = field(default_factory=list)
     max_concurrent: int | None = None
     parse_max_concurrent: int | None = None
+    metadata_update_max_concurrent: int | None = None
     published_generation_by_entity_id: dict[int, int] | None = None
     publish_max_concurrent: int | None = None
 
@@ -99,10 +100,12 @@ class RecordingBatchIndexer:
         *,
         max_concurrent: int,
         parse_max_concurrent: int | None = None,
+        metadata_update_max_concurrent: int | None = None,
     ) -> IndexingBatchResult:
         self.calls.append(dict(files))
         self.max_concurrent = max_concurrent
         self.parse_max_concurrent = parse_max_concurrent
+        self.metadata_update_max_concurrent = metadata_update_max_concurrent
         return self.result
 
     async def publish_relation_generations(
@@ -258,6 +261,7 @@ async def test_index_batch_runtime_indexes_loaded_files_and_reconciles_note_cont
 
     assert batch_indexer.max_concurrent == 4
     assert batch_indexer.parse_max_concurrent == 2
+    assert batch_indexer.metadata_update_max_concurrent == 1
     assert batch_indexer.calls[0]["ok.md"] == IndexInputFile(
         path="ok.md",
         size=5,


### PR DESCRIPTION
## Summary

- thread the caller-provided metadata update concurrency through the portable batch runtime
- apply it to the internal search-index refresh phase instead of always using the independent application default
- preserve the existing application default when callers do not provide an override

## Why

Basic Memory Cloud derives an indexing fan-out from the worker process tenant database budget. The runtime already accepted that value for note-content reconciliation and relation publication, but the earlier entity search refresh still used `index_metadata_update_max_concurrent`. Two Cloud batch jobs could therefore exceed the process-wide tenant connection budget on the observed `search.index_entity_data` path.

## Verification

- `uv run pytest tests/indexing/test_batch_indexer.py tests/indexing/test_index_batch_runtime.py -q` (26 passed)
- focused ruff and ty checks passed
- regression test observes peak in-flight search writes across two files and requires the explicit limit of 1

Companion dependency for basicmachines-co/basic-memory-cloud#1845.