### PR TITLE
fix(core): unresolve inbound relations on entity delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- **#1344**: Deleting a note no longer erases the relations pointing at it. The
+  `relation.to_id` foreign key is now `ON DELETE SET NULL` rather than
+  `ON DELETE CASCADE`, and `Entity.incoming_relations` no longer cascades deletes
+  through the ORM. Deleting a target leaves its inbound relations in the unresolved
+  state the indexer already produces for a link to a note that does not exist yet --
+  `to_id` null, `to_name` holding the source's original link text -- so a
+  broken-link report stops coming back clean over a vault full of them, and
+  recreating the target re-links the references through the existing
+  forward-reference pass. `from_id` keeps `CASCADE`: an entity does own the
+  relations it declares. Rows already lost to the old behavior stay lost; re-index
+  the affected notes to bring them back as unresolved.
+
 ## v0.23.2 (2026-08-25)
 
 Patch release fixing case-duplicate folder creation.

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -101,6 +101,13 @@ A relation is a directed semantic statement owned by its source entity.
 Incoming graph navigation does not transfer ownership to the target. Re-indexing the source note
 may recreate, resolve, or remove its outgoing relations.
 
+Deleting the target is not one of those events. When a target entity is deleted, its inbound
+relations survive with `to_id` cleared and `to_name` intact -- the same unresolved state the
+indexer produces for a link to a note that does not exist yet. The source note's markdown still
+carries the reference, so the graph must keep carrying it too; a graph that quietly drops the edge
+reports a clean bill of health over a broken link. Forward-reference resolution re-links the row
+if the target is ever recreated.
+
 ### NoteContent
 
 `NoteContent` is the operational record of accepted Markdown bytes and their file materialization

--- a/src/basic_memory/alembic/versions/bcdbd5a942ca_relation_to_id_set_null_on_delete.py
+++ b/src/basic_memory/alembic/versions/bcdbd5a942ca_relation_to_id_set_null_on_delete.py
@@ -1,0 +1,77 @@
+"""relation.to_id foreign key becomes ON DELETE SET NULL
+
+Deleting an entity used to take every inbound relation row with it. The wikilink
+stayed in the source note's markdown, but the graph forgot the edge existed, so a
+"find broken links" report came back clean over a vault full of them.
+
+to_id has always been nullable, and the indexer already produces exactly the state
+we want here -- to_id NULL with to_name holding the source's link text -- for a link
+pointing at a note that does not exist yet. A deleted target should land in that same
+unresolved state instead of vanishing, and forward-reference resolution then re-links
+the row for free if the target is ever recreated.
+
+from_id keeps CASCADE. An entity really does own the relations it declares.
+
+Revision ID: bcdbd5a942ca
+Revises: 7f6a2b8c9d10
+Create Date: 2026-08-28 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "bcdbd5a942ca"
+down_revision: Union[str, None] = "7f6a2b8c9d10"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# The initial schema created relation's entity foreign keys without names, and SQLite
+# has no way to reference an anonymous constraint. Handing batch_alter_table a naming
+# convention lets it address the reflected FK by the name the convention would have
+# given it. Side effect worth knowing about: the table recreate writes those names into
+# the schema, so from_id's FK comes out named too. Cosmetic, and an improvement.
+RELATION_NAMING_CONVENTION = {"fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s"}
+SQLITE_TO_ID_FK = "fk_relation_to_id_entity"
+
+# Postgres named it for us when the initial schema left it anonymous.
+POSTGRES_TO_ID_FK = "relation_to_id_fkey"
+
+
+def _set_to_id_ondelete(ondelete: str) -> None:
+    """Point relation.to_id's foreign key at a different ON DELETE action."""
+    dialect = op.get_bind().dialect.name
+
+    if dialect == "sqlite":
+        # SQLite cannot alter a foreign key in place; batch mode does the copy-and-swap.
+        # Same shape as a1b2c3d4e5f6.
+        with op.batch_alter_table(
+            "relation", schema=None, naming_convention=RELATION_NAMING_CONVENTION
+        ) as batch_op:
+            batch_op.drop_constraint(SQLITE_TO_ID_FK, type_="foreignkey")
+            batch_op.create_foreign_key(
+                SQLITE_TO_ID_FK, "entity", ["to_id"], ["id"], ondelete=ondelete
+            )
+    else:
+        op.drop_constraint(POSTGRES_TO_ID_FK, "relation", type_="foreignkey")
+        op.create_foreign_key(
+            POSTGRES_TO_ID_FK, "relation", "entity", ["to_id"], ["id"], ondelete=ondelete
+        )
+
+
+def upgrade() -> None:
+    """Stop erasing an entity's inbound relations along with the entity."""
+    _set_to_id_ondelete("SET NULL")
+
+
+def downgrade() -> None:
+    """Go back to erasing inbound relations on delete.
+
+    Rows already unresolved (to_id NULL) stay that way. This restores the constraint;
+    it cannot un-forget what CASCADE already ate.
+    """
+    _set_to_id_ondelete("CASCADE")

--- a/src/basic_memory/models/knowledge.py
+++ b/src/basic_memory/models/knowledge.py
@@ -113,11 +113,17 @@ class Entity(Base):
         foreign_keys="[Relation.from_id]",
         cascade="all, delete-orphan",
     )
+    # No delete cascade here, and the asymmetry with outgoing_relations is the point.
+    # An entity owns the relations it declares; it does not own the ones other entities
+    # declare at it. Deleting this entity unresolves the inbound rows (to_id -> NULL) and
+    # leaves to_name holding the source's original link text -- the same state the indexer
+    # produces for a link to a note that does not exist yet. passive_deletes hands the job
+    # to the database's ON DELETE SET NULL instead of having the ORM null the rows itself.
     incoming_relations = relationship(
         "Relation",
         back_populates="to_entity",
         foreign_keys="[Relation.to_id]",
-        cascade="all, delete-orphan",
+        passive_deletes=True,
     )
     note_content = relationship(
         "NoteContent",
@@ -354,8 +360,12 @@ class Relation(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)  # pyright: ignore [reportIncompatibleVariableOverride]
     project_id: Mapped[int] = mapped_column(Integer, ForeignKey("project.id"), index=True)
     from_id: Mapped[int] = mapped_column(Integer, ForeignKey("entity.id", ondelete="CASCADE"))
+    # SET NULL, not CASCADE. Deleting the target must not erase the record that some other
+    # entity still points here -- the wikilink is still sitting in that note's markdown, so
+    # a graph that forgets the edge reports a clean bill of health over a broken link.
+    # from_id above keeps CASCADE: an entity really does own the relations it declares.
     to_id: Mapped[Optional[int]] = mapped_column(
-        Integer, ForeignKey("entity.id", ondelete="CASCADE"), nullable=True
+        Integer, ForeignKey("entity.id", ondelete="SET NULL"), nullable=True
     )
     to_name: Mapped[str] = mapped_column(String)
     relation_type: Mapped[str] = mapped_column(String)

--- a/tests/api/v2/test_delete_unresolves_inbound_relations.py
+++ b/tests/api/v2/test_delete_unresolves_inbound_relations.py
@@ -1,0 +1,243 @@
+"""Deleting a note must not erase the relations other notes point at it.
+
+Before this fix, deleting note Beta took every relation row aimed at Beta with it --
+even though note Alpha's markdown still said `[[Beta]]`. The text asserted an edge and
+the graph denied one, so a "find the links that lead nowhere" report came back clean
+over a vault full of them. Alpha only got its row back, correctly marked unresolved, if
+something happened to re-index Alpha, and nothing schedules that.
+
+`to_id` has always been nullable, and unresolved-with-`to_name`-preserved is the state
+the indexer already produces for a link to a note that does not exist yet. These tests
+pin the two HTTP delete paths onto that state -- the single-entity delete and the
+directory delete -- plus the unique-constraint question that SET NULL raises.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from basic_memory import db
+from basic_memory.indexing.forward_reference_resolution import (
+    RepositoryForwardReferenceRelationSource,
+    RepositoryForwardReferenceResolutionRuntime,
+    run_forward_reference_resolution,
+)
+from basic_memory.models import Project, Relation
+from basic_memory.schemas.v2.entity import EntityResponseV2
+
+
+async def _relations_from(session_maker, entity_repository, file_path: str):
+    """Load one note's outgoing relations straight from the database."""
+    async with db.scoped_session(session_maker) as session:
+        source = await entity_repository.get_by_file_path(session, file_path)
+        assert source is not None
+        rows = (
+            (await session.execute(select(Relation).where(Relation.from_id == source.id)))
+            .scalars()
+            .all()
+        )
+        return source.id, list(rows)
+
+
+async def _resolve_forward_references(session_maker, project_id: int) -> None:
+    """Run the deferred forward-reference pass the API only schedules.
+
+    The v2 API test app stubs the resolution scheduler out, so nothing runs it for us.
+    This is the same pass the real scheduler drives.
+    """
+    relation_source = RepositoryForwardReferenceRelationSource(
+        session_maker=session_maker,
+        project_id=project_id,
+    )
+    runtime = RepositoryForwardReferenceResolutionRuntime(
+        session_maker=session_maker,
+        project_id=project_id,
+    )
+    await run_forward_reference_resolution(
+        runtime,
+        await relation_source.list_unresolved_forward_references(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_entity_unresolves_inbound_relation_and_recreate_relinks(
+    client: AsyncClient,
+    v2_project_url,
+    entity_repository,
+    session_maker,
+    test_project: Project,
+):
+    """API single-entity delete: the inbound edge survives unresolved, and comes back."""
+    response = await client.post(
+        f"{v2_project_url}/knowledge/entities",
+        json={"title": "Beta", "directory": "unresolve", "content": "# Beta"},
+    )
+    assert response.status_code == 202
+    beta = EntityResponseV2.model_validate(response.json())
+
+    response = await client.post(
+        f"{v2_project_url}/knowledge/entities",
+        json={
+            "title": "Alpha",
+            "directory": "unresolve",
+            "content": "# Alpha\n\n- links_to [[Beta]]",
+        },
+    )
+    assert response.status_code == 202
+
+    alpha_id, relations = await _relations_from(
+        session_maker, entity_repository, "unresolve/Alpha.md"
+    )
+    assert len(relations) == 1
+    assert relations[0].to_id == beta.id
+    assert relations[0].to_name == "Beta"
+
+    response = await client.delete(f"{v2_project_url}/knowledge/entities/{beta.external_id}")
+    assert response.status_code == 202
+
+    _, after_delete = await _relations_from(session_maker, entity_repository, "unresolve/Alpha.md")
+    assert len(after_delete) == 1, "the inbound relation must survive its target's deletion"
+    assert after_delete[0].from_id == alpha_id
+    assert after_delete[0].to_id is None
+    assert after_delete[0].to_name == "Beta"
+    assert after_delete[0].relation_type == "links_to"
+
+    # Recreating the target re-links the row through the existing forward-reference
+    # pass. Nothing new was built for this; unresolved was already a supported state.
+    response = await client.post(
+        f"{v2_project_url}/knowledge/entities",
+        json={"title": "Beta", "directory": "unresolve", "content": "# Beta again"},
+    )
+    assert response.status_code == 202
+    recreated_beta = EntityResponseV2.model_validate(response.json())
+
+    await _resolve_forward_references(session_maker, test_project.id)
+
+    _, after_recreate = await _relations_from(
+        session_maker, entity_repository, "unresolve/Alpha.md"
+    )
+    assert len(after_recreate) == 1
+    assert after_recreate[0].to_id == recreated_beta.id
+    assert after_recreate[0].to_name == "Beta"
+
+
+@pytest.mark.asyncio
+async def test_delete_directory_unresolves_inbound_relations_from_outside(
+    client: AsyncClient,
+    v2_project_url,
+    entity_repository,
+    session_maker,
+    test_project: Project,
+):
+    """Directory delete: a keeper outside the directory keeps its edge, unresolved."""
+    response = await client.post(
+        f"{v2_project_url}/knowledge/entities",
+        json={
+            "title": "Dir Target",
+            "directory": "unresolve-dir",
+            "content": "# Dir Target",
+        },
+    )
+    assert response.status_code == 202
+    target = EntityResponseV2.model_validate(response.json())
+
+    response = await client.post(
+        f"{v2_project_url}/knowledge/entities",
+        json={
+            "title": "Dir Keeper",
+            "directory": "unresolve-keep",
+            "content": "# Dir Keeper\n\n- links_to [[Dir Target]]",
+        },
+    )
+    assert response.status_code == 202
+
+    _, before = await _relations_from(
+        session_maker, entity_repository, "unresolve-keep/Dir Keeper.md"
+    )
+    assert len(before) == 1
+    assert before[0].to_id == target.id
+
+    response = await client.post(
+        f"{v2_project_url}/knowledge/delete-directory",
+        json={"directory": "unresolve-dir"},
+    )
+    assert response.status_code == 200
+
+    _, after = await _relations_from(
+        session_maker, entity_repository, "unresolve-keep/Dir Keeper.md"
+    )
+    assert len(after) == 1, "the keeper's relation must survive the directory delete"
+    assert after[0].to_id is None
+    assert after[0].to_name == "Dir Target"
+    assert after[0].relation_type == "links_to"
+
+    response = await client.post(
+        f"{v2_project_url}/knowledge/entities",
+        json={
+            "title": "Dir Target",
+            "directory": "unresolve-dir",
+            "content": "# Dir Target again",
+        },
+    )
+    assert response.status_code == 202
+    recreated = EntityResponseV2.model_validate(response.json())
+
+    await _resolve_forward_references(session_maker, test_project.id)
+
+    _, relinked = await _relations_from(
+        session_maker, entity_repository, "unresolve-keep/Dir Keeper.md"
+    )
+    assert len(relinked) == 1
+    assert relinked[0].to_id == recreated.id
+
+
+@pytest.mark.asyncio
+async def test_two_deleted_targets_unresolve_without_unique_constraint_collision(
+    client: AsyncClient,
+    v2_project_url,
+    entity_repository,
+    session_maker,
+):
+    """Unresolving two rows to the same (from_id, NULL, relation_type) must not collide.
+
+    `uix_relation_from_id_to_id` covers (from_id, to_id, relation_type), so the obvious
+    worry about SET NULL is two inbound rows from one source colliding once both targets
+    are gone. They do not: NULL is distinct from NULL under both backends' unique
+    constraints, and `uix_relation_from_id_to_name` still tells the two rows apart by the
+    link text the author wrote.
+    """
+    for title in ("Collide One", "Collide Two"):
+        response = await client.post(
+            f"{v2_project_url}/knowledge/entities",
+            json={"title": title, "directory": "collide", "content": f"# {title}"},
+        )
+        assert response.status_code == 202
+
+    response = await client.post(
+        f"{v2_project_url}/knowledge/entities",
+        json={
+            "title": "Collide Source",
+            "directory": "collide-src",
+            "content": "# Collide Source\n\n- links_to [[Collide One]]\n- links_to [[Collide Two]]",
+        },
+    )
+    assert response.status_code == 202
+
+    _, before = await _relations_from(
+        session_maker, entity_repository, "collide-src/Collide Source.md"
+    )
+    assert len(before) == 2
+    assert all(relation.to_id is not None for relation in before)
+
+    response = await client.post(
+        f"{v2_project_url}/knowledge/delete-directory",
+        json={"directory": "collide"},
+    )
+    assert response.status_code == 200
+
+    _, after = await _relations_from(
+        session_maker, entity_repository, "collide-src/Collide Source.md"
+    )
+    assert len(after) == 2, "both inbound relations must survive, unresolved"
+    assert [relation.to_id for relation in after] == [None, None]
+    assert sorted(relation.to_name for relation in after) == ["Collide One", "Collide Two"]

--- a/tests/index/test_local_project_index.py
+++ b/tests/index/test_local_project_index.py
@@ -2140,7 +2140,11 @@ type: note
 
     assert source_after is not None
     assert source_after.id == source_entity_id
-    assert source_after.outgoing_relations == []
+    # Same story as the watcher parity test: the surviving relation is now unresolved
+    # rather than gone. This test is about repairing the survivor's search row.
+    assert len(source_after.outgoing_relations) == 1
+    assert source_after.outgoing_relations[0].to_id is None
+    assert source_after.outgoing_relations[0].to_name == "Deleted Target"
     assert deleted_target is None
     assert deleted_other is None
     assert target_note_content_after is None

--- a/tests/index/test_local_watch_regular_file_parity.py
+++ b/tests/index/test_local_watch_regular_file_parity.py
@@ -224,7 +224,19 @@ title: Source
     assert deleted_target is None
     assert source_after is not None
     assert source_after.id == source_entity_id
-    assert source_after.outgoing_relations == []
-    assert stale_relation_rows == []
+    # The relation survives its target's deletion, unresolved. This test is about the
+    # stale search row; the empty-relations assertion was scenery, and keeping it would
+    # have turned an accident into a contract.
+    assert len(source_after.outgoing_relations) == 1
+    assert source_after.outgoing_relations[0].to_id is None
+    assert source_after.outgoing_relations[0].to_name == "asset.pdf"
+    # The search row is repaired in place rather than removed. `asset.pdf` and the target
+    # entity's permalink both reduce to `asset`, so the unresolved relation's permalink is
+    # the same string the resolved one had -- the refresh rewrites that row with a null
+    # target instead of deleting it. Repair either way; what must not happen is a row still
+    # claiming a live target.
+    assert len(stale_relation_rows) == 1
+    assert stale_relation_rows[0].to_id is None
+    assert stale_relation_rows[0].from_id == source_entity_id
     assert watch_service.state.recent_events[0].action == "index"
     assert watch_service.state.recent_events[0].status == "success"

--- a/tests/index/test_watch_delete_unresolves_inbound_relation.py
+++ b/tests/index/test_watch_delete_unresolves_inbound_relation.py
@@ -1,0 +1,147 @@
+"""The file watcher must not erase the relations pointing at a deleted note.
+
+The watcher takes a different route to the same place as the API: a bulk SQL
+`DELETE` rather than an ORM `session.delete`. That is exactly why it gets its own
+test -- the database constraint and the ORM cascade were two separate mechanisms
+doing the same damage, and fixing one without the other just moves the bug.
+
+Measured shape of the bug: note Alpha links to note Beta, Beta's file is removed on
+disk, the watcher notices, and Alpha's relation row disappears along with Beta --
+while Alpha's markdown still says `[[Beta]]`.
+"""
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from watchfiles import Change
+
+from basic_memory import db
+from basic_memory.config import BasicMemoryConfig
+from basic_memory.index.local_project import (
+    LocalProjectIndexRuntimeFactory,
+    run_local_project_index_for_project,
+)
+from basic_memory.index.local_runtime import LocalWatchEventIndexRuntimeFactory
+from basic_memory.index.watch_service import WatchService
+from basic_memory.indexing.forward_reference_resolution import (
+    RepositoryForwardReferenceRelationSource,
+    RepositoryForwardReferenceResolutionRuntime,
+    run_forward_reference_resolution,
+)
+from basic_memory.models.knowledge import Entity, Relation
+
+
+BETA_NOTE = """---
+type: note
+title: Beta
+---
+# Beta
+"""
+
+ALPHA_NOTE = """---
+type: note
+title: Alpha
+---
+# Alpha
+
+- links_to [[Beta]]
+"""
+
+
+async def create_test_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_watch_delete_unresolves_inbound_relation_and_recreate_relinks(
+    app_config: BasicMemoryConfig,
+    project_repository,
+    session_maker,
+    test_project,
+    project_config,
+    entity_repository,
+) -> None:
+    """Watcher delete path: the inbound relation survives unresolved, and re-links."""
+    alpha_path = project_config.home / "alpha.md"
+    beta_path = project_config.home / "beta.md"
+    await create_test_file(beta_path, BETA_NOTE)
+    await create_test_file(alpha_path, ALPHA_NOTE)
+
+    indexed = await run_local_project_index_for_project(
+        test_project,
+        runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+        force_full=True,
+    )
+    assert indexed.enqueued_files == 2
+
+    async with db.scoped_session(session_maker) as session:
+        alpha = await entity_repository.get_by_file_path(session, "alpha.md")
+        beta = await entity_repository.get_by_file_path(session, "beta.md")
+        assert alpha is not None
+        assert beta is not None
+        assert len(alpha.outgoing_relations) == 1
+        assert alpha.outgoing_relations[0].to_id == beta.id
+        alpha_id = alpha.id
+        beta_id = beta.id
+
+    beta_path.unlink()
+
+    watch_service = WatchService(
+        app_config=app_config,
+        project_repository=project_repository,
+        session_maker=session_maker,
+        event_index_runtime_factory=LocalWatchEventIndexRuntimeFactory(),
+    )
+    await watch_service.handle_changes(test_project, {(Change.deleted, str(beta_path))})
+
+    async with db.scoped_session(session_maker) as session:
+        assert await session.get(Entity, beta_id) is None
+        rows = (
+            (await session.execute(select(Relation).where(Relation.from_id == alpha_id)))
+            .scalars()
+            .all()
+        )
+
+    assert len(rows) == 1, "the inbound relation must survive the watcher's bulk delete"
+    assert rows[0].to_id is None
+    assert rows[0].to_name == "Beta"
+    assert rows[0].relation_type == "links_to"
+
+    # Alpha's markdown never changed, and now the graph agrees with it again.
+    assert "[[Beta]]" in alpha_path.read_text(encoding="utf-8")
+
+    # Put Beta back. Forward-reference resolution -- which already existed for links
+    # written before their target -- picks the row up and re-links it.
+    await create_test_file(beta_path, BETA_NOTE)
+    await run_local_project_index_for_project(
+        test_project,
+        runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+    )
+
+    relation_source = RepositoryForwardReferenceRelationSource(
+        session_maker=session_maker,
+        project_id=test_project.id,
+    )
+    runtime = RepositoryForwardReferenceResolutionRuntime(
+        session_maker=session_maker,
+        project_id=test_project.id,
+    )
+    await run_forward_reference_resolution(
+        runtime,
+        await relation_source.list_unresolved_forward_references(),
+    )
+
+    async with db.scoped_session(session_maker) as session:
+        recreated_beta = await entity_repository.get_by_file_path(session, "beta.md")
+        assert recreated_beta is not None
+        rows = (
+            (await session.execute(select(Relation).where(Relation.from_id == alpha_id)))
+            .scalars()
+            .all()
+        )
+
+    assert len(rows) == 1
+    assert rows[0].to_id == recreated_beta.id
+    assert rows[0].to_name == "Beta"

--- a/tests/test_relation_to_id_set_null_migration.py
+++ b/tests/test_relation_to_id_set_null_migration.py
@@ -1,0 +1,244 @@
+"""Migration tests for the relation.to_id ON DELETE change.
+
+The rest of the SQLite suite builds its schema straight from SQLAlchemy metadata, so a
+corrected model with a missing or wrong migration would sail through green while every
+database already on disk kept the old CASCADE. These tests run the real Alembic chain
+and read the constraint back out.
+"""
+
+import sqlite3
+from importlib import import_module
+from pathlib import Path
+from types import SimpleNamespace
+
+from alembic import command
+from alembic.config import Config
+
+from basic_memory import db
+
+
+migration = import_module(
+    "basic_memory.alembic.versions.bcdbd5a942ca_relation_to_id_set_null_on_delete"
+)
+
+# Read off the module so a renamed revision breaks here rather than drifting silently.
+REVISION: str = str(migration.revision)
+DOWN_REVISION: str = str(migration.down_revision)
+
+
+def sqlite_alembic_config(database_path: Path) -> Config:
+    """Build an Alembic config that upgrades a temporary SQLite database."""
+    alembic_dir = Path(db.__file__).parent / "alembic"
+    config = Config()
+    config.set_main_option("script_location", str(alembic_dir))
+    config.set_main_option(
+        "file_template",
+        "%%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s",
+    )
+    config.set_main_option("timezone", "UTC")
+    config.set_main_option("revision_environment", "false")
+    config.set_main_option("sqlalchemy.url", f"sqlite:///{database_path}")
+    return config
+
+
+def _relation_fk_actions(database_path: Path) -> dict[str, str]:
+    """Map relation's foreign key columns to the ON DELETE action SQLite recorded."""
+    connection = sqlite3.connect(database_path)
+    try:
+        # PRAGMA columns: id, seq, table, from, to, on_update, on_delete, match
+        return {
+            str(row[3]): str(row[6])
+            for row in connection.execute("PRAGMA foreign_key_list(relation)")
+        }
+    finally:
+        connection.close()
+
+
+def test_sqlite_upgrade_sets_relation_to_id_null_on_delete(tmp_path, monkeypatch):
+    """A migrated SQLite database must unresolve inbound relations, not delete them."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BASIC_MEMORY_HOME", str(tmp_path / "basic-memory"))
+
+    database_path = tmp_path / "relation-to-id-set-null.db"
+    config = sqlite_alembic_config(database_path)
+
+    command.upgrade(config, DOWN_REVISION)
+    before = _relation_fk_actions(database_path)
+    assert before["to_id"] == "CASCADE"
+
+    command.upgrade(config, REVISION)
+    after = _relation_fk_actions(database_path)
+
+    assert after["to_id"] == "SET NULL"
+    # The table gets rebuilt, so prove the swap did not disturb the other two.
+    assert after["from_id"] == "CASCADE"
+    assert after["project_id"] == "NO ACTION"
+
+
+def test_sqlite_upgrade_preserves_relation_rows_and_indexes(tmp_path, monkeypatch):
+    """The SQLite copy-and-swap must not drop data, indexes, or unique constraints."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BASIC_MEMORY_HOME", str(tmp_path / "basic-memory"))
+
+    database_path = tmp_path / "relation-to-id-set-null-data.db"
+    config = sqlite_alembic_config(database_path)
+    command.upgrade(config, DOWN_REVISION)
+
+    timestamp = "2026-08-28 00:00:00"
+    connection = sqlite3.connect(database_path)
+    try:
+        connection.execute(
+            """
+            INSERT INTO project (
+                id, name, permalink, path, is_active, is_default,
+                created_at, updated_at, external_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (1, "test", "test", "/test", True, True, timestamp, timestamp, "project-1"),
+        )
+        connection.executemany(
+            """
+            INSERT INTO entity (
+                id, title, note_type, content_type, file_path,
+                created_at, updated_at, project_id, external_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    entity_id,
+                    f"Note {entity_id}",
+                    "note",
+                    "text/markdown",
+                    f"note-{entity_id}.md",
+                    timestamp,
+                    timestamp,
+                    1,
+                    f"entity-{entity_id}",
+                )
+                for entity_id in (1, 2)
+            ],
+        )
+        connection.execute(
+            """
+            INSERT INTO relation (
+                id, from_id, to_id, to_name, relation_type, project_id
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (1, 1, 2, "Note 2", "links_to", 1),
+        )
+        connection.commit()
+        indexes_before = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='relation'"
+            )
+        }
+    finally:
+        connection.close()
+
+    command.upgrade(config, REVISION)
+
+    connection = sqlite3.connect(database_path)
+    try:
+        assert connection.execute("SELECT COUNT(*) FROM relation").fetchone()[0] == 1
+        row = connection.execute(
+            "SELECT from_id, to_id, to_name, relation_type, generation FROM relation"
+        ).fetchone()
+        assert row == (1, 2, "Note 2", "links_to", 0)
+
+        indexes_after = {
+            name
+            for name in (
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='relation'"
+                )
+            )
+        }
+        assert indexes_before <= indexes_after
+
+        table_sql = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE name='relation'"
+        ).fetchone()[0]
+        assert "uix_relation_from_id_to_id" in table_sql
+        assert "uix_relation_from_id_to_name" in table_sql
+
+        # The whole point: the delete now unresolves the inbound row.
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("DELETE FROM entity WHERE id = 2")
+        connection.commit()
+        assert connection.execute("SELECT to_id, to_name FROM relation").fetchone() == (
+            None,
+            "Note 2",
+        )
+    finally:
+        connection.close()
+
+
+def test_sqlite_downgrade_restores_cascade(tmp_path, monkeypatch):
+    """Downgrading must put the old CASCADE back, so the step is reversible."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BASIC_MEMORY_HOME", str(tmp_path / "basic-memory"))
+
+    database_path = tmp_path / "relation-to-id-downgrade.db"
+    config = sqlite_alembic_config(database_path)
+
+    command.upgrade(config, REVISION)
+    assert _relation_fk_actions(database_path)["to_id"] == "SET NULL"
+
+    command.downgrade(config, DOWN_REVISION)
+    restored = _relation_fk_actions(database_path)
+
+    assert restored["to_id"] == "CASCADE"
+    assert restored["from_id"] == "CASCADE"
+
+
+# What op.drop_constraint / op.create_foreign_key get called with, recorded verbatim.
+DropConstraintCall = tuple[str, str, str]
+CreateForeignKeyCall = tuple[str, str, str, list[str], list[str], str]
+
+
+def _postgres_bind() -> SimpleNamespace:
+    return SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+
+
+def _record_postgres_constraint_calls(
+    monkeypatch,
+) -> tuple[list[DropConstraintCall], list[CreateForeignKeyCall]]:
+    """Swap op's constraint calls for recorders; Postgres alters the FK in place."""
+    dropped: list[DropConstraintCall] = []
+    created: list[CreateForeignKeyCall] = []
+    monkeypatch.setattr(migration.op, "get_bind", _postgres_bind)
+    monkeypatch.setattr(
+        migration.op,
+        "drop_constraint",
+        lambda name, table, type_: dropped.append((name, table, type_)),
+    )
+    monkeypatch.setattr(
+        migration.op,
+        "create_foreign_key",
+        lambda name, source, referent, local_cols, remote_cols, ondelete: created.append(
+            (name, source, referent, local_cols, remote_cols, ondelete)
+        ),
+    )
+    return dropped, created
+
+
+def test_postgres_upgrade_recreates_to_id_fk_with_set_null(monkeypatch):
+    """Postgres has no batch dance; it drops and recreates the named constraint."""
+    dropped, created = _record_postgres_constraint_calls(monkeypatch)
+
+    migration.upgrade()
+
+    assert dropped == [("relation_to_id_fkey", "relation", "foreignkey")]
+    assert created == [("relation_to_id_fkey", "relation", "entity", ["to_id"], ["id"], "SET NULL")]
+
+
+def test_postgres_downgrade_recreates_to_id_fk_with_cascade(monkeypatch):
+    """And puts CASCADE back on the way down."""
+    dropped, created = _record_postgres_constraint_calls(monkeypatch)
+
+    migration.downgrade()
+
+    assert dropped == [("relation_to_id_fkey", "relation", "foreignkey")]
+    assert created == [("relation_to_id_fkey", "relation", "entity", ["to_id"], ["id"], "CASCADE")]


### PR DESCRIPTION
Fixes #1344.

## What was wrong

Delete a note, and every link pointing *at* it quietly disappeared from the graph too.

The notes doing the pointing were never touched. Their markdown still said `[[That Note]]`, right there on the page. But as far as the database was concerned, no such link had ever been written. So if you asked for the links that lead nowhere — the report every knowledge base eventually needs, and the one that catches rot before it spreads — it came back clean over a vault full of them.

That is the part worth caring about. Not that the answer was missing, but that the system gave a confident wrong one. A tool that says "no broken links" is telling you to stop looking.

The link came back only if something happened to re-index the note containing it. Nothing schedules that. For a note nobody edits again: never.

## The cause

`relation.to_id` carried `ON DELETE CASCADE`, and `Entity.incoming_relations` carried a matching ORM `delete-orphan` cascade — two separate mechanisms doing the same damage on two different delete routes. The watcher and directory runners take a bulk SQL `DELETE`, so the database constraint ate the rows. The API single-entity delete takes `session.delete(entity)`, so the ORM ate them.

`to_id` has always been nullable, and unresolved-with-`to_name`-preserved is a state the system already produces and already handles everywhere — it is what the indexer writes for a link to a note that does not exist yet. The schema could hold the right answer the whole time. Nothing chose `CASCADE` over it; it was inherited from `from_id`, where it *is* correct.

`docs/DOMAIN_MODEL.md` already said as much: the relation is owned by its source, and resolution "enriches that statement; it does not replace it". Deleting the target should un-enrich, not delete.

## The fix

`to_id` becomes `ON DELETE SET NULL`, and `incoming_relations` drops `delete-orphan` for `passive_deletes=True` so the ORM hands the job to the database instead of doing it itself. `from_id` keeps `CASCADE` — an entity really does own the relations it declares.

Both halves are load-bearing, and the tests below demonstrate that separately rather than asserting it.

Because unresolved is an already-supported state, nothing downstream needed teaching. Forward-reference resolution already sweeps `to_id IS NULL` rows, so **recreating a deleted note re-links its inbound references for free** — no new pass was built, and the generation fence in `find_unresolved_relations` is untouched. The `relation_cleanup_entity_ids` machinery in the watcher and directory runners still works unchanged; it now repairs surviving sources' search rows to a null target rather than watching the rows disappear.

### Migration

`bcdbd5a942ca_relation_to_id_set_null_on_delete.py`, revising `7f6a2b8c9d10`.

SQLite goes through `op.batch_alter_table("relation")`, following `a1b2c3d4e5f6`. The initial-schema foreign key is unnamed, and SQLite cannot address an anonymous constraint, so the batch gets a `naming_convention` and refers to the reflected FK by the name that convention would have given it. One visible side effect: the table recreate writes those names into the schema, so `from_id`'s foreign key comes out named too. Verified against a real migrated database — the resulting DDL is identical except for the `ON DELETE` action and those two constraint names, with every index, unique constraint, the `generation` column's server default, and all rows intact.

Postgres drops and recreates `relation_to_id_fkey`. Verified against a real Postgres: after the migration, `pg_constraint.confdeltype` for `relation_to_id_fkey` is `n` (set null) while `relation_from_id_fkey` stays `c` (cascade).

**Rows already lost to the old behavior stay lost.** The migration changes the rule going forward; it cannot recover what `CASCADE` already ate. Re-index the affected notes to bring them back as unresolved.

## Tests, watched failing

Three new behavior tests, one per delete path, each doing delete → unresolved → recreate → re-linked:

- `tests/api/v2/test_delete_unresolves_inbound_relations.py` — the API single-entity delete (`DELETE /knowledge/entities/{id}`, the ORM `session.delete` route) and the directory delete (`POST /knowledge/delete-directory`, the guarded bulk-SQL route).
- `tests/index/test_watch_delete_unresolves_inbound_relation.py` — the watcher removing a note whose file vanished from disk (the `delete_by_fields` bulk-SQL route).

A fourth test pins the constraint question you raised. `uix_relation_from_id_to_id` covers `(from_id, to_id, relation_type)`, so the obvious worry about `SET NULL` is two inbound rows from one source colliding once both their targets are gone. They do not — NULL is distinct from NULL under both backends — but that is the kind of thing that should be a test rather than a paragraph, so it is one: one source linking to two notes in a directory, the directory deleted, both rows surviving unresolved and still told apart by `to_name`.

**How they were made to fail.** I reverted the model change three ways and re-ran, because "it passes now" says nothing on its own:

| Model state | Result |
|---|---|
| Both halves reverted — `ON DELETE CASCADE` + ORM `delete-orphan` (i.e. `main` today) | **3 failed** |
| Only the FK reverted — `CASCADE`, ORM keeps `passive_deletes` | **3 failed** |
| Only the ORM reverted — `SET NULL` kept, ORM back to `delete-orphan` | **1 failed** (the API path) |

```
FAILED tests/api/v2/...::test_delete_entity_unresolves_inbound_relation_and_recreate_relinks
  - AssertionError: the inbound relation must survive its target's deletion
FAILED tests/api/v2/...::test_delete_directory_unresolves_inbound_relations_from_outside
  - AssertionError: the keeper's relation must survive the directory delete
FAILED tests/index/...::test_watch_delete_unresolves_inbound_relation_and_recreate_relinks
  - AssertionError: the inbound relation must survive the watcher's bulk delete
```

That third row is the interesting one, and it is exactly the trap you flagged: with the database fixed but the ORM cascade left in place, the two bulk-SQL paths go green and only the ORM path stays red. Fix one and not the other and the bug does not go away — it just moves somewhere quieter and gets harder to find.

### Migration test

`tests/test_relation_to_id_set_null_migration.py`, five tests, following `tests/test_note_content_migration.py`.

This one earns its place: the SQLite suite builds its schema straight from SQLAlchemy metadata, so a corrected model with a missing or wrong migration would sail through the entire suite green while every database on disk kept the old `CASCADE`.

It runs the real Alembic chain to the previous revision, asserts `CASCADE`, upgrades, and asserts `SET NULL` — plus a data-preservation test that inserts a project, two entities and a relation before the upgrade, then deletes the target with `PRAGMA foreign_keys = ON` and watches the row survive with `to_name` intact. A downgrade test proves the step reverses. The Postgres branch is covered by recording the `op` calls, the way `tests/test_postgres_full_content_search_migration.py` does.

Made to fail by pointing `upgrade()` at `CASCADE`:

```
FAILED ...::test_sqlite_upgrade_sets_relation_to_id_null_on_delete
  - AssertionError: assert 'CASCADE' == 'SET NULL'
FAILED ...::test_sqlite_upgrade_preserves_relation_rows_and_indexes
  - AssertionError: assert None == (None, 'Note 2')
FAILED ...::test_sqlite_downgrade_restores_cascade
  - AssertionError: assert 'CASCADE' == 'SET NULL'
FAILED ...::test_postgres_upgrade_recreates_to_id_fk_with_set_null
  - AssertionError: ... 'CASCADE') != ... 'SET NULL')
```

The second line there is the bug itself reproduced at the schema level: the relation row was gone, so the query returned `None` instead of the unresolved row.

### Two existing assertions changed

`tests/index/test_local_watch_regular_file_parity.py` and `tests/index/test_local_project_index.py` each asserted `outgoing_relations == []` after a target delete. Both tests are *about* search-row repair; the empty-relations line rode along as scenery. Nobody argued for it, but leaving it would have turned an accident into a contract. Both now assert the surviving unresolved row.

## Out of scope

The stale `search_index` row on the API delete path — your #1351 — is untouched here, as you asked.

## Local run

`just test` — all four stages, SQLite and Postgres, unit and integration:

| Stage | Result |
|---|---|
| unit / SQLite | 5032 passed, 3 failed |
| integration / SQLite | 475 passed, 0 failed |
| unit / Postgres | 5014 passed, 3 failed |
| integration / Postgres | 0 failed, reached 73% before the recipe's own 600s `gtimeout` fired (exit 137, which `test-int-postgres` treats as success — the documented FastMCP/asyncpg cleanup hang) |

The three failures in both unit stages are the same three, all in `tests/cli/test_cloud_promo.py`, and they are not mine: I checked out unmodified `upstream/main` and ran them there, where they fail identically. The five files this PR touches or adds were also run explicitly against Postgres — 56 passed.

Two notes on running the suite locally, offered only in case they are useful to someone else:

- A shell exporting `FORCE_COLOR` fails ~41 CLI tests on any checkout, fix or not: Rich emits escape codes into `CliRunner`'s captured output and the assertions compare against plain strings. I ran with it unset.
- `just check` fails on a clean tree with four `unresolved-import` diagnostics for `pymilvus`, which `uv sync` does not install. Reproduced on unmodified `main`. `just lint` and `just format` are clean; `just format` runs `ruff format .`, which also reformats `benchmarks/`, so I formatted only `src tests test-int` to keep that out of the diff.
