### PR TITLE
fix(cli): stop accepting a private project visibility the cloud does not have

### DIFF
--- a/src/basic_memory/cli/commands/project.py
+++ b/src/basic_memory/cli/commands/project.py
@@ -279,10 +279,12 @@ def _normalize_project_visibility(visibility: str | None) -> ProjectVisibility:
         return "workspace"
 
     normalized = visibility.strip().lower()
-    if normalized in {"workspace", "shared", "private"}:
+    if normalized == "workspace" or normalized == "shared":
         return normalized
 
-    raise ValueError("Invalid visibility. Expected one of: workspace, shared, private.")
+    # "private" was accepted here while the cloud has no such tier, so users
+    # were told their project was private when the whole team could see it (#1343).
+    raise ValueError("Invalid visibility. Expected one of: workspace, shared.")
 
 
 def _resolve_workspace_id(config, workspace: str | None) -> str | None:
@@ -747,7 +749,7 @@ def add_project(
     visibility: str = typer.Option(
         None,
         "--visibility",
-        help="Cloud project visibility: workspace, shared, or private",
+        help="Cloud project visibility: workspace (everyone in the workspace) or shared (invite-only)",
     ),
     set_default: bool = typer.Option(False, "--default", help="Set as default project"),
     local: bool = typer.Option(

--- a/src/basic_memory/schemas/cloud.py
+++ b/src/basic_memory/schemas/cloud.py
@@ -4,7 +4,9 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-type ProjectVisibility = Literal["workspace", "shared", "private"]
+# The tiers the cloud's project-share API implements. A "private" (just-me)
+# tier does not exist server-side, so it must not be accepted here (#1343).
+type ProjectVisibility = Literal["workspace", "shared"]
 
 
 class TenantMountInfo(BaseModel):

--- a/tests/cli/test_project_add_with_local_path.py
+++ b/tests/cli/test_project_add_with_local_path.py
@@ -359,3 +359,17 @@ def test_project_add_rejects_invalid_visibility(runner, mock_config):
 
     assert result.exit_code == 1
     assert "Invalid visibility" in result.stdout
+
+
+def test_project_add_rejects_private_visibility(runner, mock_config, mock_api_client):
+    """The cloud has no "private" tier; accepting it reported a private project the whole team could see (#1343)."""
+    result = runner.invoke(
+        app,
+        ["project", "add", "test-project", "--cloud", "--visibility", "private"],
+    )
+
+    assert result.exit_code == 1
+    assert "Expected one of: workspace, shared." in result.stdout
+    assert mock_api_client["calls"] == [], (
+        "nothing may be created with a tier the cloud can't apply"
+    )


### PR DESCRIPTION
Core half of #1343 (the cloud half is basicmachines-co/basic-memory-cloud#1851).

## What's wrong

`bm project add --cloud --visibility private` validates `private` as a legal tier and prints "added successfully". The cloud's project-share schema only knows `workspace` and `shared` (`project_share_schemas.py`: `Literal["workspace", "shared"]`), and its `create_project` doesn't read `visibility` at all — so the project is created team-visible while the user believes it is private. The CLI side that made this *silently* wrong is accepting a tier that doesn't exist.

## Change

- `ProjectVisibility` narrows to `Literal["workspace", "shared"]`; `_normalize_project_visibility` rejects `private` with the corrected tier list; the `--visibility` help text describes the two real tiers.
- Test: `--visibility private` exits 1 before any create call.

Not in this PR: honoring `shared` at create time (cloud#1851), and exposing the effective visibility in `project list/info` — that needs the create/list responses to carry it, which is also on the cloud side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017STCpbNsYjZgUdftxgEAZ4