### PR TITLE
docs(core): drop the broken star-history chart and document CJK keyword-search limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,14 +692,4 @@ Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 [AGPL-3.0](LICENSE).
 
-## Star History
-
-<a href="https://www.star-history.com/#basicmachines-co/basic-memory&Date">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=basicmachines-co/basic-memory&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=basicmachines-co/basic-memory&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=basicmachines-co/basic-memory&type=Date" />
- </picture>
-</a>
-
 Built with ♥️ by [Basic Machines](https://basicmachines.co?utm_source=github&utm_medium=referral&utm_campaign=readme)

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -201,6 +201,19 @@ bm reindex --embeddings
 Rebuild embeddings after changing either prefix so stored document vectors and new query vectors
 use the same model contract.
 
+### Chinese, Japanese, Korean and other unsegmented scripts
+
+Keyword (full-text) search does not segment CJK text. Both backends tokenize a run of CJK
+characters as a single token — SQLite's FTS5 `unicode61` tokenizer and Postgres's default text
+search parser alike — so a query such as `生存` only matches a note where `生存` appears as a
+standalone run, not inside `适者生存`. Prefix matching does not help with substrings in the
+middle of a run.
+
+Until a segmenting tokenizer option ships (tracked in
+[#1294](https://github.com/basicmachines-co/basic-memory/issues/1294)), use semantic or hybrid
+search with a multilingual embedding model for these languages — the Jina Chinese-English model
+or multilingual E5 configured above both work — and treat keyword search as exact-run matching.
+
 ### OpenAI
 
 Uses OpenAI's embeddings API for higher-dimensional vectors. Requires an API key.

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -205,14 +205,15 @@ use the same model contract.
 
 Keyword (full-text) search does not segment CJK text. Both backends tokenize a run of CJK
 characters as a single token — SQLite's FTS5 `unicode61` tokenizer and Postgres's default text
-search parser alike — so a query such as `生存` only matches a note where `生存` appears as a
-standalone run, not inside `适者生存`. Prefix matching does not help with substrings in the
-middle of a run.
+search parser alike. Query terms are matched as prefixes, so `生存` finds a note containing
+`生存竞争` (the run starts with the query) but not one containing only `适者生存`, where the
+query sits in the middle of a run.
 
 Until a segmenting tokenizer option ships (tracked in
 [#1294](https://github.com/basicmachines-co/basic-memory/issues/1294)), use semantic or hybrid
 search with a multilingual embedding model for these languages — the Jina Chinese-English model
-or multilingual E5 configured above both work — and treat keyword search as exact-run matching.
+or multilingual E5 configured above both work — and expect keyword search to match whole runs
+and run prefixes only.
 
 ### OpenAI
 


### PR DESCRIPTION
Two small doc fixes from the issue triage.

- **#1287** — the README star-history embed has rendered "GitHub restricted access to star data" since GitHub locked the stargazers API on 2026-06-30 (verified live today). Removed the section; a broken image under the license is worse than none. Fixes #1287.
- **#1294** — keyword search treats a CJK run as a single token on both SQLite (`unicode61`) and Postgres (default parser), so substring queries miss. Added a short note in `docs/semantic-search.md` next to the multilingual embedding models saying exactly that and pointing at semantic/hybrid search as the working path, with the issue linked for the tokenizer option. Refs #1294.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017STCpbNsYjZgUdftxgEAZ4