### PR TITLE
fix(core): sanitize quoted PostgreSQL Boolean searches

### DIFF
--- a/src/basic_memory/repository/postgres_search_repository.py
+++ b/src/basic_memory/repository/postgres_search_repository.py
@@ -394,7 +394,7 @@ class PostgresSearchRepository(SearchRepositoryBase):
         # Split on Boolean keywords first, then sanitize each operand using the
         # same rules as ordinary terms. This keeps user punctuation (including
         # quotes and unbalanced grouping characters) from reaching to_tsquery.
-        parts = re.split(r"\b(AND|OR|NOT)\b", query, flags=re.IGNORECASE)
+        parts = re.split(r"\b(AND|OR|NOT)\b", query)
         result: list[str] = []
         for index, part in enumerate(parts):
             if index % 2:

--- a/src/basic_memory/repository/postgres_search_repository.py
+++ b/src/basic_memory/repository/postgres_search_repository.py
@@ -391,16 +391,27 @@ class PostgresSearchRepository(SearchRepositoryBase):
             "(pour OR french) AND press" -> "(pour | french) & press"
             "coffee NOT decaf" -> "coffee & !decaf"
         """
-        # Replace Boolean operators with tsquery operators
-        # Keep parentheses for grouping
-        result = query
-        result = re.sub(r"\bAND\b", "&", result)
-        result = re.sub(r"\bOR\b", "|", result)
-        # NOT must be converted to "& !" and the ! must be attached to the following term
-        # "Python NOT Django" -> "Python & !Django"
-        result = re.sub(r"\bNOT\s+", "& !", result)
+        # Split on Boolean keywords first, then sanitize each operand using the
+        # same rules as ordinary terms. This keeps user punctuation (including
+        # quotes and unbalanced grouping characters) from reaching to_tsquery.
+        parts = re.split(r"\b(AND|OR|NOT)\b", query, flags=re.IGNORECASE)
+        result: list[str] = []
+        for index, part in enumerate(parts):
+            if index % 2:
+                operator = part.upper()
+                result.append({"AND": "&", "OR": "|", "NOT": "& !"}[operator])
+                continue
 
-        return result
+            operand = part.strip()
+            opening = len(operand) - len(operand.lstrip("("))
+            closing = len(operand) - len(operand.rstrip(")"))
+            operand = operand[opening : len(operand) - closing if closing else None]
+            operand = operand.replace('"', " ").strip()
+            if operand:
+                prepared = self._prepare_single_term(operand, is_prefix=False)
+                result.append("(" * opening + prepared + ")" * closing)
+
+        return " ".join(result).replace("& ! ", "& !")
 
     def _prepare_single_term(self, term: str, is_prefix: bool = True) -> str:
         """Prepare a single search term for tsquery.

--- a/tests/repository/test_search_repository.py
+++ b/tests/repository/test_search_repository.py
@@ -648,6 +648,7 @@ class TestSearchTermPreparation:
         assert quoted_or == "foo & bar | baz & qux"
         assert '"' not in quoted_or
         assert '"' not in search_repository._prepare_search_term('"unbalanced OR phrase')
+        assert search_repository._prepare_search_term("foo OR not") == "foo | not"
 
     def test_hyphenated_terms_with_boolean_operators(self, search_repository):
         """Hyphenated terms with Boolean operators should be properly quoted."""

--- a/tests/repository/test_search_repository.py
+++ b/tests/repository/test_search_repository.py
@@ -640,6 +640,15 @@ class TestSearchTermPreparation:
                 == "(hello AND world) OR test"
             )
 
+    def test_postgres_boolean_queries_sanitize_quoted_operands(self, search_repository):
+        if not is_postgres_backend(search_repository):
+            pytest.skip("This test is for PostgreSQL tsquery preparation")
+
+        quoted_or = search_repository._prepare_search_term('"foo bar" OR "baz qux"')
+        assert quoted_or == "foo & bar | baz & qux"
+        assert '"' not in quoted_or
+        assert '"' not in search_repository._prepare_search_term('"unbalanced OR phrase')
+
     def test_hyphenated_terms_with_boolean_operators(self, search_repository):
         """Hyphenated terms with Boolean operators should be properly quoted."""
         if is_postgres_backend(search_repository):


### PR DESCRIPTION
## Summary

Fix PostgreSQL search parsing for quoted Boolean-looking input such as quoted phrases joined by `OR`.

The PostgreSQL Boolean preparer now sanitizes each operand with the existing single-term rules while preserving supported `AND`, `OR`, `NOT`, and grouping behavior. This prevents quote and punctuation syntax from reaching `to_tsquery()` as invalid expressions.

## Testing

- `uv run --frozen pytest -p pytest_mock -q tests/repository/test_search_repository.py --no-cov` (48 passed, 1 skipped)
- `uv run --frozen ruff check src/basic_memory/repository/postgres_search_repository.py tests/repository/test_search_repository.py`
- `uv run --frozen ty check src/basic_memory/repository/postgres_search_repository.py tests/repository/test_search_repository.py`

Fixes #1359
