### PR TITLE
feat(core): configure custom OpenAI embedding endpoints

### DIFF
--- a/src/basic_memory/repository/embedding_provider_factory.py
+++ b/src/basic_memory/repository/embedding_provider_factory.py
@@ -116,17 +116,17 @@ def _provider_cache_key(app_config: BasicMemoryConfig) -> ProviderCacheKey:
     runtime CPU budget makes the key drift between calls in a container (#872).
     """
     provider_name = app_config.semantic_embedding_provider.strip().lower()
-    litellm_api_base_digest = None
-    litellm_api_key_digest = None
-    if provider_name == "litellm":
-        litellm_api_base_digest = _sensitive_value_digest(app_config.semantic_embedding_api_base)
-        litellm_api_key_digest = _sensitive_value_digest(app_config.semantic_embedding_api_key)
+    api_base_digest = None
+    api_key_digest = None
+    if provider_name in {"openai", "litellm"}:
+        api_base_digest = _sensitive_value_digest(app_config.semantic_embedding_api_base)
+        api_key_digest = _sensitive_value_digest(app_config.semantic_embedding_api_key)
 
     return (
         provider_name,
         app_config.semantic_embedding_model,
-        litellm_api_base_digest,
-        litellm_api_key_digest,
+        api_base_digest,
+        api_key_digest,
         app_config.semantic_embedding_dimensions,
         app_config.semantic_embedding_forward_dimensions,
         app_config.semantic_embedding_batch_size,
@@ -266,6 +266,8 @@ def create_embedding_provider(app_config: BasicMemoryConfig) -> EmbeddingProvide
             model_name = "text-embedding-3-small"
         provider = OpenAIEmbeddingProvider(
             model_name=model_name,
+            api_key=app_config.semantic_embedding_api_key,
+            base_url=app_config.semantic_embedding_api_base,
             batch_size=app_config.semantic_embedding_batch_size,
             request_concurrency=app_config.semantic_embedding_request_concurrency,
             **extra_kwargs,

--- a/tests/repository/test_openai_provider.py
+++ b/tests/repository/test_openai_provider.py
@@ -10,6 +10,7 @@ import pytest
 from basic_memory.config import BasicMemoryConfig
 import basic_memory.repository.embedding_provider_factory as embedding_provider_factory_module
 from basic_memory.repository.embedding_provider_factory import (
+    _provider_cache_key,
     create_embedding_provider,
     reset_embedding_provider_cache,
 )
@@ -177,6 +178,47 @@ def test_embedding_provider_factory_selects_openai_and_applies_default_model():
     provider = create_embedding_provider(config)
     assert isinstance(provider, OpenAIEmbeddingProvider)
     assert provider.model_name == "text-embedding-3-small"
+
+
+def test_embedding_provider_factory_forwards_openai_api_configuration():
+    config = BasicMemoryConfig(
+        env="test",
+        projects={"test-project": "/tmp/basic-memory-test"},
+        default_project="test-project",
+        semantic_search_enabled=True,
+        semantic_embedding_provider="openai",
+        semantic_embedding_api_base="https://embedding.example/v1",
+        semantic_embedding_api_key="test-key",
+    )
+
+    provider = create_embedding_provider(config)
+
+    assert isinstance(provider, OpenAIEmbeddingProvider)
+    assert provider._base_url == "https://embedding.example/v1"
+    assert provider._api_key == "test-key"
+
+
+def test_embedding_provider_factory_separates_openai_api_cache_keys():
+    base = dict(
+        env="test",
+        projects={"test-project": "/tmp/basic-memory-test"},
+        default_project="test-project",
+        semantic_search_enabled=True,
+        semantic_embedding_provider="openai",
+        semantic_embedding_api_base="https://one.example/v1",
+        semantic_embedding_api_key="test-key",
+    )
+
+    first = _provider_cache_key(BasicMemoryConfig(**base))
+    second = _provider_cache_key(
+        BasicMemoryConfig(**{**base, "semantic_embedding_api_base": "https://two.example/v1"})
+    )
+    third = _provider_cache_key(
+        BasicMemoryConfig(**{**base, "semantic_embedding_api_key": "other-key"})
+    )
+
+    assert first != second
+    assert first != third
 
 
 def test_embedding_provider_factory_rejects_unknown_provider():


### PR DESCRIPTION
## Summary

Allow the OpenAI embedding provider to use the configured `semantic_embedding_api_base` and `semantic_embedding_api_key`.

The provider factory now forwards both values and includes safe digests in the process cache key, preventing stale provider reuse when an endpoint or credential changes. LiteLLM cache behavior remains covered while sharing the same configuration identity rule.

## Testing

- `uv run --frozen pytest -q -p pytest_mock tests/repository/test_openai_provider.py -k 'forwards_openai_api_configuration or separates_openai_api_cache_keys' --no-cov` (2 passed)
- `uv run --frozen ruff check src/basic_memory/repository/embedding_provider_factory.py tests/repository/test_openai_provider.py`
- `git diff --check`

Fixes #1336
