### PR TITLE
fix(integrations): make the memory write path insistent and its result citable

### DIFF
--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -121,7 +121,11 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
     {
         "name": "bm_write",
         "description": (
-            "Create a new note in the knowledge graph. Use clear titles and a folder "
+            "Create a new note in the knowledge graph. Call this whenever the user "
+            "asks to remember, record, save, or note something — acknowledging "
+            "without this call saves nothing. The result returns the note's "
+            "permalink: quote it when confirming the save, never a filename "
+            "recalled from memory. Use clear titles and a folder "
             "(e.g. 'projects', 'decisions', 'meetings')."
         ),
         "parameters": {
@@ -143,7 +147,8 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
         "name": "bm_edit",
         "description": (
             "Edit an existing note. Operations: append, prepend, find_replace, replace_section. "
-            "find_replace requires find_text. replace_section requires section."
+            "find_replace requires find_text. replace_section requires section. "
+            "The result returns the note's permalink — quote it when confirming the edit."
         ),
         "parameters": {
             "type": "object",
@@ -1127,6 +1132,13 @@ class BasicMemoryProvider(MemoryProvider):
             "active one\n"
             "- `bm_workspaces()` — list BM Cloud workspaces; pair with "
             "`bm_projects` to disambiguate same-named projects\n"
+            "\n"
+            "**Saves must be real.** When the user asks you to remember, "
+            "record, save, or note something, call `bm_write` (or `bm_edit`) "
+            "in that same turn. Never say information was saved, recorded, or "
+            "remembered unless the tool call returned a result, and when "
+            "confirming a save quote the `permalink` from that result — never "
+            "a filename recalled from memory.\n"
             "\n"
             "**Cross-project routing.** Read/write tools accept optional `project` "
             "(name) or `project_id` (UUID). Omit both to use the active "

--- a/integrations/hermes/skill/SKILL.md
+++ b/integrations/hermes/skill/SKILL.md
@@ -220,9 +220,10 @@ Background and current situation.
 
 1. **Search before answering.** If the user asks "what did we decide about X?", run `bm_search` first.
 2. **Offer to capture.** When the user shares decisions or meeting outcomes, ask: "Should I save this as a note?"
-3. **Suggest connections.** When a search returns related notes, surface them so the user knows what already exists.
-4. **Don't over-capture.** Auto-capture is already running per turn. Don't create a `bm_write` for every response — only for substantive content the user wants preserved.
-5. **Sensitive info.** Don't capture credentials or personal data without confirmation.
+3. **Never claim an unwritten save.** "Remember/record/save/note this" means calling `bm_write` (or `bm_edit`) in that turn. Only report a save after the tool returned a result, and quote the returned permalink — never a filename recalled from memory.
+4. **Suggest connections.** When a search returns related notes, surface them so the user knows what already exists.
+5. **Don't over-capture.** Auto-capture is already running per turn. Don't create a `bm_write` for every response — only for substantive content the user wants preserved.
+6. **Sensitive info.** Don't capture credentials or personal data without confirmation.
 
 ## Footgun
 

--- a/integrations/hermes/tests/test_prompts.py
+++ b/integrations/hermes/tests/test_prompts.py
@@ -1,0 +1,31 @@
+"""
+Prompt/description hardening tests (#1341, part 1).
+
+These assert the always-on guidance that makes the write path insistent and the
+returned permalink citable: the bm_write/bm_edit tool descriptions and the
+system_prompt_block wording. This is the durable half of the #1341 fix — the
+reply-scanning save-claim guard was dropped as unreliable.
+"""
+
+from __future__ import annotations
+
+
+def test_system_prompt_block_forbids_unwritten_save_reports(bm):
+    p = bm.BasicMemoryProvider()
+    p._initialized = True
+    p._project = "test-proj"
+    p._mode = "local"
+    out = p.system_prompt_block()
+    assert "Never say information was saved" in out
+    assert "permalink" in out
+
+
+def test_bm_write_description_is_insistent(bm):
+    schema = next(s for s in bm.TOOL_SCHEMAS if s["name"] == "bm_write")
+    assert "remember, record, save, or note" in schema["description"]
+    assert "permalink" in schema["description"]
+
+
+def test_bm_edit_description_mentions_permalink(bm):
+    schema = next(s for s in bm.TOOL_SCHEMAS if s["name"] == "bm_edit")
+    assert "permalink" in schema["description"]

--- a/integrations/openclaw/CLAUDE.md
+++ b/integrations/openclaw/CLAUDE.md
@@ -468,6 +468,8 @@ Use `write_note` when:
 - Meeting notes or insights need to be preserved
 - Creating structured documentation
 
+Any "remember/record/save/note this" request maps to a `write_note` (or `edit_note`) call in that same turn — an acknowledgement without the call saves nothing.
+
 ### Edit for Updates
 Use `edit_note` when:
 - Adding updates to existing notes
@@ -488,6 +490,7 @@ Use `build_context` when:
 - **Search first**: Before answering questions, search the knowledge graph
 - **Suggest connections**: Point out related notes and concepts
 - **Offer to save**: When users share important info, offer to document it
+- **Never claim an unwritten save**: Only say something was saved or recorded after a `write_note`/`edit_note` call returned a result, and cite the `permalink` or `file_path` from that result — never a filename recalled from memory. If you decline to write, say plainly that nothing new was saved
 - **Recommend organization**: Help users structure their knowledge well
 
 ### Helpful Patterns

--- a/integrations/openclaw/tools/edit-note.test.ts
+++ b/integrations/openclaw/tools/edit-note.test.ts
@@ -43,6 +43,17 @@ describe("edit tool", () => {
         { name: "edit_note" },
       )
     })
+
+    it("tells the model to cite the result permalink (#1341)", () => {
+      registerEditTool(mockApi, mockClient)
+
+      const toolConfig = (mockApi.registerTool as jest.MockedFunction<any>).mock
+        .calls[0][0]
+      expect(toolConfig.description).toContain("permalink")
+      expect(toolConfig.description).toContain(
+        "never report a save that no tool call performed",
+      )
+    })
   })
 
   describe("tool execution", () => {

--- a/integrations/openclaw/tools/edit-note.ts
+++ b/integrations/openclaw/tools/edit-note.ts
@@ -14,7 +14,9 @@ export function registerEditTool(
       description:
         "Incrementally edit an existing note in the Basic Memory knowledge graph. " +
         "Supports append, prepend, find/replace, and section replacement " +
-        "without rewriting the entire note.",
+        "without rewriting the entire note. The result returns the note's " +
+        "permalink and file_path: cite those exact values when confirming " +
+        "the edit — never report a save that no tool call performed.",
       parameters: Type.Object({
         identifier: Type.String({
           description: "Note title, permalink, or memory:// URL to edit",

--- a/integrations/openclaw/tools/write-note.test.ts
+++ b/integrations/openclaw/tools/write-note.test.ts
@@ -57,6 +57,18 @@ describe("write tool", () => {
         { name: "write_note" },
       )
     })
+
+    it("insists the write actually happens and the result is cited (#1341)", () => {
+      registerWriteTool(mockApi, mockClient)
+
+      const toolConfig = (mockApi.registerTool as jest.MockedFunction<any>).mock
+        .calls[0][0]
+      expect(toolConfig.description).toContain(
+        "remember, record, save, or note",
+      )
+      expect(toolConfig.description).toContain("permalink")
+      expect(toolConfig.description).toContain("never a recalled filename")
+    })
   })
 
   describe("tool execution", () => {

--- a/integrations/openclaw/tools/write-note.ts
+++ b/integrations/openclaw/tools/write-note.ts
@@ -14,6 +14,10 @@ export function registerWriteTool(
       label: "Write Note",
       description:
         "Create a note in the Basic Memory knowledge graph. " +
+        "Call this whenever the user asks to remember, record, save, or note " +
+        "something — saying 'saved' without this call saves nothing. The result " +
+        "returns the note's permalink and file_path: cite those exact values " +
+        "when confirming, never a recalled filename. " +
         "If the note already exists, returns an error by default. " +
         "Pass overwrite=true to replace, or use edit_note for incremental updates.",
       parameters: Type.Object({


### PR DESCRIPTION
Refs #1341.

Agents in the Hermes and OpenClaw integrations reported saving to Basic Memory when no write tool ran — a silent false success on the core "remember this" promise.

## Scope (narrowed)

The PR originally also added a Hermes reply-scanning "save-claim guard" that regex-detected save claims in the assistant's prose and injected a correction. Detecting a claim from arbitrary reply text is unreliable and turned into an unbounded regex arms race (historical tense, quoted/relayed content, single quotes, code spans, typographic apostrophes, participles …), so **that guard has been removed**. What's left is the durable half that generalizes and has no false-positive surface:

- `bm_write` / `bm_edit` tool descriptions and the Hermes `system_prompt_block`: call the write tool in the same turn whenever the user asks to remember/record/save/note something; never claim a save without a tool result; quote the returned `permalink`, not a filename recalled from memory.
- The Hermes `SKILL.md` guideline and the OpenClaw `write-note`/`edit-note` descriptions + agent instructions get the same wording.

Net change is 8 integration files (+82/-6): descriptions, one system-prompt paragraph, and their assertion tests.

## Tests

- Hermes hermetic suite: 272 passed, 12 skipped (`tests/test_prompts.py` covers the description/system-prompt wording).
- `just package-check-hermes` and `just package-check-openclaw` pass; ruff/ty clean.

Squashed to one commit; rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017STCpbNsYjZgUdftxgEAZ4