### PR TITLE
fix(core): refresh linking notes' search rows on API note delete

### DIFF
--- a/src/basic_memory/deps/services.py
+++ b/src/basic_memory/deps/services.py
@@ -79,6 +79,9 @@ from basic_memory.indexing.directory_delete_runner import (
 )
 from basic_memory.indexing.index_file_runner import IndexFileExecutor
 from basic_memory.indexing.models import StorageIndexFileWriter
+from basic_memory.indexing.project_index_maintenance import (
+    RepositoryProjectIndexMovedEntitySearchRefresher,
+)
 from basic_memory.markdown import EntityParser
 from basic_memory.markdown.markdown_processor import MarkdownProcessor
 from basic_memory.services import EntityService, ProjectService
@@ -509,6 +512,8 @@ async def get_note_content_materialization_provider(
     ],
     file_service: FileServiceV2ExternalDep,
     file_indexer: IndexFileExecutorV2ExternalDep,
+    entity_repository: EntityRepositoryV2ExternalDep,
+    search_service: SearchServiceV2ExternalDep,
     session_maker: SessionMakerDep,
     app_config: AppConfigDep,
     relation_resolution_scheduler: RelationResolutionSchedulerDep,
@@ -529,6 +534,11 @@ async def get_note_content_materialization_provider(
         test_mode=app_config.is_test_env,
         materialization_workers=app_config.materialization_workers,
         relation_resolution_scheduler=relation_resolution_scheduler,
+        relation_cleanup_refresher=RepositoryProjectIndexMovedEntitySearchRefresher(
+            session_maker=session_maker,
+            entity_repository=entity_repository,
+            entity_indexer=search_service,
+        ),
     )
 
 

--- a/src/basic_memory/index/note_content_materialization.py
+++ b/src/basic_memory/index/note_content_materialization.py
@@ -765,17 +765,39 @@ class LocalNoteContentMaterializationProvider:
         #      nothing else re-indexes those sources on this path — unlike the watcher
         #      and directory delete paths, which run this same refresh (#1351).
         # Outcome: re-index each surviving source so its relation rows rebuild from
-        #      the now-unresolved relation table state. Failure stays non-fatal: the
-        #      delete already committed, and stale search rows are derived state that
-        #      converges on the source's next edit or a reindex.
+        #      the now-unresolved relation table state.
         if self.relation_cleanup_refresher is not None and accepted.relation_cleanup_entity_ids:
-            try:
-                await self.relation_cleanup_refresher.refresh_moved_entities(
-                    sorted(accepted.relation_cleanup_entity_ids)
-                )
-            except Exception:
-                logger.exception(
-                    "Relation search cleanup failed after accepted note delete",
-                    entity_ids=sorted(accepted.relation_cleanup_entity_ids),
+            if self.test_mode:
+                # Inline only so tests can assert search state synchronously.
+                await self._refresh_relation_cleanup(accepted)
+            else:
+                # Deleting a hub note can leave thousands of inbound links, and each
+                # refresh rereads a markdown file and rewrites its search rows. The
+                # DB delete has already committed, so blocking the 202 on that makes
+                # latency scale with inbound degree. Hand it to the same bounded
+                # worker pool that defers materialization, keyed on the deleted note.
+                _materialization_pool.submit(
+                    self._refresh_relation_cleanup(accepted),
+                    workers=self.materialization_workers,
+                    key=(accepted.file_delete.project_id, accepted.file_delete.entity_id),
                 )
         return accepted
+
+    async def _refresh_relation_cleanup(
+        self,
+        accepted: RuntimeAcceptedNoteChange[RuntimeNoteContentResponsePayload],
+    ) -> None:
+        """Re-index the surviving relation sources; non-fatal derived-state repair."""
+        if self.relation_cleanup_refresher is None:  # pragma: no cover - guarded by caller
+            return
+        try:
+            await self.relation_cleanup_refresher.refresh_moved_entities(
+                sorted(accepted.relation_cleanup_entity_ids)
+            )
+        except Exception:
+            # Non-fatal: the delete already committed, and stale search rows are
+            # derived state that converges on the source's next edit or a reindex.
+            logger.exception(
+                "Relation search cleanup failed after accepted note delete",
+                entity_ids=sorted(accepted.relation_cleanup_entity_ids),
+            )

--- a/src/basic_memory/index/note_content_materialization.py
+++ b/src/basic_memory/index/note_content_materialization.py
@@ -26,6 +26,9 @@ from basic_memory.indexing.note_materialization_runner import (
     RepositoryNoteMaterializationStatusPublisher,
     run_note_materialization,
 )
+from basic_memory.indexing.project_index_maintenance import (
+    ProjectIndexMovedEntitySearchRefresher,
+)
 from basic_memory.runtime.cleanup import (
     RuntimeNoteFileDeleteJobRequest,
     plan_note_file_delete_job_request,
@@ -616,6 +619,10 @@ class LocalNoteContentMaterializationProvider:
     test_mode: bool = False
     materialization_workers: int = 4
     relation_resolution_scheduler: RelationResolutionScheduler | None = None
+    # Re-indexes surviving notes whose relation search rows named a deleted
+    # target (#1351). Optional so providers wired without it (cloud, focused
+    # tests) keep working; cloud relies on its orphan sweeper instead.
+    relation_cleanup_refresher: ProjectIndexMovedEntitySearchRefresher | None = None
 
     async def materialize_write_change(
         self,
@@ -752,4 +759,23 @@ class LocalNoteContentMaterializationProvider:
             storage,
             vacate_clearer=RepositoryMoveVacateClearer(session_maker=self.session_maker),
         ).enqueue_note_file_delete(plan_note_file_delete_job_request(accepted.file_delete))
+
+        # Trigger: surviving notes still linked to the deleted target at commit time.
+        # Why: their relation search rows carry the deleted entity's id and title, and
+        #      nothing else re-indexes those sources on this path — unlike the watcher
+        #      and directory delete paths, which run this same refresh (#1351).
+        # Outcome: re-index each surviving source so its relation rows rebuild from
+        #      the now-unresolved relation table state. Failure stays non-fatal: the
+        #      delete already committed, and stale search rows are derived state that
+        #      converges on the source's next edit or a reindex.
+        if self.relation_cleanup_refresher is not None and accepted.relation_cleanup_entity_ids:
+            try:
+                await self.relation_cleanup_refresher.refresh_moved_entities(
+                    sorted(accepted.relation_cleanup_entity_ids)
+                )
+            except Exception:
+                logger.exception(
+                    "Relation search cleanup failed after accepted note delete",
+                    entity_ids=sorted(accepted.relation_cleanup_entity_ids),
+                )
         return accepted

--- a/src/basic_memory/indexing/accepted_note_write_runner.py
+++ b/src/basic_memory/indexing/accepted_note_write_runner.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from typing import Any, Protocol
 
@@ -12,6 +12,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from basic_memory import file_utils
 from basic_memory.indexing.accepted_note_search import build_accepted_note_search_row
+from basic_memory.indexing.external_file_delete_runner import (
+    relation_cleanup_sources_for_deleted_entity,
+)
 from basic_memory.indexing.models import IndexedObservation, IndexedRelation
 from basic_memory.indexing.relation_persistence import (
     ObservationGenerationStore,
@@ -777,6 +780,14 @@ async def delete_accepted_note(
                 project_id=project_id,
                 entity_id=entity.id,
             )
+        # Capture surviving linkers before the entity delete: its SET NULL cascade
+        # erases their relations' to_id, after which nothing identifies which
+        # sources' search rows still name the deleted target (#1351).
+        relation_cleanup_entity_ids = await relation_cleanup_sources_for_deleted_entity(
+            session,
+            project_id=project_id,
+            entity_id=entity.id,
+        )
         await delete_accepted_note_search_index(
             session,
             project_id=project_id,
@@ -790,4 +801,5 @@ async def delete_accepted_note(
             repositories=repositories,
         )
         await session.delete(entity)
+        accepted = replace(accepted, relation_cleanup_entity_ids=relation_cleanup_entity_ids)
     return accepted

--- a/src/basic_memory/runtime/accepted_note_changes.py
+++ b/src/basic_memory/runtime/accepted_note_changes.py
@@ -215,6 +215,11 @@ class RuntimeAcceptedNoteChange(Generic[_PayloadT_co]):
     payload: _PayloadT_co
     materialization: RuntimePendingNoteMaterialization | None = None
     file_delete: RuntimePendingNoteFileDelete | None = None
+    # Surviving notes whose relations pointed at a deleted target. Their search
+    # rows still carry the deleted entity's id/title, so the runtime re-indexes
+    # them after commit — the same repair the watcher and directory delete paths
+    # run (#1351). Empty for every non-delete change.
+    relation_cleanup_entity_ids: frozenset[RuntimeEntityId] = frozenset()
 
 
 def plan_accepted_note_delete_change(

--- a/tests/api/v2/test_delete_unresolves_inbound_relations.py
+++ b/tests/api/v2/test_delete_unresolves_inbound_relations.py
@@ -14,7 +14,7 @@ directory delete -- plus the unique-constraint question that SET NULL raises.
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 from basic_memory import db
 from basic_memory.indexing.forward_reference_resolution import (
@@ -119,6 +119,94 @@ async def test_delete_entity_unresolves_inbound_relation_and_recreate_relinks(
     assert len(after_recreate) == 1
     assert after_recreate[0].to_id == recreated_beta.id
     assert after_recreate[0].to_name == "Beta"
+
+
+async def _relation_search_rows(session_maker, project_id: int, entity_id: int):
+    """Load one note's relation search rows straight from search_index."""
+    async with db.scoped_session(session_maker) as session:
+        rows = (
+            await session.execute(
+                text("""
+                    SELECT title, from_id, to_id
+                    FROM search_index
+                    WHERE project_id = :project_id
+                      AND type = 'relation'
+                      AND entity_id = :entity_id
+                """),
+                {"project_id": project_id, "entity_id": entity_id},
+            )
+        ).all()
+    return rows
+
+
+async def _search_rows_referencing(session_maker, project_id: int, entity_id: int) -> int:
+    """Count search rows that still name an entity as owner, source, or target."""
+    async with db.scoped_session(session_maker) as session:
+        return (
+            await session.execute(
+                text("""
+                    SELECT COUNT(*)
+                    FROM search_index
+                    WHERE project_id = :project_id
+                      AND (entity_id = :entity_id
+                           OR from_id = :entity_id
+                           OR to_id = :entity_id)
+                """),
+                {"project_id": project_id, "entity_id": entity_id},
+            )
+        ).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_delete_entity_refreshes_linking_notes_search_rows(
+    client: AsyncClient,
+    v2_project_url,
+    entity_repository,
+    session_maker,
+    test_project: Project,
+):
+    """API single-entity delete refreshes the search rows of surviving linkers (#1351).
+
+    Every other delete path (watcher, directory delete, project scan) re-indexes the
+    notes that linked to the deleted target. Before this fix the API/MCP delete left
+    Alpha's relation search row saying "Alpha -> Beta" with Beta's dead id, and
+    nothing ever re-indexed Alpha to repair it.
+    """
+    response = await client.post(
+        f"{v2_project_url}/knowledge/entities",
+        json={"title": "Beta", "directory": "search-refresh", "content": "# Beta"},
+    )
+    assert response.status_code == 202
+    beta = EntityResponseV2.model_validate(response.json())
+
+    response = await client.post(
+        f"{v2_project_url}/knowledge/entities",
+        json={
+            "title": "Alpha",
+            "directory": "search-refresh",
+            "content": "# Alpha\n\n- links_to [[Beta]]",
+        },
+    )
+    assert response.status_code == 202
+    alpha = EntityResponseV2.model_validate(response.json())
+
+    before = await _relation_search_rows(session_maker, test_project.id, alpha.id)
+    assert len(before) == 1
+    assert before[0].to_id == beta.id
+    assert before[0].title == "Alpha -> Beta"
+
+    response = await client.delete(f"{v2_project_url}/knowledge/entities/{beta.external_id}")
+    assert response.status_code == 202
+
+    after = await _relation_search_rows(session_maker, test_project.id, alpha.id)
+    assert len(after) == 1, "the linker keeps a relation search row, rebuilt unresolved"
+    assert after[0].from_id == alpha.id
+    assert after[0].to_id is None
+    assert "Beta" not in after[0].title
+
+    assert await _search_rows_referencing(session_maker, test_project.id, beta.id) == 0, (
+        "no search row may still point at the deleted note"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/cloud/test_note_content_materialization.py
+++ b/tests/cloud/test_note_content_materialization.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from hashlib import sha256
 from typing import Any, cast
@@ -41,6 +42,7 @@ from basic_memory.runtime.note_content import (
     RuntimeNoteMaterializationJobRequest,
     RuntimeNoteMaterializationResult,
     RuntimeNoteMaterializationStatus,
+    RuntimePendingNoteFileDelete,
     RuntimePendingNoteMaterialization,
     runtime_note_content_payload_as_dict,
 )
@@ -212,6 +214,95 @@ async def test_inline_delete_removes_genuine_old_file(tmp_path) -> None:
     )
 
     assert not old.exists(), "genuine old file was not cleaned up after move"
+
+
+class RecordingRelationCleanupRefresher:
+    def __init__(self) -> None:
+        self.refreshed: list[list[int]] = []
+
+    async def refresh_moved_entities(self, entity_ids: Sequence[int]) -> None:
+        self.refreshed.append(list(entity_ids))
+
+
+class FailingRelationCleanupRefresher:
+    async def refresh_moved_entities(self, entity_ids: Sequence[int]) -> None:
+        raise RuntimeError("search refresh unavailable")
+
+
+def accepted_delete_change(
+    relation_cleanup_entity_ids: frozenset[int] = frozenset(),
+) -> RuntimeAcceptedNoteChange[RuntimeNoteContentResponsePayload]:
+    # file_checksum=None makes the guarded file cleanup a planning no-op, so these
+    # tests exercise only the post-delete relation search refresh.
+    return RuntimeAcceptedNoteChange(
+        status_code=200,
+        payload={"deleted": True},
+        file_delete=RuntimePendingNoteFileDelete(
+            project_id=7,
+            entity_id=42,
+            file_path="notes/test.md",
+        ),
+        relation_cleanup_entity_ids=relation_cleanup_entity_ids,
+    )
+
+
+def delete_materialization_provider(
+    relation_cleanup_refresher: RecordingRelationCleanupRefresher
+    | FailingRelationCleanupRefresher
+    | None,
+) -> LocalNoteContentMaterializationProvider:
+    return LocalNoteContentMaterializationProvider(
+        session_maker=cast(async_sessionmaker[AsyncSession], object()),
+        file_service=cast(FileService, object()),
+        project_external_id=PROJECT_EXTERNAL_ID,
+        read_cache=None,
+        relation_cleanup_refresher=relation_cleanup_refresher,
+    )
+
+
+@pytest.mark.asyncio
+async def test_materialize_delete_refreshes_surviving_relation_sources() -> None:
+    """Sources that linked to the deleted note get their search rows re-indexed (#1351)."""
+    refresher = RecordingRelationCleanupRefresher()
+    provider = delete_materialization_provider(refresher)
+
+    accepted = accepted_delete_change(relation_cleanup_entity_ids=frozenset({9, 3}))
+    result = await provider.materialize_delete_change(accepted)
+
+    assert result is accepted
+    assert refresher.refreshed == [[3, 9]]
+
+
+@pytest.mark.asyncio
+async def test_materialize_delete_skips_refresh_without_surviving_sources() -> None:
+    refresher = RecordingRelationCleanupRefresher()
+    provider = delete_materialization_provider(refresher)
+
+    await provider.materialize_delete_change(accepted_delete_change())
+
+    assert refresher.refreshed == []
+
+
+@pytest.mark.asyncio
+async def test_materialize_delete_without_refresher_leaves_cleanup_to_runtime() -> None:
+    """A provider wired without the refresher (cloud) must not crash on cleanup ids."""
+    provider = delete_materialization_provider(None)
+
+    accepted = accepted_delete_change(relation_cleanup_entity_ids=frozenset({3}))
+    result = await provider.materialize_delete_change(accepted)
+
+    assert result is accepted
+
+
+@pytest.mark.asyncio
+async def test_materialize_delete_refresh_failure_is_non_fatal() -> None:
+    """The delete already committed; a failed derived-state refresh must not fail it."""
+    provider = delete_materialization_provider(FailingRelationCleanupRefresher())
+
+    accepted = accepted_delete_change(relation_cleanup_entity_ids=frozenset({3}))
+    result = await provider.materialize_delete_change(accepted)
+
+    assert result is accepted
 
 
 @pytest.mark.asyncio

--- a/tests/cloud/test_note_content_materialization.py
+++ b/tests/cloud/test_note_content_materialization.py
@@ -257,6 +257,10 @@ def delete_materialization_provider(
         project_external_id=PROJECT_EXTERNAL_ID,
         read_cache=None,
         relation_cleanup_refresher=relation_cleanup_refresher,
+        # test_mode keeps the cleanup inline so these unit tests can assert
+        # synchronously; production defers it to the worker pool (see the
+        # deferral test below).
+        test_mode=True,
     )
 
 
@@ -303,6 +307,42 @@ async def test_materialize_delete_refresh_failure_is_non_fatal() -> None:
     result = await provider.materialize_delete_change(accepted)
 
     assert result is accepted
+
+
+@pytest.mark.asyncio
+async def test_materialize_delete_defers_refresh_off_the_response_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In production the linker reindex is submitted to the pool, not awaited (#1368 review)."""
+    import basic_memory.index.note_content_materialization as materialization_module
+
+    submitted: list[tuple[object, int, tuple[int, int]]] = []
+
+    class _RecordingPool:
+        def submit(self, work, *, workers, key) -> None:
+            submitted.append((work, workers, key))
+            work.close()  # we assert submission, not execution
+
+    monkeypatch.setattr(materialization_module, "_materialization_pool", _RecordingPool())
+
+    refresher = RecordingRelationCleanupRefresher()
+    provider = LocalNoteContentMaterializationProvider(
+        session_maker=cast(async_sessionmaker[AsyncSession], object()),
+        file_service=cast(FileService, object()),
+        project_external_id=PROJECT_EXTERNAL_ID,
+        read_cache=None,
+        relation_cleanup_refresher=refresher,
+        test_mode=False,
+    )
+
+    accepted = accepted_delete_change(relation_cleanup_entity_ids=frozenset({9, 3}))
+    result = await provider.materialize_delete_change(accepted)
+
+    assert result is accepted
+    # The refresh was handed to the pool, keyed on the deleted note, and NOT run inline.
+    assert len(submitted) == 1
+    assert submitted[0][2] == (7, 42)
+    assert refresher.refreshed == []
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_accepted_note_mutation_runner.py
+++ b/tests/indexing/test_accepted_note_mutation_runner.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -138,6 +138,10 @@ class _EmptyResult:
 
     def all(self) -> list[object]:
         return []
+
+    def __iter__(self) -> Iterator[object]:
+        # The delete path iterates the surviving-relation-sources scalars directly.
+        return iter(())
 
 
 class _MutationSession:
@@ -1988,6 +1992,7 @@ async def test_run_accepted_note_delete_removes_entity_and_returns_cleanup() -> 
     assert change.file_delete is not None
     assert change.file_delete.file_path == "notes/accepted.md"
     assert change.file_delete.file_checksum == "file-checksum"
+    assert change.relation_cleanup_entity_ids == frozenset()
     assert result.relation_publication is None
 
 

--- a/tests/indexing/test_accepted_note_write_runner.py
+++ b/tests/indexing/test_accepted_note_write_runner.py
@@ -218,19 +218,41 @@ def test_accepted_note_write_repositories_name_persistence_behavior() -> None:
     assert isinstance(repositories.relation_repository(7), _RelationRepository)
 
 
+class _RelationSourcesResult:
+    def __init__(self, source_ids: tuple[int, ...]) -> None:
+        self._source_ids = source_ids
+
+    def scalars(self) -> tuple[int, ...]:
+        return self._source_ids
+
+
 class _DeleteSession:
-    def __init__(self, events: list[tuple[str, int]] | None = None) -> None:
+    def __init__(
+        self,
+        events: list[tuple[str, int]] | None = None,
+        *,
+        relation_source_ids: tuple[int, ...] = (),
+    ) -> None:
         self.deleted: list[object] = []
         self.scalar_count = 0
+        self.execute_count = 0
+        self.execute_count_at_entity_delete = 0
         self.events = events
+        self.relation_source_ids = relation_source_ids
 
     async def scalar(self, statement: object) -> int:
         assert statement is not None
         self.scalar_count += 1
         return 42
 
+    async def execute(self, statement: object) -> _RelationSourcesResult:
+        assert statement is not None
+        self.execute_count += 1
+        return _RelationSourcesResult(self.relation_source_ids)
+
     async def delete(self, entity: object) -> None:
         self.deleted.append(entity)
+        self.execute_count_at_entity_delete = self.execute_count
         if self.events is not None:
             self.events.append(("entity", cast(Entity, entity).id))
 
@@ -1138,15 +1160,19 @@ async def test_delete_accepted_note_plans_missing_response_without_deleting() ->
     )
 
     assert session.deleted == []
+    assert session.execute_count == 0, "a missing entity has no relation sources to capture"
     assert accepted.status_code == 200
     assert accepted.payload == {"deleted": False}
     assert accepted.file_delete is None
+    assert accepted.relation_cleanup_entity_ids == frozenset()
 
 
 @pytest.mark.asyncio
 async def test_delete_accepted_note_plans_cleanup_and_deletes_entity() -> None:
     events: list[tuple[str, int]] = []
-    session = _DeleteSession(events)
+    # Two surviving notes still link to the deleted target; their ids must ride
+    # the accepted change so the runtime can refresh their search rows (#1351).
+    session = _DeleteSession(events, relation_source_ids=(11, 5))
     entity = _entity()
     entity.external_id = "entity-42"
     entity.checksum = "entity-file-checksum"
@@ -1166,6 +1192,10 @@ async def test_delete_accepted_note_plans_cleanup_and_deletes_entity() -> None:
     assert search_repository.deleted_vector_entity_ids == [entity.id]
     assert session.scalar_count == 1
     assert session.deleted == [entity]
+    assert accepted.relation_cleanup_entity_ids == frozenset({5, 11})
+    # The capture must precede the entity delete: the SET NULL cascade erases the
+    # to_id evidence that identifies which sources need search repair.
+    assert session.execute_count_at_entity_delete == 1
     assert events == [
         ("search", entity.id),
         ("vectors", entity.id),


### PR DESCRIPTION
Fixes #1351.

## The gap

The API/MCP single-note delete (`DELETE /v2/.../entities/{id}` → `delete_note` → `run_accepted_note_delete` → `delete_accepted_note`) removes the deleted note's own `search_index` rows and vectors, then `session.delete(entity)`. It never refreshes the `search_index` rows of surviving notes that *linked* to the deleted one. Since #1358 the relation TABLE row for a linker (Alpha → Beta) correctly goes `to_id=NULL` on Beta's delete, but Alpha's relation SEARCH row still carries the old `to_id` and "Alpha -> Beta" title, so `search_notes(entity_types=["relation"])` returns a permalink to a deleted note and it never self-heals.

Every other delete path already handles this (watcher/external, directory, project scan): capture surviving relation sources before the delete, refresh their search rows after. This brings the API path in line.

## Change (matches the external-delete precedent)

- **Capture, in-transaction** — `delete_accepted_note` (`accepted_note_write_runner.py`): after the existing NoteContent lock and before `session.delete(entity)`, call the reusable `relation_cleanup_sources_for_deleted_entity` (from `external_file_delete_runner.py`, not reimplemented) and attach the ids via `dataclasses.replace`. Capture must precede the delete because the SET NULL cascade erases the identifying `to_id`s. No new locking.
- **Carrier** — `RuntimeAcceptedNoteChange` gains an additive `relation_cleanup_entity_ids: frozenset = frozenset()`.
- **Refresh, post-commit** — `LocalNoteContentMaterializationProvider` gains an optional `relation_cleanup_refresher`; `materialize_delete_change` calls `refresh_moved_entities(sorted(ids))` after the guarded file delete, mirroring `local_runtime.py`'s external-delete path. Refresh failure is logged and non-fatal — stale search rows are derived state that converge on the source's next edit or a reindex.
- **Wiring** — `deps/services.py` builds the refresher from the existing entity-repository and search-service deps (the same `RepositoryProjectIndexMovedEntitySearchRefresher` the watcher uses).

**Cloud parity:** both new fields default empty/None; cloud injects its own provider via the factory and is untouched, keeping its orphan-sweeper backstop. The only shared-path cost is one pre-delete SELECT.

## Tests

- `test_delete_entity_refreshes_linking_notes_search_rows` (real ASGI flow, #1358 fixtures): before delete Alpha's relation row resolves to Beta; after `DELETE Beta`, Alpha's relation search row is rebuilt with `to_id` NULL and no "Beta" in the title, and zero search rows reference Beta's id. **Verified red on unpatched main, green with the fix** (I re-confirmed by disabling the refresh: the test fails; restored: passes).
- 4 provider unit tests (refresh runs sorted / skips on empty / cloud no-refresher path / failure non-fatal); delete-runner tests assert the captured ids and capture-before-delete ordering.
- Broad sweep `tests/api tests/index tests/indexing tests/services tests/cloud`: 1422 passed. `ruff`/`ty` clean (the only `ty` diagnostics are the pre-existing `pymilvus` optional-extra imports). Postgres not run locally (no Docker); the SQL is backend-neutral. MCP `delete_note` rides the same route, covered transitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017STCpbNsYjZgUdftxgEAZ4