### PR TITLE
fix(core): bound production indexing convergence

### DIFF
--- a/src/basic_memory/index/local_dependencies.py
+++ b/src/basic_memory/index/local_dependencies.py
@@ -25,7 +25,6 @@ from basic_memory.indexing.file_indexer import (
     MAX_NOTE_CONTENT_INDEX_ATTEMPTS,
     IndexMarkdownEntityRepository,
     IndexMarkdownNoteContentReconciler,
-    NoteContentChangedDuringIndexError,
 )
 from basic_memory.indexing.index_batch_runtime import (
     IndexBatchRuntime,
@@ -69,7 +68,11 @@ from basic_memory.repository.accepted_note_vector_cleanup import (
     ProjectIndexExternalVectorCleaner,
 )
 from basic_memory.repository.search_repository import create_search_repository
-from basic_memory.runtime.storage import ProjectId, RuntimeFilePath
+from basic_memory.runtime.storage import (
+    ProjectId,
+    RuntimeFilePath,
+    runtime_file_path_is_markdown_note,
+)
 from basic_memory.runtime.vector_sync import VectorSyncBatchResult
 from basic_memory.services import EntityService, FileService
 from basic_memory.services.bulk_link_resolver import BulkLinkResolver
@@ -282,7 +285,9 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
         source: str,
     ) -> FileIndexResult:
         """Read and index the current file with markdown-specific reconciliation when needed."""
-        if self.file_service.is_markdown(file_path):
+        if self.file_service.is_markdown(file_path) and runtime_file_path_is_markdown_note(
+            file_path
+        ):
             return await self.index_markdown_file(file_path, source=source)
 
         return await self.index_regular_file(file_path, source=source)
@@ -303,6 +308,7 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
                 load_relations=False,
             )
         operation = FileIndexOperation.created if existing is None else FileIndexOperation.updated
+        content_superseded = False
 
         for attempt in range(MAX_NOTE_CONTENT_INDEX_ATTEMPTS):
             if attempt > 0:
@@ -334,6 +340,7 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
             # Why: retrying identical bytes cannot make that file lineage current.
             # Outcome: preserve accepted relations and finish without publishing this pass.
             if reconciliation.status == "deferred":
+                content_superseded = True
                 break
 
             if reconciliation.generation is not None:
@@ -352,8 +359,13 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
                 reconciliation_status=reconciliation.status,
             )
         else:
-            raise NoteContentChangedDuringIndexError(
-                f"Note content changed repeatedly while indexing {file_path}"
+            # A hot note already has a newer coalesced write waiting. Returning
+            # the last coherent snapshot prevents futile whole-job retries.
+            content_superseded = True
+            logger.info(
+                "Finished markdown index with superseded derived state: {}",
+                file_path,
+                entity_id=synced.entity.id,
             )
 
         logger.info(
@@ -373,6 +385,7 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
             permalink=synced.entity.permalink,
             checksum=synced.checksum,
             operation=operation,
+            content_superseded=content_superseded,
         )
 
     async def index_regular_file(

--- a/src/basic_memory/index/local_runtime.py
+++ b/src/basic_memory/index/local_runtime.py
@@ -219,6 +219,7 @@ class LocalInlineStorageEventResultRecorder:
             self.index_embeddings
             and result.status == IndexFileJobStatus.processed
             and result.entity_id is not None
+            and not result.content_superseded
         ):
             await self.search_service.sync_entity_vectors_batch([result.entity_id])
             logger.info(

--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -39,7 +39,7 @@ from basic_memory.indexing.relation_resolution import (
     RepositoryRelationResolutionRuntime,
 )
 from basic_memory.indexing.relation_persistence import RelationGenerationPublisher
-from basic_memory.models import Entity, Relation, RelationSearchRefresh
+from basic_memory.models import Entity, NoteContent, Relation, RelationSearchRefresh
 from basic_memory.repository import EntityRepository, ObservationRepository, RelationRepository
 from basic_memory.repository.note_content_repository import NoteContentRepository
 from basic_memory.repository.semantic_errors import SemanticDependenciesMissingError
@@ -601,6 +601,30 @@ class BatchIndexer:
                     project_id=self.relation_repository.project_id,
                     entity_ids=tuple(sorted({entity_id, *expected_incoming_source_ids})),
                 )
+                fenced_source_ids = set(
+                    (
+                        await session.scalars(
+                            select(NoteContent.entity_id).where(
+                                NoteContent.project_id == self.relation_repository.project_id,
+                                NoteContent.entity_id.in_(expected_incoming_source_ids),
+                            )
+                        )
+                    ).all()
+                )
+                if fenced_source_ids != expected_incoming_source_ids:
+                    # Legacy sources without NoteContent cannot join the
+                    # canonical source-before-target lock order. Leave their
+                    # inbound relations untouched until a later indexed pass.
+                    return _PreparedEntity(
+                        path=file.path,
+                        entity_id=entity_id,
+                        permalink=existing.permalink,
+                        checksum=existing.checksum or checksum,
+                        content_type=existing.content_type,
+                        search_content=None,
+                        resolve_relations=False,
+                        refresh_search=False,
+                    )
                 locked_note_content = await NoteContentRepository(
                     project_id=self.relation_repository.project_id
                 ).get_by_entity_id(session, entity_id)

--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -33,7 +33,10 @@ from basic_memory.indexing.models import (
     IndexInputFile,
     RelationGenerationBatchResult,
 )
-from basic_memory.indexing.relation_resolution import RepositoryRelationResolutionRuntime
+from basic_memory.indexing.relation_resolution import (
+    RelationSearchRefreshResult,
+    RepositoryRelationResolutionRuntime,
+)
 from basic_memory.indexing.relation_persistence import RelationGenerationPublisher
 from basic_memory.models import Entity
 from basic_memory.repository import EntityRepository, ObservationRepository, RelationRepository
@@ -75,12 +78,19 @@ class RelationResolutionSearchWriter:
         entities: Sequence[Entity],
         *,
         content_by_entity_id: Mapping[int, str],
-    ) -> None:
+    ) -> RelationSearchRefreshResult:
+        missing_content_entity_ids: set[int] = set()
         for entity in sorted(entities, key=lambda item: item.id):
-            await self.search_writer.index_entity_data(
-                entity,
-                content=content_by_entity_id.get(entity.id),
-            )
+            try:
+                await self.search_writer.index_entity_data(
+                    entity,
+                    content=content_by_entity_id.get(entity.id),
+                )
+            except FileNotFoundError:
+                missing_content_entity_ids.add(entity.id)
+        return RelationSearchRefreshResult(
+            missing_content_entity_ids=frozenset(missing_content_entity_ids)
+        )
 
 
 @dataclass(slots=True)
@@ -936,9 +946,10 @@ class BatchIndexer:
             setattr(entity, key, value)
 
     def _is_markdown(self, file: IndexInputFile) -> bool:
+        path_is_markdown_note = runtime_file_path_is_markdown_note(Path(file.path).as_posix())
         if file.content_type is not None:
-            return file.content_type == RUNTIME_MARKDOWN_CONTENT_TYPE
-        return runtime_file_path_is_markdown_note(Path(file.path).as_posix())
+            return file.content_type == RUNTIME_MARKDOWN_CONTENT_TYPE and path_is_markdown_note
+        return path_is_markdown_note
 
     async def _run_bounded(
         self,

--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -559,6 +559,19 @@ class BatchIndexer:
             entity_id = existing.id
 
         async with db.scoped_session(self.session_maker) as session:
+            should_clear_note_state = (
+                existing is not None
+                and existing.is_markdown
+                and content_type != RUNTIME_MARKDOWN_CONTENT_TYPE
+            )
+            if should_clear_note_state:
+                # Accepted-note writers lock NoteContent before Entity. Poison-row
+                # repair must use the same order or the two paths can deadlock.
+                await lock_note_content_before_entity_mutation(
+                    session,
+                    project_id=self.relation_repository.project_id,
+                    entity_ids=(entity_id,),
+                )
             existing = await self.entity_repository.get_by_id(
                 session,
                 entity_id,
@@ -608,12 +621,6 @@ class BatchIndexer:
 
     async def _clear_note_only_state(self, session: AsyncSession, entity: Entity) -> None:
         """Retire semantic projections when a poison Markdown row becomes a resource."""
-        await lock_note_content_before_entity_mutation(
-            session,
-            project_id=self.relation_repository.project_id,
-            entity_ids=(entity.id,),
-        )
-
         incoming_source_ids = {
             relation.from_id
             for relation in entity.incoming_relations

--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Awaitable, Callable, Mapping, Sequence, TypeVar
 
 from loguru import logger
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -39,7 +39,7 @@ from basic_memory.indexing.relation_resolution import (
     RepositoryRelationResolutionRuntime,
 )
 from basic_memory.indexing.relation_persistence import RelationGenerationPublisher
-from basic_memory.models import Entity, RelationSearchRefresh
+from basic_memory.models import Entity, Relation, RelationSearchRefresh
 from basic_memory.repository import EntityRepository, ObservationRepository, RelationRepository
 from basic_memory.repository.note_content_repository import NoteContentRepository
 from basic_memory.repository.semantic_errors import SemanticDependenciesMissingError
@@ -519,6 +519,24 @@ class BatchIndexer:
                 if existing is not None and existing.is_markdown
                 else None
             )
+            expected_incoming_source_ids = (
+                frozenset(
+                    int(source_id)
+                    for source_id in await session.scalars(
+                        select(Relation.from_id).where(
+                            Relation.project_id == self.relation_repository.project_id,
+                            Relation.to_id == existing.id,
+                            Relation.from_id != existing.id,
+                        )
+                    )
+                )
+                if (
+                    existing is not None
+                    and existing.is_markdown
+                    and content_type != RUNTIME_MARKDOWN_CONTENT_TYPE
+                )
+                else frozenset()
+            )
         expected_note_db_version = (
             existing_note_content.db_version if existing_note_content is not None else None
         )
@@ -581,7 +599,7 @@ class BatchIndexer:
                 await lock_note_content_before_entity_mutation(
                     session,
                     project_id=self.relation_repository.project_id,
-                    entity_ids=(entity_id,),
+                    entity_ids=tuple(sorted({entity_id, *expected_incoming_source_ids})),
                 )
                 locked_note_content = await NoteContentRepository(
                     project_id=self.relation_repository.project_id
@@ -596,6 +614,27 @@ class BatchIndexer:
             )
             if existing is None:
                 raise ValueError(f"Entity not found before file metadata update: {file.path}")
+            current_incoming_source_ids = {
+                relation.from_id
+                for relation in existing.incoming_relations
+                if relation.from_id != existing.id
+            }
+            if should_clear_note_state and not current_incoming_source_ids.issubset(
+                expected_incoming_source_ids
+            ):
+                # A source published a new inbound edge after the fence snapshot.
+                # Leave this pass non-destructive so a later pass can lock that
+                # source before rewriting its relation.
+                return _PreparedEntity(
+                    path=file.path,
+                    entity_id=existing.id,
+                    permalink=existing.permalink,
+                    checksum=existing.checksum or checksum,
+                    content_type=existing.content_type,
+                    search_content=None,
+                    resolve_relations=False,
+                    refresh_search=False,
+                )
             if (
                 should_clear_note_state
                 and (locked_note_content.db_version if locked_note_content is not None else None)

--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -127,6 +127,7 @@ class _PreparedEntity:
     observations: tuple[IndexedObservation, ...] = ()
     relations: tuple[IndexedRelation, ...] = ()
     resolve_relations: bool = True
+    refresh_search: bool = True
 
 
 @dataclass(slots=True)
@@ -580,6 +581,24 @@ class BatchIndexer:
             )
             if existing is None:
                 raise ValueError(f"Entity not found before file metadata update: {file.path}")
+            if (
+                not should_clear_note_state
+                and existing.is_markdown
+                and content_type != RUNTIME_MARKDOWN_CONTENT_TYPE
+            ):
+                # A newer Markdown pass won between the initial classification
+                # read and this lock. Preserve its canonical state and projections;
+                # this stale resource pass has nothing left to publish.
+                return _PreparedEntity(
+                    path=file.path,
+                    entity_id=existing.id,
+                    permalink=existing.permalink,
+                    checksum=existing.checksum or checksum,
+                    content_type=existing.content_type,
+                    search_content=None,
+                    resolve_relations=False,
+                    refresh_search=False,
+                )
             if existing.is_markdown and content_type != RUNTIME_MARKDOWN_CONTENT_TYPE:
                 await self._clear_note_only_state(session, existing)
 
@@ -822,17 +841,18 @@ class BatchIndexer:
     async def _refresh_search_index(
         self, prepared: _PreparedEntity, entity: Entity
     ) -> IndexedEntity:
-        try:
-            await self.search_service.index_entity_data(entity, content=prepared.search_content)
-        except SemanticDependenciesMissingError as exc:
-            # Semantic search is optional infrastructure; missing provider deps must not undo
-            # the durable file/entity work that already completed.
-            logger.warning(
-                "Skipping semantic index refresh because dependencies are unavailable",
-                path=prepared.path,
-                entity_id=entity.id,
-                error=str(exc),
-            )
+        if prepared.refresh_search:
+            try:
+                await self.search_service.index_entity_data(entity, content=prepared.search_content)
+            except SemanticDependenciesMissingError as exc:
+                # Semantic search is optional infrastructure; missing provider deps must not undo
+                # the durable file/entity work that already completed.
+                logger.warning(
+                    "Skipping semantic index refresh because dependencies are unavailable",
+                    path=prepared.path,
+                    entity_id=entity.id,
+                    error=str(exc),
+                )
         return IndexedEntity(
             path=prepared.path,
             entity_id=entity.id,

--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -614,6 +614,20 @@ class BatchIndexer:
             )
             if existing is None:
                 raise ValueError(f"Entity not found before file metadata update: {file.path}")
+            if should_clear_note_state and locked_note_content is None:
+                # A missing canonical row cannot be fenced against concurrent
+                # bootstrap. Leave the Markdown state intact until a later pass
+                # can lock an accepted NoteContent generation.
+                return _PreparedEntity(
+                    path=file.path,
+                    entity_id=existing.id,
+                    permalink=existing.permalink,
+                    checksum=existing.checksum or checksum,
+                    content_type=existing.content_type,
+                    search_content=None,
+                    resolve_relations=False,
+                    refresh_search=False,
+                )
             current_incoming_source_ids = {
                 relation.from_id
                 for relation in existing.incoming_relations

--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -615,19 +615,26 @@ class BatchIndexer:
             if existing is None:
                 raise ValueError(f"Entity not found before file metadata update: {file.path}")
             if should_clear_note_state and locked_note_content is None:
-                # A missing canonical row cannot be fenced against concurrent
-                # bootstrap. Leave the Markdown state intact until a later pass
-                # can lock an accepted NoteContent generation.
-                return _PreparedEntity(
-                    path=file.path,
-                    entity_id=existing.id,
-                    permalink=existing.permalink,
-                    checksum=existing.checksum or checksum,
-                    content_type=existing.content_type,
-                    search_content=None,
-                    resolve_relations=False,
-                    refresh_search=False,
+                # A missing row cannot be locked, so recheck after the Entity
+                # fence. A completed bootstrap is now visible and must win;
+                # a still-absent row is a stable legacy poison row we can repair.
+                bootstrapped_note_content = await NoteContentRepository(
+                    project_id=self.relation_repository.project_id
+                ).get_by_entity_id(
+                    session,
+                    entity_id,
                 )
+                if bootstrapped_note_content is not None:
+                    return _PreparedEntity(
+                        path=file.path,
+                        entity_id=existing.id,
+                        permalink=existing.permalink,
+                        checksum=existing.checksum or checksum,
+                        content_type=existing.content_type,
+                        search_content=None,
+                        resolve_relations=False,
+                        refresh_search=False,
+                    )
             current_incoming_source_ids = {
                 relation.from_id
                 for relation in existing.incoming_relations

--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -52,6 +52,17 @@ from basic_memory.services.bulk_link_resolver import BulkLinkResolver
 from basic_memory.services.exceptions import SyncFatalError
 
 T = TypeVar("T")
+RUNTIME_RESOURCE_CONTENT_TYPE = "application/octet-stream"
+
+
+def regular_file_content_type(file: IndexInputFile) -> str:
+    """Return a persisted MIME type that cannot reclassify a resource as a note."""
+    if (
+        file.content_type == RUNTIME_MARKDOWN_CONTENT_TYPE
+        and not runtime_file_path_is_markdown_note(Path(file.path).as_posix())
+    ):
+        return RUNTIME_RESOURCE_CONTENT_TYPE
+    return file.content_type or "text/plain"
 
 
 @dataclass(frozen=True, slots=True)
@@ -492,6 +503,7 @@ class BatchIndexer:
 
     async def _upsert_regular_file(self, file: IndexInputFile) -> _PreparedEntity:
         checksum = await self._resolve_checksum(file)
+        content_type = regular_file_content_type(file)
         async with db.scoped_session(self.session_maker) as session:
             existing = await self.entity_repository.get_by_file_path(
                 session, file.path, load_relations=False
@@ -508,7 +520,7 @@ class BatchIndexer:
                 title=Path(file.path).name,
                 created_at=file.created_at or datetime.now().astimezone(),
                 updated_at=file.last_modified or datetime.now().astimezone(),
-                content_type=file.content_type or "text/plain",
+                content_type=content_type,
                 mtime=file.last_modified.timestamp() if file.last_modified else None,
                 size=file.size,
             )
@@ -544,14 +556,19 @@ class BatchIndexer:
             entity_id = existing.id
 
         async with db.scoped_session(self.session_maker) as session:
+            metadata_updates = self._resource_metadata_updates(
+                file,
+                checksum,
+                include_created_at=is_new_entity,
+            )
+            # MIME alone is the downstream note discriminator. A malformed
+            # Markdown basename must therefore be normalized both for new rows
+            # and for poison rows created by older indexers.
+            metadata_updates["content_type"] = content_type
             updated = await self.entity_repository.update(
                 session,
                 entity_id,
-                self._resource_metadata_updates(
-                    file,
-                    checksum,
-                    include_created_at=is_new_entity,
-                ),
+                metadata_updates,
             )
         if updated is None:
             raise ValueError(f"Failed to update file entity metadata for {file.path}")
@@ -561,7 +578,7 @@ class BatchIndexer:
             entity_id=updated.id,
             permalink=updated.permalink,
             checksum=checksum,
-            content_type=file.content_type,
+            content_type=content_type,
             search_content=None,
             markdown_content=None,
             observations=(),

--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Awaitable, Callable, Mapping, Sequence, TypeVar
 
 from loguru import logger
+from sqlalchemy import delete
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -38,10 +39,11 @@ from basic_memory.indexing.relation_resolution import (
     RepositoryRelationResolutionRuntime,
 )
 from basic_memory.indexing.relation_persistence import RelationGenerationPublisher
-from basic_memory.models import Entity
+from basic_memory.models import Entity, RelationSearchRefresh
 from basic_memory.repository import EntityRepository, ObservationRepository, RelationRepository
 from basic_memory.repository.note_content_repository import NoteContentRepository
 from basic_memory.repository.semantic_errors import SemanticDependenciesMissingError
+from basic_memory.repository.relation_repository import lock_note_content_before_entity_mutation
 from basic_memory.runtime.storage import (
     ProjectId,
     RUNTIME_MARKDOWN_CONTENT_TYPE,
@@ -154,6 +156,7 @@ class BatchIndexer:
         self.entity_repository = entity_repository
         self.observation_repository = observation_repository
         self.relation_repository = relation_repository
+        self.note_content_repository = NoteContentRepository(project_id=project_id)
         self.search_service = search_service
         self.file_writer = file_writer
         self.session_maker = session_maker
@@ -166,7 +169,7 @@ class BatchIndexer:
             session_maker=session_maker,
             relation_repository=relation_repository,
             entity_repository=entity_repository,
-            note_content_repository=NoteContentRepository(project_id=project_id),
+            note_content_repository=self.note_content_repository,
             target_resolver=BulkLinkResolver(
                 entity_repository=entity_repository,
                 app_config=app_config,
@@ -556,6 +559,17 @@ class BatchIndexer:
             entity_id = existing.id
 
         async with db.scoped_session(self.session_maker) as session:
+            existing = await self.entity_repository.get_by_id(
+                session,
+                entity_id,
+                load_relations=True,
+                lock_for_update=True,
+            )
+            if existing is None:
+                raise ValueError(f"Entity not found before file metadata update: {file.path}")
+            if existing.is_markdown and content_type != RUNTIME_MARKDOWN_CONTENT_TYPE:
+                await self._clear_note_only_state(session, existing)
+
             metadata_updates = self._resource_metadata_updates(
                 file,
                 checksum,
@@ -564,7 +578,13 @@ class BatchIndexer:
             # MIME alone is the downstream note discriminator. A malformed
             # Markdown basename must therefore be normalized both for new rows
             # and for poison rows created by older indexers.
-            metadata_updates["content_type"] = content_type
+            metadata_updates.update(
+                content_type=content_type,
+                permalink=None,
+                note_type="file",
+                title=Path(file.path).name,
+                entity_metadata={},
+            )
             updated = await self.entity_repository.update(
                 session,
                 entity_id,
@@ -584,6 +604,40 @@ class BatchIndexer:
             observations=(),
             relations=(),
             resolve_relations=False,
+        )
+
+    async def _clear_note_only_state(self, session: AsyncSession, entity: Entity) -> None:
+        """Retire semantic projections when a poison Markdown row becomes a resource."""
+        await lock_note_content_before_entity_mutation(
+            session,
+            project_id=self.relation_repository.project_id,
+            entity_ids=(entity.id,),
+        )
+
+        incoming_source_ids = {
+            relation.from_id
+            for relation in entity.incoming_relations
+            if relation.from_id != entity.id
+        }
+        for relation in entity.incoming_relations:
+            relation.to_id = None
+            relation.to_entity = None
+
+        await self.observation_repository.delete_by_fields(session, entity_id=entity.id)
+        await self.relation_repository.delete_by_fields(session, from_id=entity.id)
+        await self.note_content_repository.delete_by_entity_id(session, entity.id)
+        await session.execute(
+            delete(RelationSearchRefresh).where(
+                RelationSearchRefresh.project_id == self.relation_repository.project_id,
+                RelationSearchRefresh.entity_id == entity.id,
+            )
+        )
+        session.add_all(
+            RelationSearchRefresh(
+                project_id=self.relation_repository.project_id,
+                entity_id=source_id,
+            )
+            for source_id in sorted(incoming_source_ids)
         )
 
     # --- Relations ---

--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -512,6 +512,16 @@ class BatchIndexer:
             existing = await self.entity_repository.get_by_file_path(
                 session, file.path, load_relations=False
             )
+            existing_note_content = (
+                await NoteContentRepository(
+                    project_id=self.relation_repository.project_id
+                ).get_by_entity_id(session, existing.id)
+                if existing is not None and existing.is_markdown
+                else None
+            )
+        expected_note_db_version = (
+            existing_note_content.db_version if existing_note_content is not None else None
+        )
         is_new_entity = existing is None
 
         if existing is None:
@@ -573,6 +583,11 @@ class BatchIndexer:
                     project_id=self.relation_repository.project_id,
                     entity_ids=(entity_id,),
                 )
+                locked_note_content = await NoteContentRepository(
+                    project_id=self.relation_repository.project_id
+                ).get_by_entity_id(session, entity_id)
+            else:
+                locked_note_content = None
             existing = await self.entity_repository.get_by_id(
                 session,
                 entity_id,
@@ -581,6 +596,23 @@ class BatchIndexer:
             )
             if existing is None:
                 raise ValueError(f"Entity not found before file metadata update: {file.path}")
+            if (
+                should_clear_note_state
+                and (locked_note_content.db_version if locked_note_content is not None else None)
+                != expected_note_db_version
+            ):
+                # A newer accepted Markdown generation landed after the initial
+                # classification read. This resource pass no longer owns cleanup.
+                return _PreparedEntity(
+                    path=file.path,
+                    entity_id=existing.id,
+                    permalink=existing.permalink,
+                    checksum=existing.checksum or checksum,
+                    content_type=existing.content_type,
+                    search_content=None,
+                    resolve_relations=False,
+                    refresh_search=False,
+                )
             if (
                 not should_clear_note_state
                 and existing.is_markdown

--- a/src/basic_memory/indexing/file_indexer.py
+++ b/src/basic_memory/indexing/file_indexer.py
@@ -185,6 +185,7 @@ class FileIndexer:
                 load_relations=False,
             )
         operation = FileIndexOperation.created if existing is None else FileIndexOperation.updated
+        content_superseded = False
 
         for attempt in range(MAX_NOTE_CONTENT_INDEX_ATTEMPTS):
             if attempt > 0:
@@ -217,6 +218,7 @@ class FileIndexer:
             # Why: retrying identical bytes cannot make that file lineage current.
             # Outcome: preserve accepted relations and finish without publishing this pass.
             if reconciliation.status == "deferred":
+                content_superseded = True
                 break
 
             if reconciliation.generation is not None:
@@ -235,8 +237,14 @@ class FileIndexer:
                 reconciliation_status=reconciliation.status,
             )
         else:
-            raise NoteContentChangedDuringIndexError(
-                f"Note content changed repeatedly while indexing {file_path}"
+            # A continuously edited note is normal convergent workload, not a
+            # retryable failure. Keep the last coherent snapshot and let the
+            # already-coalesced newer write own the next derived-state pass.
+            content_superseded = True
+            log.info(
+                "Finished markdown index with superseded derived state: {}",
+                file_path,
+                entity_id=synced.entity.id,
             )
 
         log.info(
@@ -256,6 +264,7 @@ class FileIndexer:
             permalink=synced.entity.permalink,
             checksum=synced.checksum,
             operation=operation,
+            content_superseded=content_superseded,
         )
 
 

--- a/src/basic_memory/indexing/models.py
+++ b/src/basic_memory/indexing/models.py
@@ -176,6 +176,10 @@ class FileIndexResult:
     permalink: str | None
     checksum: str
     operation: FileIndexOperation
+    # The indexed snapshot committed successfully, but a newer accepted note
+    # generation won before derived relations could be published. The next
+    # coalesced write owns convergence; callers must not enqueue stale followups.
+    content_superseded: bool = False
 
     @classmethod
     def from_fields(
@@ -188,6 +192,7 @@ class FileIndexResult:
         permalink: object,
         checksum: str,
         operation: FileIndexOperation,
+        content_superseded: bool = False,
     ) -> FileIndexResult:
         """Validate entity fields loaded for a completed file-index result.
 
@@ -215,6 +220,7 @@ class FileIndexResult:
             ),
             checksum=checksum,
             operation=operation,
+            content_superseded=content_superseded,
         )
 
 
@@ -296,6 +302,8 @@ def plan_index_file_embedding_job(
     if not context.index_embeddings:
         return None
     if context.result.status != IndexFileJobStatus.processed:
+        return None
+    if context.result.content_superseded:
         return None
     if context.result.entity_id is None:
         raise RuntimeError("index_file processed without an entity id")
@@ -401,7 +409,8 @@ def index_file_job_result_from_indexed_file(
         ),
         db_version=live_update_plan.db_version if live_update_plan is not None else None,
         content_superseded=(
-            live_update_plan.content_superseded if live_update_plan is not None else False
+            indexed_file.content_superseded
+            or (live_update_plan.content_superseded if live_update_plan is not None else False)
         ),
     )
 

--- a/src/basic_memory/indexing/note_content_reconciler.py
+++ b/src/basic_memory/indexing/note_content_reconciler.py
@@ -30,7 +30,7 @@ from basic_memory.indexing.note_content_reconciliation import (
     bootstrap_note_content_plan,
     plan_existing_note_content_reconciliation,
 )
-from basic_memory.models import NoteContent
+from basic_memory.models import Entity, NoteContent
 from basic_memory.repository import NoteContentRepository
 from basic_memory.runtime.storage import ProjectId, RuntimeEntityId, RuntimeFilePath
 
@@ -351,6 +351,20 @@ class NoteContentReconciler:
                     return NoteContentReconciliationResult.stale()
 
             if note_content is None:
+                # Missing NoteContent cannot itself fence a bootstrap. Lock and
+                # revalidate the Entity so a resource reclassification that won
+                # the race cannot receive canonical Markdown state afterward.
+                locked_entity = await session.get(
+                    Entity,
+                    entity.id,
+                    with_for_update=True,
+                )
+                if locked_entity is None or not locked_entity.is_markdown:
+                    logger.debug(
+                        "Skipped note_content bootstrap for non-Markdown entity {}",
+                        entity.id,
+                    )
+                    return NoteContentReconciliationResult.stale()
                 bootstrap = bootstrap_note_content_plan(observed=observed)
 
                 try:

--- a/src/basic_memory/indexing/relation_resolution.py
+++ b/src/basic_memory/indexing/relation_resolution.py
@@ -216,8 +216,18 @@ class BatchRelationResolutionEntityIndexer(Protocol):
         entities: Sequence[Entity],
         *,
         content_by_entity_id: Mapping[EntityId, str],
-    ) -> None:
-        """Refresh derived index rows for a group of entities."""
+    ) -> RelationSearchRefreshResult | None:
+        """Refresh derived rows, optionally reporting bounded per-entity outcomes.
+
+        ``None`` remains the complete-success result for legacy extension adapters.
+        """
+
+
+@dataclass(frozen=True, slots=True)
+class RelationSearchRefreshResult:
+    """Bounded per-entity outcomes from a relation-driven search refresh."""
+
+    missing_content_entity_ids: frozenset[EntityId] = frozenset()
 
 
 def accepted_search_content_for_pending_notes(
@@ -374,10 +384,19 @@ class RepositoryRelationResolutionRuntime:
             # materializer, while synchronized notes still need missing files to surface.
             # Outcome: pending sources use accepted DB content; all others retain disk fallback.
             content_by_entity_id = accepted_search_content_for_pending_notes(note_contents)
-            await self.entity_indexer.index_entities(
+            refresh_result = await self.entity_indexer.index_entities(
                 sorted(source_entities, key=lambda entity: entity.id),
                 content_by_entity_id=content_by_entity_id,
             )
+            if refresh_result is not None and refresh_result.missing_content_entity_ids:
+                # A synchronized entity whose backing object is gone cannot be
+                # repaired by retrying relation resolution. Orphan cleanup owns
+                # DB/storage convergence; retire this observed refresh marker.
+                logger.warning(
+                    "Skipped relation search refresh for missing entity content",
+                    entity_ids=sorted(refresh_result.missing_content_entity_ids),
+                    entity_count=len(refresh_result.missing_content_entity_ids),
+                )
             async with db.scoped_session(self.session_maker) as session:
                 await self.relation_repository.clear_pending_search_refreshes(
                     session,

--- a/src/basic_memory/services/search_service.py
+++ b/src/basic_memory/services/search_service.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 import logfire
 
 from basic_memory import db
+from basic_memory.indexing.relation_resolution import RelationSearchRefreshResult
 from basic_memory.models import Entity
 from basic_memory.repository import EntityRepository
 from basic_memory.repository.search_repository import (
@@ -539,7 +540,7 @@ class SearchService:
         entities: Sequence[Entity],
         *,
         content_by_entity_id: Mapping[int, str],
-    ) -> None:
+    ) -> RelationSearchRefreshResult:
         """Refresh a group of entity search rows through one batch entry point.
 
         Index writes stay sequential because local SQLite connections cannot
@@ -548,11 +549,18 @@ class SearchService:
         Accepted content bypasses the disk read while its Markdown projection
         remains pending.
         """
+        missing_content_entity_ids: set[int] = set()
         for entity in entities:
-            await self.index_entity_data(
-                entity,
-                content=content_by_entity_id.get(entity.id),
-            )
+            try:
+                await self.index_entity_data(
+                    entity,
+                    content=content_by_entity_id.get(entity.id),
+                )
+            except FileNotFoundError:
+                missing_content_entity_ids.add(entity.id)
+        return RelationSearchRefreshResult(
+            missing_content_entity_ids=frozenset(missing_content_entity_ids)
+        )
 
     async def index_entity_data(
         self,

--- a/tests/index/test_local_inline_result_recorder.py
+++ b/tests/index/test_local_inline_result_recorder.py
@@ -88,8 +88,18 @@ def _recorder(
     )
 
 
-def _result(status: IndexFileJobStatus, entity_id: int | None) -> IndexFileJobResult:
-    return IndexFileJobResult(status=status, reason="file indexed", entity_id=entity_id)
+def _result(
+    status: IndexFileJobStatus,
+    entity_id: int | None,
+    *,
+    content_superseded: bool = False,
+) -> IndexFileJobResult:
+    return IndexFileJobResult(
+        status=status,
+        reason="file indexed",
+        entity_id=entity_id,
+        content_superseded=content_superseded,
+    )
 
 
 async def test_processed_file_embeds_and_resolves_when_enabled() -> None:
@@ -111,6 +121,20 @@ async def test_processed_file_skips_embedding_when_disabled() -> None:
     await recorder.index_file_completed(_operation(), _result(IndexFileJobStatus.processed, 42))
 
     # Relation repair still runs; embedding is gated off.
+    assert search.batches == []
+    assert relations.resolve_calls == 1
+
+
+async def test_superseded_file_skips_embedding_when_enabled() -> None:
+    search = StubSearchService()
+    relations = StubRelationRuntime()
+    recorder = _recorder(search, relations, index_embeddings=True)
+
+    await recorder.index_file_completed(
+        _operation(),
+        _result(IndexFileJobStatus.processed, 42, content_superseded=True),
+    )
+
     assert search.batches == []
     assert relations.resolve_calls == 1
 

--- a/tests/index/test_local_markdown_file_indexer.py
+++ b/tests/index/test_local_markdown_file_indexer.py
@@ -16,7 +16,12 @@ from basic_memory.index.local_dependencies import (
 )
 from basic_memory.indexing.batch_indexer import BatchIndexer
 from basic_memory.indexing.file_indexer import IndexMarkdownNoteContentReconciler
-from basic_memory.indexing.models import IndexEntitySearchWriter, SyncedMarkdownFile
+from basic_memory.indexing.models import (
+    FileIndexOperation,
+    FileIndexResult,
+    IndexEntitySearchWriter,
+    SyncedMarkdownFile,
+)
 from basic_memory.indexing.note_content_reconciliation import NoteContentReconciliationResult
 from basic_memory.services import FileService
 
@@ -107,3 +112,42 @@ async def test_local_file_indexer_logs_brace_path_through_retry(
     assert f"Indexed markdown file: {file_path}" in rendered_messages
     assert result.file_path == file_path
     assert result.title == "{AG} Plan"
+
+
+@pytest.mark.asyncio
+async def test_local_file_indexer_treats_empty_markdown_basename_as_regular_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A MIME-marked ``.md`` object is a resource, not a poison markdown job."""
+    file_service = Mock()
+    file_service.is_markdown.return_value = True
+    indexer = LocalMarkdownFileIndexer(
+        file_service=cast(FileService, file_service),
+        session_maker=cast(async_sessionmaker[AsyncSession], _FakeSession),
+        entity_repository=cast(LocalIndexEntityRepository, Mock()),
+        batch_indexer=cast(BatchIndexer, Mock()),
+        search_service=cast(IndexEntitySearchWriter, Mock()),
+        note_content_reconciler=cast(IndexMarkdownNoteContentReconciler, Mock()),
+    )
+    regular_result = FileIndexResult(
+        file_path="_phase7_import/.md",
+        entity_id=42,
+        external_id="resource-42",
+        title=".md",
+        permalink=None,
+        checksum="abc123",
+        operation=FileIndexOperation.created,
+    )
+    markdown_index = AsyncMock()
+    regular_index = AsyncMock(return_value=regular_result)
+    monkeypatch.setattr(LocalMarkdownFileIndexer, "index_markdown_file", markdown_index)
+    monkeypatch.setattr(LocalMarkdownFileIndexer, "index_regular_file", regular_index)
+
+    result = await indexer.index_file("_phase7_import/.md", source="s3_webhook")
+
+    markdown_index.assert_not_awaited()
+    regular_index.assert_awaited_once_with(
+        "_phase7_import/.md",
+        source="s3_webhook",
+    )
+    assert result == regular_result

--- a/tests/indexing/test_file_indexer.py
+++ b/tests/indexing/test_file_indexer.py
@@ -13,7 +13,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from basic_memory.indexing.file_indexer import (
     FileIndexer,
     IndexCurrentMarkdownFileIndexer,
-    NoteContentChangedDuringIndexError,
     build_default_file_indexer,
 )
 from basic_memory.indexing.models import FileIndexOperation, FileIndexResult, SyncedMarkdownFile
@@ -374,8 +373,8 @@ async def test_file_indexer_reloads_entity_after_initial_absence_becomes_stale()
 
 
 @pytest.mark.asyncio
-async def test_file_indexer_fails_for_retry_after_repeated_stale_indexes() -> None:
-    """Repeated concurrent writes must fail the job instead of reporting stale derived state."""
+async def test_file_indexer_reports_superseded_after_repeated_stale_indexes() -> None:
+    """A hot note must finish with a bounded outcome so its next write can converge."""
     existing_entity = _entity(entity_id=7)
     file_indexer, markdown_indexer, note_content_reconciler = _file_indexer(
         existing_entity=existing_entity,
@@ -389,13 +388,10 @@ async def test_file_indexer_fails_for_retry_after_repeated_stale_indexes() -> No
         NoteContentReconciliationResult.stale(),
     ]
 
-    with pytest.raises(
-        NoteContentChangedDuringIndexError,
-        match="changed repeatedly",
-    ):
-        await file_indexer.index_markdown_file("notes/note.md")
+    result = await file_indexer.index_markdown_file("notes/note.md")
 
     assert markdown_indexer.index_current_markdown_file.await_count == 2
+    assert result.content_superseded is True
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_note_content_reconciler.py
+++ b/tests/indexing/test_note_content_reconciler.py
@@ -34,6 +34,7 @@ class FakeSession:
 
     def __init__(self) -> None:
         self.rollback_count = 0
+        self.get = AsyncMock(return_value=SimpleNamespace(is_markdown=True))
 
     async def rollback(self) -> None:
         self.rollback_count += 1
@@ -125,6 +126,42 @@ async def test_reconciler_converges_after_concurrent_create_conflict() -> None:
         last_materialization_error=None,
         last_materialization_attempt_at=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_reconciler_does_not_bootstrap_reclassified_resource() -> None:
+    """A resource reclassification that wins the Entity lock blocks bootstrap."""
+    repository = SimpleNamespace(
+        get_by_entity_id=AsyncMock(return_value=None),
+        create=AsyncMock(),
+        update_state_fields=AsyncMock(),
+    )
+    session = FakeSession()
+    session.get.return_value = SimpleNamespace(is_markdown=False)
+
+    @asynccontextmanager
+    async def fake_scoped_session(_session_maker: object):
+        yield session
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "basic_memory.indexing.note_content_reconciler.db.scoped_session",
+            fake_scoped_session,
+        )
+        outcome = await NoteContentReconciler(
+            note_content_repository=cast(Any, repository),
+            session_maker=cast(Any, object()),
+        ).reconcile(
+            entity=cast(Entity, SimpleNamespace(id=42)),
+            markdown_content="# Stale Markdown\n",
+            observed_at=datetime(2026, 4, 13, 15, 0, tzinfo=UTC),
+            source="file_indexer",
+        )
+
+    session.get.assert_awaited_once_with(Entity, 42, with_for_update=True)
+    repository.create.assert_not_awaited()
+    assert outcome.status == "stale"
+    assert outcome.generation is None
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_regular_file_classification.py
+++ b/tests/indexing/test_regular_file_classification.py
@@ -1,0 +1,29 @@
+"""Tests for resource MIME normalization at the indexing boundary."""
+
+from basic_memory.indexing.batch_indexer import (
+    RUNTIME_RESOURCE_CONTENT_TYPE,
+    regular_file_content_type,
+)
+from basic_memory.indexing.models import IndexInputFile
+
+
+def test_markdown_mime_without_note_basename_is_persisted_as_resource() -> None:
+    file = IndexInputFile(
+        path="_phase7_import/.md",
+        content_type="text/markdown",
+        content=b"poison object",
+        size=13,
+    )
+
+    assert regular_file_content_type(file) == RUNTIME_RESOURCE_CONTENT_TYPE
+
+
+def test_regular_file_content_type_preserves_real_resource_mime() -> None:
+    file = IndexInputFile(
+        path="assets/report.pdf",
+        content_type="application/pdf",
+        content=b"report",
+        size=6,
+    )
+
+    assert regular_file_content_type(file) == "application/pdf"

--- a/tests/indexing/test_regular_file_classification.py
+++ b/tests/indexing/test_regular_file_classification.py
@@ -508,3 +508,62 @@ async def test_missing_note_content_fence_preserves_concurrent_bootstrap(
     assert preserved.is_markdown
     assert note_content is not None
     assert note_content.markdown_content == "# Accepted during bootstrap"
+
+
+async def test_legacy_poison_without_note_content_converges_to_resource(
+    app_config,
+    entity_service,
+    entity_repository,
+    relation_repository,
+    search_service,
+    file_service,
+) -> None:
+    project_id = relation_repository.project_id
+    assert project_id is not None
+    now = datetime.now(tz=UTC)
+    poison_path = "_phase7_import/.md"
+    poison = Entity(
+        project_id=project_id,
+        title="Legacy poison",
+        note_type="note",
+        content_type=RUNTIME_MARKDOWN_CONTENT_TYPE,
+        permalink="legacy-poison",
+        file_path=poison_path,
+        checksum="old-checksum",
+        created_at=now,
+        updated_at=now,
+    )
+    async with db.scoped_session(search_service.session_maker) as session:
+        poison = await entity_repository.add(session, poison)
+
+    batch_indexer = BatchIndexer(
+        project_id=project_id,
+        app_config=app_config,
+        entity_service=entity_service,
+        entity_repository=entity_repository,
+        observation_repository=entity_service.observation_repository,
+        relation_repository=relation_repository,
+        search_service=search_service,
+        file_writer=StorageIndexFileWriter(storage=file_service),
+        session_maker=search_service.session_maker,
+    )
+    result = await batch_indexer.index_files(
+        {
+            poison_path: IndexInputFile(
+                path=poison_path,
+                content_type=RUNTIME_MARKDOWN_CONTENT_TYPE,
+                content=b"legacy poison bytes",
+                size=19,
+            )
+        },
+        max_concurrent=1,
+    )
+
+    assert result.errors == []
+    assert result.indexed[0].content_type == RUNTIME_RESOURCE_CONTENT_TYPE
+    async with db.scoped_session(search_service.session_maker) as session:
+        repaired = await entity_repository.get_by_id(session, poison.id)
+
+    assert repaired is not None
+    assert repaired.content_type == RUNTIME_RESOURCE_CONTENT_TYPE
+    assert repaired.permalink is None

--- a/tests/indexing/test_regular_file_classification.py
+++ b/tests/indexing/test_regular_file_classification.py
@@ -311,3 +311,100 @@ async def test_stale_resource_pass_preserves_newer_markdown_state(
     assert preserved.permalink == "current-note"
     assert note_content is not None
     assert note_content.markdown_content == "# Current note"
+
+
+async def test_stale_markdown_snapshot_preserves_newer_note_generation(
+    monkeypatch,
+    app_config,
+    entity_service,
+    entity_repository,
+    relation_repository,
+    search_service,
+    file_service,
+) -> None:
+    project_id = relation_repository.project_id
+    assert project_id is not None
+    now = datetime.now(tz=UTC)
+    note_path = "notes/current.md"
+    note = Entity(
+        project_id=project_id,
+        title="Current note",
+        note_type="note",
+        content_type=RUNTIME_MARKDOWN_CONTENT_TYPE,
+        permalink="current-note",
+        file_path=note_path,
+        checksum="new-markdown-checksum",
+        created_at=now,
+        updated_at=now,
+    )
+    async with db.scoped_session(search_service.session_maker) as session:
+        note = await entity_repository.add(session, note)
+        await NoteContentRepository(project_id=project_id).create(
+            session,
+            {
+                "entity_id": note.id,
+                "markdown_content": "# Current note",
+                "db_version": 2,
+                "db_checksum": "new-markdown-checksum",
+                "file_write_status": "synced",
+            },
+        )
+
+    original_get_by_entity_id = NoteContentRepository.get_by_entity_id
+    note_content_reads = 0
+
+    async def stale_then_current_note_content(
+        repository: NoteContentRepository,
+        session: AsyncSession,
+        entity_id: int,
+    ) -> object:
+        nonlocal note_content_reads
+        note_content_reads += 1
+        if note_content_reads == 1:
+            return SimpleNamespace(db_version=1)
+        return await original_get_by_entity_id(repository, session, entity_id)
+
+    monkeypatch.setattr(
+        NoteContentRepository,
+        "get_by_entity_id",
+        stale_then_current_note_content,
+    )
+    batch_indexer = BatchIndexer(
+        project_id=project_id,
+        app_config=app_config,
+        entity_service=entity_service,
+        entity_repository=entity_repository,
+        observation_repository=entity_service.observation_repository,
+        relation_repository=relation_repository,
+        search_service=search_service,
+        file_writer=StorageIndexFileWriter(storage=file_service),
+        session_maker=search_service.session_maker,
+    )
+
+    result = await batch_indexer.index_files(
+        {
+            note_path: IndexInputFile(
+                path=note_path,
+                content_type=RUNTIME_RESOURCE_CONTENT_TYPE,
+                content=b"stale resource bytes",
+                size=20,
+            )
+        },
+        max_concurrent=1,
+    )
+
+    assert result.errors == []
+    assert result.indexed[0].content_type == RUNTIME_MARKDOWN_CONTENT_TYPE
+    async with db.scoped_session(search_service.session_maker) as session:
+        preserved = await entity_repository.get_by_id(session, note.id)
+        note_content = await original_get_by_entity_id(
+            NoteContentRepository(project_id=project_id),
+            session,
+            note.id,
+        )
+
+    assert preserved is not None
+    assert preserved.is_markdown
+    assert note_content is not None
+    assert note_content.db_version == 2
+    assert note_content.markdown_content == "# Current note"

--- a/tests/indexing/test_regular_file_classification.py
+++ b/tests/indexing/test_regular_file_classification.py
@@ -128,6 +128,7 @@ async def test_poison_markdown_reclassification_clears_note_only_state(
         )
 
     lock_order: list[str] = []
+    locked_note_content_ids: list[int] = []
     original_note_content_lock = batch_indexer_module.lock_note_content_before_entity_mutation
     original_get_by_id = entity_repository.get_by_id
 
@@ -138,6 +139,7 @@ async def test_poison_markdown_reclassification_clears_note_only_state(
         entity_ids: Sequence[int],
     ) -> None:
         lock_order.append("note_content")
+        locked_note_content_ids.extend(entity_ids)
         await original_note_content_lock(
             session,
             project_id=project_id,
@@ -192,6 +194,7 @@ async def test_poison_markdown_reclassification_clears_note_only_state(
 
     assert result.errors == []
     assert lock_order[:2] == ["note_content", "entity"]
+    assert locked_note_content_ids == sorted([poison.id, source.id])
     async with db.scoped_session(search_service.session_maker) as session:
         repaired = await entity_repository.get_by_id(session, poison.id)
         note_content = await NoteContentRepository(project_id=project_id).get_by_entity_id(

--- a/tests/indexing/test_regular_file_classification.py
+++ b/tests/indexing/test_regular_file_classification.py
@@ -411,3 +411,100 @@ async def test_stale_markdown_snapshot_preserves_newer_note_generation(
     assert note_content is not None
     assert note_content.db_version == 2
     assert note_content.markdown_content == "# Current note"
+
+
+async def test_missing_note_content_fence_preserves_concurrent_bootstrap(
+    monkeypatch,
+    app_config,
+    entity_service,
+    entity_repository,
+    relation_repository,
+    search_service,
+    file_service,
+) -> None:
+    project_id = relation_repository.project_id
+    assert project_id is not None
+    now = datetime.now(tz=UTC)
+    note_path = "notes/bootstrap.md"
+    note = Entity(
+        project_id=project_id,
+        title="Bootstrap note",
+        note_type="note",
+        content_type=RUNTIME_MARKDOWN_CONTENT_TYPE,
+        permalink="bootstrap-note",
+        file_path=note_path,
+        checksum="bootstrap-checksum",
+        created_at=now,
+        updated_at=now,
+    )
+    async with db.scoped_session(search_service.session_maker) as session:
+        note = await entity_repository.add(session, note)
+
+    original_get_by_id = entity_repository.get_by_id
+    bootstrapped = False
+
+    async def bootstrap_before_entity_lock(
+        session: AsyncSession,
+        entity_id: int,
+        *,
+        load_relations: bool = True,
+        lock_for_update: bool = False,
+    ) -> Entity | None:
+        nonlocal bootstrapped
+        if lock_for_update and not bootstrapped:
+            await NoteContentRepository(project_id=project_id).create(
+                session,
+                {
+                    "entity_id": note.id,
+                    "markdown_content": "# Accepted during bootstrap",
+                    "db_version": 1,
+                    "db_checksum": "bootstrap-checksum",
+                    "file_write_status": "synced",
+                },
+            )
+            bootstrapped = True
+        return await original_get_by_id(
+            session,
+            entity_id,
+            load_relations=load_relations,
+            lock_for_update=lock_for_update,
+        )
+
+    monkeypatch.setattr(entity_repository, "get_by_id", bootstrap_before_entity_lock)
+    batch_indexer = BatchIndexer(
+        project_id=project_id,
+        app_config=app_config,
+        entity_service=entity_service,
+        entity_repository=entity_repository,
+        observation_repository=entity_service.observation_repository,
+        relation_repository=relation_repository,
+        search_service=search_service,
+        file_writer=StorageIndexFileWriter(storage=file_service),
+        session_maker=search_service.session_maker,
+    )
+
+    result = await batch_indexer.index_files(
+        {
+            note_path: IndexInputFile(
+                path=note_path,
+                content_type=RUNTIME_RESOURCE_CONTENT_TYPE,
+                content=b"stale resource bytes",
+                size=20,
+            )
+        },
+        max_concurrent=1,
+    )
+
+    assert result.errors == []
+    assert result.indexed[0].content_type == RUNTIME_MARKDOWN_CONTENT_TYPE
+    async with db.scoped_session(search_service.session_maker) as session:
+        preserved = await original_get_by_id(session, note.id)
+        note_content = await NoteContentRepository(project_id=project_id).get_by_entity_id(
+            session,
+            note.id,
+        )
+
+    assert preserved is not None
+    assert preserved.is_markdown
+    assert note_content is not None
+    assert note_content.markdown_content == "# Accepted during bootstrap"

--- a/tests/indexing/test_regular_file_classification.py
+++ b/tests/indexing/test_regular_file_classification.py
@@ -1,10 +1,16 @@
 """Tests for resource MIME normalization at the indexing boundary."""
 
+from datetime import UTC, datetime
+
+from basic_memory import db
 from basic_memory.indexing.batch_indexer import (
+    BatchIndexer,
     RUNTIME_RESOURCE_CONTENT_TYPE,
     regular_file_content_type,
 )
-from basic_memory.indexing.models import IndexInputFile
+from basic_memory.indexing.models import IndexInputFile, StorageIndexFileWriter
+from basic_memory.models import Entity, Observation, Relation, RelationSearchRefresh
+from basic_memory.repository import NoteContentRepository
 
 
 def test_markdown_mime_without_note_basename_is_persisted_as_resource() -> None:
@@ -27,3 +33,149 @@ def test_regular_file_content_type_preserves_real_resource_mime() -> None:
     )
 
     assert regular_file_content_type(file) == "application/pdf"
+
+
+async def test_poison_markdown_reclassification_clears_note_only_state(
+    app_config,
+    entity_service,
+    entity_repository,
+    relation_repository,
+    search_service,
+    file_service,
+) -> None:
+    project_id = relation_repository.project_id
+    assert project_id is not None
+    now = datetime.now(tz=UTC)
+    poison_path = "_phase7_import/.md"
+
+    poison = Entity(
+        project_id=project_id,
+        title="Poison note",
+        note_type="note",
+        entity_metadata={"status": "draft"},
+        content_type="text/markdown",
+        permalink="poison-note",
+        file_path=poison_path,
+        checksum="old-checksum",
+        created_at=now,
+        updated_at=now,
+    )
+    source = Entity(
+        project_id=project_id,
+        title="Source note",
+        note_type="note",
+        content_type="text/markdown",
+        permalink="source-note",
+        file_path="notes/source.md",
+        checksum="source-checksum",
+        created_at=now,
+        updated_at=now,
+    )
+    async with db.scoped_session(search_service.session_maker) as session:
+        poison = await entity_repository.add(session, poison)
+        source = await entity_repository.add(session, source)
+        await entity_service.observation_repository.add(
+            session,
+            Observation(
+                project_id=project_id,
+                entity_id=poison.id,
+                content="stale observation",
+                category="note",
+            ),
+        )
+        await relation_repository.add(
+            session,
+            Relation(
+                project_id=project_id,
+                from_id=poison.id,
+                to_name="old-target",
+                relation_type="links-to",
+                generation=1,
+            ),
+        )
+        inbound = await relation_repository.add(
+            session,
+            Relation(
+                project_id=project_id,
+                from_id=source.id,
+                to_id=poison.id,
+                to_name="poison-note",
+                relation_type="links-to",
+                generation=1,
+            ),
+        )
+        await NoteContentRepository(project_id=project_id).create(
+            session,
+            {
+                "entity_id": poison.id,
+                "markdown_content": "# Poison note",
+                "db_version": 1,
+                "db_checksum": "old-checksum",
+                "file_write_status": "synced",
+            },
+        )
+        session.add(
+            RelationSearchRefresh(
+                project_id=project_id,
+                entity_id=poison.id,
+            )
+        )
+
+    batch_indexer = BatchIndexer(
+        project_id=project_id,
+        app_config=app_config,
+        entity_service=entity_service,
+        entity_repository=entity_repository,
+        observation_repository=entity_service.observation_repository,
+        relation_repository=relation_repository,
+        search_service=search_service,
+        file_writer=StorageIndexFileWriter(storage=file_service),
+        session_maker=search_service.session_maker,
+    )
+    result = await batch_indexer.index_files(
+        {
+            poison_path: IndexInputFile(
+                path=poison_path,
+                content_type="text/markdown",
+                content=b"poison object",
+                size=13,
+            )
+        },
+        max_concurrent=1,
+    )
+
+    assert result.errors == []
+    async with db.scoped_session(search_service.session_maker) as session:
+        repaired = await entity_repository.get_by_id(session, poison.id)
+        note_content = await NoteContentRepository(project_id=project_id).get_by_entity_id(
+            session,
+            poison.id,
+        )
+        observations = await entity_service.observation_repository.find_by_entity(
+            session,
+            poison.id,
+        )
+        refreshed_inbound = await relation_repository.select_by_id(session, inbound.id)
+        poison_refreshes = await relation_repository.list_pending_search_refreshes(
+            session,
+            entity_id=poison.id,
+        )
+        source_refreshes = await relation_repository.list_pending_search_refreshes(
+            session,
+            entity_id=source.id,
+        )
+
+    assert repaired is not None
+    assert repaired.id == poison.id
+    assert repaired.content_type == RUNTIME_RESOURCE_CONTENT_TYPE
+    assert repaired.permalink is None
+    assert repaired.note_type == "file"
+    assert repaired.title == ".md"
+    assert repaired.entity_metadata == {}
+    assert note_content is None
+    assert observations == []
+    assert repaired.outgoing_relations == []
+    assert refreshed_inbound is not None
+    assert refreshed_inbound.to_id is None
+    assert poison_refreshes == []
+    assert [refresh.entity_id for refresh in source_refreshes] == [source.id]

--- a/tests/indexing/test_regular_file_classification.py
+++ b/tests/indexing/test_regular_file_classification.py
@@ -1,7 +1,10 @@
 """Tests for resource MIME normalization at the indexing boundary."""
 
+from collections.abc import Sequence
 from datetime import UTC, datetime
 
+import basic_memory.indexing.batch_indexer as batch_indexer_module
+from sqlalchemy.ext.asyncio import AsyncSession
 from basic_memory import db
 from basic_memory.indexing.batch_indexer import (
     BatchIndexer,
@@ -36,6 +39,7 @@ def test_regular_file_content_type_preserves_real_resource_mime() -> None:
 
 
 async def test_poison_markdown_reclassification_clears_note_only_state(
+    monkeypatch,
     app_config,
     entity_service,
     entity_repository,
@@ -121,6 +125,46 @@ async def test_poison_markdown_reclassification_clears_note_only_state(
             )
         )
 
+    lock_order: list[str] = []
+    original_note_content_lock = batch_indexer_module.lock_note_content_before_entity_mutation
+    original_get_by_id = entity_repository.get_by_id
+
+    async def record_note_content_lock(
+        session: AsyncSession,
+        *,
+        project_id: int,
+        entity_ids: Sequence[int],
+    ) -> None:
+        lock_order.append("note_content")
+        await original_note_content_lock(
+            session,
+            project_id=project_id,
+            entity_ids=entity_ids,
+        )
+
+    async def record_entity_lock(
+        session: AsyncSession,
+        entity_id: int,
+        *,
+        load_relations: bool = True,
+        lock_for_update: bool = False,
+    ) -> Entity | None:
+        if lock_for_update:
+            lock_order.append("entity")
+        return await original_get_by_id(
+            session,
+            entity_id,
+            load_relations=load_relations,
+            lock_for_update=lock_for_update,
+        )
+
+    monkeypatch.setattr(
+        batch_indexer_module,
+        "lock_note_content_before_entity_mutation",
+        record_note_content_lock,
+    )
+    monkeypatch.setattr(entity_repository, "get_by_id", record_entity_lock)
+
     batch_indexer = BatchIndexer(
         project_id=project_id,
         app_config=app_config,
@@ -145,6 +189,7 @@ async def test_poison_markdown_reclassification_clears_note_only_state(
     )
 
     assert result.errors == []
+    assert lock_order[:2] == ["note_content", "entity"]
     async with db.scoped_session(search_service.session_maker) as session:
         repaired = await entity_repository.get_by_id(session, poison.id)
         note_content = await NoteContentRepository(project_id=project_id).get_by_entity_id(

--- a/tests/indexing/test_regular_file_classification.py
+++ b/tests/indexing/test_regular_file_classification.py
@@ -120,6 +120,16 @@ async def test_poison_markdown_reclassification_clears_note_only_state(
                 "file_write_status": "synced",
             },
         )
+        await NoteContentRepository(project_id=project_id).create(
+            session,
+            {
+                "entity_id": source.id,
+                "markdown_content": "# Source note",
+                "db_version": 1,
+                "db_checksum": "source-checksum",
+                "file_write_status": "synced",
+            },
+        )
         session.add(
             RelationSearchRefresh(
                 project_id=project_id,
@@ -229,6 +239,100 @@ async def test_poison_markdown_reclassification_clears_note_only_state(
     assert refreshed_inbound.to_id is None
     assert poison_refreshes == []
     assert [refresh.entity_id for refresh in source_refreshes] == [source.id]
+
+
+async def test_unfenced_legacy_inbound_source_defers_poison_cleanup(
+    app_config,
+    entity_service,
+    entity_repository,
+    relation_repository,
+    search_service,
+    file_service,
+) -> None:
+    project_id = relation_repository.project_id
+    assert project_id is not None
+    now = datetime.now(tz=UTC)
+    poison_path = "_phase7_import/.md"
+    poison = Entity(
+        project_id=project_id,
+        title="Poison note",
+        note_type="note",
+        content_type=RUNTIME_MARKDOWN_CONTENT_TYPE,
+        permalink="poison-note",
+        file_path=poison_path,
+        checksum="old-checksum",
+        created_at=now,
+        updated_at=now,
+    )
+    legacy_source = Entity(
+        project_id=project_id,
+        title="Legacy source",
+        note_type="note",
+        content_type=RUNTIME_MARKDOWN_CONTENT_TYPE,
+        permalink="legacy-source",
+        file_path="notes/legacy-source.md",
+        checksum="legacy-checksum",
+        created_at=now,
+        updated_at=now,
+    )
+    async with db.scoped_session(search_service.session_maker) as session:
+        poison = await entity_repository.add(session, poison)
+        legacy_source = await entity_repository.add(session, legacy_source)
+        inbound = await relation_repository.add(
+            session,
+            Relation(
+                project_id=project_id,
+                from_id=legacy_source.id,
+                to_id=poison.id,
+                to_name="poison-note",
+                relation_type="links-to",
+                generation=0,
+            ),
+        )
+        await NoteContentRepository(project_id=project_id).create(
+            session,
+            {
+                "entity_id": poison.id,
+                "markdown_content": "# Poison note",
+                "db_version": 1,
+                "db_checksum": "old-checksum",
+                "file_write_status": "synced",
+            },
+        )
+
+    batch_indexer = BatchIndexer(
+        project_id=project_id,
+        app_config=app_config,
+        entity_service=entity_service,
+        entity_repository=entity_repository,
+        observation_repository=entity_service.observation_repository,
+        relation_repository=relation_repository,
+        search_service=search_service,
+        file_writer=StorageIndexFileWriter(storage=file_service),
+        session_maker=search_service.session_maker,
+    )
+    result = await batch_indexer.index_files(
+        {
+            poison_path: IndexInputFile(
+                path=poison_path,
+                content_type=RUNTIME_RESOURCE_CONTENT_TYPE,
+                content=b"legacy poison bytes",
+                size=19,
+            )
+        },
+        max_concurrent=1,
+    )
+
+    assert result.errors == []
+    assert result.indexed[0].content_type == RUNTIME_MARKDOWN_CONTENT_TYPE
+    async with db.scoped_session(search_service.session_maker) as session:
+        preserved = await entity_repository.get_by_id(session, poison.id)
+        preserved_inbound = await relation_repository.select_by_id(session, inbound.id)
+
+    assert preserved is not None
+    assert preserved.is_markdown
+    assert preserved_inbound is not None
+    assert preserved_inbound.to_id == poison.id
 
 
 async def test_stale_resource_pass_preserves_newer_markdown_state(

--- a/tests/indexing/test_regular_file_classification.py
+++ b/tests/indexing/test_regular_file_classification.py
@@ -2,12 +2,14 @@
 
 from collections.abc import Sequence
 from datetime import UTC, datetime
+from types import SimpleNamespace
 
 import basic_memory.indexing.batch_indexer as batch_indexer_module
 from sqlalchemy.ext.asyncio import AsyncSession
 from basic_memory import db
 from basic_memory.indexing.batch_indexer import (
     BatchIndexer,
+    RUNTIME_MARKDOWN_CONTENT_TYPE,
     RUNTIME_RESOURCE_CONTENT_TYPE,
     regular_file_content_type,
 )
@@ -224,3 +226,88 @@ async def test_poison_markdown_reclassification_clears_note_only_state(
     assert refreshed_inbound.to_id is None
     assert poison_refreshes == []
     assert [refresh.entity_id for refresh in source_refreshes] == [source.id]
+
+
+async def test_stale_resource_pass_preserves_newer_markdown_state(
+    monkeypatch,
+    app_config,
+    entity_service,
+    entity_repository,
+    relation_repository,
+    search_service,
+    file_service,
+) -> None:
+    project_id = relation_repository.project_id
+    assert project_id is not None
+    now = datetime.now(tz=UTC)
+    note_path = "notes/current.md"
+    note = Entity(
+        project_id=project_id,
+        title="Current note",
+        note_type="note",
+        content_type="text/markdown",
+        permalink="current-note",
+        file_path=note_path,
+        checksum="new-markdown-checksum",
+        created_at=now,
+        updated_at=now,
+    )
+    async with db.scoped_session(search_service.session_maker) as session:
+        note = await entity_repository.add(session, note)
+        await NoteContentRepository(project_id=project_id).create(
+            session,
+            {
+                "entity_id": note.id,
+                "markdown_content": "# Current note",
+                "db_version": 2,
+                "db_checksum": "new-markdown-checksum",
+                "file_write_status": "synced",
+            },
+        )
+
+    async def stale_resource_snapshot(
+        *_args: object,
+        **_kwargs: object,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(id=note.id, is_markdown=False)
+
+    monkeypatch.setattr(entity_repository, "get_by_file_path", stale_resource_snapshot)
+    batch_indexer = BatchIndexer(
+        project_id=project_id,
+        app_config=app_config,
+        entity_service=entity_service,
+        entity_repository=entity_repository,
+        observation_repository=entity_service.observation_repository,
+        relation_repository=relation_repository,
+        search_service=search_service,
+        file_writer=StorageIndexFileWriter(storage=file_service),
+        session_maker=search_service.session_maker,
+    )
+
+    result = await batch_indexer.index_files(
+        {
+            note_path: IndexInputFile(
+                path=note_path,
+                content_type=RUNTIME_RESOURCE_CONTENT_TYPE,
+                content=b"stale resource bytes",
+                size=20,
+            )
+        },
+        max_concurrent=1,
+    )
+
+    assert result.errors == []
+    assert result.indexed[0].content_type == RUNTIME_MARKDOWN_CONTENT_TYPE
+    assert result.indexed[0].checksum == "new-markdown-checksum"
+    async with db.scoped_session(search_service.session_maker) as session:
+        preserved = await entity_repository.get_by_id(session, note.id)
+        note_content = await NoteContentRepository(project_id=project_id).get_by_entity_id(
+            session,
+            note.id,
+        )
+
+    assert preserved is not None
+    assert preserved.is_markdown
+    assert preserved.permalink == "current-note"
+    assert note_content is not None
+    assert note_content.markdown_content == "# Current note"

--- a/tests/indexing/test_relation_resolution.py
+++ b/tests/indexing/test_relation_resolution.py
@@ -14,6 +14,7 @@ from basic_memory.indexing.relation_resolution import (
     RELATION_RESOLUTION_WRITE_BATCH_SIZE,
     RESOLVE_RELATIONS_DEBOUNCE_SECONDS,
     RepositoryRelationResolutionRuntime,
+    RelationSearchRefreshResult,
     ResolveRelationsJobRequest,
     ResolveRelationsResult,
     plan_index_file_relation_resolution,
@@ -247,10 +248,11 @@ class StubEntityIndexer:
         entities: Sequence[Entity],
         *,
         content_by_entity_id: Mapping[int, str],
-    ) -> None:
+    ) -> RelationSearchRefreshResult:
         self.indexed_batches.append(tuple(entities))
         self.indexed_content_batches.append(dict(content_by_entity_id))
         self.indexed_entities.extend(entities)
+        return RelationSearchRefreshResult()
 
 
 class MissingFileEntityIndexer(StubEntityIndexer):
@@ -262,13 +264,15 @@ class MissingFileEntityIndexer(StubEntityIndexer):
         entities: Sequence[Entity],
         *,
         content_by_entity_id: Mapping[int, str],
-    ) -> None:
+    ) -> RelationSearchRefreshResult:
         missing_entity_ids = [
             entity.id for entity in entities if entity.id not in content_by_entity_id
         ]
         if missing_entity_ids:
-            raise FileNotFoundError(f"Missing Markdown for entities {missing_entity_ids}")
-        await super().index_entities(
+            return RelationSearchRefreshResult(
+                missing_content_entity_ids=frozenset(missing_entity_ids)
+            )
+        return await super().index_entities(
             entities,
             content_by_entity_id=content_by_entity_id,
         )
@@ -749,7 +753,7 @@ async def test_repository_runtime_refreshes_pending_source_from_accepted_content
 
 
 @pytest.mark.asyncio
-async def test_repository_runtime_preserves_missing_file_error_for_synced_source() -> None:
+async def test_repository_runtime_retires_missing_file_refresh_for_synced_source() -> None:
     repo = StubRelationRepository([[FakeRelation(id=1, from_id=10, to_name="Target A")]])
     runtime = build_repository_runtime(
         relation_repository=repo,
@@ -764,8 +768,8 @@ async def test_repository_runtime_preserves_missing_file_error_for_synced_source
         ],
     )
 
-    with pytest.raises(FileNotFoundError, match=r"entities \[10\]"):
-        await runtime.resolve_relations()
+    assert await runtime.resolve_relations() == {10}
+    assert repo.pending_search_refreshes == []
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_relation_resolution_search_writer.py
+++ b/tests/indexing/test_relation_resolution_search_writer.py
@@ -1,0 +1,43 @@
+"""Tests for per-entity relation search refresh outcomes."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from basic_memory.indexing.batch_indexer import RelationResolutionSearchWriter
+from basic_memory.indexing.relation_resolution import RelationSearchRefreshResult
+
+
+@pytest.mark.asyncio
+async def test_relation_search_writer_skips_only_missing_entity_content() -> None:
+    first = Mock(id=1)
+    missing = Mock(id=2)
+    last = Mock(id=3)
+    search_writer = Mock()
+    search_writer.index_entity_data = AsyncMock(
+        side_effect=[None, FileNotFoundError("missing object"), None]
+    )
+
+    result = await RelationResolutionSearchWriter(search_writer).index_entities(
+        [last, missing, first],
+        content_by_entity_id={1: "first", 3: "last"},
+    )
+
+    assert result == RelationSearchRefreshResult(missing_content_entity_ids=frozenset({2}))
+    assert [call.args[0].id for call in search_writer.index_entity_data.await_args_list] == [
+        1,
+        2,
+        3,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_relation_search_writer_preserves_unexpected_failures() -> None:
+    search_writer = Mock()
+    search_writer.index_entity_data = AsyncMock(side_effect=RuntimeError("search unavailable"))
+
+    with pytest.raises(RuntimeError, match="search unavailable"):
+        await RelationResolutionSearchWriter(search_writer).index_entities(
+            [Mock(id=1)],
+            content_by_entity_id={},
+        )

--- a/tests/indexing/test_relation_search_refresh_retry.py
+++ b/tests/indexing/test_relation_search_refresh_retry.py
@@ -8,7 +8,10 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from basic_memory import db
-from basic_memory.indexing.relation_resolution import RepositoryRelationResolutionRuntime
+from basic_memory.indexing.relation_resolution import (
+    RelationSearchRefreshResult,
+    RepositoryRelationResolutionRuntime,
+)
 from basic_memory.models import Entity, Relation, RelationSearchRefresh
 from basic_memory.repository.entity_repository import EntityRepository
 from basic_memory.repository.note_content_repository import (
@@ -151,14 +154,14 @@ async def test_relation_refresh_retries_after_search_write_failure_and_runtime_r
         entities: Sequence[Entity],
         *,
         content_by_entity_id: Mapping[int, str],
-    ) -> None:
+    ) -> RelationSearchRefreshResult:
         nonlocal refresh_attempts
         assert [entity.id for entity in entities] == [source_id]
         assert content_by_entity_id == {source_id: source_content}
         refresh_attempts += 1
         if refresh_attempts == 1:
             raise OSError("transient search refresh failure")
-        await original_index_entities(
+        return await original_index_entities(
             entities,
             content_by_entity_id=content_by_entity_id,
         )


### PR DESCRIPTION
## Why

Three production indexing failures share a Core-owned boundary: hot notes exhaust whole-job retries while a newer accepted generation is already queued, MIME-marked `.md` resource paths enter the note parser despite having no note basename, and relation search refreshes crash-loop when one entity's backing object is permanently absent.

This is the prerequisite for the coordinated Basic Memory Cloud production-bug shipment. The Cloud PR pins this exact commit and ships after Core.

## What Changed

- Return an explicit `content_superseded` file-index outcome after bounded stale-generation attempts and skip stale embedding follow-ups.
- Require both Markdown MIME and a valid Markdown note path before entering note parsing, so paths such as `_phase7_import/.md` remain ordinary resources.
- Reclassify legacy poison Markdown rows as resources while removing note-only graph and content projections.
- Report missing entity content as a bounded per-entity relation-search outcome, retire the corresponding refresh markers, and preserve unexpected search failures.

## Implementation Details

- The hot-note path keeps the last coherent derived snapshot and relies on the already-coalesced newer accepted write for convergence; it does not add locks or broaden transactions.
- `FileIndexResult.content_superseded` carries the convergence obligation into the existing job result and embedding planner.
- Legacy poison-row repair follows the canonical NoteContent-before-Entity lock order so it cannot deadlock accepted-note writers.
- `RelationSearchRefreshResult` is a typed aggregate result. Only `FileNotFoundError` becomes a missing-content outcome; other failures still propagate for retry and diagnosis.
- Local and portable indexing adapters use the same path-validity rule.

## Testing

### Automated

- `just fast-check`: passed on the current head.
- `uv run pytest tests/indexing/test_note_content_reconciler.py tests/indexing/test_regular_file_classification.py -q`: 21 passed, covering stable legacy cleanup, both sides of the bootstrap/reclassification race, and conservative deferral for unfenced legacy inbound sources.
- Focused SQLite indexing and relation tests: passed.
- Focused PostgreSQL indexing and relation tests: 35 passed.
- `just doctor`: passed (write, index, search, and status round trip).
- `just test`: SQLite phases passed; the broad PostgreSQL unit phase hit the repository's 120-second timeout watchdog. The focused PostgreSQL tests for every changed path pass.

## Risks / Follow-ups

- The Cloud shipment must pin this commit before its integration tests and merge after this PR.
- Production verification and any tenant-specific reconciliation remain Cloud release-window work and require separate authorization.
- Related Cloud issues: basicmachines-co/basic-memory-cloud#1782, basicmachines-co/basic-memory-cloud#1779, and basicmachines-co/basic-memory-cloud#1328.
