### PR TITLE
feat(mcp): surface similar existing notes after write_note creates a note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Features
+
+- **#1259**: `write_note` now tells the caller when a freshly created note looks like
+  notes that already exist. With semantic search enabled, a create probes the vector
+  index with the new note's title and opening content and appends a "Similar existing
+  notes" section listing the closest matches, phrased as a question -- did you mean to
+  write to one of these? -- with the ways out spelled out: merge into the existing note
+  with `edit_note` and delete the new one, link the two with a relation, or ignore it.
+  JSON output carries the same list as `similar_notes`. No similarity scores are shown
+  and nothing is overwritten on the caller's behalf: on the default embedding model a
+  near-duplicate and a merely related note score in the same band, so the decision
+  stays with the agent, which has the context the score does not.
+
 ### Bug Fixes
 
 - **#1344**: Deleting a note no longer erases the relations pointing at it. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,15 @@
 ### Features
 
 - **#1259**: `write_note` now tells the caller when a freshly created note looks like
-  notes that already exist. With semantic search enabled, a create probes the vector
-  index with the new note's title and opening content and appends a "Similar existing
-  notes" section listing the closest matches, phrased as a question -- did you mean to
-  write to one of these? -- with the ways out spelled out: merge into the existing note
-  with `edit_note` and delete the new one, link the two with a relation, or ignore it.
-  JSON output carries the same list as `similar_notes`. No similarity scores are shown
-  and nothing is overwritten on the caller's behalf: on the default embedding model a
-  near-duplicate and a merely related note score in the same band, so the decision
-  stays with the agent, which has the context the score does not.
+  notes that already exist. On a server with semantic search enabled, a create probes
+  the vector index with the new note's title and opening content and appends a
+  "Similar existing notes" section listing the closest matches, phrased as a question
+  -- did you mean to write to one of these? -- with the ways out spelled out: merge
+  into the existing note with `edit_note` and delete the new one, link the two with a
+  relation, or ignore it. JSON output carries the same list as `similar_notes`. No
+  similarity scores are shown and nothing is overwritten on the caller's behalf: on the
+  default embedding model a near-duplicate and a merely related note score in the same
+  band, so the decision stays with the agent, which has the context the score does not.
 
 ### Bug Fixes
 

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -579,8 +579,9 @@ note score in the same similarity band (roughly 0.78–0.94 on a 200-note vault
 with no true duplicates), so no threshold separates them and no scores are
 shown. Ranking is reliable — the note an agent probably meant is almost always
 first — which is why the list is short and ordered. Only creates ask the index;
-an overwrite already names its target. A probe failure is logged and never
-fails the write.
+an overwrite already names its target. When the API refuses or cannot complete
+the probe (semantic search disabled server-side, a transport failure), the
+failure is logged and the write is still reported as successful.
 
 ## The Reindex Command
 

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -551,9 +551,9 @@ not change stored embeddings, so it does not require `bm reindex --embeddings`.
 
 ## Similar Notes on Write
 
-When semantic search is enabled, `write_note` checks the vector index after it
-creates a note and appends a **Similar existing notes** section when the index
-holds close neighbors:
+When the project's server has semantic search enabled, `write_note` checks the
+vector index after it creates a note and appends a **Similar existing notes**
+section when the index holds close neighbors:
 
 ```markdown
 ## Similar existing notes
@@ -579,9 +579,12 @@ note score in the same similarity band (roughly 0.78–0.94 on a 200-note vault
 with no true duplicates), so no threshold separates them and no scores are
 shown. Ranking is reliable — the note an agent probably meant is almost always
 first — which is why the list is short and ordered. Only creates ask the index;
-an overwrite already names its target. When the API refuses or cannot complete
-the probe (semantic search disabled server-side, a transport failure), the
-failure is logged and the write is still reported as successful.
+an overwrite already names its target. The probe is always attempted rather
+than gated on the local `semantic_search_enabled` setting, because a local MCP
+can route a write to a cloud project whose server has semantic search on while
+the local install does not; a server that declines the probe (semantic search
+disabled, no embedding provider) or cannot complete it (a transport failure)
+suppresses the section, and the write is still reported as successful.
 
 ## The Reindex Command
 

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -549,6 +549,39 @@ Start with the defaults, then tune only if measurements justify it:
 Changing reranker providers, models, candidate counts, or document caps does
 not change stored embeddings, so it does not require `bm reindex --embeddings`.
 
+## Similar Notes on Write
+
+When semantic search is enabled, `write_note` checks the vector index after it
+creates a note and appends a **Similar existing notes** section when the index
+holds close neighbors:
+
+```markdown
+## Similar existing notes
+This note looks similar to notes that already exist. Did you mean to write to one of these?
+- Reference BU Product Mapping (`main/reference/reference-bu-product-mapping`)
+- Product Catalog (`main/reference/product-catalog`)
+
+| If it is... | Then |
+|---|---|
+| The same topic | `read_note("main/reference/reference-bu-product-mapping")`, then `edit_note(..., operation="append", ...)` and `delete_note("main/analysis/bu-mapping-analysis")` |
+| Related but distinct | Add a relation here, e.g. `- relates_to [[Reference BU Product Mapping]]` |
+| Unrelated | Nothing to do |
+```
+
+The probe is the new note's title and opening content, run as a vector-only
+search with the new note's own row removed (vectors publish in the background,
+so it may or may not be indexed yet). `output_format="json"` returns the same
+list as `similar_notes`.
+
+The advisory is deliberately a question, not a decision. On the default
+`bge-small-en-v1.5` model a rewrite of an existing note and a merely related
+note score in the same similarity band (roughly 0.78–0.94 on a 200-note vault
+with no true duplicates), so no threshold separates them and no scores are
+shown. Ranking is reliable — the note an agent probably meant is almost always
+first — which is why the list is short and ordered. Only creates ask the index;
+an overwrite already names its target. A probe failure is logged and never
+fails the write.
+
 ## The Reindex Command
 
 The `bm reindex` command rebuilds search indexes without dropping the database.

--- a/src/basic_memory/mcp/tools/write_note.py
+++ b/src/basic_memory/mcp/tools/write_note.py
@@ -15,6 +15,7 @@ from basic_memory.file_utils import remove_frontmatter
 from basic_memory.mcp.project_context import get_project_client, add_project_metadata
 from basic_memory.mcp.server import mcp
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from basic_memory.schemas.base import Entity
 from basic_memory.schemas.search import (
     SearchItemType,
@@ -489,10 +490,13 @@ async def write_note(
                         exclude_file_path=result.file_path,
                         exclude_permalink=result.permalink,
                     )
-                except Exception as probe_error:
-                    # The note is on disk. Raising here would report a successful write as
-                    # a failure and invite a retry that creates the very duplicate this
-                    # advisory exists to catch, so the probe degrades to silence.
+                except ToolError as probe_error:
+                    # ToolError is what the search client raises when the API refuses or
+                    # cannot complete the probe: semantic search disabled server-side,
+                    # missing embedding dependencies, a 5xx, a transport failure. The note
+                    # is already on disk, so those expected failures must not be reported
+                    # as a failed write. Anything else is a defect in this code path and
+                    # stays visible rather than degrading to an empty advisory.
                     logger.warning(
                         f"write_note similar-note probe failed project={active_project.name} "
                         f"permalink={result.permalink}: {probe_error}"

--- a/src/basic_memory/mcp/tools/write_note.py
+++ b/src/basic_memory/mcp/tools/write_note.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Annotated, List, Union, Optional, Literal
 
 import logfire
+from httpx import HTTPStatusError
 from loguru import logger
 from pydantic import AliasChoices, BeforeValidator, Field
 
@@ -118,6 +119,21 @@ async def _find_similar_notes(
         exclude_permalink=exclude_permalink,
         limit=SIMILAR_NOTES_LIMIT,
     )
+
+
+def _probe_declined_by_server(error: BaseException) -> bool:
+    """Return whether the search API refused the probe outright (HTTP 400).
+
+    That is how the API answers when semantic search is disabled or has no embedding
+    provider: a configuration state of the routed server, not a failure worth a warning
+    on every create.
+    """
+    current: BaseException | None = error
+    while current is not None:
+        if isinstance(current, HTTPStatusError):
+            return current.response.status_code == 400
+        current = current.__cause__
+    return False
 
 
 def _format_similar_notes_section(
@@ -283,8 +299,8 @@ async def write_note(
         - Observation counts by category
         - Relation counts (resolved/unresolved)
         - Tags if present
-        - Closest existing notes when the note was created and semantic search is
-          enabled, so an accidental near-duplicate can be merged instead of kept
+        - Closest existing notes when the note was created and the project's server has
+          semantic search enabled, so an accidental near-duplicate can be merged instead of kept
         - Session tracking metadata for project awareness
 
     Examples:
@@ -336,9 +352,8 @@ async def write_note(
     # Resolve overwrite flag: explicit parameter > config default
     # Trigger: caller omitted the parameter (None)
     # Why: lets users set a global default without breaking per-call overrides
-    app_config = ConfigManager().config
     effective_overwrite = (
-        overwrite if overwrite is not None else app_config.write_note_overwrite_default
+        overwrite if overwrite is not None else ConfigManager().config.write_note_overwrite_default
     )
     project = _compose_workspace_project_route(
         workspace=workspace,
@@ -473,15 +488,19 @@ async def write_note(
                     # Re-raise if it's not a conflict error
                     raise  # pragma: no cover
             # --- Similar-note advisory ---
-            # Trigger: the note was created (not updated) and semantic search is on.
+            # Trigger: the note was created (not updated).
             # Why: agents writing across sessions know the topic but not whether a note on
             #      it already exists (#1259). A near-duplicate and a merely related note are
             #      not separable by similarity score, so nothing is overwritten on the
             #      caller's behalf; the closest notes are surfaced and the call is theirs.
+            #      Whether semantic search is available is the routed server's call, not
+            #      this process's config: a local MCP can route a write to a cloud project
+            #      whose vectors are on while the local install's are off, so the probe is
+            #      always attempted and the server's refusal suppresses it.
             # Outcome: the summary gains a "Similar existing notes" section when the index
             #          has neighbors. The write itself is already complete either way.
             similar_notes: list[SimilarNote] = []
-            if action == "Created" and app_config.semantic_search_enabled:
+            if action == "Created":
                 try:
                     similar_notes = await _find_similar_notes(
                         SearchClient(client, active_project.external_id),
@@ -497,7 +516,10 @@ async def write_note(
                     # is already on disk, so those expected failures must not be reported
                     # as a failed write. Anything else is a defect in this code path and
                     # stays visible rather than degrading to an empty advisory.
-                    logger.warning(
+                    probe_log = (
+                        logger.debug if _probe_declined_by_server(probe_error) else logger.warning
+                    )
+                    probe_log(
                         f"write_note similar-note probe failed project={active_project.name} "
                         f"permalink={result.permalink}: {probe_error}"
                     )

--- a/src/basic_memory/mcp/tools/write_note.py
+++ b/src/basic_memory/mcp/tools/write_note.py
@@ -1,18 +1,27 @@
 """Write note tool for Basic Memory MCP server."""
 
+import dataclasses
 import textwrap
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Annotated, List, Union, Optional, Literal
+from typing import TYPE_CHECKING, Any, Annotated, List, Union, Optional, Literal
 
 import logfire
 from loguru import logger
 from pydantic import AliasChoices, BeforeValidator, Field
 
 from basic_memory.config import ConfigManager
+from basic_memory.file_utils import remove_frontmatter
 from basic_memory.mcp.project_context import get_project_client, add_project_metadata
 from basic_memory.mcp.server import mcp
 from fastmcp import Context
 from basic_memory.schemas.base import Entity
+from basic_memory.schemas.search import (
+    SearchItemType,
+    SearchQuery,
+    SearchResult,
+    SearchRetrievalMode,
+)
 from basic_memory.utils import (
     build_qualified_permalink_reference,
     coerce_dict,
@@ -21,8 +30,122 @@ from basic_memory.utils import (
 )
 from basic_memory.workspace_context import current_workspace_permalink_context
 
+if TYPE_CHECKING:  # pragma: no cover
+    from basic_memory.mcp.clients import SearchClient
+
 # Define TagType as a Union that can accept either a string or a list of strings or None
 TagType = Union[List[str], str, None]
+
+# --- Similar-note advisory -------------------------------------------------------------
+# How many neighbors to surface after a create. Ranking is reliable enough to put the note
+# an agent probably meant at the top; a longer list adds noise, not signal.
+SIMILAR_NOTES_LIMIT = 3
+# The vector index embeds a note's title and opening content as its first chunk, so the
+# probe copies that shape and length to land in the same neighborhood as the note itself.
+SIMILAR_NOTES_PROBE_CHARS = 900
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SimilarNote:
+    """An existing note the search index ranked closest to a freshly created one."""
+
+    title: str
+    permalink: str | None
+    file_path: str
+
+
+def _compose_similarity_probe(title: str, content: str) -> str:
+    """Build the text used to look for existing notes near a freshly written one."""
+    body = remove_frontmatter(content)
+    return f"{title}\n\n{body}"[:SIMILAR_NOTES_PROBE_CHARS].strip()
+
+
+def _collapse_similar_notes(
+    results: Sequence[SearchResult],
+    *,
+    exclude_file_path: str,
+    exclude_permalink: str | None,
+    limit: int,
+) -> list[SimilarNote]:
+    """Drop the note that was just written and keep one row per remaining note.
+
+    The new note's own row may or may not be indexed yet — vectors publish in the
+    background — so it is removed when present rather than expected.
+    """
+    similar_notes: list[SimilarNote] = []
+    seen_paths: set[str] = set()
+    for result in results:
+        is_new_note = result.file_path == exclude_file_path or (
+            exclude_permalink is not None and result.permalink == exclude_permalink
+        )
+        if is_new_note or result.file_path in seen_paths:
+            continue
+        seen_paths.add(result.file_path)
+        similar_notes.append(
+            SimilarNote(title=result.title, permalink=result.permalink, file_path=result.file_path)
+        )
+        if len(similar_notes) == limit:
+            break
+    return similar_notes
+
+
+async def _find_similar_notes(
+    search_client: "SearchClient",
+    *,
+    title: str,
+    content: str,
+    exclude_file_path: str,
+    exclude_permalink: str | None,
+) -> list[SimilarNote]:
+    """Ask the vector index which existing notes sit closest to the note just written.
+
+    Vector-only retrieval keeps the probe out of the FTS query parser, which would read
+    parentheses and boolean words in ordinary prose as operators.
+    """
+    query = SearchQuery(
+        text=_compose_similarity_probe(title, content),
+        retrieval_mode=SearchRetrievalMode.VECTOR,
+        entity_types=[SearchItemType.ENTITY],
+    )
+    # One extra row leaves room for the new note's own hit before collapsing.
+    response = await search_client.search(
+        query.model_dump(), page=1, page_size=SIMILAR_NOTES_LIMIT + 1
+    )
+    return _collapse_similar_notes(
+        response.results,
+        exclude_file_path=exclude_file_path,
+        exclude_permalink=exclude_permalink,
+        limit=SIMILAR_NOTES_LIMIT,
+    )
+
+
+def _format_similar_notes_section(
+    similar_notes: Sequence[SimilarNote], *, new_permalink: str | None
+) -> str:
+    """Render the advisory as a question with the ways out spelled out.
+
+    Similarity scores are deliberately absent: on the default model a near-duplicate and
+    a merely related note score in the same band, so a number would imply a precision the
+    signal does not have. Ranking is the useful part.
+    """
+    closest = similar_notes[0]
+    closest_ref = closest.permalink or closest.file_path
+    lines = [
+        "",
+        "## Similar existing notes",
+        "This note looks similar to notes that already exist. "
+        "Did you mean to write to one of these?",
+        *(f"- {note.title} (`{note.permalink or note.file_path}`)" for note in similar_notes),
+        "",
+        "| If it is... | Then |",
+        "|---|---|",
+        f'| The same topic | `read_note("{closest_ref}")`, then '
+        f'`edit_note("{closest_ref}", operation="append", content="...")` '
+        f'and `delete_note("{new_permalink}")` |',
+        f"| Related but distinct | Add a relation here, e.g. `- relates_to [[{closest.title}]]` |",
+        "| Unrelated | Nothing to do |",
+    ]
+    return "\n".join(lines)
 
 
 def _compose_workspace_project_route(
@@ -159,6 +282,8 @@ async def write_note(
         - Observation counts by category
         - Relation counts (resolved/unresolved)
         - Tags if present
+        - Closest existing notes when the note was created and semantic search is
+          enabled, so an accidental near-duplicate can be merged instead of kept
         - Session tracking metadata for project awareness
 
     Examples:
@@ -210,8 +335,9 @@ async def write_note(
     # Resolve overwrite flag: explicit parameter > config default
     # Trigger: caller omitted the parameter (None)
     # Why: lets users set a global default without breaking per-call overrides
+    app_config = ConfigManager().config
     effective_overwrite = (
-        overwrite if overwrite is not None else ConfigManager().config.write_note_overwrite_default
+        overwrite if overwrite is not None else app_config.write_note_overwrite_default
     )
     project = _compose_workspace_project_route(
         workspace=workspace,
@@ -281,7 +407,7 @@ async def write_note(
             )
 
             # Import here to avoid circular import
-            from basic_memory.mcp.clients import KnowledgeClient
+            from basic_memory.mcp.clients import KnowledgeClient, SearchClient
 
             # Use typed KnowledgeClient for API calls
             knowledge_client = KnowledgeClient(client, active_project.external_id)
@@ -345,14 +471,55 @@ async def write_note(
                 else:
                     # Re-raise if it's not a conflict error
                     raise  # pragma: no cover
+            # --- Similar-note advisory ---
+            # Trigger: the note was created (not updated) and semantic search is on.
+            # Why: agents writing across sessions know the topic but not whether a note on
+            #      it already exists (#1259). A near-duplicate and a merely related note are
+            #      not separable by similarity score, so nothing is overwritten on the
+            #      caller's behalf; the closest notes are surfaced and the call is theirs.
+            # Outcome: the summary gains a "Similar existing notes" section when the index
+            #          has neighbors. The write itself is already complete either way.
+            similar_notes: list[SimilarNote] = []
+            if action == "Created" and app_config.semantic_search_enabled:
+                try:
+                    similar_notes = await _find_similar_notes(
+                        SearchClient(client, active_project.external_id),
+                        title=title,
+                        content=content,
+                        exclude_file_path=result.file_path,
+                        exclude_permalink=result.permalink,
+                    )
+                except Exception as probe_error:
+                    # The note is on disk. Raising here would report a successful write as
+                    # a failure and invite a retry that creates the very duplicate this
+                    # advisory exists to catch, so the probe degrades to silence.
+                    logger.warning(
+                        f"write_note similar-note probe failed project={active_project.name} "
+                        f"permalink={result.permalink}: {probe_error}"
+                    )
+
             response_permalink = result.permalink
             workspace_context = current_workspace_permalink_context()
-            if response_permalink and workspace_context is not None:
-                response_permalink = build_qualified_permalink_reference(
-                    active_project.permalink,
-                    response_permalink,
-                    workspace_permalink=workspace_context.workspace_slug,
-                )
+            if workspace_context is not None:
+                if response_permalink:
+                    response_permalink = build_qualified_permalink_reference(
+                        active_project.permalink,
+                        response_permalink,
+                        workspace_permalink=workspace_context.workspace_slug,
+                    )
+                similar_notes = [
+                    dataclasses.replace(
+                        note,
+                        permalink=build_qualified_permalink_reference(
+                            active_project.permalink,
+                            note.permalink,
+                            workspace_permalink=workspace_context.workspace_slug,
+                        ),
+                    )
+                    if note.permalink
+                    else note
+                    for note in similar_notes
+                ]
 
             summary = [
                 f"# {action} note",
@@ -393,9 +560,14 @@ async def write_note(
             if tag_list:
                 summary.append(f"\n## Tags\n- {', '.join(tag_list)}")
 
+            if similar_notes:
+                summary.append(
+                    _format_similar_notes_section(similar_notes, new_permalink=response_permalink)
+                )
+
             # Log the response with structured data
             logger.info(
-                f"MCP tool response: tool=write_note project={active_project.name} action={action} permalink={response_permalink} observations_count={len(result.observations)} relations_count={len(result.relations)} resolved_relations={resolved} unresolved_relations={unresolved}"
+                f"MCP tool response: tool=write_note project={active_project.name} action={action} permalink={response_permalink} observations_count={len(result.observations)} relations_count={len(result.relations)} resolved_relations={resolved} unresolved_relations={unresolved} similar_notes_count={len(similar_notes)}"
             )
             if output_format == "json":
                 return {
@@ -404,6 +576,7 @@ async def write_note(
                     "file_path": result.file_path,
                     "checksum": result.checksum,
                     "action": action.lower(),
+                    "similar_notes": [dataclasses.asdict(note) for note in similar_notes],
                 }
 
             summary_result = "\n".join(summary)

--- a/tests/mcp/test_tool_write_note.py
+++ b/tests/mcp/test_tool_write_note.py
@@ -1,6 +1,5 @@
 """Tests for note tools that exercise the full stack with SQLite."""
 
-import importlib
 from textwrap import dedent
 from typing import Any
 
@@ -21,10 +20,6 @@ from basic_memory.mcp.tools.write_note import (
 from basic_memory.repository.relation_repository import RelationRepository
 from basic_memory.schemas.search import SearchItemType, SearchResponse, SearchResult
 from basic_memory.workspace_context import workspace_permalink_context
-
-# The tools package re-exports the write_note *function* under the submodule's name,
-# so the module has to be fetched by path to patch what the tool reads.
-write_note_module = importlib.import_module("basic_memory.mcp.tools.write_note")
 
 
 # ---------------------------------------------------------------------------
@@ -1650,28 +1645,8 @@ def stub_search_client(monkeypatch) -> type[_StubSearchClient]:
     return StubSearchClient
 
 
-@pytest.fixture
-def semantic_search_on(monkeypatch, app_config):
-    """Enable the advisory the way write_note sees it, without touching the app's config.
-
-    Flipping the real app_config would also make the API schedule embeddings for every
-    write in this test, which needs the ONNX model. The tool layer only reads two fields.
-    """
-
-    class ToolConfig:
-        write_note_overwrite_default = app_config.write_note_overwrite_default
-        semantic_search_enabled = True
-
-    class ToolConfigManager:
-        config = ToolConfig()
-
-    monkeypatch.setattr(write_note_module, "ConfigManager", ToolConfigManager)
-
-
 @pytest.mark.asyncio
-async def test_write_note_surfaces_similar_existing_notes(
-    app, test_project, semantic_search_on, stub_search_client
-):
+async def test_write_note_surfaces_similar_existing_notes(app, test_project, stub_search_client):
     """A create lists the closest existing notes as a question, never as a decision."""
     new_permalink = f"{test_project.name}/analysis/bu-mapping-analysis"
     reference_permalink = f"{test_project.name}/reference/reference-bu-product-mapping"
@@ -1722,9 +1697,7 @@ async def test_write_note_surfaces_similar_existing_notes(
 
 
 @pytest.mark.asyncio
-async def test_write_note_json_output_carries_similar_notes(
-    app, test_project, semantic_search_on, stub_search_client
-):
+async def test_write_note_json_output_carries_similar_notes(app, test_project, stub_search_client):
     stub_search_client.results = [
         _entity_result(
             "Reference BU Product Mapping",
@@ -1755,7 +1728,7 @@ async def test_write_note_json_output_carries_similar_notes(
 
 @pytest.mark.asyncio
 async def test_write_note_omits_advisory_when_index_has_no_neighbors(
-    app, test_project, semantic_search_on, stub_search_client
+    app, test_project, stub_search_client
 ):
     stub_search_client.results = []
 
@@ -1780,30 +1753,27 @@ async def test_write_note_omits_advisory_when_index_has_no_neighbors(
 
 
 @pytest.mark.asyncio
-async def test_write_note_skips_advisory_when_semantic_search_is_disabled(
-    app, test_project, stub_search_client
-):
-    """The test config leaves semantic search off, so no probe should be attempted."""
-    stub_search_client.results = [
-        _entity_result("Neighbor", f"{test_project.name}/n/neighbor", "n/Neighbor.md", 0.9)
-    ]
+async def test_write_note_omits_advisory_when_server_declines_the_probe(app, test_project):
+    """The test app runs with semantic search off; the API's refusal suppresses the section.
 
+    No stub here: the probe goes through the real search client and the real router, which
+    is the path a local install without embeddings takes on every create. The gate is the
+    routed server's, not this process's config, because a local MCP can route a write to a
+    cloud project whose semantic search is on while the local install's is off.
+    """
     result = await write_note(
         project=test_project.name,
         title="Plain Write",
         directory="analysis",
-        content="# Plain Write\n\nSemantic search is off here.",
+        content="# Plain Write\n\nSemantic search is off on this server.",
     )
 
     assert "# Created note" in result
     assert "## Similar existing notes" not in result
-    assert stub_search_client.calls == []
 
 
 @pytest.mark.asyncio
-async def test_write_note_does_not_probe_on_overwrite(
-    app, test_project, semantic_search_on, stub_search_client
-):
+async def test_write_note_does_not_probe_on_overwrite(app, test_project, stub_search_client):
     """An overwrite already names its target; only creates ask the index."""
     stub_search_client.results = [
         _entity_result("Neighbor", f"{test_project.name}/n/neighbor", "n/Neighbor.md", 0.9)
@@ -1833,7 +1803,7 @@ async def test_write_note_does_not_probe_on_overwrite(
 
 @pytest.mark.asyncio
 async def test_write_note_survives_expected_similar_note_probe_failure(
-    app, test_project, semantic_search_on, stub_search_client
+    app, test_project, stub_search_client
 ):
     """An API refusal or transport failure (ToolError) must not undo a completed write."""
     stub_search_client.error = ToolError("Semantic search is disabled.")
@@ -1853,7 +1823,7 @@ async def test_write_note_survives_expected_similar_note_probe_failure(
 
 @pytest.mark.asyncio
 async def test_write_note_qualifies_similar_note_permalinks_in_workspace_context(
-    app, test_project, semantic_search_on, stub_search_client
+    app, test_project, stub_search_client
 ):
     """Cloud requests carry a workspace slug; neighbors get the same qualified form as the note."""
     stub_search_client.results = [
@@ -1894,7 +1864,7 @@ async def test_write_note_qualifies_similar_note_permalinks_in_workspace_context
 
 @pytest.mark.asyncio
 async def test_write_note_surfaces_unexpected_similar_note_probe_errors(
-    app, test_project, semantic_search_on, stub_search_client
+    app, test_project, stub_search_client
 ):
     """A defect in the probe path stays visible instead of degrading to an empty advisory."""
     stub_search_client.error = RuntimeError("search response contract changed")

--- a/tests/mcp/test_tool_write_note.py
+++ b/tests/mcp/test_tool_write_note.py
@@ -1,15 +1,30 @@
 """Tests for note tools that exercise the full stack with SQLite."""
 
+import importlib
 from textwrap import dedent
 from typing import Any
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 from basic_memory import db
 from basic_memory import config as config_module
+from basic_memory.mcp import clients as clients_module
 from basic_memory.mcp.tools import write_note, read_note, delete_note
-from basic_memory.mcp.tools.write_note import _compose_workspace_project_route
+from basic_memory.mcp.tools.write_note import (
+    SIMILAR_NOTES_LIMIT,
+    SIMILAR_NOTES_PROBE_CHARS,
+    _collapse_similar_notes,
+    _compose_similarity_probe,
+    _compose_workspace_project_route,
+)
 from basic_memory.repository.relation_repository import RelationRepository
+from basic_memory.schemas.search import SearchItemType, SearchResponse, SearchResult
+from basic_memory.workspace_context import workspace_permalink_context
+
+# The tools package re-exports the write_note *function* under the submodule's name,
+# so the module has to be fetched by path to patch what the tool reads.
+write_note_module = importlib.import_module("basic_memory.mcp.tools.write_note")
 
 
 # ---------------------------------------------------------------------------
@@ -1547,3 +1562,331 @@ class TestWriteNoteOverwriteGuard:
             assert stray is None, (
                 f"overwrite=True minted a stray '{suffix}' suffix on the canonical permalink"
             )
+
+
+# ---------------------------------------------------------------------------
+# Similar-note advisory (#1259)
+# ---------------------------------------------------------------------------
+
+
+def _entity_result(title: str, permalink: str | None, file_path: str, score: float) -> SearchResult:
+    return SearchResult(
+        title=title,
+        type=SearchItemType.ENTITY,
+        score=score,
+        permalink=permalink,
+        file_path=file_path,
+    )
+
+
+def test_similarity_probe_leads_with_title_and_drops_frontmatter():
+    probe = _compose_similarity_probe(
+        "BU Product Mapping",
+        "---\ntitle: ignored\n---\n\n# BU Product Mapping\n\nWhich units own which products.",
+    )
+    assert probe.startswith("BU Product Mapping\n\n# BU Product Mapping")
+    assert "title: ignored" not in probe
+
+
+def test_similarity_probe_is_bounded_to_the_index_chunk_size():
+    probe = _compose_similarity_probe("Long", "word " * 1000)
+    assert len(probe) <= SIMILAR_NOTES_PROBE_CHARS
+
+
+def test_collapse_similar_notes_drops_the_new_note_and_repeat_rows():
+    rows = [
+        # The freshly written note, already indexed: matched by file_path ...
+        _entity_result("New", "p/new", "new/New.md", 0.99),
+        # ... and by permalink, in case the index holds it under another path.
+        _entity_result("New again", "p/new", "elsewhere/New.md", 0.98),
+        _entity_result("A", "p/a", "a/A.md", 0.9),
+        _entity_result("A (second row)", "p/a-2", "a/A.md", 0.89),
+        _entity_result("B", "p/b", "b/B.md", 0.8),
+        _entity_result("C", "p/c", "c/C.md", 0.7),
+        _entity_result("D", "p/d", "d/D.md", 0.6),
+    ]
+
+    similar = _collapse_similar_notes(
+        rows, exclude_file_path="new/New.md", exclude_permalink="p/new", limit=3
+    )
+
+    assert [note.title for note in similar] == ["A", "B", "C"]
+    assert similar[0].permalink == "p/a"
+
+
+class _StubSearchClient:
+    """Stands in for the typed search client: records the probe, returns canned rows."""
+
+    calls: list[dict[str, Any]]
+    results: list[SearchResult]
+    error: Exception | None
+
+    def __init__(self, http_client: Any, project_id: str) -> None:
+        self.project_id = project_id
+
+    async def search(self, payload: dict[str, Any], *, page: int, page_size: int) -> SearchResponse:
+        type(self).calls.append({"payload": payload, "page": page, "page_size": page_size})
+        error = type(self).error
+        if error is not None:
+            raise error
+        return SearchResponse(
+            results=type(self).results,
+            current_page=page,
+            page_size=page_size,
+            total=0,
+            total_is_exact=False,
+        )
+
+
+@pytest.fixture
+def stub_search_client(monkeypatch) -> type[_StubSearchClient]:
+    class StubSearchClient(_StubSearchClient):
+        calls: list[dict[str, Any]] = []
+        results: list[SearchResult] = []
+        error: Exception | None = None
+
+    # write_note imports the client at call time, so patching the package attribute is enough.
+    monkeypatch.setattr(clients_module, "SearchClient", StubSearchClient)
+    return StubSearchClient
+
+
+@pytest.fixture
+def semantic_search_on(monkeypatch, app_config):
+    """Enable the advisory the way write_note sees it, without touching the app's config.
+
+    Flipping the real app_config would also make the API schedule embeddings for every
+    write in this test, which needs the ONNX model. The tool layer only reads two fields.
+    """
+
+    class ToolConfig:
+        write_note_overwrite_default = app_config.write_note_overwrite_default
+        semantic_search_enabled = True
+
+    class ToolConfigManager:
+        config = ToolConfig()
+
+    monkeypatch.setattr(write_note_module, "ConfigManager", ToolConfigManager)
+
+
+@pytest.mark.asyncio
+async def test_write_note_surfaces_similar_existing_notes(
+    app, test_project, semantic_search_on, stub_search_client
+):
+    """A create lists the closest existing notes as a question, never as a decision."""
+    new_permalink = f"{test_project.name}/analysis/bu-mapping-analysis"
+    reference_permalink = f"{test_project.name}/reference/reference-bu-product-mapping"
+    stub_search_client.results = [
+        # The note we just wrote may already be indexed; it must not be offered to itself.
+        _entity_result(
+            "BU Mapping Analysis", new_permalink, "analysis/BU Mapping Analysis.md", 0.99
+        ),
+        _entity_result(
+            "Reference BU Product Mapping",
+            reference_permalink,
+            "reference/Reference BU Product Mapping.md",
+            0.86,
+        ),
+        _entity_result(
+            "Product Catalog",
+            f"{test_project.name}/reference/product-catalog",
+            "reference/Product Catalog.md",
+            0.74,
+        ),
+    ]
+
+    result = await write_note(
+        project=test_project.name,
+        title="BU Mapping Analysis",
+        directory="analysis",
+        content="# BU Mapping Analysis\n\nWhich business units (BUs) own which products.",
+    )
+
+    assert isinstance(result, str)
+    assert "# Created note" in result
+    _, section = result.split("## Similar existing notes", 1)
+    assert "Did you mean to write to one of these?" in section
+    assert f"- Reference BU Product Mapping (`{reference_permalink}`)" in section
+    assert "- Product Catalog (`" in section
+    assert "- BU Mapping Analysis (`" not in section
+    assert f'read_note("{reference_permalink}")' in section
+    assert f'delete_note("{new_permalink}")' in section
+    assert "relates_to [[Reference BU Product Mapping]]" in section
+    assert "score" not in section.lower()
+
+    [call] = stub_search_client.calls
+    assert call["payload"]["retrieval_mode"] == "vector"
+    assert call["payload"]["entity_types"] == ["entity"]
+    assert call["payload"]["text"].startswith("BU Mapping Analysis\n\n# BU Mapping Analysis")
+    assert call["page"] == 1
+    assert call["page_size"] == SIMILAR_NOTES_LIMIT + 1
+
+
+@pytest.mark.asyncio
+async def test_write_note_json_output_carries_similar_notes(
+    app, test_project, semantic_search_on, stub_search_client
+):
+    stub_search_client.results = [
+        _entity_result(
+            "Reference BU Product Mapping",
+            f"{test_project.name}/reference/reference-bu-product-mapping",
+            "reference/Reference BU Product Mapping.md",
+            0.86,
+        ),
+    ]
+
+    result = await write_note(
+        project=test_project.name,
+        title="BU Mapping Analysis",
+        directory="analysis",
+        content="# BU Mapping Analysis\n\nWhich business units own which products.",
+        output_format="json",
+    )
+
+    assert isinstance(result, dict)
+    assert result["action"] == "created"
+    assert result["similar_notes"] == [
+        {
+            "title": "Reference BU Product Mapping",
+            "permalink": f"{test_project.name}/reference/reference-bu-product-mapping",
+            "file_path": "reference/Reference BU Product Mapping.md",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_write_note_omits_advisory_when_index_has_no_neighbors(
+    app, test_project, semantic_search_on, stub_search_client
+):
+    stub_search_client.results = []
+
+    text_result = await write_note(
+        project=test_project.name,
+        title="Lonely Note",
+        directory="analysis",
+        content="# Lonely Note\n\nNothing else like it.",
+    )
+    json_result = await write_note(
+        project=test_project.name,
+        title="Lonely Note Two",
+        directory="analysis",
+        content="# Lonely Note Two\n\nStill nothing like it.",
+        output_format="json",
+    )
+
+    assert "# Created note" in text_result
+    assert "## Similar existing notes" not in text_result
+    assert isinstance(json_result, dict)
+    assert json_result["similar_notes"] == []
+
+
+@pytest.mark.asyncio
+async def test_write_note_skips_advisory_when_semantic_search_is_disabled(
+    app, test_project, stub_search_client
+):
+    """The test config leaves semantic search off, so no probe should be attempted."""
+    stub_search_client.results = [
+        _entity_result("Neighbor", f"{test_project.name}/n/neighbor", "n/Neighbor.md", 0.9)
+    ]
+
+    result = await write_note(
+        project=test_project.name,
+        title="Plain Write",
+        directory="analysis",
+        content="# Plain Write\n\nSemantic search is off here.",
+    )
+
+    assert "# Created note" in result
+    assert "## Similar existing notes" not in result
+    assert stub_search_client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_write_note_does_not_probe_on_overwrite(
+    app, test_project, semantic_search_on, stub_search_client
+):
+    """An overwrite already names its target; only creates ask the index."""
+    stub_search_client.results = [
+        _entity_result("Neighbor", f"{test_project.name}/n/neighbor", "n/Neighbor.md", 0.9)
+    ]
+    first = await write_note(
+        project=test_project.name,
+        title="Probe Once",
+        directory="analysis",
+        content="# Probe Once\n\nOriginal",
+    )
+    assert "## Similar existing notes" in first
+    assert len(stub_search_client.calls) == 1
+    stub_search_client.calls.clear()
+
+    second = await write_note(
+        project=test_project.name,
+        title="Probe Once",
+        directory="analysis",
+        content="# Probe Once\n\nReplacement",
+        overwrite=True,
+    )
+
+    assert "# Updated note" in second
+    assert "## Similar existing notes" not in second
+    assert stub_search_client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_write_note_survives_similar_note_probe_failure(
+    app, test_project, semantic_search_on, stub_search_client
+):
+    """The note is already written when the probe runs; its failure must not undo that."""
+    stub_search_client.error = ToolError("Semantic search is disabled.")
+
+    result = await write_note(
+        project=test_project.name,
+        title="Written Anyway",
+        directory="analysis",
+        content="# Written Anyway\n\nThe probe fails, the write does not.",
+    )
+
+    assert "# Created note" in result
+    assert "## Similar existing notes" not in result
+    content = await read_note("analysis/written-anyway", project=test_project.name)
+    assert "The probe fails, the write does not." in content
+
+
+@pytest.mark.asyncio
+async def test_write_note_qualifies_similar_note_permalinks_in_workspace_context(
+    app, test_project, semantic_search_on, stub_search_client
+):
+    """Cloud requests carry a workspace slug; neighbors get the same qualified form as the note."""
+    stub_search_client.results = [
+        _entity_result(
+            "Reference BU Product Mapping",
+            f"{test_project.name}/reference/reference-bu-product-mapping",
+            "reference/Reference BU Product Mapping.md",
+            0.86,
+        ),
+        # A row without a permalink is listed by file path and left alone.
+        _entity_result("Unlinked Draft", None, "drafts/Unlinked Draft.md", 0.7),
+    ]
+
+    with workspace_permalink_context(workspace_slug="team-paul", workspace_type="organization"):
+        result = await write_note(
+            project=test_project.name,
+            title="BU Mapping Analysis",
+            directory="analysis",
+            content="# BU Mapping Analysis\n\nWhich business units own which products.",
+            output_format="json",
+        )
+
+    assert isinstance(result, dict)
+    assert result["permalink"] == f"team-paul/{test_project.name}/analysis/bu-mapping-analysis"
+    assert result["similar_notes"] == [
+        {
+            "title": "Reference BU Product Mapping",
+            "permalink": f"team-paul/{test_project.name}/reference/reference-bu-product-mapping",
+            "file_path": "reference/Reference BU Product Mapping.md",
+        },
+        {
+            "title": "Unlinked Draft",
+            "permalink": None,
+            "file_path": "drafts/Unlinked Draft.md",
+        },
+    ]

--- a/tests/mcp/test_tool_write_note.py
+++ b/tests/mcp/test_tool_write_note.py
@@ -1832,10 +1832,10 @@ async def test_write_note_does_not_probe_on_overwrite(
 
 
 @pytest.mark.asyncio
-async def test_write_note_survives_similar_note_probe_failure(
+async def test_write_note_survives_expected_similar_note_probe_failure(
     app, test_project, semantic_search_on, stub_search_client
 ):
-    """The note is already written when the probe runs; its failure must not undo that."""
+    """An API refusal or transport failure (ToolError) must not undo a completed write."""
     stub_search_client.error = ToolError("Semantic search is disabled.")
 
     result = await write_note(
@@ -1890,3 +1890,23 @@ async def test_write_note_qualifies_similar_note_permalinks_in_workspace_context
             "file_path": "drafts/Unlinked Draft.md",
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_write_note_surfaces_unexpected_similar_note_probe_errors(
+    app, test_project, semantic_search_on, stub_search_client
+):
+    """A defect in the probe path stays visible instead of degrading to an empty advisory."""
+    stub_search_client.error = RuntimeError("search response contract changed")
+
+    with pytest.raises(RuntimeError, match="contract changed"):
+        await write_note(
+            project=test_project.name,
+            title="Loud Failure",
+            directory="analysis",
+            content="# Loud Failure\n\nThe write lands; the defect is not hidden.",
+        )
+
+    # The note was created before the probe ran, so it is on disk regardless.
+    content = await read_note("analysis/loud-failure", project=test_project.name)
+    assert "The write lands; the defect is not hidden." in content


### PR DESCRIPTION
Closes #1259

## Why

Agents writing to Basic Memory across many sessions know the *topic* of a note but not whether a note on that topic already exists or what it is called, so they create near-duplicates with slightly different titles (`reference_bu_product_mapping` vs. `bu-mapping-analysis-2026-08-15`). Retrieval then returns both, sometimes with conflicting content, and nothing tells anyone which is current. "Search before write" as a prompt rule works most of the time and fails exactly when it matters: long contexts, hurried agents, subagents that did not inherit the rule.

#1259 proposed an `upsert_note` tool that picks a match by embedding similarity above a threshold and overwrites it. We measured that before building anything (data in the [issue comment](https://github.com/basicmachines-co/basic-memory/issues/1259#issuecomment-5463898629)): on a 206-note vault with **no** true duplicates, the nearest non-duplicate neighbor scores a median 0.837 (p95 0.904; 78/206 notes have a non-duplicate neighbor ≥ 0.85), while hand-written rewrites of existing notes scored 0.78–0.87 against their originals. No threshold separates "duplicate" from "related". An auto-overwrite at 0.85 would have missed 3 of 4 real duplicates and clobbered an adjacent chapter in the other case. What *did* work is ranking: the true original was the top-1 result in 5/5 cases.

So the signal is good for a question and unfit for a decision. This PR ships the question.

## What Changed

- `write_note` now appends a **Similar existing notes** section after it *creates* a note (not on overwrite) when the project's server has semantic search enabled:

  ```markdown
  ## Similar existing notes
  This note looks similar to notes that already exist. Did you mean to write to one of these?
  - Reference BU Product Mapping (`main/reference/reference-bu-product-mapping`)
  - Product Catalog (`main/reference/product-catalog`)

  | If it is... | Then |
  |---|---|
  | The same topic | `read_note(...)`, then `edit_note(..., operation="append", ...)` and `delete_note(<new note>)` |
  | Related but distinct | Add a relation here, e.g. `- relates_to [[Reference BU Product Mapping]]` |
  | Unrelated | Nothing to do |
  ```

- `output_format="json"` carries the same list as `similar_notes: [{title, permalink, file_path}]` (empty when nothing was surfaced).
- No new tool, no threshold parameter, no similarity scores in the output, nothing overwritten on the caller's behalf.
- The "related but distinct → link them" row turns the same signal into a graph-quality nudge; a lot of apparent duplication is a missing relation.
- CHANGELOG entry under Unreleased and a "Similar Notes on Write" section in `docs/semantic-search.md`.

## Implementation Details

`src/basic_memory/mcp/tools/write_note.py`

- **Probe** — `_compose_similarity_probe` builds title + opening content (frontmatter removed, capped at 900 chars). That mirrors the leading chunk the vector index stores for a note (`compose_row_source_text` + `MAX_VECTOR_CHUNK_CHARS`), so the probe lands in the same neighborhood as the note's own embedding.
- **Retrieval** — `_find_similar_notes` runs the existing `SearchClient.search` with `retrieval_mode=VECTOR`, `entity_types=[entity]`, `page_size=4`. Vector-only on purpose: routing prose through the FTS parser would read parentheses and `AND`/`OR`/`NOT` in ordinary sentences as operators. No repository or API changes.
- **Self-exclusion** — `_collapse_similar_notes` drops the new note's own row (by `file_path`, and by permalink as a second key) *if present*. Vectors publish in the background, so the new note may or may not be indexed by the time the probe runs; the code removes it when it is there rather than expecting it. One row per note, top 3.
- **Gating** — the probe is attempted on every create; the routed server decides. A local MCP can route a write to a cloud project whose server has semantic search on while the local install does not (deps missing on some platforms, or disabled locally), and the routing decision lives inside `get_project_client` without being exposed on the yielded `ProjectItem`, so gating on the local `semantic_search_enabled` would silently disable the feature for exactly those routes and re-deriving the route in the tool would duplicate routing logic (Codex P2, fixed in e6c7999d).
- **Failure isolation** — the probe runs after the write has succeeded. It catches `ToolError` only: that is what `call_query` raises for HTTP status and transport failures, i.e. the expected "API refused or could not complete the probe" cases. A 400 refusal (semantic search disabled, no embedding provider) is a configuration state of the routed server, so it logs at debug via `_probe_declined_by_server`, which walks the cause chain the same way `_is_service_unavailable_error` does in `search.py`; 5xx and transport failures log a warning. Either way the write is still reported as successful, since the note is on disk. Anything else — a contract or programming defect — propagates rather than degrading to an empty advisory (narrowed from a blanket `except Exception` after Codex P1).
- **Workspace contexts** — candidate permalinks get the same `build_qualified_permalink_reference` treatment as the note's own permalink under a cloud workspace context.

## Testing

### Automated

- `uv run pytest tests/mcp/test_tool_write_note.py -q --cov=src/basic_memory/mcp/tools --cov-report=term-missing`: 64 passed; every new line and branch in `write_note.py` covered (11 new tests: probe composition, self-exclusion/dedupe, the full-stack advisory text and captured probe payload, JSON shape, empty index, a semantic-off server declining the probe through the *real* client and router with no stub, overwrite does not probe, expected `ToolError` keeps the write, unexpected exceptions propagate with the note still on disk, workspace qualification)
- `uv run pytest tests/mcp -q`: 892 passed on the first head; each follow-up commit re-ran the write_note module in full (64 passed) plus lint, format, and `ty` on the changed files
- `uv run pytest tests/mcp/test_tool_search.py tests/mcp/clients/test_clients.py -q`: 91 passed
- `just fast-check` (ruff fix, format, `ty check src tests test-int`): passed. It also reformatted four files untouched by this branch (`benchmarks/tests/test_concurrent_write.py`, `tests/repository/test_postgres_search_repository.py`, `tests/repository/test_semantic_chunking.py`, `tests/repository/test_sqlite_vector_search_repository.py`) — pre-existing drift on `main`, reverted here to keep scope clean
- `just lint`: passed

### Manual

- Similarity measurement behind the design: embedded the 206-note Moby Dick demo vault with `bge-small-en-v1.5` using main's post-#1371 chunker, scored five hand-written "later session" notes (four rewrites of real notes, one related-but-distinct). Numbers summarized above and on the issue. Not run against a live MCP client end to end; the tool-layer tests exercise the real write path with a stubbed search client.

## Risks / Follow-ups

- **Noise on dense vaults.** The advisory relies on the configured `semantic_min_similarity` floor (default 0.55) and shows up to 3 neighbors, so on a tightly clustered vault almost every create will list something. If that proves noisy in practice, the right fix is a higher floor *for the advisory* (a suppression heuristic), not a threshold that decides — the measurement above is why.
- **Model dependence.** The measured bands are for the default FastEmbed model. Other providers (OpenAI, Cohere) run on different similarity scales; the advisory shows no scores and applies no absolute cutoff beyond the user's configured floor, so it degrades to "closest notes" rather than to wrong verdicts.
- **Latency.** One `embed_query` plus one vector query per create; the model is already warm from the background vector sync the write itself schedules. On a server with semantic search off the cost is one request that fails fast in `_assert_semantic_available`. Not measured under load.
- Observation-only notes have thin identity chunks; #1371 improved this (a chapter-note rewrite went from rank 3 to rank 1), and the real index also returns observation rows, but a second look on a different vault before relying on it further would be worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp
