### PR TITLE
feat(core): add the pdf-inspector extraction adapter behind a pdf extra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -e ".[dev,milvus]"
+          uv pip install -e ".[dev,milvus,pdf]"
 
       - name: Run type checks
         run: |
@@ -147,7 +147,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -e ".[dev]"
+          uv pip install -e ".[dev,pdf]"
 
       - name: Run tests
         run: |
@@ -208,7 +208,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -e ".[dev]"
+          uv pip install -e ".[dev,pdf]"
 
       - name: Run tests
         run: |
@@ -283,7 +283,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -e ".[dev]"
+          uv pip install -e ".[dev,pdf]"
 
       - name: Run tests
         run: |
@@ -354,7 +354,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -e ".[dev]"
+          uv pip install -e ".[dev,pdf]"
 
       - name: Run tests
         run: |
@@ -403,7 +403,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -e ".[dev]"
+          uv pip install -e ".[dev,pdf]"
 
       - name: Run tests
         run: |
@@ -445,7 +445,7 @@ jobs:
 
       - name: Install Milvus extra
         run: |
-          uv pip install -e ".[dev,milvus]"
+          uv pip install -e ".[dev,milvus,pdf]"
 
       - name: Run Milvus tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,11 @@ milvus = [
 redis = [
     "redis>=8.0.0,<9",
 ]
+# Native PDF extraction for document ingestion. Optional so the default install
+# stays parser-free; the worker records the installed version in run identity.
+pdf = [
+    "pdf-inspector>=0.2.6,<2",
+]
 
 [project.urls]
 Homepage = "https://github.com/basicmachines-co/basic-memory"
@@ -135,6 +140,7 @@ dev = [
     "freezegun>=1.5.5",
     "testcontainers[postgres]>=4.0.0",
     "redis>=8.0.0,<9",
+    "pdf-inspector>=0.2.6,<2",
     "psycopg>=3.2.0",
     "pyright>=1.1.408",
     "pytest-testmon>=2.2.0",

--- a/src/basic_memory/document_ingestion/__init__.py
+++ b/src/basic_memory/document_ingestion/__init__.py
@@ -1,0 +1,30 @@
+"""Portable document ingestion: bounded PDF extraction and raw document mapping.
+
+This package is deliberately light to import. The ``pdf_inspector`` native
+library is imported only by the worker subprocess, so ``basic-memory[pdf]``
+stays optional for code that merely references the contracts.
+"""
+
+from basic_memory.document_ingestion.pdf_inspector import (
+    PDF_INSPECTOR_ENGINE,
+    PdfInspector,
+    PdfInspectorError,
+    PdfInspectorLimits,
+    PdfInspectorOutput,
+    PdfInspectorPdfType,
+    PdfInspectorProcessError,
+    PdfInspectorSourceTooLargeError,
+    PdfInspectorTimeoutError,
+)
+
+__all__ = [
+    "PDF_INSPECTOR_ENGINE",
+    "PdfInspector",
+    "PdfInspectorError",
+    "PdfInspectorLimits",
+    "PdfInspectorOutput",
+    "PdfInspectorPdfType",
+    "PdfInspectorProcessError",
+    "PdfInspectorSourceTooLargeError",
+    "PdfInspectorTimeoutError",
+]

--- a/src/basic_memory/document_ingestion/pdf_inspector.py
+++ b/src/basic_memory/document_ingestion/pdf_inspector.py
@@ -1,0 +1,178 @@
+"""Bounded subprocess adapter for Firecrawl's native PDF inspector.
+
+pdf-inspector is a synchronous Rust extractor that parses untrusted bytes. Every
+extraction therefore runs in a killable child process with explicit source,
+page, output, memory, CPU, wall-clock, and concurrency ceilings. This module owns
+those limits and the validated output contract. The ``pdf_inspector`` package is
+imported only by the worker module, so callers can construct limits and parse
+results without the optional ``basic-memory[pdf]`` extra installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+PDF_INSPECTOR_ENGINE = "firecrawl/pdf-inspector"
+PDF_INSPECTOR_WORKER_MODULE = "basic_memory.document_ingestion.pdf_inspector_worker"
+
+
+class PdfInspectorPdfType(StrEnum):
+    """PDF classifications exposed by pdf-inspector."""
+
+    text_based = "text_based"
+    scanned = "scanned"
+    image_based = "image_based"
+    mixed = "mixed"
+
+
+class PdfInspectorLimits(BaseModel):
+    """Resource limits enforced around one native PDF extraction."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    max_source_bytes: int = Field(default=10 * 1024 * 1024, gt=0)
+    max_pages: int = Field(default=100, gt=0)
+    max_output_bytes: int = Field(default=5 * 1024 * 1024, gt=0)
+    max_memory_bytes: int = Field(default=512 * 1024 * 1024, gt=0)
+    timeout_seconds: float = Field(default=30.0, gt=0)
+    cpu_seconds: int = Field(default=25, gt=0)
+    max_concurrency: int = Field(default=1, gt=0)
+
+
+class PdfInspectorOutput(BaseModel):
+    """Validated, serialization-safe output from the native extractor process."""
+
+    model_config = ConfigDict(frozen=True, strict=True)
+
+    engine: str = PDF_INSPECTOR_ENGINE
+    engine_version: str
+    pdf_type: PdfInspectorPdfType
+    markdown: str
+    title: str | None = None
+    page_count: int = Field(gt=0)
+    extracted_page_count: int = Field(ge=0)
+    pages_needing_ocr: tuple[int, ...] = ()
+    confidence: float = Field(ge=0.0, le=1.0)
+    processing_time_ms: int = Field(ge=0)
+    is_complex_layout: bool
+    pages_with_tables: tuple[int, ...] = ()
+    pages_with_columns: tuple[int, ...] = ()
+    has_encoding_issues: bool
+
+    @model_validator(mode="after")
+    def validate_page_diagnostics(self) -> PdfInspectorOutput:
+        """Keep page diagnostics within the document and internally consistent."""
+        page_lists = (
+            self.pages_needing_ocr,
+            self.pages_with_tables,
+            self.pages_with_columns,
+        )
+        for pages in page_lists:
+            if tuple(sorted(set(pages))) != pages:
+                raise ValueError("PDF diagnostic pages must be sorted and unique")
+            if any(page < 1 or page > self.page_count for page in pages):
+                raise ValueError("PDF diagnostic page is outside the document")
+
+        expected_extracted_pages = self.page_count - len(self.pages_needing_ocr)
+        if self.extracted_page_count != expected_extracted_pages:
+            raise ValueError("extracted_page_count must exclude exactly the pages needing OCR")
+        return self
+
+
+class PdfInspectorError(RuntimeError):
+    """Base failure for a bounded PDF inspection attempt."""
+
+
+class PdfInspectorSourceTooLargeError(PdfInspectorError):
+    """Raised before spawning when the source exceeds the configured byte limit."""
+
+
+class PdfInspectorTimeoutError(PdfInspectorError):
+    """Raised after terminating an extraction process that exceeded its deadline."""
+
+
+class PdfInspectorProcessError(PdfInspectorError):
+    """Raised when the isolated extractor exits unsuccessfully or returns invalid JSON."""
+
+
+@dataclass(slots=True)
+class PdfInspector:
+    """Run synchronous Rust extraction in killable, concurrency-bounded subprocesses."""
+
+    limits: PdfInspectorLimits = field(default_factory=PdfInspectorLimits)
+    python_executable: str = sys.executable
+    _semaphore: asyncio.Semaphore = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._semaphore = asyncio.Semaphore(self.limits.max_concurrency)
+
+    async def extract(self, pdf_bytes: bytes) -> PdfInspectorOutput:
+        """Extract one PDF without blocking the caller's event loop."""
+        if len(pdf_bytes) > self.limits.max_source_bytes:
+            raise PdfInspectorSourceTooLargeError(
+                "PDF source exceeds the configured extraction byte limit"
+            )
+
+        async with self._semaphore:
+            process = await asyncio.create_subprocess_exec(
+                self.python_executable,
+                "-m",
+                PDF_INSPECTOR_WORKER_MODULE,
+                "--max-pages",
+                str(self.limits.max_pages),
+                "--max-output-bytes",
+                str(self.limits.max_output_bytes),
+                "--max-memory-bytes",
+                str(self.limits.max_memory_bytes),
+                "--cpu-seconds",
+                str(self.limits.cpu_seconds),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                async with asyncio.timeout(self.limits.timeout_seconds):
+                    stdout, stderr = await process.communicate(input=pdf_bytes)
+            except asyncio.CancelledError:
+                await _kill_and_wait(process)
+                raise
+            except TimeoutError as error:
+                await _kill_and_wait(process)
+                raise PdfInspectorTimeoutError(
+                    "PDF extraction exceeded the configured deadline"
+                ) from error
+
+        if process.returncode != 0:
+            error_detail = stderr.decode("utf-8", errors="replace")[-2000:].strip()
+            raise PdfInspectorProcessError(
+                f"PDF extraction process failed with exit code {process.returncode}: "
+                f"{error_detail or 'no error detail'}"
+            )
+        if len(stdout) > self.limits.max_output_bytes:
+            raise PdfInspectorProcessError(
+                "PDF extraction process exceeded the configured output byte limit"
+            )
+
+        try:
+            return PdfInspectorOutput.model_validate_json(stdout, strict=True)
+        except ValueError as error:
+            raise PdfInspectorProcessError(
+                "PDF extraction process returned an invalid result"
+            ) from error
+
+
+async def _kill_and_wait(process: asyncio.subprocess.Process) -> None:
+    """Terminate and reap one extractor child before releasing worker capacity."""
+    if process.returncode is None:
+        try:
+            process.kill()
+        except ProcessLookupError:
+            # The child can exit between the returncode check and the signal.
+            # Waiting still reaps it and preserves the caller's original outcome.
+            pass
+    await process.wait()

--- a/src/basic_memory/document_ingestion/pdf_inspector.py
+++ b/src/basic_memory/document_ingestion/pdf_inspector.py
@@ -119,22 +119,32 @@ class PdfInspector:
             )
 
         async with self._semaphore:
-            process = await asyncio.create_subprocess_exec(
-                self.python_executable,
-                "-m",
-                PDF_INSPECTOR_WORKER_MODULE,
-                "--max-pages",
-                str(self.limits.max_pages),
-                "--max-output-bytes",
-                str(self.limits.max_output_bytes),
-                "--max-memory-bytes",
-                str(self.limits.max_memory_bytes),
-                "--cpu-seconds",
-                str(self.limits.cpu_seconds),
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
+            try:
+                process = await asyncio.create_subprocess_exec(
+                    self.python_executable,
+                    "-m",
+                    PDF_INSPECTOR_WORKER_MODULE,
+                    "--max-pages",
+                    str(self.limits.max_pages),
+                    "--max-output-bytes",
+                    str(self.limits.max_output_bytes),
+                    "--max-memory-bytes",
+                    str(self.limits.max_memory_bytes),
+                    "--cpu-seconds",
+                    str(self.limits.cpu_seconds),
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+            except NotImplementedError as error:
+                # Trigger: the running loop cannot spawn subprocesses. Basic Memory
+                # installs the selector loop on Windows for aiosqlite (see db.py),
+                # and that loop has no subprocess transport.
+                # Outcome: a named adapter error instead of a bare NotImplementedError.
+                raise PdfInspectorProcessError(
+                    "PDF extraction needs an event loop with subprocess support; "
+                    "Basic Memory runs the selector loop on Windows"
+                ) from error
             try:
                 async with asyncio.timeout(self.limits.timeout_seconds):
                     stdout, stderr = await process.communicate(input=pdf_bytes)

--- a/src/basic_memory/document_ingestion/pdf_inspector.py
+++ b/src/basic_memory/document_ingestion/pdf_inspector.py
@@ -147,7 +147,9 @@ class PdfInspector:
                 ) from error
             try:
                 async with asyncio.timeout(self.limits.timeout_seconds):
-                    stdout, stderr = await process.communicate(input=pdf_bytes)
+                    stdout, stderr = await _communicate_capped(
+                        process, pdf_bytes, cap=self.limits.max_output_bytes
+                    )
             except asyncio.CancelledError:
                 await _kill_and_wait(process)
                 raise
@@ -156,16 +158,16 @@ class PdfInspector:
                 raise PdfInspectorTimeoutError(
                     "PDF extraction exceeded the configured deadline"
                 ) from error
+            except PdfInspectorProcessError:
+                # A pipe crossed its ceiling while the child may still be writing.
+                await _kill_and_wait(process)
+                raise
 
         if process.returncode != 0:
             error_detail = stderr.decode("utf-8", errors="replace")[-2000:].strip()
             raise PdfInspectorProcessError(
                 f"PDF extraction process failed with exit code {process.returncode}: "
                 f"{error_detail or 'no error detail'}"
-            )
-        if len(stdout) > self.limits.max_output_bytes:
-            raise PdfInspectorProcessError(
-                "PDF extraction process exceeded the configured output byte limit"
             )
 
         try:
@@ -186,3 +188,60 @@ async def _kill_and_wait(process: asyncio.subprocess.Process) -> None:
             # Waiting still reaps it and preserves the caller's original outcome.
             pass
     await process.wait()
+
+
+# Read pipes in modest chunks so the ceiling applies as bytes arrive rather than
+# after an entire stream has already been buffered.
+_PIPE_CHUNK_BYTES = 64 * 1024
+
+
+async def _communicate_capped(
+    process: asyncio.subprocess.Process,
+    pdf_bytes: bytes,
+    *,
+    cap: int,
+) -> tuple[bytes, bytes]:
+    """Feed stdin and drain both pipes with a hard byte ceiling on each.
+
+    ``Process.communicate()`` buffers stdout and stderr without limit before the
+    caller can look at their size, so a hostile PDF that makes the worker emit a
+    huge field, or a runaway error stream, would land in parent memory. This
+    variant raises as soon as either pipe crosses ``cap``; the caller kills the
+    child.
+    """
+    stdin, stdout, stderr = process.stdin, process.stdout, process.stderr
+    if stdin is None or stdout is None or stderr is None:  # pragma: no cover - PIPE at spawn
+        raise RuntimeError("PDF extraction process was started without pipes")
+    try:
+        async with asyncio.TaskGroup() as group:
+            stdout_task = group.create_task(_read_capped(stdout, cap=cap, stream_name="stdout"))
+            stderr_task = group.create_task(_read_capped(stderr, cap=cap, stream_name="stderr"))
+            group.create_task(_feed_stdin(stdin, pdf_bytes))
+    except* PdfInspectorProcessError as overflow:
+        raise overflow.exceptions[0] from None
+    await process.wait()
+    return stdout_task.result(), stderr_task.result()
+
+
+async def _read_capped(stream: asyncio.StreamReader, *, cap: int, stream_name: str) -> bytes:
+    buffer = bytearray()
+    while chunk := await stream.read(_PIPE_CHUNK_BYTES):
+        buffer.extend(chunk)
+        if len(buffer) > cap:
+            raise PdfInspectorProcessError(
+                f"PDF extraction process exceeded the configured output byte limit on {stream_name}"
+            )
+    return bytes(buffer)
+
+
+async def _feed_stdin(stdin: asyncio.StreamWriter, pdf_bytes: bytes) -> None:
+    try:
+        stdin.write(pdf_bytes)
+        await stdin.drain()
+    except (BrokenPipeError, ConnectionResetError):
+        # The child exited before consuming its input. Its exit status and
+        # stderr carry the failure; ``Process.communicate()`` ignores the same
+        # pair for the same reason.
+        pass
+    finally:
+        stdin.close()

--- a/src/basic_memory/document_ingestion/pdf_inspector_worker.py
+++ b/src/basic_memory/document_ingestion/pdf_inspector_worker.py
@@ -1,0 +1,134 @@
+"""One-shot native PDF extraction process used by the async adapter.
+
+Runs as ``python -m basic_memory.document_ingestion.pdf_inspector_worker`` with
+PDF bytes on stdin and one validated JSON ``PdfInspectorOutput`` on stdout.
+Resource limits are applied before any source bytes are read so a malformed
+PDF cannot exhaust the parent process.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import resource
+import sys
+
+import pdf_inspector
+
+from basic_memory.document_ingestion.pdf_inspector import (
+    PDF_INSPECTOR_ENGINE,
+    PdfInspectorOutput,
+    PdfInspectorPdfType,
+)
+
+
+def _normalized_pages(pages: list[int], *, page_count: int) -> tuple[int, ...]:
+    """Validate pdf-inspector's document-level, one-indexed diagnostics."""
+    unique_pages = tuple(sorted(set(pages)))
+    if any(page < 1 or page > page_count for page in unique_pages):
+        raise ValueError("pdf-inspector returned a diagnostic page outside the document")
+    return unique_pages
+
+
+def inspect_pdf_bytes(
+    pdf_bytes: bytes,
+    *,
+    max_pages: int,
+    max_output_bytes: int,
+) -> PdfInspectorOutput:
+    """Run classification and extraction in the isolated child process."""
+    # The installed library version is part of the deterministic run identity:
+    # upgrading pdf-inspector yields a new ingestion run rather than silently
+    # rewriting an existing document's provenance.
+    engine_version = importlib.metadata.version("pdf-inspector")
+
+    classification = pdf_inspector.classify_pdf_bytes(pdf_bytes)
+    if classification.page_count > max_pages:
+        raise ValueError("PDF exceeds the configured extraction page limit")
+
+    result = pdf_inspector.process_pdf_bytes(pdf_bytes)
+    if result.page_count != classification.page_count:
+        raise RuntimeError("pdf-inspector classification and extraction page counts differ")
+
+    page_result = pdf_inspector.extract_pages_markdown_bytes(pdf_bytes)
+    if len(page_result.pages) != result.page_count:
+        raise RuntimeError("pdf-inspector omitted pages from the full-document extraction")
+
+    markdown_parts: list[str] = []
+    for page in page_result.pages:
+        page_number = page.page + 1
+        if page.needs_ocr:
+            markdown_parts.append(f"<!-- Page {page_number}: OCR required -->")
+            continue
+        markdown_parts.append(f"<!-- Page {page_number} -->\n\n{page.markdown.strip()}")
+    markdown = "\n\n".join(markdown_parts).strip()
+    if len(markdown.encode("utf-8")) > max_output_bytes:
+        raise ValueError("PDF extraction exceeds the configured output byte limit")
+
+    pages_needing_ocr = _normalized_pages(
+        page_result.pages_needing_ocr,
+        page_count=result.page_count,
+    )
+    return PdfInspectorOutput(
+        engine=PDF_INSPECTOR_ENGINE,
+        engine_version=engine_version,
+        pdf_type=PdfInspectorPdfType(result.pdf_type),
+        markdown=markdown,
+        title=result.title,
+        page_count=result.page_count,
+        extracted_page_count=sum(not page.needs_ocr for page in page_result.pages),
+        pages_needing_ocr=pages_needing_ocr,
+        confidence=result.confidence,
+        processing_time_ms=result.processing_time_ms,
+        is_complex_layout=page_result.is_complex,
+        pages_with_tables=_normalized_pages(
+            page_result.pages_with_tables,
+            page_count=result.page_count,
+        ),
+        pages_with_columns=_normalized_pages(
+            page_result.pages_with_columns,
+            page_count=result.page_count,
+        ),
+        has_encoding_issues=result.has_encoding_issues,
+    )
+
+
+def _apply_cpu_limit(cpu_seconds: int) -> None:
+    """Bound native CPU time so a malformed PDF cannot monopolize a worker."""
+    resource.setrlimit(resource.RLIMIT_CPU, (cpu_seconds, cpu_seconds + 1))
+
+
+def _apply_memory_limit(max_memory_bytes: int) -> None:
+    """Bound parser address space on Linux before reading source bytes."""
+    if sys.platform != "linux":
+        # RLIMIT_AS is the deployed Linux isolation boundary. Applying the same
+        # byte ceiling on macOS constrains its much larger virtual mappings and
+        # makes the local subprocess fail before native parsing begins.
+        return
+    resource.setrlimit(resource.RLIMIT_AS, (max_memory_bytes, max_memory_bytes))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-pages", type=int, required=True)
+    parser.add_argument("--max-output-bytes", type=int, required=True)
+    parser.add_argument("--max-memory-bytes", type=int, required=True)
+    parser.add_argument("--cpu-seconds", type=int, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Read PDF bytes from stdin and emit one validated JSON result to stdout."""
+    args = _parse_args()
+    _apply_memory_limit(args.max_memory_bytes)
+    _apply_cpu_limit(args.cpu_seconds)
+    result = inspect_pdf_bytes(
+        sys.stdin.buffer.read(),
+        max_pages=args.max_pages,
+        max_output_bytes=args.max_output_bytes,
+    )
+    sys.stdout.write(result.model_dump_json())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/basic_memory/document_ingestion/pdf_inspector_worker.py
+++ b/src/basic_memory/document_ingestion/pdf_inspector_worker.py
@@ -10,10 +10,17 @@ from __future__ import annotations
 
 import argparse
 import importlib.metadata
-import resource
 import sys
 
 import pdf_inspector
+
+# POSIX rlimits are the child's isolation boundary on the Linux workers and on
+# macOS dev machines. Windows has no `resource` module; there the parent's
+# wall-clock deadline is the only ceiling, and the limit helpers below no-op.
+if sys.platform == "win32":  # pragma: no cover - exercised only on Windows CI
+    resource = None
+else:
+    import resource
 
 from basic_memory.document_ingestion.pdf_inspector import (
     PDF_INSPECTOR_ENGINE,
@@ -95,12 +102,14 @@ def inspect_pdf_bytes(
 
 def _apply_cpu_limit(cpu_seconds: int) -> None:
     """Bound native CPU time so a malformed PDF cannot monopolize a worker."""
+    if resource is None:
+        return
     resource.setrlimit(resource.RLIMIT_CPU, (cpu_seconds, cpu_seconds + 1))
 
 
 def _apply_memory_limit(max_memory_bytes: int) -> None:
     """Bound parser address space on Linux before reading source bytes."""
-    if sys.platform != "linux":
+    if resource is None or sys.platform != "linux":
         # RLIMIT_AS is the deployed Linux isolation boundary. Applying the same
         # byte ceiling on macOS constrains its much larger virtual mappings and
         # makes the local subprocess fail before native parsing begins.

--- a/src/basic_memory/document_ingestion/pdf_inspector_worker.py
+++ b/src/basic_memory/document_ingestion/pdf_inspector_worker.py
@@ -58,8 +58,12 @@ def inspect_pdf_bytes(
         raise RuntimeError("pdf-inspector classification and extraction page counts differ")
 
     page_result = pdf_inspector.extract_pages_markdown_bytes(pdf_bytes)
-    if len(page_result.pages) != result.page_count:
-        raise RuntimeError("pdf-inspector omitted pages from the full-document extraction")
+    # Page markers and OCR provenance are keyed by page index, so a repeated,
+    # skipped, or reordered entry would mislabel canonical Markdown even when
+    # the entry count is right. Require exactly 0..page_count-1 in order.
+    page_indexes = [page.page for page in page_result.pages]
+    if page_indexes != list(range(result.page_count)):
+        raise RuntimeError("pdf-inspector page entries do not cover 0..page_count-1 exactly")
 
     markdown_parts: list[str] = []
     for page in page_result.pages:
@@ -76,6 +80,11 @@ def inspect_pdf_bytes(
         page_result.pages_needing_ocr,
         page_count=result.page_count,
     )
+    flagged_pages = tuple(page.page + 1 for page in page_result.pages if page.needs_ocr)
+    if flagged_pages != pages_needing_ocr:
+        raise RuntimeError(
+            "pdf-inspector per-page OCR flags disagree with document-level pages_needing_ocr"
+        )
     return PdfInspectorOutput(
         engine=PDF_INSPECTOR_ENGINE,
         engine_version=engine_version,

--- a/src/basic_memory/document_ingestion/pdf_inspector_worker.py
+++ b/src/basic_memory/document_ingestion/pdf_inspector_worker.py
@@ -145,7 +145,12 @@ def main() -> None:
         max_pages=args.max_pages,
         max_output_bytes=args.max_output_bytes,
     )
-    sys.stdout.write(result.model_dump_json())
+    payload = result.model_dump_json()
+    # inspect_pdf_bytes bounds the Markdown body; metadata such as the PDF title
+    # is untrusted too, so bound the whole envelope before it crosses the pipe.
+    if len(payload.encode("utf-8")) > args.max_output_bytes:
+        raise ValueError("PDF extraction result exceeds the configured output byte limit")
+    sys.stdout.write(payload)
 
 
 if __name__ == "__main__":

--- a/src/basic_memory/document_ingestion/raw_document.py
+++ b/src/basic_memory/document_ingestion/raw_document.py
@@ -1,0 +1,386 @@
+"""Portable raw PDF ingestion: stable source snapshot -> extraction -> document artifacts.
+
+The uploaded PDF stays its own file entity. This module maps one stable source
+snapshot plus the bounded extractor's output into Core's document contract (a
+``type: document`` note and its ``document_ingestion_run`` note) and orchestrates
+the read / extract / revalidate / write sequence behind narrow protocols.
+
+Storage reads and accepted-note writes are runtime-specific (Tigris and PGQueuer
+in Cloud, the project directory locally) and are supplied by the caller. The
+identity checks at the bottom let any writer verify that an already-accepted
+document or run note still matches the deterministic inputs before reusing it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import PurePosixPath
+from typing import Protocol
+from uuid import UUID
+
+from basic_memory.document_ingestion.pdf_inspector import (
+    PdfInspector,
+    PdfInspectorLimits,
+    PdfInspectorOutput,
+)
+from basic_memory.schemas.document import (
+    DocumentExtractionStatus,
+    DocumentExtractionV1,
+    DocumentIngestionRunFrontmatterV1,
+    DocumentIngestionRunMarkdownV1,
+    DocumentIngestionRunOutputV1,
+    DocumentIngestionRunStateV1,
+    DocumentIngestionStage,
+    DocumentIngestionV1,
+    DocumentMarkdownV1,
+    DocumentMetadataV1,
+    DocumentNoteFrontmatterV1,
+    DocumentRevisionKind,
+    DocumentRevisionReferenceV1,
+    DocumentSourceV1,
+    assemble_document_ingestion_run_markdown,
+    assemble_document_markdown,
+    derive_document_ingestion_run_id,
+    derive_document_ingestion_run_path,
+    derive_document_note_external_id,
+    derive_document_note_path,
+)
+
+# Actor source recorded on generated notes; see VALID_NOTE_OBJECT_SOURCES.
+DOCUMENT_INGESTION_SOURCE = "document_ingestion"
+PDF_RAW_PIPELINE_VERSION = "pdf-inspector-raw-v1"
+PDF_RAW_EXTRACTION_PROFILE = "pdf-inspector-v1"
+
+
+class DocumentSourceChangedError(RuntimeError):
+    """The source object changed while its bytes were being read."""
+
+
+# --- Values ---
+
+
+@dataclass(frozen=True, slots=True)
+class DocumentSourceEntity:
+    """Indexed identity of the PDF source file entity."""
+
+    entity_id: int
+    external_id: UUID
+    file_path: str
+    media_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class DocumentSourceSnapshot:
+    """Stable source bytes and their trusted storage provenance."""
+
+    entity: DocumentSourceEntity
+    content: bytes
+    checksum: str
+    size_bytes: int
+    storage_etag: str
+    storage_version_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RawDocumentArtifacts:
+    """Deterministic raw document values before accepted-note timestamps."""
+
+    source: DocumentSourceV1
+    extraction: DocumentExtractionV1
+    ingestion: DocumentIngestionV1
+    document_external_id: UUID
+    document_file_path: str
+    document_markdown: str
+    run_id: UUID
+    run_file_path: str
+    started_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class RawDocumentWriteResult:
+    """Accepted identities for one idempotent raw ingestion run."""
+
+    document_external_id: UUID
+    document_file_path: str
+    document_db_checksum: str
+    run_id: UUID
+    run_file_path: str
+    document_created: bool
+    run_created: bool
+
+
+# --- Runtime-supplied capabilities ---
+
+
+class DocumentSourceEntityResolver(Protocol):
+    """Resolve the indexed source entity after file indexing completes."""
+
+    async def resolve(self, file_path: str) -> DocumentSourceEntity: ...
+
+
+class DocumentSourceReader(Protocol):
+    """Read one stable storage generation for extraction."""
+
+    async def read(
+        self,
+        entity: DocumentSourceEntity,
+        *,
+        observed_etag: str | None,
+    ) -> DocumentSourceSnapshot: ...
+
+    async def require_current(self, snapshot: DocumentSourceSnapshot) -> None:
+        """Fail unless the extracted storage generation is still current."""
+
+
+class RawDocumentWriter(Protocol):
+    """Accept raw document and ingestion-run notes idempotently."""
+
+    async def write(self, artifacts: RawDocumentArtifacts) -> RawDocumentWriteResult: ...
+
+
+# --- Orchestration ---
+
+
+@dataclass(frozen=True, slots=True)
+class RawPdfDocumentRuntime:
+    """Orchestrate one stable source read, extraction, and accepted write."""
+
+    source_resolver: DocumentSourceEntityResolver
+    source_reader: DocumentSourceReader
+    extractor: PdfInspector
+    writer: RawDocumentWriter
+
+    async def ingest(
+        self,
+        *,
+        file_path: str,
+        observed_etag: str | None,
+    ) -> RawDocumentWriteResult:
+        started_at = datetime.now(tz=UTC)
+        source_entity = await self.source_resolver.resolve(file_path)
+        source = await self.source_reader.read(
+            source_entity,
+            observed_etag=observed_etag,
+        )
+        extracted = await self.extractor.extract(source.content)
+        artifacts = build_raw_document_artifacts(
+            source,
+            extracted,
+            limits=self.extractor.limits,
+            started_at=started_at,
+            extracted_at=datetime.now(tz=UTC),
+        )
+        # Extraction can take seconds; re-resolve so a source replaced or moved
+        # meanwhile is rejected instead of being written under stale provenance.
+        current_source_entity = await self.source_resolver.resolve(file_path)
+        if current_source_entity != source.entity:
+            raise DocumentSourceChangedError(
+                "Indexed PDF source identity changed during extraction"
+            )
+        await self.source_reader.require_current(source)
+        return await self.writer.write(artifacts)
+
+
+# --- Contract mapping ---
+
+
+def build_raw_document_artifacts(
+    source: DocumentSourceSnapshot,
+    extracted: PdfInspectorOutput,
+    *,
+    limits: PdfInspectorLimits,
+    started_at: datetime,
+    extracted_at: datetime,
+) -> RawDocumentArtifacts:
+    """Map native extraction output into Core's portable document contract."""
+    options_hash = extraction_options_checksum(limits)
+    run_id = UUID(
+        derive_document_ingestion_run_id(
+            source_entity_external_id=source.entity.external_id,
+            source_checksum=source.checksum,
+            pipeline_version=PDF_RAW_PIPELINE_VERSION,
+            extractor_engine=extracted.engine,
+            extractor_version=extracted.engine_version,
+            extraction_profile=PDF_RAW_EXTRACTION_PROFILE,
+            extraction_options_hash=options_hash,
+            prompt_version=None,
+        )
+    )
+    document_external_id = UUID(derive_document_note_external_id(source.entity.external_id))
+    source_contract = DocumentSourceV1(
+        media_type=source.entity.media_type,
+        entity_external_id=source.entity.external_id,
+        file_path=source.entity.file_path,
+        checksum=source.checksum,
+        size_bytes=source.size_bytes,
+        storage_version_id=source.storage_version_id,
+        storage_etag=source.storage_etag,
+    )
+    extraction = DocumentExtractionV1(
+        engine=extracted.engine,
+        engine_version=extracted.engine_version,
+        profile=PDF_RAW_EXTRACTION_PROFILE,
+        options_hash=options_hash,
+        classification=extracted.pdf_type.value,
+        status=(
+            DocumentExtractionStatus.needs_ocr
+            if extracted.pages_needing_ocr
+            else DocumentExtractionStatus.complete
+        ),
+        extracted_at=extracted_at,
+        duration_ms=extracted.processing_time_ms,
+        page_count=extracted.page_count,
+        extracted_page_count=extracted.extracted_page_count,
+        requires_ocr=bool(extracted.pages_needing_ocr),
+        ocr_page_count=len(extracted.pages_needing_ocr),
+        pages_needing_ocr=extracted.pages_needing_ocr,
+        confidence=extracted.confidence,
+        has_encoding_issues=extracted.has_encoding_issues,
+        has_tables=bool(extracted.pages_with_tables),
+        has_columns=bool(extracted.pages_with_columns),
+    )
+    ingestion = DocumentIngestionV1(
+        stage=DocumentIngestionStage.raw,
+        pipeline_version=PDF_RAW_PIPELINE_VERSION,
+        run_id=run_id,
+        input_checksum=source.checksum,
+    )
+    # Raw extraction is untrusted semantic input: keep the body searchable but
+    # opt out of observation/relation parsing until a bounded enrichment pass.
+    document = DocumentMarkdownV1(
+        frontmatter=DocumentNoteFrontmatterV1(
+            title=PurePosixPath(source.entity.file_path).name,
+            tags=("document", "pdf", "generated"),
+            source=source_contract,
+            extraction=extraction,
+            ingestion=ingestion,
+            document=DocumentMetadataV1(kind="pdf"),
+            bm_parse_semantics=False,
+        ),
+        body=extracted.markdown,
+    )
+    return RawDocumentArtifacts(
+        source=source_contract,
+        extraction=extraction,
+        ingestion=ingestion,
+        document_external_id=document_external_id,
+        document_file_path=derive_document_note_path(source.entity.file_path),
+        document_markdown=assemble_document_markdown(document),
+        run_id=run_id,
+        run_file_path=derive_document_ingestion_run_path(run_id),
+        started_at=started_at,
+    )
+
+
+def build_raw_ingestion_run_markdown(
+    artifacts: RawDocumentArtifacts,
+    *,
+    raw_checksum: str,
+    raw_created_at: datetime,
+) -> str:
+    """Build the compact queryable history note for an accepted raw revision."""
+    raw_revision = DocumentRevisionReferenceV1(
+        kind=DocumentRevisionKind.raw_extraction,
+        checksum=raw_checksum,
+        storage_version_id=None,
+        created_at=raw_created_at,
+    )
+    run = DocumentIngestionRunMarkdownV1(
+        frontmatter=DocumentIngestionRunFrontmatterV1(
+            title=str(artifacts.run_id),
+            source=artifacts.source,
+            extraction=artifacts.extraction,
+            ingestion=DocumentIngestionRunStateV1(
+                run_id=artifacts.run_id,
+                stage=DocumentIngestionStage.raw,
+                pipeline_version=artifacts.ingestion.pipeline_version,
+                prompt_version=artifacts.ingestion.prompt_version,
+                input_checksum=artifacts.ingestion.input_checksum,
+                started_at=artifacts.started_at,
+            ),
+            output=DocumentIngestionRunOutputV1(
+                document_entity_external_id=artifacts.document_external_id,
+                document_file_path=artifacts.document_file_path,
+                raw=raw_revision,
+            ),
+        ),
+        body="Raw extraction accepted; exact storage materialization is pending.\n",
+    )
+    return assemble_document_ingestion_run_markdown(run)
+
+
+def extraction_options_checksum(limits: PdfInspectorLimits) -> str:
+    """Return a stable identity for every extraction-shaping limit."""
+    encoded = json.dumps(
+        limits.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+# --- Identity checks for reusing already-accepted notes ---
+
+
+def require_matching_raw_document(
+    document: DocumentMarkdownV1,
+    artifacts: RawDocumentArtifacts,
+) -> None:
+    """Fail unless an accepted document still matches this run's deterministic inputs."""
+    if document.frontmatter.ingestion.stage is not DocumentIngestionStage.raw:
+        raise RuntimeError("Existing ingestion run document is no longer at the raw stage")
+    if (
+        document.frontmatter.source != artifacts.source
+        or document.frontmatter.ingestion != artifacts.ingestion
+        or document.frontmatter.extraction.engine != artifacts.extraction.engine
+        or document.frontmatter.extraction.engine_version != artifacts.extraction.engine_version
+    ):
+        raise RuntimeError("Existing raw document does not match the deterministic run identity")
+
+
+def require_matching_source_identity(
+    existing: DocumentSourceV1,
+    current: DocumentSourceV1,
+) -> None:
+    """Fail unless two source contracts describe the same bytes of the same entity."""
+    if (
+        existing.kind != current.kind
+        or existing.media_type != current.media_type
+        or existing.entity_external_id != current.entity_external_id
+        or existing.checksum != current.checksum
+        or existing.size_bytes != current.size_bytes
+    ):
+        raise RuntimeError("Existing ingestion run does not match the source identity")
+
+
+def require_document_run_identity(
+    document: DocumentMarkdownV1,
+    run: DocumentIngestionRunMarkdownV1,
+) -> None:
+    """Fail unless an accepted document and its run note agree on provenance."""
+    run_extraction = run.frontmatter.extraction
+    if run_extraction is None:
+        raise RuntimeError("Existing raw ingestion run has no extraction metadata")
+    if document.frontmatter.ingestion.stage is not DocumentIngestionStage.raw:
+        raise RuntimeError("Existing ingestion run document is no longer at the raw stage")
+    require_matching_source_identity(document.frontmatter.source, run.frontmatter.source)
+    if (
+        document.frontmatter.extraction != run_extraction
+        or document.frontmatter.ingestion.run_id != run.frontmatter.ingestion.run_id
+        or document.frontmatter.ingestion.pipeline_version
+        != run.frontmatter.ingestion.pipeline_version
+        or document.frontmatter.ingestion.prompt_version != run.frontmatter.ingestion.prompt_version
+        or document.frontmatter.ingestion.input_checksum != run.frontmatter.ingestion.input_checksum
+    ):
+        raise RuntimeError("Existing raw document does not match its ingestion run")
+
+
+def canonical_db_checksum(checksum: str) -> str:
+    """Return the ``sha256:``-prefixed form of an accepted note's db_checksum."""
+    normalized = checksum.removeprefix("sha256:")
+    if len(normalized) != 64 or any(char not in "0123456789abcdef" for char in normalized):
+        raise RuntimeError("Accepted document db_checksum is not canonical SHA-256")
+    return f"sha256:{normalized}"

--- a/src/basic_memory/document_ingestion/raw_document.py
+++ b/src/basic_memory/document_ingestion/raw_document.py
@@ -360,7 +360,15 @@ def require_document_run_identity(
     document: DocumentMarkdownV1,
     run: DocumentIngestionRunMarkdownV1,
 ) -> None:
-    """Fail unless an accepted document and its run note agree on provenance."""
+    """Fail unless an accepted document and its run note agree on provenance.
+
+    This compares frontmatter only. The run note's ``output.raw.checksum`` is
+    deliberately not compared to the document's accepted db_checksum here: a
+    source move re-accepts the document (new checksum) before the run note is
+    rewritten, and a retry between those two steps must still pass identity so
+    the writer can finish the move. Writers compare the raw checksum themselves
+    once they know the pair is not mid-reconcile.
+    """
     run_extraction = run.frontmatter.extraction
     if run_extraction is None:
         raise RuntimeError("Existing raw ingestion run has no extraction metadata")

--- a/tests/document_ingestion/test_pdf_inspector.py
+++ b/tests/document_ingestion/test_pdf_inspector.py
@@ -1,0 +1,279 @@
+"""Tests for the bounded pdf-inspector subprocess adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.metadata
+from typing import Any, cast
+
+import pytest
+from pydantic import ValidationError
+
+from basic_memory.document_ingestion.pdf_inspector import (
+    PDF_INSPECTOR_ENGINE,
+    PdfInspector,
+    PdfInspectorLimits,
+    PdfInspectorOutput,
+    PdfInspectorPdfType,
+    PdfInspectorProcessError,
+    PdfInspectorSourceTooLargeError,
+    PdfInspectorTimeoutError,
+    _kill_and_wait,
+)
+
+
+def minimal_text_pdf() -> bytes:
+    """Build one small text PDF without adding a PDF-generation test dependency."""
+    stream = b"BT /F1 18 Tf 72 720 Td (Hello Basic Memory) Tj ET"
+    objects = (
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        (
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            b"/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>"
+        ),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        b"<< /Length " + str(len(stream)).encode() + b" >>\nstream\n" + stream + b"\nendstream",
+    )
+
+    document = bytearray(b"%PDF-1.4\n")
+    offsets = [0]
+    for object_number, body in enumerate(objects, start=1):
+        offsets.append(len(document))
+        document.extend(f"{object_number} 0 obj\n".encode())
+        document.extend(body)
+        document.extend(b"\nendobj\n")
+
+    xref_offset = len(document)
+    document.extend(f"xref\n0 {len(objects) + 1}\n".encode())
+    document.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        document.extend(f"{offset:010d} 00000 n \n".encode())
+    document.extend(
+        (
+            f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+            f"startxref\n{xref_offset}\n%%EOF\n"
+        ).encode()
+    )
+    return bytes(document)
+
+
+class FakeProcess:
+    """Stand-in for asyncio's subprocess handle with scripted behavior."""
+
+    def __init__(
+        self,
+        *,
+        returncode: int | None = 0,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+        hang: bool = False,
+        kill_raises: bool = False,
+    ) -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self._hang = hang
+        self._kill_raises = kill_raises
+        self.communicate_started = asyncio.Event()
+        self.killed = False
+        self.waited = False
+
+    async def communicate(self, *, input: bytes) -> tuple[bytes, bytes]:
+        _ = input
+        self.communicate_started.set()
+        if self._hang:
+            await asyncio.Event().wait()
+        return self._stdout, self._stderr
+
+    def kill(self) -> None:
+        if self._kill_raises:
+            raise ProcessLookupError
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        self.waited = True
+        return self.returncode if self.returncode is not None else -9
+
+
+def install_fake_process(monkeypatch: pytest.MonkeyPatch, process: FakeProcess) -> None:
+    async def create_subprocess(*args: object, **kwargs: object) -> FakeProcess:
+        _ = (args, kwargs)
+        return process
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_subprocess)
+
+
+@pytest.mark.asyncio
+async def test_pdf_inspector_extracts_native_text_in_subprocess() -> None:
+    inspector = PdfInspector(
+        limits=PdfInspectorLimits(
+            max_source_bytes=100_000,
+            max_pages=5,
+            max_output_bytes=100_000,
+            timeout_seconds=30.0,
+            cpu_seconds=10,
+            max_concurrency=1,
+        )
+    )
+
+    result = await inspector.extract(minimal_text_pdf())
+
+    assert result.engine == PDF_INSPECTOR_ENGINE
+    assert result.engine_version == importlib.metadata.version("pdf-inspector")
+    assert result.pdf_type == "text_based"
+    assert result.page_count == 1
+    assert result.extracted_page_count == 1
+    assert result.pages_needing_ocr == ()
+    assert "Hello Basic Memory" in result.markdown
+
+
+@pytest.mark.asyncio
+async def test_pdf_inspector_rejects_oversized_source_before_spawning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def unexpected_subprocess(*args: object, **kwargs: object) -> None:
+        raise AssertionError("subprocess must not start")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", unexpected_subprocess)
+    inspector = PdfInspector(limits=PdfInspectorLimits(max_source_bytes=3))
+
+    with pytest.raises(PdfInspectorSourceTooLargeError):
+        await inspector.extract(b"four")
+
+
+@pytest.mark.asyncio
+async def test_pdf_inspector_kills_and_reaps_child_when_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling the caller must not leave its native extractor running."""
+    process = FakeProcess(returncode=None, hang=True)
+    install_fake_process(monkeypatch, process)
+    inspector = PdfInspector(limits=PdfInspectorLimits(timeout_seconds=10.0))
+
+    task = asyncio.create_task(inspector.extract(b"%PDF-test"))
+    await process.communicate_started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert process.killed is True
+    assert process.waited is True
+
+
+@pytest.mark.asyncio
+async def test_pdf_inspector_kills_child_on_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = FakeProcess(returncode=None, hang=True)
+    install_fake_process(monkeypatch, process)
+    inspector = PdfInspector(limits=PdfInspectorLimits(timeout_seconds=0.01))
+
+    with pytest.raises(PdfInspectorTimeoutError, match="deadline"):
+        await inspector.extract(b"%PDF-test")
+
+    assert process.killed is True
+    assert process.waited is True
+
+
+@pytest.mark.asyncio
+async def test_pdf_inspector_reports_a_failed_child(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_process(monkeypatch, FakeProcess(returncode=3, stderr=b"boom\n"))
+    inspector = PdfInspector()
+
+    with pytest.raises(PdfInspectorProcessError, match="exit code 3: boom"):
+        await inspector.extract(b"%PDF-test")
+
+
+@pytest.mark.asyncio
+async def test_pdf_inspector_reports_a_failed_child_without_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_process(monkeypatch, FakeProcess(returncode=1))
+    inspector = PdfInspector()
+
+    with pytest.raises(PdfInspectorProcessError, match="no error detail"):
+        await inspector.extract(b"%PDF-test")
+
+
+@pytest.mark.asyncio
+async def test_pdf_inspector_rejects_oversized_child_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_process(monkeypatch, FakeProcess(stdout=b"x" * 11))
+    inspector = PdfInspector(limits=PdfInspectorLimits(max_output_bytes=10))
+
+    with pytest.raises(PdfInspectorProcessError, match="output byte limit"):
+        await inspector.extract(b"%PDF-test")
+
+
+@pytest.mark.asyncio
+async def test_pdf_inspector_rejects_invalid_child_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_process(monkeypatch, FakeProcess(stdout=b'{"engine_version": 1}'))
+    inspector = PdfInspector()
+
+    with pytest.raises(PdfInspectorProcessError, match="invalid result"):
+        await inspector.extract(b"%PDF-test")
+
+
+@pytest.mark.asyncio
+async def test_kill_and_wait_tolerates_a_child_that_already_exited() -> None:
+    raced = FakeProcess(returncode=None, kill_raises=True)
+    await _kill_and_wait(cast(asyncio.subprocess.Process, raced))
+    assert raced.waited is True
+
+    finished = FakeProcess(returncode=0)
+    await _kill_and_wait(cast(asyncio.subprocess.Process, finished))
+    assert finished.killed is False
+    assert finished.waited is True
+
+
+def output_kwargs(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "engine_version": "0.2.6",
+        "pdf_type": PdfInspectorPdfType.mixed,
+        "markdown": "# Partial",
+        "page_count": 2,
+        "extracted_page_count": 1,
+        "pages_needing_ocr": (2,),
+        "confidence": 0.5,
+        "processing_time_ms": 1,
+        "is_complex_layout": False,
+        "pages_with_tables": (),
+        "pages_with_columns": (),
+        "has_encoding_issues": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_pdf_inspector_output_accepts_consistent_diagnostics() -> None:
+    result = PdfInspectorOutput(**output_kwargs())
+    assert result.engine == PDF_INSPECTOR_ENGINE
+    assert result.pages_needing_ocr == (2,)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"pages_needing_ocr": (3,)}, "outside the document"),
+        ({"pages_with_tables": (2, 1)}, "sorted and unique"),
+        ({"extracted_page_count": 2}, "exclude exactly"),
+    ],
+)
+def test_pdf_inspector_output_rejects_inconsistent_diagnostics(
+    overrides: dict[str, Any], message: str
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        PdfInspectorOutput(**output_kwargs(**overrides))
+
+
+def test_pdf_inspector_limits_are_strict() -> None:
+    with pytest.raises(ValidationError):
+        PdfInspectorLimits.model_validate({"max_source_bytes": "10"})

--- a/tests/document_ingestion/test_pdf_inspector.py
+++ b/tests/document_ingestion/test_pdf_inspector.py
@@ -59,8 +59,37 @@ def minimal_text_pdf() -> bytes:
     return bytes(document)
 
 
+class FakeStdin:
+    """Scripted stdin writer; flags when the adapter starts feeding the child."""
+
+    def __init__(self, *, started: asyncio.Event, broken: bool) -> None:
+        self._started = started
+        self._broken = broken
+        self.written = b""
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self._started.set()
+        self.written += data
+
+    async def drain(self) -> None:
+        if self._broken:
+            raise BrokenPipeError
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def pipe(data: bytes, *, eof: bool = True) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader()
+    reader.feed_data(data)
+    if eof:
+        reader.feed_eof()
+    return reader
+
+
 class FakeProcess:
-    """Stand-in for asyncio's subprocess handle with scripted behavior."""
+    """Stand-in for asyncio's subprocess handle with scripted pipes."""
 
     def __init__(
         self,
@@ -70,22 +99,17 @@ class FakeProcess:
         stderr: bytes = b"",
         hang: bool = False,
         kill_raises: bool = False,
+        stdin_broken: bool = False,
     ) -> None:
         self.returncode = returncode
-        self._stdout = stdout
-        self._stderr = stderr
-        self._hang = hang
         self._kill_raises = kill_raises
         self.communicate_started = asyncio.Event()
+        self.stdin = FakeStdin(started=self.communicate_started, broken=stdin_broken)
+        # A hanging child never closes stdout, so the capped read waits forever.
+        self.stdout = pipe(stdout, eof=not hang)
+        self.stderr = pipe(stderr)
         self.killed = False
         self.waited = False
-
-    async def communicate(self, *, input: bytes) -> tuple[bytes, bytes]:
-        _ = input
-        self.communicate_started.set()
-        if self._hang:
-            await asyncio.Event().wait()
-        return self._stdout, self._stderr
 
     def kill(self) -> None:
         if self._kill_raises:
@@ -222,14 +246,53 @@ async def test_pdf_inspector_reports_a_failed_child_without_detail(
 
 
 @pytest.mark.asyncio
-async def test_pdf_inspector_rejects_oversized_child_output(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("stream_name", ["stdout", "stderr"])
+async def test_pdf_inspector_kills_a_child_that_overruns_a_pipe(
+    monkeypatch: pytest.MonkeyPatch, stream_name: str
 ) -> None:
-    install_fake_process(monkeypatch, FakeProcess(stdout=b"x" * 11))
+    """The ceiling applies while bytes stream in, on both pipes, and reaps the child."""
+    overrun = b"x" * 11
+    process = FakeProcess(
+        returncode=None,
+        stdout=overrun if stream_name == "stdout" else b"",
+        stderr=overrun if stream_name == "stderr" else b"",
+    )
+    install_fake_process(monkeypatch, process)
     inspector = PdfInspector(limits=PdfInspectorLimits(max_output_bytes=10))
 
-    with pytest.raises(PdfInspectorProcessError, match="output byte limit"):
+    with pytest.raises(PdfInspectorProcessError, match=f"output byte limit on {stream_name}"):
         await inspector.extract(b"%PDF-test")
+
+    assert process.killed is True
+    assert process.waited is True
+
+
+@pytest.mark.asyncio
+async def test_pdf_inspector_tolerates_a_child_that_exits_before_reading_stdin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = FakeProcess(returncode=2, stderr=b"bad input", stdin_broken=True)
+    install_fake_process(monkeypatch, process)
+    inspector = PdfInspector()
+
+    with pytest.raises(PdfInspectorProcessError, match="exit code 2: bad input"):
+        await inspector.extract(b"%PDF-test")
+
+    assert process.stdin.closed is True
+
+
+@pytest.mark.asyncio
+async def test_pdf_inspector_feeds_the_whole_source_to_the_child(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = FakeProcess(returncode=1)
+    install_fake_process(monkeypatch, process)
+
+    with pytest.raises(PdfInspectorProcessError):
+        await PdfInspector().extract(b"%PDF-test")
+
+    assert process.stdin.written == b"%PDF-test"
+    assert process.stdin.closed is True
 
 
 @pytest.mark.asyncio

--- a/tests/document_ingestion/test_pdf_inspector.py
+++ b/tests/document_ingestion/test_pdf_inspector.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib.metadata
+import sys
 from typing import Any, cast
 
 import pytest
@@ -105,6 +106,10 @@ def install_fake_process(monkeypatch: pytest.MonkeyPatch, process: FakeProcess) 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", create_subprocess)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Basic Memory pins the selector event loop on Windows, which cannot spawn subprocesses",
+)
 @pytest.mark.asyncio
 async def test_pdf_inspector_extracts_native_text_in_subprocess() -> None:
     inspector = PdfInspector(
@@ -141,6 +146,22 @@ async def test_pdf_inspector_rejects_oversized_source_before_spawning(
 
     with pytest.raises(PdfInspectorSourceTooLargeError):
         await inspector.extract(b"four")
+
+
+@pytest.mark.asyncio
+async def test_pdf_inspector_names_a_loop_without_subprocess_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Windows selector loop raises NotImplementedError; surface it as an adapter error."""
+
+    async def selector_loop_spawn(*args: object, **kwargs: object) -> None:
+        raise NotImplementedError
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", selector_loop_spawn)
+    inspector = PdfInspector()
+
+    with pytest.raises(PdfInspectorProcessError, match="subprocess support"):
+        await inspector.extract(b"%PDF-test")
 
 
 @pytest.mark.asyncio

--- a/tests/document_ingestion/test_pdf_inspector_worker.py
+++ b/tests/document_ingestion/test_pdf_inspector_worker.py
@@ -1,0 +1,164 @@
+"""Tests for the one-shot pdf-inspector worker process."""
+
+from __future__ import annotations
+
+import io
+import sys
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from basic_memory.document_ingestion import pdf_inspector_worker
+from basic_memory.document_ingestion.pdf_inspector import PDF_INSPECTOR_ENGINE, PdfInspectorOutput
+
+
+@dataclass(frozen=True)
+class FakePage:
+    page: int
+    needs_ocr: bool
+    markdown: str
+
+
+def fake_engine(
+    *,
+    classified_pages: int = 2,
+    processed_pages: int = 2,
+    pages: tuple[FakePage, ...] | None = None,
+    pages_needing_ocr: tuple[int, ...] = (2,),
+    pages_with_tables: tuple[int, ...] = (),
+    pages_with_columns: tuple[int, ...] = (),
+) -> SimpleNamespace:
+    """Script the three pdf_inspector calls the worker makes."""
+    if pages is None:
+        pages = (FakePage(0, False, "# Page one\n"), FakePage(1, True, ""))
+    return SimpleNamespace(
+        classify_pdf_bytes=lambda data: SimpleNamespace(page_count=classified_pages),
+        process_pdf_bytes=lambda data: SimpleNamespace(
+            page_count=processed_pages,
+            pdf_type="mixed",
+            title="Doc",
+            confidence=0.9,
+            processing_time_ms=5,
+            has_encoding_issues=False,
+        ),
+        extract_pages_markdown_bytes=lambda data: SimpleNamespace(
+            pages=list(pages),
+            pages_needing_ocr=list(pages_needing_ocr),
+            is_complex=False,
+            pages_with_tables=list(pages_with_tables),
+            pages_with_columns=list(pages_with_columns),
+        ),
+    )
+
+
+def test_inspect_pdf_bytes_maps_native_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pdf_inspector_worker, "pdf_inspector", fake_engine())
+
+    result = pdf_inspector_worker.inspect_pdf_bytes(
+        b"%PDF-test", max_pages=10, max_output_bytes=10_000
+    )
+
+    assert result.engine == PDF_INSPECTOR_ENGINE
+    assert result.pdf_type == "mixed"
+    assert result.title == "Doc"
+    assert result.page_count == 2
+    assert result.extracted_page_count == 1
+    assert result.pages_needing_ocr == (2,)
+    assert result.markdown == "<!-- Page 1 -->\n\n# Page one\n\n<!-- Page 2: OCR required -->"
+
+
+@pytest.mark.parametrize(
+    ("engine_kwargs", "limits", "error", "message"),
+    [
+        ({"classified_pages": 3, "processed_pages": 3}, {"max_pages": 2}, ValueError, "page limit"),
+        ({"processed_pages": 3}, {}, RuntimeError, "page counts differ"),
+        ({"pages": (FakePage(0, False, "only"),)}, {}, RuntimeError, "omitted pages"),
+        ({}, {"max_output_bytes": 5}, ValueError, "output byte limit"),
+        ({"pages_needing_ocr": (5,)}, {}, ValueError, "outside the document"),
+    ],
+)
+def test_inspect_pdf_bytes_rejects_inconsistent_native_output(
+    monkeypatch: pytest.MonkeyPatch,
+    engine_kwargs: dict[str, Any],
+    limits: dict[str, int],
+    error: type[Exception],
+    message: str,
+) -> None:
+    monkeypatch.setattr(pdf_inspector_worker, "pdf_inspector", fake_engine(**engine_kwargs))
+
+    with pytest.raises(error, match=message):
+        pdf_inspector_worker.inspect_pdf_bytes(
+            b"%PDF-test",
+            max_pages=limits.get("max_pages", 10),
+            max_output_bytes=limits.get("max_output_bytes", 10_000),
+        )
+
+
+def test_worker_bounds_linux_address_space(monkeypatch: pytest.MonkeyPatch) -> None:
+    setrlimit = Mock()
+    monkeypatch.setattr(pdf_inspector_worker.sys, "platform", "linux")
+    monkeypatch.setattr(pdf_inspector_worker.resource, "setrlimit", setrlimit)
+
+    pdf_inspector_worker._apply_memory_limit(512 * 1024 * 1024)
+
+    setrlimit.assert_called_once_with(
+        pdf_inspector_worker.resource.RLIMIT_AS,
+        (512 * 1024 * 1024, 512 * 1024 * 1024),
+    )
+
+
+def test_worker_skips_address_space_limit_off_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    setrlimit = Mock()
+    monkeypatch.setattr(pdf_inspector_worker.sys, "platform", "darwin")
+    monkeypatch.setattr(pdf_inspector_worker.resource, "setrlimit", setrlimit)
+
+    pdf_inspector_worker._apply_memory_limit(512 * 1024 * 1024)
+
+    setrlimit.assert_not_called()
+
+
+def test_worker_bounds_cpu_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    setrlimit = Mock()
+    monkeypatch.setattr(pdf_inspector_worker.resource, "setrlimit", setrlimit)
+
+    pdf_inspector_worker._apply_cpu_limit(25)
+
+    setrlimit.assert_called_once_with(pdf_inspector_worker.resource.RLIMIT_CPU, (25, 26))
+
+
+def test_worker_main_writes_one_json_result(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    applied: list[tuple[str, int]] = []
+    monkeypatch.setattr(pdf_inspector_worker, "pdf_inspector", fake_engine())
+    monkeypatch.setattr(
+        pdf_inspector_worker, "_apply_memory_limit", lambda n: applied.append(("memory", n))
+    )
+    monkeypatch.setattr(
+        pdf_inspector_worker, "_apply_cpu_limit", lambda n: applied.append(("cpu", n))
+    )
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(buffer=io.BytesIO(b"%PDF-test")))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "pdf_inspector_worker",
+            "--max-pages",
+            "10",
+            "--max-output-bytes",
+            "10000",
+            "--max-memory-bytes",
+            "1000",
+            "--cpu-seconds",
+            "5",
+        ],
+    )
+
+    pdf_inspector_worker.main()
+
+    result = PdfInspectorOutput.model_validate_json(capsys.readouterr().out, strict=True)
+    assert result.page_count == 2
+    assert applied == [("memory", 1000), ("cpu", 5)]

--- a/tests/document_ingestion/test_pdf_inspector_worker.py
+++ b/tests/document_ingestion/test_pdf_inspector_worker.py
@@ -75,9 +75,28 @@ def test_inspect_pdf_bytes_maps_native_output(monkeypatch: pytest.MonkeyPatch) -
     [
         ({"classified_pages": 3, "processed_pages": 3}, {"max_pages": 2}, ValueError, "page limit"),
         ({"processed_pages": 3}, {}, RuntimeError, "page counts differ"),
-        ({"pages": (FakePage(0, False, "only"),)}, {}, RuntimeError, "omitted pages"),
+        ({"pages": (FakePage(0, False, "only"),)}, {}, RuntimeError, "do not cover"),
+        (
+            {"pages": (FakePage(0, False, "a"), FakePage(0, True, ""))},
+            {},
+            RuntimeError,
+            "do not cover",
+        ),
+        (
+            {"pages": (FakePage(1, True, ""), FakePage(0, False, "a"))},
+            {},
+            RuntimeError,
+            "do not cover",
+        ),
         ({}, {"max_output_bytes": 5}, ValueError, "output byte limit"),
         ({"pages_needing_ocr": (5,)}, {}, ValueError, "outside the document"),
+        ({"pages_needing_ocr": ()}, {}, RuntimeError, "disagree"),
+        (
+            {"pages": (FakePage(0, False, "a"), FakePage(1, False, "b"))},
+            {},
+            RuntimeError,
+            "disagree",
+        ),
     ],
 )
 def test_inspect_pdf_bytes_rejects_inconsistent_native_output(

--- a/tests/document_ingestion/test_pdf_inspector_worker.py
+++ b/tests/document_ingestion/test_pdf_inspector_worker.py
@@ -97,36 +97,47 @@ def test_inspect_pdf_bytes_rejects_inconsistent_native_output(
         )
 
 
+def fake_posix_resource() -> SimpleNamespace:
+    """Stand in for the POSIX ``resource`` module so limit tests run on every OS."""
+    return SimpleNamespace(setrlimit=Mock(), RLIMIT_AS="RLIMIT_AS", RLIMIT_CPU="RLIMIT_CPU")
+
+
 def test_worker_bounds_linux_address_space(monkeypatch: pytest.MonkeyPatch) -> None:
-    setrlimit = Mock()
+    resource = fake_posix_resource()
     monkeypatch.setattr(pdf_inspector_worker.sys, "platform", "linux")
-    monkeypatch.setattr(pdf_inspector_worker.resource, "setrlimit", setrlimit)
+    monkeypatch.setattr(pdf_inspector_worker, "resource", resource)
 
     pdf_inspector_worker._apply_memory_limit(512 * 1024 * 1024)
 
-    setrlimit.assert_called_once_with(
-        pdf_inspector_worker.resource.RLIMIT_AS,
-        (512 * 1024 * 1024, 512 * 1024 * 1024),
-    )
+    resource.setrlimit.assert_called_once_with("RLIMIT_AS", (512 * 1024 * 1024, 512 * 1024 * 1024))
 
 
 def test_worker_skips_address_space_limit_off_linux(monkeypatch: pytest.MonkeyPatch) -> None:
-    setrlimit = Mock()
+    resource = fake_posix_resource()
     monkeypatch.setattr(pdf_inspector_worker.sys, "platform", "darwin")
-    monkeypatch.setattr(pdf_inspector_worker.resource, "setrlimit", setrlimit)
+    monkeypatch.setattr(pdf_inspector_worker, "resource", resource)
 
     pdf_inspector_worker._apply_memory_limit(512 * 1024 * 1024)
 
-    setrlimit.assert_not_called()
+    resource.setrlimit.assert_not_called()
 
 
 def test_worker_bounds_cpu_time(monkeypatch: pytest.MonkeyPatch) -> None:
-    setrlimit = Mock()
-    monkeypatch.setattr(pdf_inspector_worker.resource, "setrlimit", setrlimit)
+    resource = fake_posix_resource()
+    monkeypatch.setattr(pdf_inspector_worker, "resource", resource)
 
     pdf_inspector_worker._apply_cpu_limit(25)
 
-    setrlimit.assert_called_once_with(pdf_inspector_worker.resource.RLIMIT_CPU, (25, 26))
+    resource.setrlimit.assert_called_once_with("RLIMIT_CPU", (25, 26))
+
+
+def test_worker_skips_rlimits_without_posix_resource(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Windows has no rlimits; the parent's deadline is the only ceiling there."""
+    monkeypatch.setattr(pdf_inspector_worker, "resource", None)
+    monkeypatch.setattr(pdf_inspector_worker.sys, "platform", "linux")
+
+    pdf_inspector_worker._apply_cpu_limit(25)
+    pdf_inspector_worker._apply_memory_limit(1024)
 
 
 def test_worker_main_writes_one_json_result(

--- a/tests/document_ingestion/test_pdf_inspector_worker.py
+++ b/tests/document_ingestion/test_pdf_inspector_worker.py
@@ -30,6 +30,7 @@ def fake_engine(
     pages_needing_ocr: tuple[int, ...] = (2,),
     pages_with_tables: tuple[int, ...] = (),
     pages_with_columns: tuple[int, ...] = (),
+    title: str = "Doc",
 ) -> SimpleNamespace:
     """Script the three pdf_inspector calls the worker makes."""
     if pages is None:
@@ -39,7 +40,7 @@ def fake_engine(
         process_pdf_bytes=lambda data: SimpleNamespace(
             page_count=processed_pages,
             pdf_type="mixed",
-            title="Doc",
+            title=title,
             confidence=0.9,
             processing_time_ms=5,
             has_encoding_issues=False,
@@ -159,11 +160,11 @@ def test_worker_skips_rlimits_without_posix_resource(monkeypatch: pytest.MonkeyP
     pdf_inspector_worker._apply_memory_limit(1024)
 
 
-def test_worker_main_writes_one_json_result(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
+def run_worker_main(
+    monkeypatch: pytest.MonkeyPatch, engine: SimpleNamespace
+) -> list[tuple[str, int]]:
     applied: list[tuple[str, int]] = []
-    monkeypatch.setattr(pdf_inspector_worker, "pdf_inspector", fake_engine())
+    monkeypatch.setattr(pdf_inspector_worker, "pdf_inspector", engine)
     monkeypatch.setattr(
         pdf_inspector_worker, "_apply_memory_limit", lambda n: applied.append(("memory", n))
     )
@@ -186,9 +187,25 @@ def test_worker_main_writes_one_json_result(
             "5",
         ],
     )
-
     pdf_inspector_worker.main()
+    return applied
+
+
+def test_worker_main_writes_one_json_result(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    applied = run_worker_main(monkeypatch, fake_engine())
 
     result = PdfInspectorOutput.model_validate_json(capsys.readouterr().out, strict=True)
     assert result.page_count == 2
     assert applied == [("memory", 1000), ("cpu", 5)]
+
+
+def test_worker_main_bounds_the_whole_result_envelope(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A small body with a huge untrusted title must not cross the pipe."""
+    with pytest.raises(ValueError, match="result exceeds"):
+        run_worker_main(monkeypatch, fake_engine(title="t" * 20_000))
+
+    assert capsys.readouterr().out == ""

--- a/tests/document_ingestion/test_raw_document.py
+++ b/tests/document_ingestion/test_raw_document.py
@@ -1,0 +1,350 @@
+"""Tests for the portable raw document contract mapping and runtime shell."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import override
+from uuid import UUID
+
+import pytest
+
+from basic_memory.document_ingestion.pdf_inspector import (
+    PdfInspector,
+    PdfInspectorLimits,
+    PdfInspectorOutput,
+    PdfInspectorPdfType,
+)
+from basic_memory.document_ingestion.raw_document import (
+    DocumentSourceChangedError,
+    DocumentSourceEntity,
+    DocumentSourceSnapshot,
+    RawDocumentArtifacts,
+    RawDocumentWriteResult,
+    RawPdfDocumentRuntime,
+    build_raw_document_artifacts,
+    build_raw_ingestion_run_markdown,
+    canonical_db_checksum,
+    extraction_options_checksum,
+    require_document_run_identity,
+    require_matching_raw_document,
+    require_matching_source_identity,
+)
+from basic_memory.schemas.document import (
+    DocumentExtractionStatus,
+    DocumentIngestionStage,
+    DocumentIngestionV1,
+    DocumentMarkdownV1,
+    parse_document_ingestion_run_markdown,
+    parse_document_markdown,
+)
+
+SOURCE_EXTERNAL_ID = UUID("11111111-1111-1111-1111-111111111111")
+STARTED_AT = datetime(2026, 8, 1, 3, 0, tzinfo=UTC)
+EXTRACTED_AT = datetime(2026, 8, 1, 3, 1, tzinfo=UTC)
+
+
+def source_entity() -> DocumentSourceEntity:
+    return DocumentSourceEntity(
+        entity_id=7,
+        external_id=SOURCE_EXTERNAL_ID,
+        file_path="research/report.pdf",
+        media_type="application/pdf",
+    )
+
+
+def source_snapshot(*, checksum_char: str = "a") -> DocumentSourceSnapshot:
+    return DocumentSourceSnapshot(
+        entity=source_entity(),
+        content=b"%PDF-test",
+        checksum="sha256:" + checksum_char * 64,
+        size_bytes=9,
+        storage_etag="etag-1",
+    )
+
+
+def extraction_output(*, engine_version: str = "0.2.6") -> PdfInspectorOutput:
+    return PdfInspectorOutput(
+        engine_version=engine_version,
+        pdf_type=PdfInspectorPdfType.text_based,
+        markdown="<!-- Page 1 -->\n\nExtracted text.\n",
+        title="Report",
+        page_count=1,
+        extracted_page_count=1,
+        confidence=1.0,
+        processing_time_ms=12,
+        is_complex_layout=False,
+        has_encoding_issues=False,
+    )
+
+
+def artifacts(
+    *,
+    checksum_char: str = "a",
+    engine_version: str = "0.2.6",
+    limits: PdfInspectorLimits | None = None,
+) -> RawDocumentArtifacts:
+    return build_raw_document_artifacts(
+        source_snapshot(checksum_char=checksum_char),
+        extraction_output(engine_version=engine_version),
+        limits=limits or PdfInspectorLimits(),
+        started_at=STARTED_AT,
+        extracted_at=EXTRACTED_AT,
+    )
+
+
+def test_build_raw_document_artifacts_is_typed_and_deterministic() -> None:
+    limits = PdfInspectorLimits()
+
+    first = artifacts(limits=limits)
+    second = artifacts(limits=limits)
+
+    assert first == second
+    assert first.document_file_path == "research/report.pdf.md"
+    assert first.run_file_path == f"document-ingestion-runs/{first.run_id}.md"
+    parsed = parse_document_markdown(first.document_markdown)
+    assert parsed.frontmatter.type == "document"
+    assert parsed.frontmatter.source.storage_etag == "etag-1"
+    assert parsed.frontmatter.extraction.status is DocumentExtractionStatus.complete
+    assert parsed.frontmatter.extraction.profile == "pdf-inspector-v1"
+    assert parsed.frontmatter.extraction.options_hash == extraction_options_checksum(limits)
+    assert parsed.frontmatter.extraction.classification == "text_based"
+    assert parsed.frontmatter.extraction.duration_ms == 12
+    assert parsed.frontmatter.ingestion.stage is DocumentIngestionStage.raw
+    assert parsed.frontmatter.bm_parse_semantics is False
+    assert parsed.body == "<!-- Page 1 -->\n\nExtracted text.\n"
+
+
+def test_engine_version_is_part_of_run_identity() -> None:
+    assert artifacts().run_id != artifacts(engine_version="1.17.0").run_id
+
+
+def test_raw_run_note_references_the_accepted_document_checksum() -> None:
+    built = artifacts()
+    markdown = build_raw_ingestion_run_markdown(
+        built,
+        raw_checksum="sha256:" + "b" * 64,
+        raw_created_at=datetime(2026, 8, 1, 3, 2, tzinfo=UTC),
+    )
+
+    run = parse_document_ingestion_run_markdown(markdown)
+    assert run.frontmatter.type == "document_ingestion_run"
+    assert run.frontmatter.extraction == built.extraction
+    assert run.frontmatter.output is not None
+    assert run.frontmatter.output.raw.checksum == "sha256:" + "b" * 64
+    assert run.frontmatter.output.raw.storage_version_id is None
+    assert run.frontmatter.bm_parse_semantics is False
+
+
+def test_extraction_options_checksum_changes_with_a_shaping_limit() -> None:
+    default = extraction_options_checksum(PdfInspectorLimits())
+    changed = extraction_options_checksum(PdfInspectorLimits(max_pages=50))
+
+    assert default.startswith("sha256:")
+    assert default != changed
+
+
+# --- Identity checks ---
+
+
+def accepted_document(built: RawDocumentArtifacts) -> DocumentMarkdownV1:
+    return parse_document_markdown(built.document_markdown)
+
+
+def with_ready_stage(document: DocumentMarkdownV1) -> DocumentMarkdownV1:
+    ingestion = document.frontmatter.ingestion
+    enriched = DocumentIngestionV1(
+        stage=DocumentIngestionStage.ready,
+        pipeline_version=ingestion.pipeline_version,
+        run_id=ingestion.run_id,
+        input_checksum=ingestion.input_checksum,
+        base_checksum="sha256:" + "c" * 64,
+    )
+    frontmatter = document.frontmatter.model_copy(update={"ingestion": enriched})
+    return document.model_copy(update={"frontmatter": frontmatter})
+
+
+def test_require_matching_raw_document_accepts_the_deterministic_document() -> None:
+    built = artifacts()
+
+    require_matching_raw_document(accepted_document(built), built)
+
+
+def test_require_matching_raw_document_rejects_another_engine_version() -> None:
+    document = accepted_document(artifacts())
+
+    with pytest.raises(RuntimeError, match="deterministic run identity"):
+        require_matching_raw_document(document, artifacts(engine_version="1.17.0"))
+
+
+def test_require_matching_raw_document_rejects_an_enriched_document() -> None:
+    built = artifacts()
+
+    with pytest.raises(RuntimeError, match="no longer at the raw stage"):
+        require_matching_raw_document(with_ready_stage(accepted_document(built)), built)
+
+
+def test_require_matching_source_identity_rejects_different_bytes() -> None:
+    require_matching_source_identity(artifacts().source, artifacts().source)
+
+    with pytest.raises(RuntimeError, match="source identity"):
+        require_matching_source_identity(artifacts().source, artifacts(checksum_char="d").source)
+
+
+def accepted_run(built: RawDocumentArtifacts):
+    return parse_document_ingestion_run_markdown(
+        build_raw_ingestion_run_markdown(
+            built,
+            raw_checksum="sha256:" + "b" * 64,
+            raw_created_at=datetime(2026, 8, 1, 3, 2, tzinfo=UTC),
+        )
+    )
+
+
+def test_require_document_run_identity_accepts_a_matching_pair() -> None:
+    built = artifacts()
+
+    require_document_run_identity(accepted_document(built), accepted_run(built))
+
+
+def test_require_document_run_identity_rejects_a_run_without_extraction() -> None:
+    built = artifacts()
+    run = accepted_run(built)
+    run = run.model_copy(
+        update={"frontmatter": run.frontmatter.model_copy(update={"extraction": None})}
+    )
+
+    with pytest.raises(RuntimeError, match="no extraction metadata"):
+        require_document_run_identity(accepted_document(built), run)
+
+
+def test_require_document_run_identity_rejects_an_enriched_document() -> None:
+    built = artifacts()
+
+    with pytest.raises(RuntimeError, match="no longer at the raw stage"):
+        require_document_run_identity(
+            with_ready_stage(accepted_document(built)), accepted_run(built)
+        )
+
+
+def test_require_document_run_identity_rejects_another_runs_note() -> None:
+    built = artifacts()
+
+    with pytest.raises(RuntimeError, match="does not match its ingestion run"):
+        require_document_run_identity(
+            accepted_document(built), accepted_run(artifacts(engine_version="1.17.0"))
+        )
+
+
+def test_canonical_db_checksum_normalizes_the_prefix() -> None:
+    bare = "e" * 64
+    assert canonical_db_checksum(bare) == f"sha256:{bare}"
+    assert canonical_db_checksum(f"sha256:{bare}") == f"sha256:{bare}"
+
+    with pytest.raises(RuntimeError, match="not canonical"):
+        canonical_db_checksum("sha256:short")
+
+
+# --- Runtime shell ---
+
+
+class RecordingSourceResolver:
+    def __init__(self, events: list[str], *, entities: list[DocumentSourceEntity]) -> None:
+        self.events = events
+        self.entities = entities
+
+    async def resolve(self, file_path: str) -> DocumentSourceEntity:
+        assert file_path == "research/report.pdf"
+        self.events.append("resolve")
+        return self.entities.pop(0)
+
+
+class RecordingSourceReader:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    async def read(
+        self,
+        entity: DocumentSourceEntity,
+        *,
+        observed_etag: str | None,
+    ) -> DocumentSourceSnapshot:
+        assert entity == source_entity()
+        assert observed_etag is None
+        self.events.append("read")
+        return source_snapshot()
+
+    async def require_current(self, snapshot: DocumentSourceSnapshot) -> None:
+        assert snapshot == source_snapshot()
+        self.events.append("require_current")
+
+
+class RecordingPdfInspector(PdfInspector):
+    events: list[str] = []
+
+    @override
+    async def extract(self, pdf_bytes: bytes) -> PdfInspectorOutput:
+        assert pdf_bytes == source_snapshot().content
+        self.events.append("extract")
+        return extraction_output()
+
+
+EXPECTED_RESULT = RawDocumentWriteResult(
+    document_external_id=UUID("33333333-3333-3333-3333-333333333333"),
+    document_file_path="research/report.pdf.md",
+    document_db_checksum="sha256:" + "c" * 64,
+    run_id=UUID("44444444-4444-4444-4444-444444444444"),
+    run_file_path="document-ingestion-runs/run.md",
+    document_created=True,
+    run_created=True,
+)
+
+
+class RecordingWriter:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    async def write(self, artifacts: RawDocumentArtifacts) -> RawDocumentWriteResult:
+        assert artifacts.document_file_path == "research/report.pdf.md"
+        self.events.append("write")
+        return EXPECTED_RESULT
+
+
+def runtime(events: list[str], *, entities: list[DocumentSourceEntity]) -> RawPdfDocumentRuntime:
+    extractor = RecordingPdfInspector(limits=PdfInspectorLimits())
+    extractor.events = events
+    return RawPdfDocumentRuntime(
+        source_resolver=RecordingSourceResolver(events, entities=entities),
+        source_reader=RecordingSourceReader(events),
+        extractor=extractor,
+        writer=RecordingWriter(events),
+    )
+
+
+@pytest.mark.asyncio
+async def test_raw_runtime_revalidates_source_immediately_before_write() -> None:
+    events: list[str] = []
+
+    result = await runtime(events, entities=[source_entity(), source_entity()]).ingest(
+        file_path="research/report.pdf", observed_etag=None
+    )
+
+    assert result == EXPECTED_RESULT
+    assert events == ["resolve", "read", "extract", "resolve", "require_current", "write"]
+
+
+@pytest.mark.asyncio
+async def test_raw_runtime_rejects_a_source_replaced_during_extraction() -> None:
+    events: list[str] = []
+    replaced = DocumentSourceEntity(
+        entity_id=8,
+        external_id=UUID("55555555-5555-5555-5555-555555555555"),
+        file_path="research/report.pdf",
+        media_type="application/pdf",
+    )
+
+    with pytest.raises(DocumentSourceChangedError, match="changed during extraction"):
+        await runtime(events, entities=[source_entity(), replaced]).ingest(
+            file_path="research/report.pdf", observed_etag=None
+        )
+
+    assert events == ["resolve", "read", "extract", "resolve"]

--- a/uv.lock
+++ b/uv.lock
@@ -334,6 +334,9 @@ milvus = [
     { name = "pymilvus" },
     { name = "pymilvus", extra = ["milvus-lite"], marker = "sys_platform != 'win32'" },
 ]
+pdf = [
+    { name = "pdf-inspector" },
+]
 redis = [
     { name = "redis" },
 ]
@@ -346,6 +349,7 @@ dev = [
     { name = "icecream" },
     { name = "libcst" },
     { name = "logfire" },
+    { name = "pdf-inspector" },
     { name = "psycopg" },
     { name = "pyright" },
     { name = "pytest" },
@@ -385,6 +389,7 @@ requires-dist = [
     { name = "mdformat-frontmatter", specifier = ">=2.0.8" },
     { name = "mdformat-gfm", specifier = ">=0.3.7" },
     { name = "openai", specifier = ">=1.100.2" },
+    { name = "pdf-inspector", marker = "extra == 'pdf'", specifier = ">=0.2.6,<2" },
     { name = "pillow", specifier = ">=11.1.0" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "psycopg", specifier = "==3.3.1" },
@@ -410,7 +415,7 @@ requires-dist = [
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0" },
     { name = "watchfiles", specifier = ">=1.0.4" },
 ]
-provides-extras = ["milvus", "redis"]
+provides-extras = ["milvus", "pdf", "redis"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -420,6 +425,7 @@ dev = [
     { name = "icecream", specifier = ">=2.1.3" },
     { name = "libcst", specifier = ">=1.8.6" },
     { name = "logfire", specifier = ">=4.19.0" },
+    { name = "pdf-inspector", specifier = ">=0.2.6,<2" },
     { name = "psycopg", specifier = ">=3.2.0" },
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=8.3.4" },
@@ -2755,6 +2761,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
+]
+
+[[package]]
+name = "pdf-inspector"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/0c/83033698e9c1a89323209d99b6709c3c542ba8cffb556effd2d7cb86df54/pdf_inspector-1.17.0.tar.gz", hash = "sha256:2494bf571df419c17bcdb3651c0b7a648e1615cc6ee997d51ed9d75505789cd4", size = 1717688, upload-time = "2026-08-21T20:57:51.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/af/6c1e5ffe1fc8a41705b07053adf28b20cd10ccbd67d4f0437b3390304904/pdf_inspector-1.17.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:8012c877900d7872dcc49aa4d83a60b14475540e97cae80c79f5d2e4f0c113d9", size = 4820371, upload-time = "2026-08-21T20:57:41.138Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d9/f49a1de9b6871c1b11c0aa4c184a295fb141605e0f5ba746a6fbae8b8ce1/pdf_inspector-1.17.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:05845dcf5af014787b50e16e38fe13409e95d6c40abff9372b0b358154bd3318", size = 4590233, upload-time = "2026-08-21T20:57:43.189Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/55/14c205ee0896738a7a48fd759dd295b9b2513668f2664fb8f1173d2dde71/pdf_inspector-1.17.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40b759e37c70708563f30ba5ba879e654308538584c3696d67cf0cecaaed0c05", size = 5111667, upload-time = "2026-08-21T20:57:45.142Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/2fe9f8a620d1c86742c27a87fe5fd15ef5dd8d1c95704223642037b16161/pdf_inspector-1.17.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bf93070239efbf781e96930c8389d04fde41a48125ceec2c08e6867acb63176", size = 5347989, upload-time = "2026-08-21T20:57:47.758Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f1/2b8843c594c27f9e7e8e552be4d9901a0c0eee78d93524be56916c4e3b8c/pdf_inspector-1.17.0-cp38-abi3-win_amd64.whl", hash = "sha256:bbe731d39eb620a03e4b79afd6e620dca824f22571560508caab97492a016578", size = 4696320, upload-time = "2026-08-21T20:57:49.704Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

#1178 gives Core the parser-neutral document contract, but the code that actually turns PDF bytes into that contract lives only in Cloud ([basic-memory-cloud#1650](https://github.com/basicmachines-co/basic-memory-cloud/pull/1650)). That leaves the local half of #1006 — `bm import pdf` — with nothing to build on, and means the hosted and local paths would drift on extraction shape, page markers, and run identity.

This PR moves the runtime-neutral pieces of that Cloud work into Core behind an optional `basic-memory[pdf]` extra. Cloud keeps everything hosted-specific (Tigris reads, PGQueuer, accepted-note writer, kill switch) and imports the rest from here.

Stacked on #1178 (`codex-document-ingestion`); retarget to `main` once that lands.

## Specification

### Scope

Core must provide, without importing `pdf_inspector` at module load anywhere outside the worker:

- a bounded subprocess adapter around `firecrawl/pdf-inspector` with explicit source, page, output, memory, CPU, wall-clock, and concurrency ceilings, and a strict validated output model;
- the one-shot worker entrypoint (`python -m basic_memory.document_ingestion.pdf_inspector_worker`) that applies rlimits before reading bytes and emits one JSON result;
- the mapping from a stable source snapshot plus extractor output into `DocumentMarkdownV1` / `DocumentIngestionRunMarkdownV1`, including deterministic run identity and `bm_parse_semantics: false`;
- the read → extract → revalidate → write orchestration shell behind `DocumentSourceEntityResolver`, `DocumentSourceReader`, and `RawDocumentWriter` protocols;
- the identity checks a writer needs before reusing an already-accepted document or run note.

### Behavioral contract

1. `PdfInspector.extract()` never blocks the caller's loop, kills and reaps the child on cancel or deadline, and rejects oversized sources before spawning.
2. The worker records the *installed* `pdf-inspector` version as `engine_version`; that version is part of the deterministic run id, so a library upgrade yields a new run rather than rewriting an existing document's provenance. There is no hard equality pin in Core — consumers that need determinism pin in their own lockfile.
3. Raw document notes keep the body searchable and set `bm_parse_semantics: false` so extracted `- [foo]` / `[[bar]]` text cannot mint graph semantics.
4. `RawPdfDocumentRuntime.ingest()` re-resolves the source entity and revalidates the storage generation after extraction and before write.

### Non-goals

- `bm import pdf` (follow-up on #1006 — this PR is the shell it will use);
- OCR;
- Cloud queues, Tigris, materialization, or the accepted-note writer.

## Acceptance Criteria

- [x] `basic-memory[pdf]` extra exists; the default install stays parser-free.
- [x] `basic_memory.document_ingestion` imports without `pdf_inspector` installed except in the worker.
- [x] Adapter, worker, and mapping ported from cloud#1650 with behavior unchanged except the version-equality check.
- [x] Identity checks (`require_matching_raw_document`, `require_matching_source_identity`, `require_document_run_identity`, `canonical_db_checksum`) are public for the Cloud writer.
- [x] Real subprocess extraction passes on pdf-inspector 0.2.6 and 1.17.0.
- [x] Worker rejects page entries that do not cover `0..page_count-1` exactly, and per-page OCR flags that disagree with `pages_needing_ocr` (Codex P2).
- [x] `max_output_bytes` is a hard ceiling on both child pipes while bytes stream in (no unbounded `communicate()` buffering), the child is killed and reaped on overrun, and the worker bounds the whole serialized envelope, not only the Markdown body (Codex P1).
- [x] 100% coverage on the new package; lightweight CLI import regression still passes.

## What Changed

- `src/basic_memory/document_ingestion/pdf_inspector.py` — limits, output model, error types, `PdfInspector` subprocess adapter.
- `src/basic_memory/document_ingestion/pdf_inspector_worker.py` — child process: classify → extract → per-page markdown with `<!-- Page N -->` / `OCR required` markers, rlimits.
- `src/basic_memory/document_ingestion/raw_document.py` — source/artifact values, protocols, `RawPdfDocumentRuntime`, `build_raw_document_artifacts`, `build_raw_ingestion_run_markdown`, `extraction_options_checksum`, identity checks.
- `pyproject.toml` — `pdf` extra (`pdf-inspector>=0.2.6,<2`) and dev-group entry; `uv.lock` updated.
- `.github/workflows/test.yml` — install the `pdf` extra in every test job so the worker module is importable under coverage.
- `tests/document_ingestion/` — adapter, worker, and mapping tests.

## Testing

- `uv run ruff check` / `ruff format --check` on the new files: clean.
- `uv run ty check src tests test-int`: All checks passed.
- `uv run pytest tests/document_ingestion tests/markdown/test_entity_parser.py tests/schemas/test_document.py tests/cli/test_cli_exit.py::test_bm_cli_import_does_not_load_heavy_stack`: 120 passed; `basic_memory/document_ingestion/*` at 100% statement coverage.
- `uv run --with 'pdf-inspector==0.2.6' pytest tests/document_ingestion/test_pdf_inspector.py -k extracts_native`: passes (lock resolves 1.17.0; both verified).

## Risks / Follow-ups

- **Windows:** `db.py` pins the selector event loop on Windows for aiosqlite, and that loop cannot spawn asyncio subprocesses. `PdfInspector.extract()` therefore raises a named `PdfInspectorProcessError` there instead of a bare `NotImplementedError`, and the real-subprocess test is skipped on `win32`. A thread-backed `subprocess.run` adapter would lift that for `bm import pdf` on Windows; out of scope here. The worker also guards its POSIX `resource` import so the module imports everywhere.
- Cloud pins `pdf-inspector==0.2.6`; PyPI is at 1.17.0 and Markdown output differs between them (headings vs. fenced text on the fixture PDF). Bumping is a deliberate Cloud decision and produces new run ids by design.
- cloud#1650 follow-up drops its copies of the adapter/worker/mapping and imports from here.
- `bm import pdf` (local `DocumentSourceReader` + writer over the project directory) is the remaining half of #1006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp
