### PR TITLE
fix(core): tolerate disappearing guarded files

### DIFF
--- a/src/basic_memory/index/local_notes.py
+++ b/src/basic_memory/index/local_notes.py
@@ -200,7 +200,12 @@ class LocalNoteFileDeleteStorage:
         # guarantee portable: never delete an object that no longer matches (basic-memory-cloud#1618).
         if not await self.file_service.exists(path):
             return False
-        if await self.file_service.compute_checksum(path) != expected_checksum:
+        try:
+            actual_checksum = await self.compute_checksum(path)
+        except FileNotFoundError:
+            # Disappearance after the final existence probe is another safe no-delete outcome.
+            return False
+        if actual_checksum != expected_checksum:
             return False
         await self.file_service.delete_file(path)
         return True

--- a/src/basic_memory/index/local_notes.py
+++ b/src/basic_memory/index/local_notes.py
@@ -180,7 +180,14 @@ class LocalNoteFileDeleteStorage:
         return await self.file_service.exists(path)
 
     async def compute_checksum(self, path: RuntimeFilePath) -> RuntimeFileChecksum:
-        return await self.file_service.compute_checksum(path)
+        try:
+            return await self.file_service.compute_checksum(path)
+        except FileError as exc:
+            if isinstance(exc.__context__, FileNotFoundError):
+                # Directory cleanup uses the portable guard, where deletion after
+                # the existence probe is the same absent-file outcome.
+                raise FileNotFoundError(path) from exc
+            raise
 
     async def delete_file_if_unchanged(
         self,

--- a/src/basic_memory/index/note_content_materialization.py
+++ b/src/basic_memory/index/note_content_materialization.py
@@ -532,7 +532,14 @@ class LocalNoteContentStorage:
         return await self.file_service.exists(path)
 
     async def compute_checksum(self, path: RuntimeFilePath) -> RuntimeFileChecksum:
-        return await self.file_service.compute_checksum(path)
+        try:
+            return await self.file_service.compute_checksum(path)
+        except file_utils.FileError as exc:
+            if isinstance(exc.__context__, FileNotFoundError):
+                # The general FileService contract reports I/O failures as FileError,
+                # while runtime guards need concurrent deletion as an absent file.
+                raise FileNotFoundError(path) from exc
+            raise
 
     async def delete_file(self, path: RuntimeFilePath) -> None:
         await self.file_service.delete_file(path)

--- a/src/basic_memory/index/note_content_materialization.py
+++ b/src/basic_memory/index/note_content_materialization.py
@@ -555,7 +555,12 @@ class LocalNoteContentStorage:
         # atomic precondition; the race is negligible on a filesystem.
         if not await self.file_service.exists(path):
             return False
-        if await self.file_service.compute_checksum(path) != expected_checksum:
+        try:
+            actual_checksum = await self.compute_checksum(path)
+        except FileNotFoundError:
+            # Disappearance after the final existence probe is another safe no-delete outcome.
+            return False
+        if actual_checksum != expected_checksum:
             return False
         await self.file_service.delete_file(path)
         return True

--- a/src/basic_memory/runtime/note_file_guards.py
+++ b/src/basic_memory/runtime/note_file_guards.py
@@ -61,7 +61,12 @@ async def read_runtime_file_checksum(
     """Return the current runtime file checksum, or None when absent."""
     if not await reader.exists(file_path):
         return None
-    return await reader.compute_checksum(file_path)
+    try:
+        return await reader.compute_checksum(file_path)
+    except FileNotFoundError:
+        # Object stores cannot make exists-plus-read atomic. A concurrent delete
+        # after the probe has the same domain meaning as an initially absent file.
+        return None
 
 
 def runtime_file_conflict(

--- a/src/basic_memory/services/file_service.py
+++ b/src/basic_memory/services/file_service.py
@@ -569,10 +569,6 @@ class FileService:
 
                 return hasher.hexdigest()
 
-            except FileNotFoundError:
-                # Runtime guards distinguish a concurrently deleted file from a
-                # checksum failure; preserve that domain outcome at the adapter boundary.
-                raise
             except Exception as e:  # pragma: no cover
                 logger.error("Failed to compute checksum", path=str(full_path), error=str(e))
                 raise FileError(f"Failed to compute checksum for {path}: {e}")

--- a/src/basic_memory/services/file_service.py
+++ b/src/basic_memory/services/file_service.py
@@ -569,6 +569,10 @@ class FileService:
 
                 return hasher.hexdigest()
 
+            except FileNotFoundError:
+                # Runtime guards distinguish a concurrently deleted file from a
+                # checksum failure; preserve that domain outcome at the adapter boundary.
+                raise
             except Exception as e:  # pragma: no cover
                 logger.error("Failed to compute checksum", path=str(full_path), error=str(e))
                 raise FileError(f"Failed to compute checksum for {path}: {e}")

--- a/tests/runtime/test_note_file_guard_races.py
+++ b/tests/runtime/test_note_file_guard_races.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from basic_memory.file_utils import FileError
+from basic_memory.index.local_notes import LocalNoteFileDeleteStorage
 from basic_memory.index.note_content_materialization import LocalNoteContentStorage
 from basic_memory.runtime.note_file_guards import read_runtime_file_checksum
 from basic_memory.services.file_service import FileService
@@ -29,3 +30,16 @@ async def test_direct_checksum_preserves_file_service_error_contract(tmp_path: P
 
     with pytest.raises(FileError):
         await file_service.compute_checksum("notes/disappeared.md")
+
+
+async def test_directory_delete_checksum_treats_post_probe_deletion_as_absent(
+    tmp_path: Path,
+) -> None:
+    """Directory cleanup should converge when its target disappears before checksum I/O."""
+    file_service = FileService(tmp_path)
+    storage = LocalNoteFileDeleteStorage(file_service)
+
+    with patch.object(file_service, "exists", AsyncMock(return_value=True)):
+        checksum = await read_runtime_file_checksum(storage, "notes/disappeared.md")
+
+    assert checksum is None

--- a/tests/runtime/test_note_file_guard_races.py
+++ b/tests/runtime/test_note_file_guard_races.py
@@ -1,0 +1,25 @@
+"""Race regressions for portable note-file concurrency guards."""
+
+from basic_memory.runtime.note_file_guards import read_runtime_file_checksum
+from basic_memory.runtime.storage import RuntimeFileChecksum, RuntimeFilePath
+
+
+class _DisappearingChecksumReader:
+    """Model an object deleted after the existence probe succeeds."""
+
+    async def exists(self, path: RuntimeFilePath) -> bool:
+        del path
+        return True
+
+    async def compute_checksum(self, path: RuntimeFilePath) -> RuntimeFileChecksum:
+        raise FileNotFoundError(path)
+
+
+async def test_checksum_read_treats_post_probe_deletion_as_absent() -> None:
+    """A disappearing object should not poison a durable materialization retry."""
+    checksum = await read_runtime_file_checksum(
+        _DisappearingChecksumReader(),
+        "notes/disappeared.md",
+    )
+
+    assert checksum is None

--- a/tests/runtime/test_note_file_guard_races.py
+++ b/tests/runtime/test_note_file_guard_races.py
@@ -1,25 +1,20 @@
 """Race regressions for portable note-file concurrency guards."""
 
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from basic_memory.index.note_content_materialization import LocalNoteContentStorage
 from basic_memory.runtime.note_file_guards import read_runtime_file_checksum
-from basic_memory.runtime.storage import RuntimeFileChecksum, RuntimeFilePath
+from basic_memory.services.file_service import FileService
 
 
-class _DisappearingChecksumReader:
-    """Model an object deleted after the existence probe succeeds."""
-
-    async def exists(self, path: RuntimeFilePath) -> bool:
-        del path
-        return True
-
-    async def compute_checksum(self, path: RuntimeFilePath) -> RuntimeFileChecksum:
-        raise FileNotFoundError(path)
-
-
-async def test_checksum_read_treats_post_probe_deletion_as_absent() -> None:
+async def test_checksum_read_treats_post_probe_deletion_as_absent(tmp_path: Path) -> None:
     """A disappearing object should not poison a durable materialization retry."""
-    checksum = await read_runtime_file_checksum(
-        _DisappearingChecksumReader(),
-        "notes/disappeared.md",
-    )
+    file_service = FileService(tmp_path)
+    storage = LocalNoteContentStorage(file_service)
+
+    # The file disappears after storage reports it present but before checksum I/O.
+    with patch.object(file_service, "exists", AsyncMock(return_value=True)):
+        checksum = await read_runtime_file_checksum(storage, "notes/disappeared.md")
 
     assert checksum is None

--- a/tests/runtime/test_note_file_guard_races.py
+++ b/tests/runtime/test_note_file_guard_races.py
@@ -8,6 +8,8 @@ import pytest
 from basic_memory.file_utils import FileError
 from basic_memory.index.local_notes import LocalNoteFileDeleteStorage
 from basic_memory.index.note_content_materialization import LocalNoteContentStorage
+from basic_memory.indexing.note_file_delete_runner import run_note_file_delete
+from basic_memory.runtime.cleanup import RuntimeDeleteStatus, RuntimeNoteFileDeleteJobRequest
 from basic_memory.runtime.note_file_guards import read_runtime_file_checksum
 from basic_memory.services.file_service import FileService
 
@@ -22,6 +24,40 @@ async def test_checksum_read_treats_post_probe_deletion_as_absent(tmp_path: Path
         checksum = await read_runtime_file_checksum(storage, "notes/disappeared.md")
 
     assert checksum is None
+
+
+async def test_directory_delete_converges_when_file_disappears_before_delete(
+    tmp_path: Path,
+) -> None:
+    """The final guarded checksum should treat a vanished target as a safe no-delete."""
+    file_service = FileService(tmp_path)
+    file_path = "notes/disappeared.md"
+    await file_service.write_file(file_path, "# Disappearing note\n")
+    accepted_checksum = await file_service.compute_checksum(file_path)
+    original_compute_checksum = file_service.compute_checksum
+    checksum_calls = 0
+
+    async def delete_before_final_checksum(path: str) -> str:
+        nonlocal checksum_calls
+        checksum_calls += 1
+        if checksum_calls == 2:
+            (tmp_path / path).unlink()
+        return await original_compute_checksum(path)
+
+    with patch.object(file_service, "compute_checksum", side_effect=delete_before_final_checksum):
+        result = await run_note_file_delete(
+            RuntimeNoteFileDeleteJobRequest(
+                project_id=101,
+                entity_id=42,
+                file_path=file_path,
+                file_checksum=accepted_checksum,
+            ),
+            storage=LocalNoteFileDeleteStorage(file_service),
+        )
+
+    assert result.status == RuntimeDeleteStatus.skipped
+    assert result.reason == f"file changed before delete: {file_path}"
+    assert not (tmp_path / file_path).exists()
 
 
 async def test_direct_checksum_preserves_file_service_error_contract(tmp_path: Path) -> None:

--- a/tests/runtime/test_note_file_guard_races.py
+++ b/tests/runtime/test_note_file_guard_races.py
@@ -3,6 +3,9 @@
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
+from basic_memory.file_utils import FileError
 from basic_memory.index.note_content_materialization import LocalNoteContentStorage
 from basic_memory.runtime.note_file_guards import read_runtime_file_checksum
 from basic_memory.services.file_service import FileService
@@ -18,3 +21,11 @@ async def test_checksum_read_treats_post_probe_deletion_as_absent(tmp_path: Path
         checksum = await read_runtime_file_checksum(storage, "notes/disappeared.md")
 
     assert checksum is None
+
+
+async def test_direct_checksum_preserves_file_service_error_contract(tmp_path: Path) -> None:
+    """Direct callers still receive FileError when the checksum source is absent."""
+    file_service = FileService(tmp_path)
+
+    with pytest.raises(FileError):
+        await file_service.compute_checksum("notes/disappeared.md")

--- a/tests/runtime/test_note_file_guard_races.py
+++ b/tests/runtime/test_note_file_guard_races.py
@@ -60,6 +60,40 @@ async def test_directory_delete_converges_when_file_disappears_before_delete(
     assert not (tmp_path / file_path).exists()
 
 
+async def test_note_delete_converges_when_file_disappears_before_delete(
+    tmp_path: Path,
+) -> None:
+    """Ordinary note cleanup should share the safe final-checksum outcome."""
+    file_service = FileService(tmp_path)
+    file_path = "notes/disappeared.md"
+    await file_service.write_file(file_path, "# Disappearing note\n")
+    accepted_checksum = await file_service.compute_checksum(file_path)
+    original_compute_checksum = file_service.compute_checksum
+    checksum_calls = 0
+
+    async def delete_before_final_checksum(path: str) -> str:
+        nonlocal checksum_calls
+        checksum_calls += 1
+        if checksum_calls == 2:
+            (tmp_path / path).unlink()
+        return await original_compute_checksum(path)
+
+    with patch.object(file_service, "compute_checksum", side_effect=delete_before_final_checksum):
+        result = await run_note_file_delete(
+            RuntimeNoteFileDeleteJobRequest(
+                project_id=101,
+                entity_id=42,
+                file_path=file_path,
+                file_checksum=accepted_checksum,
+            ),
+            storage=LocalNoteContentStorage(file_service),
+        )
+
+    assert result.status == RuntimeDeleteStatus.skipped
+    assert result.reason == f"file changed before delete: {file_path}"
+    assert not (tmp_path / file_path).exists()
+
+
 async def test_direct_checksum_preserves_file_service_error_contract(tmp_path: Path) -> None:
     """Direct callers still receive FileError when the checksum source is absent."""
     file_service = FileService(tmp_path)


### PR DESCRIPTION
## Why

A hosted note object can be deleted after the materializer confirms it exists but before it reads the checksum. That ordinary object-store race currently escapes as a terminal checksum failure and poisons every durable materialization retry.

Production Logfire issue #2533 captured the exact sequence: the S3 existence probe succeeded, `GetObject` returned `NoSuchKey`, and the materialization job failed instead of treating the destination as absent.

## What Changed

- Treat `FileNotFoundError` from the checksum read after a successful existence probe as an absent runtime file.
- Preserve the general `FileService` `FileError` contract for direct callers, and translate only a missing-file cause in the local materialization and directory-delete storage adapters.
- Preserve every other checksum failure as actionable.
- Add focused regressions using both real runtime adapters, including both full guarded-delete paths, to model post-probe deletion and preserve the direct service contract.

## Implementation Details

The portable guard remains lock-free. It does not retry or introduce a second probe: absence before the probe and absence during the checksum read have the same domain result, so both return `None` to the existing conflict planner.

Cloud's S3 adapter change is delivered in basic-memory-cloud PR #1893 so `NoSuchKey` crosses this boundary as `FileNotFoundError`.

## Testing

- `uv run pytest tests/runtime/test_note_file_guard_races.py tests/services/test_file_service.py tests/repository/test_chunk_inspection.py -q`: 59 passed, 1 skipped.
- Focused Ruff and ty checks for the changed source and test: passed.
- `git diff --check`: passed.
- Load-bearing check: removing the runtime-adapter translation makes the real-adapter race regression fail.

The broad `just fast-check` reached type checking but the fresh worktree lacks the optional `pymilvus` dependency; the four failures are unresolved optional imports outside these paths. CI installs the repository's required matrix dependencies.

## Risks / Follow-ups

- This deliberately handles only `FileNotFoundError`; permissions, transport failures, malformed content, and other checksum errors still fail.
- Codex's reviews correctly identified the fake-only coverage gap, the direct `FileService` contract regression, and the final-checksum seams in both local delete adapters; commits through `aeb09978` address those findings and the threads are resolved.
- No deployment or production mutation is included.
