### PR TITLE
refactor(core): converge wiki logs on the accepted-change vocabulary

### DIFF
--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -151,6 +151,11 @@ watermark those records advance.
 - The journal is note-scoped and project-partitioned today. A fuller event envelope (causation,
   correlation, depth, workspace scope) grows this record; it does not introduce a second journal
   beside it.
+- Scope today: only DB-first accepted note mutations reach the journal
+  (`accepted_note_mutation_runner`). File-first reconciliation — observed file indexing and
+  external delete handling — converges derived state without journal evidence yet. Journaling
+  those reconciliation paths is the intended direction; until it lands, journal consumers see
+  DB-first mutations only, and file-first changes surface through reindex and reconciliation.
 
 ### Event Surfaces And Derivation
 
@@ -168,6 +173,9 @@ storage notifications / webhooks          ingress evidence
 ```
 
 - A projection may lag the journal and must be rebuildable from it plus canonical Markdown.
+- The ingress edge is the target shape, not the current one: reconciliation of external file
+  changes does not yet advance the journal (see the journal's scope bullet above), so today the
+  diagram's top edge holds only for DB-first accepted mutations.
 - Delivery events (webhook attempts, storage notifications, SSE publishes) prove delivery, not
   acceptance; they are never the canonical semantic log.
 - Run ledgers (projection runs, index runs) record operational work, and product telemetry

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -133,6 +133,50 @@ projections. They exist to retrieve and traverse knowledge efficiently.
 - Search results point back to entities and notes; they do not become independent documents.
 - Deleting or rebuilding an index must not mutate canonical content.
 
+### Accepted Change Journal
+
+`RuntimeAcceptedProjectNoteChange` is the canonical temporal record of one accepted note mutation
+inside a project partition, and `Project.partition_position` is the strictly ordered per-project
+watermark those records advance.
+
+- An accepted change is replay-complete evidence: operation, paths, accepted content version and
+  checksum, actor, source, and acceptance time. It is recorded with the accepted mutation, not
+  reconstructed later from derived state.
+- Consumers that need ordering, coalescing, or idempotency — projectors, routines, temporal
+  reads — consume the journal watermark. Human-facing feeds are presentations of the journal,
+  not the substrate.
+- Materialization settling records when durable storage caught up with an accepted position. A
+  consumer that must not run ahead of durable files (the Wiki Projector, portable logs) holds
+  behind unsettled positions instead of guessing.
+- The journal is note-scoped and project-partitioned today. A fuller event envelope (causation,
+  correlation, depth, workspace scope) grows this record; it does not introduce a second journal
+  beside it.
+
+### Event Surfaces And Derivation
+
+Every event-shaped surface is the journal, a projection of it, ingress toward it, or a separate
+family that must not be mistaken for it:
+
+```text
+storage notifications / webhooks          ingress evidence
+  -> reconciliation commands
+    -> accepted change journal            canonical time
+         -> wiki projections              index.md, log.md, navigation
+         -> search / graph / vector       retrieval projections
+         -> activity feeds, live updates  human presentation and transient delivery
+         -> temporal reads (bm log)       CLI/API views over the journal
+```
+
+- A projection may lag the journal and must be rebuildable from it plus canonical Markdown.
+- Delivery events (webhook attempts, storage notifications, SSE publishes) prove delivery, not
+  acceptance; they are never the canonical semantic log.
+- Run ledgers (projection runs, index runs) record operational work, and product telemetry
+  (usage, subscription, journey events) records behavior. Neither is a knowledge event, and
+  neither derives from the journal.
+
+POSIX-shaped reads describe memory space; the accepted change journal describes time; the
+knowledge graph describes meaning; runtimes describe behavior.
+
 ## Source Of Truth And Authority
 
 "Markdown is the source of truth" describes the product representation. Operational authority

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -143,8 +143,9 @@ watermark those records advance.
   checksum, actor, source, and acceptance time. It is recorded with the accepted mutation, not
   reconstructed later from derived state.
 - Consumers that need ordering, coalescing, or idempotency — projectors, routines, temporal
-  reads — consume the journal watermark. Human-facing feeds are presentations of the journal,
-  not the substrate.
+  reads — consume the journal watermark. Human-facing feeds are presentations, never the
+  ordering substrate; today's recent-activity feed still derives from search state rather than
+  journal reads (see Event Surfaces And Derivation).
 - Materialization settling records when durable storage caught up with an accepted position. A
   consumer that must not run ahead of durable files (the Wiki Projector, portable logs) holds
   behind unsettled positions instead of guessing.
@@ -173,9 +174,11 @@ storage notifications / webhooks          ingress evidence
 ```
 
 - A projection may lag the journal and must be rebuildable from it plus canonical Markdown.
-- The ingress edge is the target shape, not the current one: reconciliation of external file
-  changes does not yet advance the journal (see the journal's scope bullet above), so today the
-  diagram's top edge holds only for DB-first accepted mutations.
+- The diagram is the target architecture; two edges run ahead of the code today. Ingress:
+  reconciliation of external file changes does not yet advance the journal (see the journal's
+  scope bullet above), so the top edge holds only for DB-first accepted mutations. Activity:
+  the current recent-activity feed is built from search state (`ContextService.build_context`),
+  not from journal reads — its edge names where that feed converges, not what it reads today.
 - Delivery events (webhook attempts, storage notifications, SSE publishes) prove delivery, not
   acceptance; they are never the canonical semantic log.
 - Run ledgers (projection runs, index runs) record operational work, and product telemetry

--- a/src/basic_memory/indexing/wiki_projector.py
+++ b/src/basic_memory/indexing/wiki_projector.py
@@ -10,6 +10,8 @@ import json
 from pathlib import PurePosixPath, PureWindowsPath
 import unicodedata
 
+from basic_memory.runtime.project_partition import RuntimeProjectNoteOperation
+
 OKF_VERSION = "0.2"
 WIKI_PROFILE = "wiki/1"
 WIKI_PROJECTOR_VERSION = "wiki/1.0.0"
@@ -32,13 +34,9 @@ class WikiProjectionReason(StrEnum):
     manual_rebuild = "manual_rebuild"
 
 
-class WikiChangeOperation(StrEnum):
-    """Accepted note operation represented in generated Wiki logs."""
-
-    created = "created"
-    updated = "updated"
-    moved = "moved"
-    deleted = "deleted"
+# Wiki logs present the accepted-change journal, so they reuse its operation vocabulary
+# instead of maintaining a twin enum that can drift from the journal it renders.
+WikiChangeOperation = RuntimeProjectNoteOperation
 
 
 class WikiProjectionState(StrEnum):


### PR DESCRIPTION
## Why

PR #1382 landed the accepted-change journal (`RuntimeAcceptedProjectNoteChange` + `Project.partition_position`) and the deterministic Wiki Projector, and the SPEC-88 cloud stack builds on both. The domain documentation doesn't yet name that substrate, and the projector carried a private twin of the operation enum. Several event-shaped surfaces now exist across core and cloud (accepted changes, activity feeds, live updates, storage notifications, run ledgers, telemetry), so the derivation relationships need one canonical statement before more consumers land.

Convergence decision (SPEC-83): the shipped names are the canonical ones. `RuntimeAcceptedProjectNoteChange` + `partition_position` **is** the v0 accepted-event journal; the fuller `MemoryEvent` envelope (causation, correlation, depth, workspace scope) is that record's growth path, not a second journal to build beside it.

## What changed

- `docs/DOMAIN_MODEL.md` — two new Core Concepts sections:
  - **Accepted Change Journal**: defines the journal as the canonical temporal record, the watermark as the ordering/idempotency substrate, and materialization settling as the hold-back rule for consumers that must not run ahead of durable files.
  - **Event Surfaces And Derivation**: the derivation tree (ingress → reconciliation → journal → projections), plus the explicit non-projections: delivery events prove delivery not acceptance; run ledgers and product telemetry are not knowledge events.
- `src/basic_memory/indexing/wiki_projector.py` — `WikiChangeOperation` becomes an alias of `RuntimeProjectNoteOperation` instead of a duplicate four-value `StrEnum`. The wiki-facing name survives, so all call sites (including cloud's `WikiChangeOperation(change.operation)` in `wiki_projection_snapshot.py`) keep working, and the two vocabularies can no longer drift.

## Verification

- `uv run ruff check` / `ruff format --check` — clean
- `uv run ty check src/basic_memory/indexing/wiki_projector.py` — clean
- `uv run pytest tests/indexing/test_wiki_projector.py tests/runtime/test_project_partition.py tests/repository/test_project_partition_repository.py` — 90 passed

## Related

- SPEC-83 (Accepted Memory Journal and Agent Runtime), SPEC-88 (OKF-Native Wiki Projector) — notes updated to record the naming convergence.
- Cloud convergence tracker issue lists the remaining cloud-side work (WorkspaceActivity un-overloading, routines consuming the journal, `bm log`/`bm show`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp
