### PR TITLE
fix(mcp): normalize constrained project names

### DIFF
--- a/src/basic_memory/index/watch_service.py
+++ b/src/basic_memory/index/watch_service.py
@@ -34,6 +34,7 @@ from basic_memory.index.local_watch import (
 from basic_memory.index.storage_events import StorageEventIndexRuntime
 from basic_memory.models import Project
 from basic_memory.repository import ProjectRepository
+from basic_memory.utils import generate_permalink
 
 
 class WatchEvent(BaseModel):
@@ -175,7 +176,10 @@ class WatchService:
             projects = await self.project_repository.get_active_projects(session)
 
         if self.constrained_project:
-            projects = [project for project in projects if project.name == self.constrained_project]
+            constrained_permalink = generate_permalink(self.constrained_project)
+            projects = [
+                project for project in projects if project.permalink == constrained_permalink
+            ]
 
         skipped = [
             project.name

--- a/src/basic_memory/services/initialization.py
+++ b/src/basic_memory/services/initialization.py
@@ -19,6 +19,7 @@ from basic_memory.models import Project
 from basic_memory.repository import (
     ProjectRepository,
 )
+from basic_memory.utils import generate_permalink
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -285,7 +286,8 @@ async def initialize_file_indexing(
         active_projects = await project_repository.get_active_projects(session)
 
     if constrained_project:
-        active_projects = [p for p in active_projects if p.name == constrained_project]
+        constrained_permalink = generate_permalink(constrained_project)
+        active_projects = [p for p in active_projects if p.permalink == constrained_permalink]
         logger.info(f"Background indexing constrained to project: {constrained_project}")
 
     # Only index projects that are in config (source of truth) and have an

--- a/tests/index/test_watch_service.py
+++ b/tests/index/test_watch_service.py
@@ -85,3 +85,23 @@ async def test_project_is_configured_rereads_current_config(
     assert test_project.name in watch_service.app_config.projects
     assert ConfigManager().config.projects.keys() == {"other-project"}
     assert watch_service._project_is_configured(test_project) is False
+
+
+@pytest.mark.asyncio
+async def test_select_projects_to_watch_matches_constrained_permalink_case_insensitively(
+    app_config: BasicMemoryConfig,
+    project_repository,
+    session_maker,
+    test_project: Project,
+) -> None:
+    """A mixed-case MCP project constraint must select its normalized project."""
+    watch_service = WatchService(
+        app_config=app_config,
+        project_repository=project_repository,
+        session_maker=session_maker,
+        constrained_project="Test Project",
+    )
+
+    projects = await watch_service._select_projects_to_watch()
+
+    assert [project.id for project in projects] == [test_project.id]

--- a/tests/services/test_initialization.py
+++ b/tests/services/test_initialization.py
@@ -296,6 +296,7 @@ async def test_initialize_file_indexing_uses_project_index_runtime_for_initial_s
 
         _disable_test_env_short_circuit(monkeypatch)
         monkeypatch.setattr("basic_memory.index.watch_service.WatchService", _FakeWatchService)
+        monkeypatch.setenv("BASIC_MEMORY_MCP_PROJECT", "Event Startup")
 
         original_create_task = asyncio.create_task
         created_coroutines = []


### PR DESCRIPTION
## Summary

- normalize `BASIC_MEMORY_MCP_PROJECT` before selecting startup indexing projects
- apply the same normalized matching to the local watch service
- add regression coverage for mixed-case constraints in both paths

## Root cause

Project names are normalized to permalinks during configuration reconciliation, but the MCP constraint was compared directly with the persisted project name. A mixed-case constraint therefore selected no project, leaving startup indexing and file watching idle while reporting `No projects to watch`.

## Validation

- `uv run --frozen pytest tests/index/test_watch_service.py tests/services/test_initialization.py -q`
- `uv run ruff format --check ...`
- `uv run ruff check ...`
- `uv run pyright ...`
- `git diff --check`

Closes #1388.
