### PR TITLE
feat(mcp): add POSIX read tools behind enable_posix_tools flag

### DIFF
--- a/src/basic_memory/config_models.py
+++ b/src/basic_memory/config_models.py
@@ -606,6 +606,14 @@ class BasicMemoryConfig(BaseSettings):
         ),
     )
 
+    enable_posix_tools: bool = Field(
+        default=False,
+        description=(
+            "Register the POSIX-style read-only MCP tools (cat, grep, ls, find, tail, man). "
+            "Env: BASIC_MEMORY_ENABLE_POSIX_TOOLS"
+        ),
+    )
+
     cli_output_style: Literal["rich", "plain"] = Field(
         default="rich",
         description=(

--- a/src/basic_memory/indexing/accepted_note_mutation_runner.py
+++ b/src/basic_memory/indexing/accepted_note_mutation_runner.py
@@ -355,9 +355,7 @@ async def record_accepted_project_note_change(
 ) -> RuntimeAcceptedProjectNoteChange:
     """Claim and describe one accepted change in the project's strict partition."""
     if entity.permalink is None:
-        raise RuntimeError(
-            f"Accepted note is missing permalink for entity_id={entity.id}"
-        )
+        raise RuntimeError(f"Accepted note is missing permalink for entity_id={entity.id}")
     position = await dependencies.project_repository.advance_partition_position(
         session,
         project.id,

--- a/src/basic_memory/mcp/server.py
+++ b/src/basic_memory/mcp/server.py
@@ -6,6 +6,7 @@ import time
 from contextlib import asynccontextmanager
 
 from fastmcp import FastMCP
+from fastmcp.server.transforms import Visibility
 from loguru import logger
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
@@ -23,6 +24,19 @@ from basic_memory.read_cache.lifecycle import open_redis_read_cache
 from basic_memory.repository import ProjectRepository
 from basic_memory.services.initialization import initialize_app
 import logfire
+
+# Tools carrying this tag register at import time like every other tool but stay
+# hidden until the composition root enables them from config (#1399).
+POSIX_TOOLS_TAG = "posix"
+
+
+def set_posix_tools_visibility(server: FastMCP, enabled: bool) -> None:
+    """Mark the POSIX tool group visible or hidden.
+
+    Visibility transforms stack; the mark appended last wins, so this is safe to
+    call repeatedly (each lifespan start, and both directions in tests).
+    """
+    server.add_transform(Visibility(enabled, tags={POSIX_TOOLS_TAG}))
 
 
 async def _log_embedding_status(session_maker: async_sessionmaker[AsyncSession]) -> None:
@@ -93,6 +107,13 @@ async def lifespan(app: FastMCP):
     # Create container and read config (single point of config access)
     container = McpContainer.create()
     config = container.config
+
+    # Trigger: the enable_posix_tools config flag.
+    # Why: tools register at import time; the composition root is the one place
+    #      config decides what clients see (no if-checks inside tool bodies).
+    # Outcome: flag off (default) keeps the tool listing identical to today.
+    set_posix_tools_visibility(app, config.enable_posix_tools)
+
     standalone_redis_url = None if container.mode.is_cloud else config.redis_url
 
     async with open_redis_read_cache(

--- a/src/basic_memory/mcp/tools/__init__.py
+++ b/src/basic_memory/mcp/tools/__init__.py
@@ -31,20 +31,28 @@ from basic_memory.mcp.tools.project_management import (
 # ChatGPT-compatible tools
 from basic_memory.mcp.tools.chatgpt_tools import search, fetch
 
+# POSIX-style read-side tools (hidden unless enable_posix_tools is set, #1399)
+from basic_memory.mcp.tools.posix_tools import cat, find, grep, ls, man, tail
+
 # Schema tools
 from basic_memory.mcp.tools.schema import schema_validate, schema_infer, schema_diff
 
 __all__ = [
     "basic_memory_diagnostics",
     "build_context",
+    "cat",
     "create_memory_project",
     "delete_note",
     "delete_project",
     "edit_note",
     "fetch",
+    "find",
+    "grep",
     "list_directory",
     "list_memory_projects",
     "list_workspaces",
+    "ls",
+    "man",
     "move_note",
     "read_content",
     "read_note",
@@ -56,6 +64,7 @@ __all__ = [
     "search",
     "search_notes",
     # "search_notes_ui",
+    "tail",
     "view_note",
     "write_note",
 ]

--- a/src/basic_memory/mcp/tools/posix_tools.py
+++ b/src/basic_memory/mcp/tools/posix_tools.py
@@ -1,0 +1,468 @@
+"""POSIX-style read-only tools for Basic Memory MCP server.
+
+Six familiar Unix verbs — cat, grep, ls, find, tail, man — each a thin
+translation over the same typed API clients the canonical tools use. They are
+tagged ``POSIX_TOOLS_TAG`` and hidden by default: the composition root in
+``basic_memory.mcp.server`` flips their visibility from the
+``enable_posix_tools`` config flag at lifespan startup, so no tool body ever
+checks config itself.
+"""
+
+from typing import Any, Optional
+
+from fastmcp import Context
+from fastmcp.exceptions import ToolError
+
+from basic_memory.config import ConfigManager
+from basic_memory.man import bundled_pages, find_page, parse_page_ref, render_index
+from basic_memory.mcp.container import get_container
+from basic_memory.mcp.note_reads import read_note_json_by_external_id
+from basic_memory.mcp.project_context import get_project_client
+from basic_memory.mcp.server import POSIX_TOOLS_TAG, mcp, set_posix_tools_visibility
+from basic_memory.schemas.directory import (
+    DEFAULT_DIRECTORY_PAGE_SIZE,
+    MAX_DIRECTORY_PAGE_SIZE,
+)
+from basic_memory.schemas.search import SearchItemType, SearchQuery, SearchRetrievalMode
+
+# The manual project holds the non-bundled manual pages as ordinary notes;
+# `man` falls back to it for page reads and searches it in query mode.
+_MANUAL_PROJECT = "manual"
+
+# API bound on directory recursion (directory_router depth query: ge=1, le=10).
+_MAX_FIND_DEPTH = 10
+
+# recent_activity's page-size cap; tail's `lines` maps onto it.
+_MAX_TAIL_LINES = 100
+
+
+@mcp.tool(
+    title="Cat",
+    description="Print a note's content.",
+    tags={POSIX_TOOLS_TAG, "notes"},
+    annotations={
+        "title": "Cat",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
+)
+async def cat(
+    identifier: str,
+    start_line: Optional[int] = None,
+    end_line: Optional[int] = None,
+    section: Optional[str] = None,
+    max_tokens: Optional[int] = None,
+    include_frontmatter: bool = True,
+    project: Optional[str] = None,
+    project_id: Optional[str] = None,
+    context: Context | None = None,
+) -> dict[str, Any]:
+    """Print a note's full content, optionally sliced to a 1-indexed line range.
+
+    Args:
+        identifier: Note title, permalink, or memory:// URL (resolved exactly).
+        start_line: First line to include (1-indexed, inclusive).
+        end_line: Last line to include (inclusive). Defaults to the last line.
+        section: Reserved; not yet supported.
+        max_tokens: Reserved; not yet supported.
+        include_frontmatter: Include the YAML frontmatter block in `content`.
+        project: Project name. Optional - the server resolves the default.
+        project_id: Project external_id (UUID); takes precedence over `project`.
+        context: Optional FastMCP context.
+
+    Returns:
+        The read_note JSON payload (title, permalink, file_path, content,
+        frontmatter), plus start_line/end_line/total_lines when a range applied.
+    """
+    if section is not None:
+        raise ValueError("cat: 'section' is not yet supported; use start_line/end_line")
+    if max_tokens is not None:
+        raise ValueError("cat: 'max_tokens' is not yet supported; use start_line/end_line")
+    if start_line is not None and start_line < 1:
+        raise ValueError(f"start_line must be >= 1, got {start_line}")
+    if end_line is not None and end_line < (start_line or 1):
+        raise ValueError(f"end_line must be >= start_line, got {end_line}")
+
+    async with get_project_client(project, context=context, project_id=project_id) as (
+        client,
+        active_project,
+    ):
+        # Import here to avoid circular import
+        from basic_memory.mcp.clients import KnowledgeClient, ResourceClient
+
+        knowledge_client = KnowledgeClient(client, active_project.external_id)
+        entity_id = await knowledge_client.resolve_entity(identifier, strict=True)
+        payload: dict[str, Any] = dict(
+            await read_note_json_by_external_id(
+                knowledge_client=knowledge_client,
+                resource_client=ResourceClient(client, active_project.external_id),
+                entity_external_id=entity_id,
+                include_frontmatter=include_frontmatter,
+            )
+        )
+
+    if start_line is None and end_line is None:
+        return payload
+
+    lines = str(payload["content"]).splitlines()
+    total_lines = len(lines)
+    first = start_line or 1
+    last = min(end_line, total_lines) if end_line is not None else total_lines
+    payload["content"] = "\n".join(lines[first - 1 : last])
+    payload["start_line"] = first
+    payload["end_line"] = last
+    payload["total_lines"] = total_lines
+    return payload
+
+
+def _grep_retrieval_mode(literal: bool) -> SearchRetrievalMode:
+    """Pick grep's retrieval mode: literal full-text on request, semantic when available."""
+    if literal:
+        return SearchRetrievalMode.FTS
+    try:
+        config = get_container().config
+    except RuntimeError:
+        # CLI paths call tools before the MCP container exists (search.py precedent).
+        config = ConfigManager().config
+    return SearchRetrievalMode.HYBRID if config.semantic_search_enabled else SearchRetrievalMode.FTS
+
+
+@mcp.tool(
+    title="Grep",
+    description="Search note content for a pattern.",
+    tags={POSIX_TOOLS_TAG, "search"},
+    annotations={
+        "title": "Grep",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
+)
+async def grep(
+    pattern: str,
+    literal: bool = False,
+    page: int = 1,
+    page_size: int = 10,
+    project: Optional[str] = None,
+    project_id: Optional[str] = None,
+    context: Context | None = None,
+) -> dict[str, Any]:
+    """Search note content, semantically by default.
+
+    Args:
+        pattern: Text to search for.
+        literal: Force literal full-text matching instead of semantic search.
+        page: Page number (1-indexed).
+        page_size: Results per page.
+        project: Project name. Optional - the server resolves the default.
+        project_id: Project external_id (UUID); takes precedence over `project`.
+        context: Optional FastMCP context.
+
+    Returns:
+        The search response as JSON: results, pagination, and totals.
+    """
+    if not pattern or not pattern.strip():
+        raise ValueError("pattern must not be empty")
+    if page < 1:
+        raise ValueError(f"page must be >= 1, got {page}")
+    if page_size < 1:
+        raise ValueError(f"page_size must be >= 1, got {page_size}")
+
+    query = SearchQuery(
+        text=pattern,
+        retrieval_mode=_grep_retrieval_mode(literal),
+        entity_types=[SearchItemType.ENTITY],
+    )
+    async with get_project_client(project, context=context, project_id=project_id) as (
+        client,
+        active_project,
+    ):
+        # Import here to avoid circular import
+        from basic_memory.mcp.clients import SearchClient
+
+        search_client = SearchClient(client, active_project.external_id)
+        response = await search_client.search(query.model_dump(), page=page, page_size=page_size)
+        return response.model_dump(mode="json", exclude_none=True)
+
+
+@mcp.tool(
+    title="Ls",
+    description="List one directory level.",
+    tags={POSIX_TOOLS_TAG, "navigation"},
+    annotations={
+        "title": "Ls",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
+)
+async def ls(
+    path: str = "/",
+    page: int = 1,
+    page_size: int = DEFAULT_DIRECTORY_PAGE_SIZE,
+    project: Optional[str] = None,
+    project_id: Optional[str] = None,
+    context: Context | None = None,
+) -> dict[str, Any]:
+    """List the immediate contents of one directory.
+
+    Args:
+        path: Directory path to list (default: project root).
+        page: Page number (1-indexed).
+        page_size: Nodes per page.
+        project: Project name. Optional - the server resolves the default.
+        project_id: Project external_id (UUID); takes precedence over `project`.
+        context: Optional FastMCP context.
+
+    Returns:
+        The directory listing as JSON: nodes, pagination, and totals.
+    """
+    if page < 1:
+        raise ValueError(f"page must be >= 1, got {page}")
+    if page_size < 1:
+        raise ValueError(f"page_size must be >= 1, got {page_size}")
+    if page_size > MAX_DIRECTORY_PAGE_SIZE:
+        raise ValueError(f"page_size must be <= {MAX_DIRECTORY_PAGE_SIZE}, got {page_size}")
+
+    async with get_project_client(project, context=context, project_id=project_id) as (
+        client,
+        active_project,
+    ):
+        # Import here to avoid circular import
+        from basic_memory.mcp.clients import DirectoryClient
+
+        directory_client = DirectoryClient(client, active_project.external_id)
+        listing = await directory_client.list(path, depth=1, page=page, page_size=page_size)
+        return listing.model_dump(mode="json")
+
+
+@mcp.tool(
+    title="Find",
+    description="Recursively list files matching a name glob.",
+    tags={POSIX_TOOLS_TAG, "navigation"},
+    annotations={
+        "title": "Find",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
+)
+async def find(
+    path: str = "/",
+    name: Optional[str] = None,
+    depth: int = _MAX_FIND_DEPTH,
+    page: int = 1,
+    page_size: int = DEFAULT_DIRECTORY_PAGE_SIZE,
+    project: Optional[str] = None,
+    project_id: Optional[str] = None,
+    context: Context | None = None,
+) -> dict[str, Any]:
+    """Recursively list files under a directory, optionally filtered by name glob.
+
+    Args:
+        path: Directory to start from (default: project root).
+        name: File-name glob to match, e.g. "*.md". None matches everything.
+        depth: How many levels to recurse (1-10, default: 10).
+        page: Page number (1-indexed).
+        page_size: Nodes per page.
+        project: Project name. Optional - the server resolves the default.
+        project_id: Project external_id (UUID); takes precedence over `project`.
+        context: Optional FastMCP context.
+
+    Returns:
+        The directory listing as JSON: nodes, pagination, and totals.
+    """
+    if depth < 1 or depth > _MAX_FIND_DEPTH:
+        raise ValueError(f"depth must be between 1 and {_MAX_FIND_DEPTH}, got {depth}")
+    if page < 1:
+        raise ValueError(f"page must be >= 1, got {page}")
+    if page_size < 1:
+        raise ValueError(f"page_size must be >= 1, got {page_size}")
+    if page_size > MAX_DIRECTORY_PAGE_SIZE:
+        raise ValueError(f"page_size must be <= {MAX_DIRECTORY_PAGE_SIZE}, got {page_size}")
+
+    async with get_project_client(project, context=context, project_id=project_id) as (
+        client,
+        active_project,
+    ):
+        # Import here to avoid circular import
+        from basic_memory.mcp.clients import DirectoryClient
+
+        directory_client = DirectoryClient(client, active_project.external_id)
+        listing = await directory_client.list(
+            path,
+            depth=depth,
+            file_name_glob=name,
+            page=page,
+            page_size=page_size,
+        )
+        return listing.model_dump(mode="json")
+
+
+@mcp.tool(
+    title="Tail",
+    description="Show recently changed notes.",
+    tags={POSIX_TOOLS_TAG, "navigation", "notes"},
+    annotations={
+        "title": "Tail",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
+)
+async def tail(
+    timeframe: str = "7d",
+    lines: int = 10,
+    project: Optional[str] = None,
+    project_id: Optional[str] = None,
+    context: Context | None = None,
+) -> list[dict[str, Any]]:
+    """Show the most recently changed notes in a project.
+
+    Args:
+        timeframe: Time window, e.g. "7d", "yesterday", "2 days ago".
+        lines: Maximum number of rows to return (1-100).
+        project: Project name. Optional - the server resolves the default.
+        project_id: Project external_id (UUID); takes precedence over `project`.
+        context: Optional FastMCP context.
+
+    Returns:
+        Rows of {type, title, permalink, file_path, created_at}, newest first.
+    """
+    if lines < 1:
+        raise ValueError(f"lines must be >= 1, got {lines}")
+    if lines > _MAX_TAIL_LINES:
+        raise ValueError(f"lines must be <= {_MAX_TAIL_LINES}, got {lines}")
+
+    async with get_project_client(project, context=context, project_id=project_id) as (
+        client,
+        active_project,
+    ):
+        # Import here to avoid circular import
+        from basic_memory.mcp.clients import MemoryClient
+
+        memory_client = MemoryClient(client, active_project.external_id)
+        activity = await memory_client.recent(
+            timeframe=timeframe,
+            depth=1,
+            types=[SearchItemType.ENTITY.value],
+            page=1,
+            page_size=lines,
+        )
+
+    rows: list[dict[str, Any]] = []
+    for result in activity.results:
+        primary = result.primary_result
+        rows.append(
+            {
+                "type": primary.type,
+                "title": primary.title,
+                "permalink": primary.permalink,
+                "file_path": primary.file_path,
+                "created_at": primary.created_at.isoformat() if primary.created_at else None,
+            }
+        )
+    return rows
+
+
+@mcp.tool(
+    title="Man",
+    description="Look up a manual page or search the manual.",
+    tags={POSIX_TOOLS_TAG, "notes"},
+    annotations={
+        "title": "Man",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
+    },
+)
+async def man(
+    page: Optional[str] = None,
+    query: Optional[str] = None,
+    project: Optional[str] = None,
+    project_id: Optional[str] = None,
+    context: Context | None = None,
+) -> str | dict[str, Any]:
+    """Look up one manual page, search the manual, or render the index.
+
+    Modes:
+    - No arguments: the manual index (apropos view), as markdown.
+    - page: one page — a bundled page by reference (e.g. "search-notes(3)"),
+      else a note read from the manual project.
+    - query: search notes of type "manpage" in the manual project.
+
+    Args:
+        page: Page reference, e.g. "search-notes(3)". Any common spelling works.
+        query: Apropos search text over manpage notes. Mutually exclusive with `page`.
+        project: Manual project name (default: "manual"). Bundled pages need no project.
+        project_id: Project external_id (UUID); takes precedence over `project`.
+        context: Optional FastMCP context.
+
+    Returns:
+        Markdown (index or one page) or a search response as JSON.
+    """
+    if page is not None and query is not None:
+        raise ValueError("man: pass either 'page' or 'query', not both")
+
+    if page is None and query is None:
+        # Mirror the memory://man resource: mark pages whose tool this server
+        # does not register so an agent does not call a tool that is not there.
+        tools = await mcp.list_tools(run_middleware=False)
+        return render_index(bundled_pages(), frozenset(tool.name for tool in tools))
+
+    manual_project = project or _MANUAL_PROJECT
+
+    if page is not None:
+        try:
+            page_ref = parse_page_ref(page)
+        except ValueError:
+            bundled = None
+        else:
+            bundled = find_page(page_ref)
+        if bundled is not None:
+            return bundled.read()
+
+        # Not a bundled page — the reference may name a manual note (the
+        # non-bundled sections live as notes in the manual project), mirroring
+        # the memory://man resource fallback.
+        async with get_project_client(manual_project, context=context, project_id=project_id) as (
+            client,
+            active_project,
+        ):
+            # Import here to avoid circular import
+            from basic_memory.mcp.clients import KnowledgeClient, ResourceClient
+
+            knowledge_client = KnowledgeClient(client, active_project.external_id)
+            resource_client = ResourceClient(client, active_project.external_id)
+            try:
+                entity_id = await knowledge_client.resolve_entity(page, strict=True)
+            except ToolError as error:
+                # Neither a bundled page nor a manual note — the manual's hint
+                # is the useful error, not the raw resolution failure. Only the
+                # resolve miss means "no such entry"; a failed read of a note
+                # that DID resolve is an operational error and propagates as-is.
+                raise ToolError(f"No manual entry for {page}") from error
+            response = await resource_client.read(entity_id)
+            return response.text
+
+    search_query = SearchQuery(
+        text=query,
+        note_types=["manpage"],
+        entity_types=[SearchItemType.ENTITY],
+    )
+    async with get_project_client(manual_project, context=context, project_id=project_id) as (
+        client,
+        active_project,
+    ):
+        # Import here to avoid circular import
+        from basic_memory.mcp.clients import SearchClient
+
+        search_client = SearchClient(client, active_project.external_id)
+        response = await search_client.search(search_query.model_dump(), page=1, page_size=10)
+        return response.model_dump(mode="json", exclude_none=True)
+
+
+# Default-hidden until the composition root reads config in lifespan. Keeps the
+# tool listing identical to today for any consumer that lists before startup.
+set_posix_tools_visibility(mcp, False)

--- a/tests/mcp/test_posix_tool_gate.py
+++ b/tests/mcp/test_posix_tool_gate.py
@@ -1,0 +1,52 @@
+"""The enable_posix_tools registration boundary (#1399).
+
+The POSIX tools register on the shared FastMCP server at import time but stay
+hidden until the composition root reads config in lifespan. These tests drive
+both directions of the gate; visibility marks stack with the last one winning,
+so each test restores the default-hidden state it started from.
+"""
+
+import pytest
+
+from basic_memory.mcp.server import lifespan, mcp, set_posix_tools_visibility
+
+POSIX_TOOL_NAMES = {"cat", "find", "grep", "ls", "man", "tail"}
+
+
+@pytest.mark.asyncio
+async def test_posix_tools_hidden_by_default():
+    """Importing the tools must not change what clients see before startup."""
+    names = {tool.name for tool in await mcp.list_tools()}
+    assert names.isdisjoint(POSIX_TOOL_NAMES)
+
+
+@pytest.mark.asyncio
+async def test_posix_tools_visible_when_flag_enabled(config_manager):
+    baseline = {tool.name for tool in await mcp.list_tools()}
+    cfg = config_manager.load_config()
+    cfg.enable_posix_tools = True
+    config_manager.save_config(cfg)
+
+    try:
+        async with lifespan(mcp):
+            enabled = {tool.name for tool in await mcp.list_tools()}
+    finally:
+        # The registration singleton is shared across tests; re-hide so later
+        # tests see today's default listing (the mark appended last wins).
+        set_posix_tools_visibility(mcp, False)
+
+    assert enabled == baseline | POSIX_TOOL_NAMES
+    restored = {tool.name for tool in await mcp.list_tools()}
+    assert restored == baseline
+
+
+@pytest.mark.asyncio
+async def test_posix_tools_hidden_when_flag_disabled_through_lifespan(config_manager):
+    cfg = config_manager.load_config()
+    cfg.enable_posix_tools = False
+    config_manager.save_config(cfg)
+
+    async with lifespan(mcp):
+        names = {tool.name for tool in await mcp.list_tools()}
+
+    assert names.isdisjoint(POSIX_TOOL_NAMES)

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -25,6 +25,16 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "max_related",
         "output_format",
     ],
+    "cat": [
+        "identifier",
+        "start_line",
+        "end_line",
+        "section",
+        "max_tokens",
+        "include_frontmatter",
+        "project",
+        "project_id",
+    ],
     "create_memory_project": [
         "project_name",
         "project_path",
@@ -49,6 +59,8 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "output_format",
     ],
     "fetch": ["id"],
+    "find": ["path", "name", "depth", "page", "page_size", "project", "project_id"],
+    "grep": ["pattern", "literal", "page", "page_size", "project", "project_id"],
     "list_directory": [
         "dir_name",
         "depth",
@@ -62,6 +74,8 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
     ],
     "list_memory_projects": ["output_format"],
     "list_workspaces": ["output_format"],
+    "ls": ["path", "page", "page_size", "project", "project_id"],
+    "man": ["page", "query", "project", "project_id"],
     "move_note": [
         "identifier",
         "destination_path",
@@ -113,6 +127,7 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "status",
         "min_similarity",
     ],
+    "tail": ["timeframe", "lines", "project", "project_id"],
     "view_note": ["identifier", "project", "project_id"],
     "write_note": [
         "title",
@@ -167,9 +182,18 @@ EXPECTED_TOOL_ANNOTATIONS: dict[str, dict[str, bool]] = {
 # The MCP-UI tools are disabled in tools/__init__.py but register onto the shared
 # server whenever tests import their module directly, so tolerate their presence
 # without requiring it — keeps this contract independent of test execution order.
+# The POSIX tools (#1399) are hidden unless enable_posix_tools is set, so they
+# normally don't appear in list_tools(); optional status keeps the contract
+# independent of whether a gate test has revealed them.
 OPTIONAL_TOOL_ANNOTATIONS: dict[str, dict[str, bool]] = {
     "read_note_ui": {"readOnlyHint": True, "destructiveHint": False},
     "search_notes_ui": {"readOnlyHint": True, "destructiveHint": False},
+    "cat": {"readOnlyHint": True, "destructiveHint": False},
+    "find": {"readOnlyHint": True, "destructiveHint": False},
+    "grep": {"readOnlyHint": True, "destructiveHint": False},
+    "ls": {"readOnlyHint": True, "destructiveHint": False},
+    "man": {"readOnlyHint": True, "destructiveHint": False},
+    "tail": {"readOnlyHint": True, "destructiveHint": False},
 }
 
 EXPECTED_EDIT_NOTE_OPERATIONS = [
@@ -185,14 +209,19 @@ EXPECTED_EDIT_NOTE_OPERATIONS = [
 TOOL_FUNCTIONS: dict[str, object] = {
     "basic_memory_diagnostics": tools.basic_memory_diagnostics,
     "build_context": tools.build_context,
+    "cat": tools.cat,
     "create_memory_project": tools.create_memory_project,
     "delete_note": tools.delete_note,
     "delete_project": tools.delete_project,
     "edit_note": tools.edit_note,
     "fetch": tools.fetch,
+    "find": tools.find,
+    "grep": tools.grep,
     "list_directory": tools.list_directory,
     "list_memory_projects": tools.list_memory_projects,
     "list_workspaces": tools.list_workspaces,
+    "ls": tools.ls,
+    "man": tools.man,
     "move_note": tools.move_note,
     "read_content": tools.read_content,
     "read_note": tools.read_note,
@@ -202,6 +231,7 @@ TOOL_FUNCTIONS: dict[str, object] = {
     "schema_validate": tools.schema_validate,
     "search": tools.search,
     "search_notes": tools.search_notes,
+    "tail": tools.tail,
     "view_note": tools.view_note,
     "write_note": tools.write_note,
 }

--- a/tests/mcp/test_tool_posix.py
+++ b/tests/mcp/test_tool_posix.py
@@ -1,0 +1,476 @@
+"""Tests for the POSIX-style read-side MCP tools: cat, grep, ls, find, tail, man (#1399).
+
+Each tool is a thin translation over the same typed clients the canonical tools
+use, so these tests run the real ASGI stack via the shared `client` fixture and
+assert on the JSON shapes the canonical `output_format="json"` paths produce.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+import basic_memory.mcp.tools.posix_tools as posix_tools
+from basic_memory.mcp.tools import cat, find, grep, ls, man, tail, write_note
+from basic_memory.schemas.search import SearchRetrievalMode
+
+# --- cat ---
+
+
+@pytest.mark.asyncio
+async def test_cat_returns_full_note_round_trip(client, test_project):
+    await write_note(
+        title="Cat Note",
+        directory="test",
+        content="# Cat Note\n\nline one\nline two",
+        project=test_project.name,
+    )
+
+    result = await cat("Cat Note", project=test_project.name)
+
+    assert result["title"] == "Cat Note"
+    assert result["file_path"] == "test/Cat Note.md"
+    assert "line one" in result["content"]
+    assert "line two" in result["content"]
+    assert result["frontmatter"] is not None
+    assert result["frontmatter"]["title"] == "Cat Note"
+    # No range requested: the payload carries no slice bookkeeping.
+    assert "start_line" not in result
+    assert "end_line" not in result
+    assert "total_lines" not in result
+
+
+@pytest.mark.asyncio
+async def test_cat_include_frontmatter_toggle(client, test_project):
+    await write_note(
+        title="Cat Frontmatter Note",
+        directory="test",
+        content="body text only",
+        project=test_project.name,
+    )
+
+    with_frontmatter = await cat("Cat Frontmatter Note", project=test_project.name)
+    without_frontmatter = await cat(
+        "Cat Frontmatter Note", project=test_project.name, include_frontmatter=False
+    )
+
+    assert with_frontmatter["content"].startswith("---")
+    assert not without_frontmatter["content"].startswith("---")
+    assert "body text only" in without_frontmatter["content"]
+
+
+@pytest.mark.asyncio
+async def test_cat_line_range_slices_content(client, test_project):
+    await write_note(
+        title="Cat Range Note",
+        directory="test",
+        content="alpha\nbravo\ncharlie\ndelta",
+        project=test_project.name,
+    )
+    full = await cat("Cat Range Note", project=test_project.name, include_frontmatter=False)
+    lines = full["content"].splitlines()
+
+    ranged = await cat(
+        "Cat Range Note",
+        project=test_project.name,
+        include_frontmatter=False,
+        start_line=2,
+        end_line=3,
+    )
+
+    assert ranged["content"] == "\n".join(lines[1:3])
+    assert ranged["start_line"] == 2
+    assert ranged["end_line"] == 3
+    assert ranged["total_lines"] == len(lines)
+
+
+@pytest.mark.asyncio
+async def test_cat_start_line_only_runs_to_end(client, test_project):
+    await write_note(
+        title="Cat Tail Note",
+        directory="test",
+        content="alpha\nbravo\ncharlie",
+        project=test_project.name,
+    )
+    full = await cat("Cat Tail Note", project=test_project.name, include_frontmatter=False)
+    lines = full["content"].splitlines()
+
+    result = await cat(
+        "Cat Tail Note", project=test_project.name, include_frontmatter=False, start_line=2
+    )
+
+    assert result["content"] == "\n".join(lines[1:])
+    assert result["start_line"] == 2
+    assert result["end_line"] == len(lines)
+    assert result["total_lines"] == len(lines)
+
+
+@pytest.mark.asyncio
+async def test_cat_end_line_clamped_to_total(client, test_project):
+    await write_note(
+        title="Cat Clamp Note",
+        directory="test",
+        content="alpha\nbravo",
+        project=test_project.name,
+    )
+    full = await cat("Cat Clamp Note", project=test_project.name, include_frontmatter=False)
+    lines = full["content"].splitlines()
+
+    result = await cat(
+        "Cat Clamp Note",
+        project=test_project.name,
+        include_frontmatter=False,
+        start_line=1,
+        end_line=999,
+    )
+
+    assert result["content"] == "\n".join(lines)
+    assert result["end_line"] == len(lines)
+    assert result["total_lines"] == len(lines)
+
+
+@pytest.mark.asyncio
+async def test_cat_section_not_supported():
+    with pytest.raises(ValueError, match="'section' is not yet supported"):
+        await cat("anything", section="Overview")
+
+
+@pytest.mark.asyncio
+async def test_cat_max_tokens_not_supported():
+    with pytest.raises(ValueError, match="'max_tokens' is not yet supported"):
+        await cat("anything", max_tokens=100)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("start_line", "end_line", "message"),
+    [
+        (0, None, "start_line must be >= 1"),
+        (-1, None, "start_line must be >= 1"),
+        (2, 1, "end_line must be >= start_line"),
+        (None, 0, "end_line must be >= start_line"),
+    ],
+)
+async def test_cat_rejects_bad_line_ranges(start_line, end_line, message):
+    with pytest.raises(ValueError, match=message):
+        await cat("anything", start_line=start_line, end_line=end_line)
+
+
+@pytest.mark.asyncio
+async def test_cat_unknown_identifier_raises(client, test_project):
+    with pytest.raises(ToolError):
+        await cat("no-such-note-anywhere", project=test_project.name)
+
+
+# --- grep ---
+
+
+@pytest.mark.asyncio
+async def test_grep_literal_finds_seeded_content(client, test_project):
+    await write_note(
+        title="Grep Target",
+        directory="test",
+        content="# Grep Target\n\nThe posixgrepneedle hides here.",
+        project=test_project.name,
+    )
+
+    result = await grep("posixgrepneedle", literal=True, project=test_project.name)
+
+    assert result["current_page"] == 1
+    assert isinstance(result["total_is_exact"], bool)
+    titles = [row["title"] for row in result["results"]]
+    assert "Grep Target" in titles
+
+
+@pytest.mark.asyncio
+async def test_grep_default_mode_resolves_fts_and_finds(client, test_project, monkeypatch):
+    """With semantic search disabled the default mode falls back to full-text."""
+    container = SimpleNamespace(config=SimpleNamespace(semantic_search_enabled=False))
+    monkeypatch.setattr(posix_tools, "get_container", lambda: container)
+
+    await write_note(
+        title="Grep Default Target",
+        directory="test",
+        content="# Grep Default Target\n\nThe posixdefaultneedle hides here.",
+        project=test_project.name,
+    )
+
+    result = await grep("posixdefaultneedle", project=test_project.name)
+
+    titles = [row["title"] for row in result["results"]]
+    assert "Grep Default Target" in titles
+
+
+def test_grep_retrieval_mode_literal_is_always_fts():
+    assert posix_tools._grep_retrieval_mode(True) is SearchRetrievalMode.FTS
+
+
+def test_grep_retrieval_mode_hybrid_when_semantic_enabled(monkeypatch):
+    container = SimpleNamespace(config=SimpleNamespace(semantic_search_enabled=True))
+    monkeypatch.setattr(posix_tools, "get_container", lambda: container)
+
+    assert posix_tools._grep_retrieval_mode(False) is SearchRetrievalMode.HYBRID
+
+
+def test_grep_retrieval_mode_fts_when_semantic_disabled(monkeypatch):
+    container = SimpleNamespace(config=SimpleNamespace(semantic_search_enabled=False))
+    monkeypatch.setattr(posix_tools, "get_container", lambda: container)
+
+    assert posix_tools._grep_retrieval_mode(False) is SearchRetrievalMode.FTS
+
+
+def test_grep_retrieval_mode_falls_back_to_config_manager(monkeypatch):
+    """CLI paths call tools before the MCP container exists."""
+
+    def raise_uninitialized():
+        raise RuntimeError("MCP container not initialized")
+
+    monkeypatch.setattr(posix_tools, "get_container", raise_uninitialized)
+    manager = SimpleNamespace(config=SimpleNamespace(semantic_search_enabled=True))
+    monkeypatch.setattr(posix_tools, "ConfigManager", lambda: manager)
+
+    assert posix_tools._grep_retrieval_mode(False) is SearchRetrievalMode.HYBRID
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"pattern": ""}, "pattern must not be empty"),
+        ({"pattern": "   "}, "pattern must not be empty"),
+        ({"pattern": "ok", "page": 0}, "page must be >= 1"),
+        ({"pattern": "ok", "page_size": 0}, "page_size must be >= 1"),
+    ],
+)
+async def test_grep_rejects_bad_arguments(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        await grep(**kwargs)
+
+
+# --- ls ---
+
+
+@pytest.mark.asyncio
+async def test_ls_root_listing(client, test_graph, test_project):
+    result = await ls(project=test_project.name)
+
+    assert result["total"] == 1
+    assert result["has_more"] is False
+    assert result["nodes"][0]["name"] == "test"
+    assert result["nodes"][0]["type"] == "directory"
+
+
+@pytest.mark.asyncio
+async def test_ls_directory_contents(client, test_graph, test_project):
+    result = await ls(path="/test", project=test_project.name)
+
+    assert result["total"] == 5
+    names = {node["name"] for node in result["nodes"]}
+    assert names == {
+        "Connected Entity 1.md",
+        "Connected Entity 2.md",
+        "Deep Entity.md",
+        "Deeper Entity.md",
+        "Root.md",
+    }
+
+
+@pytest.mark.asyncio
+async def test_ls_empty_project(client, test_project):
+    result = await ls(project=test_project.name)
+
+    assert result["total"] == 0
+    assert result["nodes"] == []
+    assert result["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_ls_pagination(client, test_graph, test_project):
+    first_page = await ls(path="/test", page_size=2, project=test_project.name)
+    last_page = await ls(path="/test", page=3, page_size=2, project=test_project.name)
+
+    assert len(first_page["nodes"]) == 2
+    assert first_page["has_more"] is True
+    assert first_page["total"] == 5
+    assert len(last_page["nodes"]) == 1
+    assert last_page["has_more"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"page": 0}, "page must be >= 1"),
+        ({"page_size": 0}, "page_size must be >= 1"),
+        ({"page_size": 201}, "page_size must be <= 200"),
+    ],
+)
+async def test_ls_rejects_bad_arguments(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        await ls(**kwargs)
+
+
+# --- find ---
+
+
+@pytest.mark.asyncio
+async def test_find_glob_recurses_from_root(client, test_graph, test_project):
+    result = await find(name="*.md", project=test_project.name)
+
+    assert result["total"] == 5
+    names = {node["name"] for node in result["nodes"]}
+    assert "Root.md" in names
+    assert all(node["type"] == "file" for node in result["nodes"])
+
+
+@pytest.mark.asyncio
+async def test_find_without_name_lists_everything(client, test_graph, test_project):
+    result = await find(project=test_project.name)
+
+    # The default depth recurses: the /test directory plus its five files.
+    assert result["total"] == 6
+    names = {node["name"] for node in result["nodes"]}
+    assert "test" in names
+    assert "Root.md" in names
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"depth": 0}, "depth must be between 1 and 10"),
+        ({"depth": 11}, "depth must be between 1 and 10"),
+        ({"page": 0}, "page must be >= 1"),
+        ({"page_size": 0}, "page_size must be >= 1"),
+        ({"page_size": 201}, "page_size must be <= 200"),
+    ],
+)
+async def test_find_rejects_bad_arguments(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        await find(**kwargs)
+
+
+# --- tail ---
+
+
+@pytest.mark.asyncio
+async def test_tail_returns_recent_rows(client, test_graph, test_project):
+    rows = await tail(project=test_project.name)
+
+    assert rows
+    for row in rows:
+        assert set(row) == {"type", "title", "permalink", "file_path", "created_at"}
+        assert row["type"] == "entity"
+        assert isinstance(row["created_at"], str)
+    titles = {row["title"] for row in rows}
+    assert "Root" in titles
+
+
+@pytest.mark.asyncio
+async def test_tail_lines_caps_row_count(client, test_graph, test_project):
+    rows = await tail(lines=2, project=test_project.name)
+
+    assert len(rows) <= 2
+
+
+@pytest.mark.asyncio
+async def test_tail_custom_timeframe(client, test_graph, test_project):
+    rows = await tail(timeframe="1d", project=test_project.name)
+
+    assert isinstance(rows, list)
+    assert {row["title"] for row in rows} >= {"Root"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("lines", "message"),
+    [
+        (0, "lines must be >= 1"),
+        (101, "lines must be <= 100"),
+    ],
+)
+async def test_tail_rejects_bad_lines(lines, message):
+    with pytest.raises(ValueError, match=message):
+        await tail(lines=lines)
+
+
+# --- man ---
+
+
+@pytest.mark.asyncio
+async def test_man_index_renders_the_manual(client):
+    result = await man()
+
+    assert isinstance(result, str)
+    assert result.startswith("# Basic Memory manual")
+    assert "## Section 3 — MCP tools" in result
+
+
+@pytest.mark.asyncio
+async def test_man_bundled_page_by_reference():
+    result = await man(page="search-notes(3)")
+
+    assert isinstance(result, str)
+    assert "# search-notes(3)" in result
+
+
+@pytest.mark.asyncio
+async def test_man_page_and_query_mutually_exclusive():
+    with pytest.raises(ValueError, match="not both"):
+        await man(page="search-notes(3)", query="search")
+
+
+@pytest.mark.asyncio
+async def test_man_note_fallback_reads_manual_notes(client, test_project):
+    await write_note(
+        title="posix-custom-guide",
+        directory="man",
+        content="# posix-custom-guide\n\nCustom manual body for fallback.",
+        project=test_project.name,
+    )
+
+    result = await man(page="posix-custom-guide", project=test_project.name)
+
+    assert isinstance(result, str)
+    assert "Custom manual body for fallback." in result
+
+
+@pytest.mark.asyncio
+async def test_man_missing_page_raises_clear_error(client, test_project):
+    with pytest.raises(ToolError, match="No manual entry for totally-unknown-page"):
+        await man(page="totally-unknown-page", project=test_project.name)
+
+
+@pytest.mark.asyncio
+async def test_man_unparseable_page_falls_back_to_notes(client, test_project):
+    # "docs/..." cannot name a bundled page (the directory is not a section), so
+    # the reference goes to the note fallback and misses there too.
+    with pytest.raises(ToolError, match="No manual entry for docs/unknown-guide"):
+        await man(page="docs/unknown-guide", project=test_project.name)
+
+
+@pytest.mark.asyncio
+async def test_man_query_finds_manpage_notes(client, test_project):
+    await write_note(
+        title="posix-grep-manual",
+        directory="man",
+        content="# posix-grep-manual\n\nHow to grep with posixmanualneedle.",
+        note_type="manpage",
+        project=test_project.name,
+    )
+
+    result = await man(query="posixmanualneedle", project=test_project.name)
+
+    assert isinstance(result, dict)
+    titles = [row["title"] for row in result["results"]]
+    assert "posix-grep-manual" in titles
+
+
+@pytest.mark.asyncio
+async def test_man_query_missing_manual_project_raises(client, test_project):
+    # No "manual" project exists in the test config. Unknown project names route
+    # cloud by default (get_project_mode defaults CLOUD for unknown identifiers),
+    # so without credentials the query fails fast with the setup hint instead of
+    # silently searching the wrong project.
+    with pytest.raises(RuntimeError, match="no credentials found"):
+        await man(query="anything")

--- a/tests/repository/test_postgres_search_repository.py
+++ b/tests/repository/test_postgres_search_repository.py
@@ -682,9 +682,7 @@ async def test_postgres_vector_sync_skips_unchanged_and_reembeds_changed_content
             project_id=test_project.id,
             id=421,
             title="Auth and Schema Notes",
-            content_stems=(
-                f"{_vector_chunk_section('Auth')}\n\n{_vector_chunk_section('Schema')}"
-            ),
+            content_stems=(f"{_vector_chunk_section('Auth')}\n\n{_vector_chunk_section('Schema')}"),
             content_snippet=(
                 f"{_vector_chunk_section('Auth')}\n\n{_vector_chunk_section('Schema')}"
             ),

--- a/tests/repository/test_semantic_chunking.py
+++ b/tests/repository/test_semantic_chunking.py
@@ -221,7 +221,9 @@ class TestSplitTextIntoChunks:
     def test_oversized_nested_list_preserves_indentation_at_boundaries(self):
         # A chunk that begins mid-block must keep the line's indentation; a naive
         # strip() would turn a nested item into top-level text in the embedding.
-        nested = "\n".join(f"    - nested detail {index} about the subsystem" for index in range(1, 61))
+        nested = "\n".join(
+            f"    - nested detail {index} about the subsystem" for index in range(1, 61)
+        )
         text = f"- parent item\n{nested}"
 
         result = split_text_into_chunks(text)

--- a/tests/repository/test_sqlite_vector_search_repository.py
+++ b/tests/repository/test_sqlite_vector_search_repository.py
@@ -982,9 +982,7 @@ async def test_sqlite_vector_sync_skips_unchanged_and_reembeds_changed_content(s
             entity_id=111,
             title="Auth and Schema Notes",
             permalink="specs/auth-and-schema",
-            content_stems=(
-                f"{_vector_chunk_section('Auth')}\n\n{_vector_chunk_section('Schema')}"
-            ),
+            content_stems=(f"{_vector_chunk_section('Auth')}\n\n{_vector_chunk_section('Schema')}"),
         )
     )
 

--- a/tests/test_man_pages.py
+++ b/tests/test_man_pages.py
@@ -91,7 +91,9 @@ def test_bundled_pages_are_well_formed_and_sorted() -> None:
 # The section-3 corpus and the tool registry are meant to match one to one. Both
 # lists change deliberately; this pins the known gaps so a new tool without a page
 # (or a page for a retired tool) shows up here instead of going unnoticed.
-TOOLS_WITHOUT_PAGES: set[str] = set()
+# The POSIX read-side tools (#1399) ship without section-3 pages for now; the
+# manual campaign adds them next. Their wire descriptions stay one-liners.
+TOOLS_WITHOUT_PAGES: set[str] = {"cat", "find", "grep", "ls", "man", "tail"}
 PAGES_WITHOUT_LOCAL_TOOLS = {"cloud_info"}  # hosted-only; see cloud-info(3)
 
 


### PR DESCRIPTION
## Why

First slice of the POSIX tool surface tracker (#1398): SPEC-47's read-side tool shapes, implemented behind a config flag so the rich-vs-POSIX token/accuracy evals (#1401) can A/B the two surfaces on the same server. Off by default — the existing tool surface is byte-identical until `enable_posix_tools` is set.

Closes #1399.

## What changed

- **`enable_posix_tools: bool = False`** on `BasicMemoryConfig` (`config_models.py`, `BASIC_MEMORY_` env prefix).
- **`mcp/tools/posix_tools.py`** — six read-only tools, thin translations over existing API routes via the typed clients / `get_project_client` routing:
  - `cat` — note read with optional line ranges; `section`/`max_tokens` params exist but return a clear not-yet-supported error until #1403 lands
  - `grep` — search; semantic by default, literal mode following the existing `search.py` retrieval-mode precedent
  - `ls` / `find` — directory listing, single-level and recursive+glob (bounds match `directory_router`: depth ≤ 10, page_size ≤ MAX_DIRECTORY_PAGE_SIZE)
  - `tail` — recent activity
  - `man` — manual lookup: apropos over `type: manpage` in the manual project, page reads via resolve + resource read (mirrors `mcp/resources/man.py` error handling)
- **Gating at the server boundary** (`mcp/server.py`): fastmcp Visibility transform — flag off both hides the six tools from `list_tools()` *and* blocks calls; no config checks inside tool bodies. No existing tool renamed or modified.
- **Tests**: `tests/mcp/test_tool_posix.py` (per-tool happy paths + edges), `tests/mcp/test_posix_tool_gate.py` (flag-off listing byte-identical, flag-on adds exactly the six). 978 existing `tests/mcp` tests still pass; `posix_tools.py` at 100% line coverage.
- Separate `chore` commit: ruff-format line-reflows of four files that were drifted at base `a5fb68e4` — no semantic changes, kept out of the feature commit for reviewability.

## How it was built

Implemented by a reviewed multi-agent workflow: codebase mapping → design → implement → tests → verify loop (ruff/format/ty/pytest) → adversarial house-style review. The review's one should-fix (the `man` note-fallback wrapped both resolve and read in the same `except ToolError`, masking transient read failures as lookup misses) was fixed and re-verified: the miss translation now covers only the resolve call, and read failures propagate.

## Verification

- `uv run ruff check src/ tests/` / `ruff format --check` — clean
- `uv run ty check src tests` — clean (with milvus extra)
- `uv run pytest tests/mcp -q` — 978 passed
- New posix + gate + man tests — 84 passed
- Empirical gate check: flag off → tools absent from listing and calls rejected; flag on → exactly `{cat, find, grep, ls, man, tail}` added

## Notes for review

- `man(query=...)` with no local manual project routes cloud and fails with a credentials error — documented as deliberate fail-fast in `test_man_query_missing_manual_project_raises`; fixing it inside the tool body would need exactly the scattered config checks this design forbids. Flagged in the tracker for a later product decision.
- CLI verbs (`bm cat` …) are #1404 and will reuse this translation layer; section/range reads are #1403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp
