### PR TITLE
feat(core): add BEAM benchmark integration to the benchmarks package

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -19,6 +19,7 @@ benchmarks/bm-home/
 benchmarks/datasets/longmemeval/longmemeval_s.json
 benchmarks/datasets/longmemeval/longmemeval_s.provenance.json
 benchmarks/datasets/locomo-audit/
+benchmarks/datasets/beam/upstream/
 benchmarks/.mem0-qdrant/
 benchmarks/datasets/convomem/
 benchmarks/.bm-homes/

--- a/benchmarks/AGENTS.md
+++ b/benchmarks/AGENTS.md
@@ -32,12 +32,17 @@ CLI entrypoint: `uv run bm-bench ...`
 Dataset and conversion:
 - `uv run bm-bench datasets fetch --dataset locomo`
 - `uv run bm-bench convert locomo --dataset-path benchmarks/datasets/locomo/locomo10.json --output-dir benchmarks/generated/locomo`
+- `bash benchmarks/datasets/beam/download.sh` (BEAM data is never vendored; sparse clone)
+- `uv run bm-bench convert beam --tier 100K --output-dir benchmarks/generated/beam-100k`
 
 Run retrieval:
 - `uv run bm-bench run retrieval --providers bm-local,mem0-local --dataset-id locomo --dataset-path benchmarks/datasets/locomo/locomo10.json --corpus-dir benchmarks/generated/locomo/docs --queries-path benchmarks/generated/locomo/queries.json --output-root benchmarks/runs --allow-provider-skip`
 
 Run end-to-end QA scoring:
 - `uv run bm-bench run qa --run-dir benchmarks/runs/<run-id> --answerer claude:claude-haiku-4-5 --judge claude:claude-sonnet-4-6`
+
+BEAM nugget scoring (post-hoc, after `run qa` on a BEAM run):
+- `uv run bm-bench run beam-score --run-dir benchmarks/runs/<run-id> --judge claude:claude-sonnet-4-6`
 
 Validate and publish:
 - `uv run bm-bench validate-artifacts --run-dir benchmarks/runs/<run-id>`
@@ -49,6 +54,9 @@ Validate and publish:
 - `BM_LOCAL_PATH=.. just bench-concurrent-write-load`
 - `just bench-fetch-locomo`
 - `just bench-convert-locomo`
+- `just bench-prepare-beam`
+- `just bench-run-beam-100k`
+- `just bench-beam-score benchmarks/runs/<run-id>`
 - `just bench-run-bm-local`
 - `just bench-run-mem0-local`
 - `just bench-run-full`

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -21,6 +21,7 @@ dependencies remain isolated from the product environment.
 - Datasets:
   - LoCoMo (primary)
   - LongMemEval scaffold (placeholder)
+  - BEAM (grouped, 100K/500K/1M tiers; never vendored)
   - Built-in synthetic smoke corpus
 
 ## Installation
@@ -155,6 +156,41 @@ multiple questions each, all sharing one ingested group corpus.
 Anti-leakage: raw conversations carry `containsEvidence`/`model_name` fields;
 rendered docs include neither and conversation ids are remapped to neutral
 positional ids.
+
+## BEAM
+
+BEAM ("Beyond a Million Tokens", arXiv 2510.27246, ICLR 2026;
+mohammadtavakoli78/BEAM, code MIT / data CC BY-SA 4.0) probes ten memory
+abilities — abstention, contradiction resolution, event ordering, information
+extraction, instruction following, knowledge update, multi-session ("multi-hop")
+reasoning, preference following, summarization, temporal reasoning — over
+synthetic multi-month conversations. Each conversation is its own haystack, so
+it runs in **grouped mode** like LongMemEval. The data is **never vendored**;
+fetch it with the documented sparse clone (see
+`benchmarks/datasets/beam/README.md`).
+
+```bash
+just bench-prepare-beam        # sparse-clone 100K/500K tiers + convert 100K
+just bench-convert-beam-500k   # or the 500K tier
+just bench-run-beam-100k       # grouped retrieval (bm-local + mem0-local)
+just bench-qa benchmarks/runs/<run-id>            # answers via the shared QA stage
+just bench-beam-score benchmarks/runs/<run-id>    # BEAM nugget/ordering scoring
+```
+
+Answering uses the package's fixed answer prompt and context budget for every
+provider (the fairness contract), so absolute numbers are not directly
+comparable to the paper's tables. Scoring follows BEAM's nugget methodology:
+the probe rubric's atomic nuggets are judged 0/0.5/1 each, Event Ordering is
+scored with Kendall tau-b over an LLM-aligned event sequence, and
+`beam-summary.md` reports per-ability scores plus per-answer token accounting
+— never just an overall average. Runs pass the converter's `conversion.json`
+as `--dataset-path`, which pins per-file sha256s of the exact BEAM inputs.
+
+Anti-leakage: upstream message content ends with a `->-> <batch>,<question>`
+marker (the question field is sometimes non-numeric, e.g. `N/A`) linking
+transcript text to probe indices; the converter strips it and fails fast if a
+marker variant survives, and rubrics/reference answers live only in
+`queries.json`, never in ingested docs.
 
 ## Concurrent-write benchmark (basic-memory#1248)
 

--- a/benchmarks/benchmarks/datasets/beam/README.md
+++ b/benchmarks/benchmarks/datasets/beam/README.md
@@ -1,0 +1,62 @@
+# BEAM Dataset
+
+BEAM ("Beyond a Million Tokens: Benchmarking the Long-Term Memory of Large
+Language Models", arXiv 2510.27246, ICLR 2026) probes long-term conversational
+memory across ten abilities over synthetic multi-month chat histories.
+
+- Upstream: https://github.com/mohammadtavakoli78/BEAM
+- License: the upstream **code is MIT**; the **benchmark data is CC BY-SA 4.0**
+  — attribution and share-alike are required for any redistributed derivative.
+  The data is therefore never vendored into this repo; fetch it locally.
+
+## Fetch
+
+The data lives in-tree upstream under `chats/{100K,500K,1M,10M}/<N>/`. Fetch
+only the tiers you need with a sparse clone (the full tree is thousands of
+blobs):
+
+```bash
+bash benchmarks/datasets/beam/download.sh
+# or via just:
+just bench-fetch-beam
+```
+
+This clones into `benchmarks/datasets/beam/upstream/` (gitignored) with only
+`chats/100K` and `chats/500K` checked out. To add the 1M tier:
+
+```bash
+git -C benchmarks/datasets/beam/upstream sparse-checkout add chats/1M
+```
+
+## Tiers
+
+| Tier | Layout | Supported |
+| --- | --- | --- |
+| 100K | `chats/100K/<N>/` per-conversation | yes |
+| 500K | `chats/500K/<N>/` per-conversation | yes |
+| 1M   | `chats/1M/<N>/` per-conversation | yes (same layout) |
+| 10M  | combined plan-N layout | no (v1 out of scope) |
+
+Each conversation directory contains `chat.json` (and sometimes
+`chat_trunecated.json` — sic, upstream misspelling — which is preferred when
+present, mirroring upstream's answer generation) plus
+`probing_questions/probing_questions.json` keyed by the ten abilities.
+
+## Convert and run
+
+```bash
+uv run bm-bench convert beam --tier 100K --output-dir benchmarks/generated/beam-100k
+uv run bm-bench run retrieval \
+  --dataset-id beam-100k \
+  --dataset-path benchmarks/generated/beam-100k/conversion.json \
+  --corpus-dir benchmarks/generated/beam-100k/groups \
+  --queries-path benchmarks/generated/beam-100k/queries.json \
+  --providers bm-local,mem0-local --allow-provider-skip
+uv run bm-bench run qa --run-dir benchmarks/runs/<run-id> --answerer ... --judge ...
+uv run bm-bench run beam-score --run-dir benchmarks/runs/<run-id> --judge ...
+```
+
+`conversion.json` is the provenance manifest the converter writes: it records
+the tier, per-conversation source filenames and sha256 checksums of every chat
+and probing-questions file consumed. Runs pass it as `--dataset-path` so the
+run manifest's dataset checksum pins the exact converted inputs.

--- a/benchmarks/benchmarks/datasets/beam/download.sh
+++ b/benchmarks/benchmarks/datasets/beam/download.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# BEAM benchmark data (CC BY-SA 4.0) is never vendored into this repo.
+# The upstream repo carries the data in-tree, so a sparse blobless clone of
+# just the needed tiers is the minimal fetch. Destination is gitignored.
+
+dest="benchmarks/datasets/beam/upstream"
+
+if [ ! -d "$dest/.git" ]; then
+  git clone --filter=blob:none --sparse https://github.com/mohammadtavakoli78/BEAM "$dest"
+fi
+git -C "$dest" sparse-checkout set chats/100K chats/500K
+
+echo "BEAM 100K/500K tiers available under $dest/chats"
+echo "Add more tiers with: git -C $dest sparse-checkout add chats/1M"

--- a/benchmarks/benchmarks/datasets/beam/source.json
+++ b/benchmarks/benchmarks/datasets/beam/source.json
@@ -1,0 +1,6 @@
+{
+  "dataset_id": "beam",
+  "source_url": "https://github.com/mohammadtavakoli78/BEAM",
+  "citation": "BEAM: Beyond a Million Tokens (ICLR 2026, arXiv 2510.27246)",
+  "license_note": "Code MIT; benchmark data CC BY-SA 4.0"
+}

--- a/benchmarks/docs/benchmarks.md
+++ b/benchmarks/docs/benchmarks.md
@@ -31,6 +31,11 @@ It covers:
 
 - Official headline: LoCoMo categories 1-4 (`official_headline` in summaries)
 - Adversarial breakout: LoCoMo category 5 (`adversarial_breakout`)
+- BEAM datasets reuse the same two containers with a dataset-keyed split:
+  the nine answerable abilities are the headline and abstention is the
+  breakout (abstention rows have empty ground truth, so their recall is 0 by
+  construction). The field names are kept for artifact-schema stability and
+  read as generic headline/breakout.
 
 ### Fairness contract
 
@@ -77,9 +82,12 @@ just bench-prepare-long
 - `bench-concurrent-write-load`
 - `bench-prepare-short`
 - `bench-prepare-long`
+- `bench-prepare-beam`
 - `bench-run-short`
 - `bench-run-long`
 - `bench-run-full`
+- `bench-run-beam-100k`
+- `bench-beam-score`
 - `bench-validate`
 - `bench-publish`
 - `bench-compare`
@@ -91,10 +99,12 @@ Top-level commands:
 
 - `datasets fetch`
 - `convert locomo`
+- `convert beam`
 - `run retrieval`
 - `run concurrent-write`
 - `run full`
 - `run qa`
+- `run beam-score`
 - `run rejudge`
 - `run review`
 - `compare`
@@ -199,6 +209,12 @@ Optional QA files:
 - `review.html`
 - `qa-diagnosis.json`
 
+Optional BEAM files (only on BEAM runs, after `run beam-score`):
+
+- `per-query-beam.jsonl`
+- `beam-summary.json`
+- `beam-summary.md`
+
 ### Key provenance fields
 
 From `manifest.json`:
@@ -229,6 +245,82 @@ Publish bundle:
 ```bash
 just bench-publish run_dir="$(just bench-latest-run)"
 ```
+
+## 6b) BEAM (arXiv 2510.27246)
+
+BEAM probes ten long-term-memory abilities (abstention, contradiction
+resolution, event ordering, information extraction, instruction following,
+knowledge update, multi-session reasoning, preference following,
+summarization, temporal reasoning) over synthetic multi-month conversations.
+Each conversation is an isolated haystack, so BEAM runs in grouped mode.
+
+### Workflow
+
+```bash
+just bench-fetch-beam            # sparse clone of chats/100K + chats/500K (never vendored)
+just bench-convert-beam-100k     # -> benchmarks/generated/beam-100k/{groups,queries.json,conversion.json}
+just bench-run-beam-100k         # grouped retrieval, unchanged runner/fairness surface
+just bench-qa benchmarks/runs/<run-id>          # answers via the shared fixed QA stage
+just bench-beam-score benchmarks/runs/<run-id>  # BEAM nugget/ordering scoring (post-hoc)
+```
+
+Runs pass `benchmarks/generated/beam-<tier>/conversion.json` as
+`--dataset-path`: the converter records per-file sha256 of every consumed
+chat/probing file there, so the run manifest's dataset checksum pins the exact
+converted inputs. Tiers 100K/500K/1M share a layout and are supported; the
+10M tier's combined plan-N layout is rejected in v1.
+
+### Scoring definition
+
+- Every probe's reference answer is pre-decomposed upstream into atomic
+  nuggets (`rubric`). The judge scores each nugget 0/0.5/1 against the stored
+  generated answer; the per-question nugget score is the mean.
+- Event Ordering: the answer's lines are aligned against the ordered
+  reference events with an LLM equivalence judge (greedy first-match, matched
+  lines replaced by the reference label), then scored with set P/R/F1 and
+  Kendall tau-b over union rank vectors; `tau_norm = (tau_b + 1) / 2` and
+  `final_score = tau_norm * f1` are both recorded.
+- Per-ability headline: mean `tau_norm` for event_ordering, mean nugget score
+  for the other nine — mirroring upstream `report_results.py`. Reports always
+  show all ten abilities plus per-answer token accounting; the macro average
+  is reported beside them, never instead of them.
+- Errored cases (answerer/judge failure, malformed verdict) are excluded from
+  means and counted explicitly — never silently zero-scored.
+
+### Runner provenance
+
+Adapted from `mohammadtavakoli78/BEAM` (MIT code / CC BY-SA 4.0 data):
+
+- `unified_llm_judge_base_prompt` (`src/prompts.py:11547`) →
+  `BEAM_NUGGET_JUDGE_PROMPT` in `scoring/beam.py`. Modification: the probing
+  question is injected as an explicit input — upstream's RESPONSIVENESS
+  section references "the QUESTION" without ever providing it.
+- `llm_equivalence` + `align_with_llm` + `event_ordering_score`
+  (`src/evaluation/compute_metrics.py`) → equivalence prompt merged to
+  single-prompt form for the package `LLMRunner`; the math (union ranks,
+  tie rank, tau-b, normalisation, `final = tau_norm * f1`) is replicated,
+  with one deviation: when the tie-corrected denominator is 0 (e.g. a
+  single-event probe), upstream propagates scipy's NaN into its means,
+  while this port maps undefined tau to `tau_norm = 0.0` so the case stays
+  countable. System list = the response split on newlines (the shipped
+  path; upstream's commented-out fact-extraction variant is not adopted),
+  with blank lines dropped. Caveat: the package's fixed answer prompt asks
+  for concise answers, which can yield single-line orderings that collapse
+  to one system item and deflate F1/tau for every provider alike; a
+  per-ability format hint would breach the fixed-prompt fairness contract,
+  so v1 accepts and discloses this instead.
+- Aggregation from `src/evaluation/report_results.py` as described above.
+- Not reused, and why: `scipy.stats.kendalltau` (pure-Python tau-b instead —
+  rank vectors are tiny); `json_repair` (silent repair conflicts with the
+  package's fail-fast rule; malformed verdicts become explicit per-case
+  errors); upstream's LangChain gpt-4.1-mini judge (replaced by the package
+  `LLMRunner` seam — the judge is an operator flag recorded in artifacts, so
+  published numbers must note the judge differs from the paper's); BEAM's
+  answering baselines and RAG prompt (answers go through this package's fixed
+  `ANSWER_PROMPT_TEMPLATE` + context budget so all providers face identical
+  conditions — absolute numbers are therefore not directly comparable to the
+  paper's tables); the HF materialization script and `chat.pickle` (the
+  repo's JSON layout is read directly); the 10M tier.
 
 ## 7) Commit-to-Commit Comparison (Current Manual Method)
 

--- a/benchmarks/justfile
+++ b/benchmarks/justfile
@@ -12,6 +12,9 @@ locomo_c1_output_dir := "benchmarks/generated/locomo-c1"
 longmemeval_dataset_path := "benchmarks/datasets/longmemeval/longmemeval_s.json"
 longmemeval_output_dir := "benchmarks/generated/longmemeval-s"
 longmemeval_dev_output_dir := "benchmarks/generated/longmemeval-s-dev"
+beam_root := "benchmarks/datasets/beam/upstream/chats"
+beam_100k_output_dir := "benchmarks/generated/beam-100k"
+beam_500k_output_dir := "benchmarks/generated/beam-500k"
 
 # --- Repo maintenance ---
 
@@ -69,6 +72,33 @@ bench-convert-convomem:
     uv run bm-bench convert convomem --sample-per-stratum 25 --seed 42
 
 bench-prepare-convomem: bench-fetch-convomem bench-convert-convomem
+
+# BEAM data is never vendored: sparse-clone the 100K/500K tiers locally
+bench-fetch-beam:
+    bash benchmarks/datasets/beam/download.sh
+
+bench-convert-beam-100k:
+    uv run bm-bench convert beam --dataset-root {{beam_root}} --tier 100K --output-dir {{beam_100k_output_dir}}
+
+bench-convert-beam-500k:
+    uv run bm-bench convert beam --dataset-root {{beam_root}} --tier 500K --output-dir {{beam_500k_output_dir}}
+
+bench-prepare-beam: bench-fetch-beam bench-convert-beam-100k
+
+# Grouped retrieval over BEAM 100K (one isolated corpus per conversation)
+bench-run-beam-100k:
+    uv run bm-bench run retrieval \
+      --dataset-id beam-100k \
+      --dataset-path {{beam_100k_output_dir}}/conversion.json \
+      --corpus-dir {{beam_100k_output_dir}}/groups \
+      --queries-path {{beam_100k_output_dir}}/queries.json \
+      --providers bm-local,mem0-local \
+      {{bm_local_path_flag}} \
+      --allow-provider-skip
+
+# BEAM nugget/ordering scoring over a run's stored QA answers
+bench-beam-score run_dir judge="claude:claude-sonnet-4-6":
+    uv run bm-bench run beam-score --run-dir "{{run_dir}}" --judge "{{judge}}"
 
 bench-fetch-locomo-audit:
     uv run bm-bench datasets fetch --dataset locomo-audit

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -47,6 +47,12 @@ markers = [
 line-length = 100
 target-version = "py312"
 
+# Same explicit selection as the root pyproject: pin the rule set the package
+# was written against so ruff default-select drift across versions (e.g. the
+# 0.16 default expansion) cannot change lint results between environments.
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
 [tool.pyright]
 include = ["src", "tests", "test-int"]
 pythonVersion = "3.12"

--- a/benchmarks/src/basic_memory_benchmarks/cli.py
+++ b/benchmarks/src/basic_memory_benchmarks/cli.py
@@ -13,11 +13,12 @@ from basic_memory_benchmarks.concurrent_write import (
     ConcurrentWriteConfig,
     run_concurrent_write,
 )
+from basic_memory_benchmarks.converters.beam_to_corpus import convert_beam_to_corpus
+from basic_memory_benchmarks.converters.convomem_to_corpus import convert_convomem_to_corpus
 from basic_memory_benchmarks.converters.locomo_to_corpus import convert_locomo_to_corpus
 from basic_memory_benchmarks.converters.longmemeval_to_corpus import convert_longmemeval_to_corpus
-from basic_memory_benchmarks.datasets.locomo import LOCOMO_URL, fetch_locomo_dataset
-from basic_memory_benchmarks.converters.convomem_to_corpus import convert_convomem_to_corpus
 from basic_memory_benchmarks.datasets.convomem import fetch_convomem_batches
+from basic_memory_benchmarks.datasets.locomo import LOCOMO_URL, fetch_locomo_dataset
 from basic_memory_benchmarks.datasets.locomo_audit import fetch_locomo_audit_corrections
 from basic_memory_benchmarks.datasets.longmemeval import (
     LONGMEMEVAL_S_URL,
@@ -29,11 +30,12 @@ from basic_memory_benchmarks.reporting.compare import (
     load_retrieval_summary,
 )
 from basic_memory_benchmarks.runner import (
+    run_beam_score_stage,
     run_diagnose_stage,
     run_qa_stage,
     run_rejudge_stage,
-    run_review_stage,
     run_retrieval,
+    run_review_stage,
 )
 from basic_memory_benchmarks.utils import sha256_file
 
@@ -185,6 +187,34 @@ def convert_longmemeval(
     )
     console.print(f"Groups: [cyan]{groups_dir}[/cyan] ({query_count} groups, {doc_count} docs)")
     console.print(f"Queries: [cyan]{queries_path}[/cyan] ({query_count})")
+
+
+@convert_app.command("beam")
+def convert_beam(
+    dataset_root: Path = typer.Option(
+        Path("benchmarks/datasets/beam/upstream/chats"),
+        "--dataset-root",
+        help="The chats/ directory of a local BEAM checkout (see datasets/beam/download.sh)",
+    ),
+    output_dir: Path = typer.Option(Path("benchmarks/generated/beam-100k"), "--output-dir"),
+    tier: str = typer.Option("100K", "--tier", help="100K | 500K | 1M"),
+    max_conversations: int | None = typer.Option(None, "--max-conversations"),
+) -> None:
+    """Convert a BEAM tier into grouped corpora + query manifest.
+
+    The dataset is never vendored; fetch it first with
+    `benchmarks/datasets/beam/download.sh`. Runs then pass the written
+    `conversion.json` as --dataset-path so provenance pins the exact inputs.
+    """
+    groups_dir, queries_path, doc_count, query_count = convert_beam_to_corpus(
+        dataset_root=dataset_root,
+        output_dir=output_dir,
+        tier=tier,
+        max_conversations=max_conversations,
+    )
+    console.print(f"Groups: [cyan]{groups_dir}[/cyan] ({doc_count} docs)")
+    console.print(f"Queries: [cyan]{queries_path}[/cyan] ({query_count})")
+    console.print(f"Conversion manifest: [cyan]{output_dir / 'conversion.json'}[/cyan]")
 
 
 @convert_app.command("convomem")
@@ -415,6 +445,30 @@ def run_diagnose_command(
         )
     console.print(table)
     console.print(f"Wrote [green]{out}[/green]")
+
+
+@run_app.command("beam-score")
+def run_beam_score_command(
+    run_dir: Path = typer.Option(..., "--run-dir"),
+    judge: str = typer.Option(
+        "claude:claude-sonnet-4-6",
+        "--judge",
+        help="Runner spec: claude:<model> or openai-compat:<model>@<base_url>",
+    ),
+    source: str = typer.Option("auto", "--source", help="qa | rejudge | auto"),
+    max_workers: int = typer.Option(4, "--max-workers"),
+) -> None:
+    """Score a BEAM run's stored QA answers with the nugget methodology.
+
+    Requires a completed `run qa` on a corpus converted via `convert beam`.
+    Writes per-query-beam.jsonl, beam-summary.json, and beam-summary.md with
+    per-ability scores (never just an overall average).
+    """
+    out = run_beam_score_stage(
+        run_dir=run_dir, judge_spec=judge, source=source, max_workers=max_workers
+    )
+    console.print(f"BEAM scoring complete: [green]{out}[/green]")
+    console.print(f"See [cyan]{out / 'beam-summary.md'}[/cyan]")
 
 
 @run_app.command("rejudge")

--- a/benchmarks/src/basic_memory_benchmarks/converters/beam_to_corpus.py
+++ b/benchmarks/src/basic_memory_benchmarks/converters/beam_to_corpus.py
@@ -1,0 +1,258 @@
+"""Convert BEAM conversations into grouped benchmark corpora and a query manifest.
+
+BEAM is per-conversation-haystack: each conversation is a distinct persona whose
+probing questions are answered against that conversation alone upstream —
+exactly the LongMemEval grouped shape. The converter writes one corpus per
+conversation (``groups/<group_id>/docs``) plus a single ``queries.json`` whose
+entries name their group, so the existing grouped runner ingests and queries
+each conversation in isolation with zero orchestration changes.
+
+Ingestion-mode seam: loading (``datasets.beam``) is mode-independent; rendering
+is a function from a ``BeamConversation`` to docs plus a message-id→doc-id map
+(``RenderedGroup``). Ground truth is derived from that map, never from raw
+layout assumptions, so a future agent-curated renderer can return its own
+mapping and queries/ground truth/scoring stay valid unchanged. v1 ships only
+the ``raw`` transcript-as-notes mode.
+
+Anti-leakage: upstream message content carries a trailing ``->-> <b>,<q>``
+index marker (``<q>`` is sometimes non-numeric, e.g. ``N/A``) linking
+transcript text to probe indices; it is stripped from rendered docs, and
+conversion fails fast if any marker survives the strip. Rubrics and reference
+answers exist only in ``queries.json`` and are never ingested.
+
+Provenance: ``RunConfig.dataset_path`` must be a checksummable file, but the
+BEAM source is a directory tree. The converter therefore writes
+``<output_dir>/conversion.json`` recording the tier, source root, per-file
+sha256 of every chat/probing file consumed, and converter options — BEAM runs
+pass that manifest as ``--dataset-path`` so the run checksum pins the exact
+converted inputs.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from basic_memory_benchmarks.datasets.beam import BeamConversation, BeamMessage, load_beam_tier
+from basic_memory_benchmarks.utils import sha256_file, utc_now_iso
+
+BEAM_SOURCE_URL = "https://github.com/mohammadtavakoli78/BEAM"
+BEAM_CITATION = "BEAM: Beyond a Million Tokens (ICLR 2026, arXiv 2510.27246)"
+BEAM_LICENSE_NOTE = "Code MIT; benchmark data CC BY-SA 4.0"
+
+# Trailing probe-index marker in message content (e.g. "... ->-> 1,2"). The
+# second field is not always numeric — upstream 100K/1/chat.json ends one
+# message with "->-> 2,N/A" — so both fields match any non-space token. It
+# links transcript text back to probe indices, so it must never be ingested.
+_INDEX_MARKER_PATTERN = re.compile(r"\s*->->\s*\S+,\S+\s*$")
+
+
+@dataclass(frozen=True)
+class RenderedGroup:
+    """Result of rendering one conversation into a group corpus."""
+
+    doc_count: int
+    doc_id_for_message: dict[int, str]  # global message id -> owning source_doc_id
+
+
+def _clean_message_content(content: str) -> str:
+    # Strip the leakage marker first, then collapse whitespace so each turn
+    # stays on one line and bullet-level chunking stays intact.
+    stripped = _INDEX_MARKER_PATTERN.sub("", content)
+    # Trigger: "->->" survives the strip (a marker variant the pattern does
+    # not know, or a marker that is not trailing).
+    # Why: a surviving marker leaks probe indices into ingested docs and
+    # silently corrupts the benchmark's anti-leakage guarantee.
+    # Outcome: conversion aborts so the pattern is widened deliberately.
+    if "->->" in stripped:
+        raise ValueError(
+            f"BEAM probe-index marker survived cleaning (unhandled variant): {content[-120:]!r}"
+        )
+    return " ".join(stripped.split())
+
+
+def _batch_anchor(batch_messages: list[BeamMessage], batch_time_anchor: str | None) -> str | None:
+    if batch_time_anchor:
+        return batch_time_anchor
+    for message in batch_messages:
+        if message.time_anchor:
+            return message.time_anchor
+    return None
+
+
+def render_raw_group(
+    conversation: BeamConversation, group_id: str, group_dir: Path, dataset_id: str
+) -> RenderedGroup:
+    """Render one conversation as raw transcript notes: one doc per session."""
+    docs_dir = group_dir / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+
+    doc_id_for_message: dict[int, str] = {}
+    doc_count = 0
+    # The time anchor is carried forward as "current anchor" until the next
+    # one appears: without an anchor in the doc, temporal probes ("how long
+    # after March 15...") are unanswerable by any provider — same rationale
+    # as the LoCoMo session_date handling.
+    current_anchor: str | None = None
+
+    for batch in conversation.batches:
+        batch_messages = [message for session in batch.turns for message in session]
+        anchor = _batch_anchor(batch_messages, batch.time_anchor)
+        if anchor:
+            current_anchor = anchor
+
+        for session_index, session in enumerate(batch.turns):
+            doc_id = f"{group_id}-b{batch.batch_number:02d}-s{session_index:03d}"
+            date_suffix = f" ({current_anchor})" if current_anchor else ""
+
+            lines: list[str] = [
+                "---",
+                f"title: {doc_id}{date_suffix}",
+                "type: note",
+                f"source_doc_id: {doc_id}",
+                f"dataset_id: {dataset_id}",
+                f"conversation_id: {group_id}",
+            ]
+            if current_anchor:
+                lines.append(f"session_date: {current_anchor}")
+            lines += [
+                "---",
+                "",
+                f"# Chat session ({current_anchor})" if current_anchor else f"# {doc_id}",
+                "",
+                "## Conversation",
+            ]
+            for message in session:
+                doc_id_for_message[message.id] = doc_id
+                content = _clean_message_content(message.content)
+                if not content:
+                    continue
+                speaker = "User" if message.role == "user" else "Assistant"
+                lines.append(f"- **{speaker}:** {content}")
+
+            (docs_dir / f"{doc_id}.md").write_text(
+                "\n".join(lines).rstrip() + "\n", encoding="utf-8"
+            )
+            doc_count += 1
+
+    return RenderedGroup(doc_count=doc_count, doc_id_for_message=doc_id_for_message)
+
+
+def _probe_queries(
+    conversation: BeamConversation,
+    group_id: str,
+    dataset_id: str,
+    rendered: RenderedGroup,
+) -> list[dict]:
+    queries: list[dict] = []
+    for probe in conversation.probes:
+        ground_truth: set[str] = set()
+        for chat_id in probe.source_chat_ids:
+            doc_id = rendered.doc_id_for_message.get(chat_id)
+            if doc_id is None:
+                raise ValueError(
+                    f"BEAM conversation {conversation.conversation_id}: probe "
+                    f"{probe.ability}[{probe.index}] cites chat id {chat_id} "
+                    "not present in the chat"
+                )
+            ground_truth.add(doc_id)
+
+        # Abstention probes get empty ground_truth (diagnose keys
+        # "unanswerable" off that) and their ideal_response gold ("...there is
+        # no information related to...") triggers the binary QA judge's
+        # unanswerable branch — abstention grading works with no QA changes.
+        queries.append(
+            {
+                "id": f"{group_id}-{probe.ability}-{probe.index}",
+                "query": probe.question,
+                # category feeds every existing by_category breakdown.
+                "category": probe.ability,
+                "group": group_id,
+                "ground_truth": sorted(ground_truth),
+                "expected_answer": probe.reference_answer,
+                "metadata": {
+                    "dataset_id": dataset_id,
+                    "tier": conversation.tier,
+                    "ability": probe.ability,
+                    "probe_index": probe.index,
+                    "difficulty": probe.difficulty,
+                    # The nugget list rides query metadata into the retrieval
+                    # rows, where the beam-score stage picks it up.
+                    "rubric": probe.rubric,
+                    "abstention": probe.ability == "abstention",
+                },
+            }
+        )
+    return queries
+
+
+def convert_beam_to_corpus(
+    *,
+    dataset_root: Path,
+    output_dir: Path,
+    tier: str,
+    max_conversations: int | None = None,
+    mode: str = "raw",
+) -> tuple[Path, Path, int, int]:
+    """Convert one BEAM tier into per-conversation corpora + query manifest.
+
+    ``dataset_root`` is the upstream ``chats/`` directory of a local BEAM
+    checkout. Returns ``(groups_dir, queries_path, doc_count, query_count)``.
+    """
+    if mode != "raw":
+        raise ValueError(
+            f"Unsupported BEAM ingestion mode {mode!r}; v1 supports only 'raw' "
+            "(agent-curated ingestion is a future renderer behind the same seam)"
+        )
+
+    conversations = load_beam_tier(dataset_root, tier, max_conversations=max_conversations)
+    dataset_id = f"beam-{tier.lower()}"
+
+    groups_dir = output_dir / "groups"
+    groups_dir.mkdir(parents=True, exist_ok=True)
+
+    all_queries: list[dict] = []
+    doc_count = 0
+    conversation_manifests: list[dict] = []
+
+    for conversation in conversations:
+        group_id = f"{dataset_id}-c{int(conversation.conversation_id):02d}"
+        rendered = render_raw_group(conversation, group_id, groups_dir / group_id, dataset_id)
+        doc_count += rendered.doc_count
+        all_queries.extend(_probe_queries(conversation, group_id, dataset_id, rendered))
+
+        conv_dir = dataset_root / tier / conversation.conversation_id
+        conversation_manifests.append(
+            {
+                "conversation_id": conversation.conversation_id,
+                "group_id": group_id,
+                "chat_file": conversation.source_chat_file,
+                "chat_sha256": sha256_file(conv_dir / conversation.source_chat_file),
+                "probing_file": "probing_questions/probing_questions.json",
+                "probing_sha256": sha256_file(
+                    conv_dir / "probing_questions" / "probing_questions.json"
+                ),
+            }
+        )
+
+    queries_path = output_dir / "queries.json"
+    queries_path.write_text(json.dumps(all_queries, indent=2), encoding="utf-8")
+
+    conversion_manifest = {
+        "dataset_id": dataset_id,
+        "tier": tier,
+        "source_url": BEAM_SOURCE_URL,
+        "citation": BEAM_CITATION,
+        "license_note": BEAM_LICENSE_NOTE,
+        "dataset_root": str(dataset_root),
+        "converter": {"mode": mode, "max_conversations": max_conversations},
+        "created_at_utc": utc_now_iso(),
+        "conversations": conversation_manifests,
+    }
+    (output_dir / "conversion.json").write_text(
+        json.dumps(conversion_manifest, indent=2), encoding="utf-8"
+    )
+
+    return groups_dir, queries_path, doc_count, len(all_queries)

--- a/benchmarks/src/basic_memory_benchmarks/datasets/beam.py
+++ b/benchmarks/src/basic_memory_benchmarks/datasets/beam.py
@@ -1,0 +1,278 @@
+"""BEAM dataset loading.
+
+BEAM ("Beyond a Million Tokens", arXiv 2510.27246, ICLR 2026;
+https://github.com/mohammadtavakoli78/BEAM) probes long-term conversational
+memory across ten abilities over synthetic multi-month chat histories. The
+upstream repo ships the data in-tree as ``chats/{100K,500K,1M,10M}/<N>/`` where
+each numeric directory is one conversation: a ``chat.json`` (list of batches,
+each batch a list of chat sessions) plus
+``probing_questions/probing_questions.json`` (dict keyed by ability).
+
+The dataset is never vendored into this repo — see
+``benchmarks/datasets/beam/download.sh`` for the sparse-clone fetch. This
+module only loads a local checkout; there is no fetch code here.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# 10M is deliberately absent: that tier uses the combined "plan-N" layout
+# (top-level plan directories, differently shaped chat.json) rather than the
+# per-conversation layout below, and is out of scope for v1.
+BEAM_TIERS = ("100K", "500K", "1M")
+
+# Exact upstream ability keys (see BEAM src/evaluation/report_results.py).
+# Note: the issue text's "Multi-hop Reasoning" is upstream's
+# multi_session_reasoning.
+ABILITY_KEYS = (
+    "abstention",
+    "contradiction_resolution",
+    "event_ordering",
+    "information_extraction",
+    "instruction_following",
+    "knowledge_update",
+    "multi_session_reasoning",
+    "preference_following",
+    "summarization",
+    "temporal_reasoning",
+)
+
+# The reference-answer field name varies per ability upstream — mirror exactly.
+REFERENCE_ANSWER_FIELDS: dict[str, str] = {
+    "abstention": "ideal_response",
+    "contradiction_resolution": "ideal_answer",
+    "event_ordering": "answer",
+    "information_extraction": "answer",
+    "instruction_following": "expected_compliance",
+    "knowledge_update": "answer",
+    "multi_session_reasoning": "answer",
+    "preference_following": "expected_compliance",
+    "summarization": "ideal_summary",
+    "temporal_reasoning": "answer",
+}
+
+
+@dataclass(frozen=True)
+class BeamMessage:
+    role: str  # "user" | "assistant"
+    id: int  # global per conversation, 0-based, interleaved across batches
+    content: str
+    question_type: str | None  # "main_question" | "answer_ai_question" | "followup_question" | None
+    time_anchor: str | None  # e.g. "March-15-2024"; sparse (usually one per batch)
+    index: str | None  # "batch,question"; also echoed in content as a trailing "->-> b,q" marker
+
+
+@dataclass(frozen=True)
+class BeamBatch:
+    batch_number: int
+    time_anchor: str | None
+    turns: list[list[BeamMessage]]  # sessions; each session is a list of messages
+
+
+@dataclass(frozen=True)
+class BeamProbe:
+    ability: str  # one of ABILITY_KEYS
+    index: int  # position within the ability list — the upstream identity key
+    question: str
+    difficulty: str  # passed through verbatim (upstream has a stray "clear")
+    rubric: list[str]  # THE nugget list; for event_ordering: the ordered event labels
+    reference_answer: str  # resolved via REFERENCE_ANSWER_FIELDS
+    source_chat_ids: list[int]  # normalized flat sorted ids; [] for abstention
+    extras: dict[str, Any]  # remaining upstream fields verbatim (abstention_type, ...)
+
+
+@dataclass(frozen=True)
+class BeamConversation:
+    conversation_id: str  # the bare integer dir name, e.g. "1"
+    tier: str
+    source_chat_file: str  # "chat_trunecated.json" or "chat.json" (which one was loaded)
+    batches: list[BeamBatch]
+    probes: list[BeamProbe]  # flattened, ability-major, upstream order preserved
+
+
+def _parse_message(raw: object, conv_dir: Path) -> BeamMessage:
+    if not isinstance(raw, dict):
+        raise ValueError(f"BEAM chat message is not an object in {conv_dir}: {raw!r}")
+    for key in ("role", "id", "content"):
+        if key not in raw:
+            raise ValueError(f"BEAM chat message missing {key!r} in {conv_dir}: {raw!r}")
+    question_type = raw.get("question_type")
+    time_anchor = raw.get("time_anchor")
+    index = raw.get("index")
+    return BeamMessage(
+        role=str(raw["role"]),
+        id=int(raw["id"]),
+        content=str(raw["content"]),
+        question_type=str(question_type) if question_type is not None else None,
+        time_anchor=str(time_anchor) if time_anchor is not None else None,
+        index=str(index) if index is not None else None,
+    )
+
+
+def _parse_batch(raw: object, conv_dir: Path) -> BeamBatch:
+    # Trigger: a chat entry without batch_number/turns.
+    # Why: the 10M tier's combined "plan-N" files are lists of single-key
+    # plan objects, not batches — silently mis-parsing them would produce a
+    # corrupt corpus.
+    # Outcome: fail fast, naming the unsupported layout.
+    if not isinstance(raw, dict) or "batch_number" not in raw or "turns" not in raw:
+        raise ValueError(
+            f"BEAM chat entry in {conv_dir} is not a batch object with "
+            "'batch_number' and 'turns'. The 10M tier uses the plan-N combined "
+            "layout, which is not supported in v1."
+        )
+    turns = raw["turns"]
+    if not isinstance(turns, list) or not all(isinstance(session, list) for session in turns):
+        raise ValueError(f"BEAM batch 'turns' must be a list of sessions in {conv_dir}")
+    time_anchor = raw.get("time_anchor")
+    return BeamBatch(
+        batch_number=int(raw["batch_number"]),
+        time_anchor=str(time_anchor) if time_anchor is not None else None,
+        turns=[[_parse_message(message, conv_dir) for message in session] for session in turns],
+    )
+
+
+def _normalize_source_chat_ids(value: object, *, ability: str, conv_dir: Path) -> list[int]:
+    """Normalize the per-probe evidence ids to a flat sorted list.
+
+    Usually a list of ints, but knowledge_update ships a dict (e.g.
+    ``{"original_info": [86], "updated_info": [114]}``) and abstention omits
+    the field entirely — normalize to dict-values union / empty list.
+    """
+    if value is None:
+        return []
+    if isinstance(value, dict):
+        merged: list[object] = []
+        for group in value.values():
+            if not isinstance(group, list):
+                raise ValueError(
+                    f"BEAM {ability} source_chat_ids dict values must be lists in {conv_dir}"
+                )
+            merged.extend(group)
+    elif isinstance(value, list):
+        merged = list(value)
+    else:
+        raise ValueError(
+            f"BEAM {ability} source_chat_ids must be a list or dict in {conv_dir}: {value!r}"
+        )
+    chat_ids: set[int] = set()
+    for item in merged:
+        if not isinstance(item, int):
+            raise ValueError(
+                f"BEAM {ability} source_chat_ids must contain ints in {conv_dir}: {item!r}"
+            )
+        chat_ids.add(item)
+    return sorted(chat_ids)
+
+
+def _parse_probe(raw: object, *, ability: str, index: int, conv_dir: Path) -> BeamProbe:
+    if not isinstance(raw, dict):
+        raise ValueError(f"BEAM {ability} probe {index} is not an object in {conv_dir}")
+    question = str(raw.get("question") or "").strip()
+    if not question:
+        raise ValueError(f"BEAM {ability} probe {index} has no question in {conv_dir}")
+    rubric = raw.get("rubric")
+    if not isinstance(rubric, list) or not rubric:
+        raise ValueError(f"BEAM {ability} probe {index} has no rubric list in {conv_dir}")
+    reference_field = REFERENCE_ANSWER_FIELDS[ability]
+    reference_answer = str(raw.get(reference_field) or "").strip()
+    if not reference_answer:
+        raise ValueError(
+            f"BEAM {ability} probe {index} missing reference answer field "
+            f"{reference_field!r} in {conv_dir}"
+        )
+    consumed = {"question", "rubric", "difficulty", "source_chat_ids", reference_field}
+    return BeamProbe(
+        ability=ability,
+        index=index,
+        question=question,
+        difficulty=str(raw.get("difficulty") or ""),
+        rubric=[str(item) for item in rubric],
+        reference_answer=reference_answer,
+        source_chat_ids=_normalize_source_chat_ids(
+            raw.get("source_chat_ids"), ability=ability, conv_dir=conv_dir
+        ),
+        extras={key: value for key, value in raw.items() if key not in consumed},
+    )
+
+
+def load_beam_conversation(conv_dir: Path, tier: str) -> BeamConversation:
+    """Load one BEAM conversation directory (chat + probing questions).
+
+    Prefers ``chat_trunecated.json`` (sic — upstream misspelling) over
+    ``chat.json`` when present, mirroring upstream's answer-generation batch
+    worker which reads the truncated variant.
+    """
+    chat_file = "chat_trunecated.json"
+    chat_path = conv_dir / chat_file
+    if not chat_path.exists():
+        chat_file = "chat.json"
+        chat_path = conv_dir / chat_file
+    if not chat_path.exists():
+        raise FileNotFoundError(f"BEAM conversation has no chat file: {conv_dir}")
+
+    chat_payload = json.loads(chat_path.read_text(encoding="utf-8"))
+    if not isinstance(chat_payload, list) or not chat_payload:
+        raise ValueError(f"BEAM chat file must be a non-empty list of batches: {chat_path}")
+    batches = [_parse_batch(entry, conv_dir) for entry in chat_payload]
+
+    probing_path = conv_dir / "probing_questions" / "probing_questions.json"
+    if not probing_path.exists():
+        raise FileNotFoundError(f"BEAM conversation has no probing questions: {probing_path}")
+    probing_payload = json.loads(probing_path.read_text(encoding="utf-8"))
+    if not isinstance(probing_payload, dict):
+        raise ValueError(f"BEAM probing questions must be an object: {probing_path}")
+    missing = [key for key in ABILITY_KEYS if key not in probing_payload]
+    if missing:
+        raise ValueError(f"BEAM probing questions missing abilities {missing}: {probing_path}")
+
+    probes: list[BeamProbe] = []
+    # Ability-major, upstream order preserved: (ability, index) is the
+    # upstream identity of a probe, so ordering here is load-bearing.
+    for ability in ABILITY_KEYS:
+        records = probing_payload[ability]
+        if not isinstance(records, list):
+            raise ValueError(f"BEAM ability {ability!r} must map to a list: {probing_path}")
+        for index, record in enumerate(records):
+            probes.append(_parse_probe(record, ability=ability, index=index, conv_dir=conv_dir))
+
+    return BeamConversation(
+        conversation_id=conv_dir.name,
+        tier=tier,
+        source_chat_file=chat_file,
+        batches=batches,
+        probes=probes,
+    )
+
+
+def load_beam_tier(
+    root: Path, tier: str, max_conversations: int | None = None
+) -> list[BeamConversation]:
+    """Load every conversation of one tier from a local BEAM ``chats/`` dir.
+
+    ``root`` is the upstream ``chats/`` directory (containing 100K/500K/...).
+    Conversation directories are numeric and loaded in numeric order.
+    """
+    if tier not in BEAM_TIERS:
+        if tier.upper() == "10M":
+            raise ValueError("BEAM 10M tier uses the plan-N combined layout; not supported in v1")
+        raise ValueError(f"Unknown BEAM tier {tier!r}; supported tiers: {', '.join(BEAM_TIERS)}")
+
+    tier_dir = root / tier
+    if not tier_dir.is_dir():
+        raise FileNotFoundError(f"BEAM tier directory not found: {tier_dir}")
+
+    conv_dirs = sorted(
+        (entry for entry in tier_dir.iterdir() if entry.is_dir() and entry.name.isdigit()),
+        key=lambda entry: int(entry.name),
+    )
+    if not conv_dirs:
+        raise ValueError(f"BEAM tier directory has no numeric conversation dirs: {tier_dir}")
+    if max_conversations is not None:
+        conv_dirs = conv_dirs[:max_conversations]
+
+    return [load_beam_conversation(conv_dir, tier) for conv_dir in conv_dirs]

--- a/benchmarks/src/basic_memory_benchmarks/models.py
+++ b/benchmarks/src/basic_memory_benchmarks/models.py
@@ -169,6 +169,72 @@ class ProviderDiagnosis(BaseModel):
     by_category: dict[str, CategoryDiagnosis] = Field(default_factory=dict)
 
 
+class BeamNuggetVerdict(BaseModel):
+    """One judged rubric item (BEAM nugget methodology)."""
+
+    nugget: str
+    score: float  # 0.0 | 0.5 | 1.0
+    reason: str
+
+
+class BeamOrderingScore(BaseModel):
+    """Event-ordering metrics (BEAM compute_metrics.event_ordering_score)."""
+
+    precision: float
+    recall: float
+    f1: float
+    tau_norm: float  # (tau_b + 1) / 2, 0.0 when tau is undefined
+    final_score: float  # tau_norm * f1 (recorded; the ability headline is tau_norm)
+
+
+class BeamCaseScore(BaseModel):
+    provider: str
+    query_id: str
+    ability: str
+    question: str
+    generated_answer: str
+    nugget_verdicts: list[BeamNuggetVerdict] = Field(default_factory=list)
+    nugget_score: float = 0.0  # mean over rubric items
+    ordering: BeamOrderingScore | None = None  # event_ordering only
+    ability_score: float = 0.0  # tau_norm for event_ordering, nugget_score otherwise
+    # End-to-end token accounting per answer: answer-side numbers are copied
+    # from the joined QACaseResult; judge-side numbers sum the nugget and
+    # alignment calls this stage made.
+    answer_input_tokens: int
+    answer_output_tokens: int
+    answer_prompt_chars: int
+    answer_latency_ms: float
+    judge_input_tokens: int = 0
+    judge_output_tokens: int = 0
+    judge_calls: int = 0
+    judge_model: str
+    error: str | None = None
+
+
+class BeamAbilitySummary(BaseModel):
+    ability: str
+    question_count: int
+    error_count: int = 0
+    mean_score: float  # the per-ability headline (tau_norm for event_ordering)
+    mean_nugget_score: float  # also reported for event_ordering (upstream records both)
+    mean_f1: float | None = None  # event_ordering only
+    total_answer_input_tokens: int = 0
+    total_answer_output_tokens: int = 0
+    total_judge_input_tokens: int = 0
+    total_judge_output_tokens: int = 0
+    mean_answer_prompt_chars: float = 0.0
+
+
+class BeamSummary(BaseModel):
+    provider: str
+    judge_model: str
+    total_cases: int
+    error_count: int
+    by_ability: dict[str, BeamAbilitySummary]  # always all ten upstream ability keys
+    # Mean of ability means — reported beside, never instead of, per-ability.
+    macro_average: float
+
+
 class ProviderStatus(BaseModel):
     provider: str
     state: PROVIDER_STATE

--- a/benchmarks/src/basic_memory_benchmarks/reporting/artifacts.py
+++ b/benchmarks/src/basic_memory_benchmarks/reporting/artifacts.py
@@ -105,7 +105,17 @@ def build_summary_markdown(
         )
     lines.append("")
 
-    lines.append("## Official Headline (LoCoMo Categories 1-4)")
+    # The headline/breakout containers are generic; the section labels follow
+    # the dataset (BEAM: answerable abilities vs abstention; default: the
+    # LoCoMo category split).
+    if manifest.config.dataset_id.startswith("beam"):
+        headline_label = "## Answerable Abilities (BEAM headline)"
+        breakout_label = "## Abstention Breakout"
+    else:
+        headline_label = "## Official Headline (LoCoMo Categories 1-4)"
+        breakout_label = "## Adversarial (Category 5)"
+
+    lines.append(headline_label)
     lines.append("")
     lines.append("| Provider | Recall@5 | Recall@10 | MRR |")
     lines.append("| --- | --- | --- | --- |")
@@ -116,7 +126,7 @@ def build_summary_markdown(
         )
     lines.append("")
 
-    lines.append("## Adversarial (Category 5)")
+    lines.append(breakout_label)
     lines.append("")
     lines.append("| Provider | Recall@5 | Recall@10 | MRR |")
     lines.append("| --- | --- | --- | --- |")

--- a/benchmarks/src/basic_memory_benchmarks/runner.py
+++ b/benchmarks/src/basic_memory_benchmarks/runner.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from basic_memory_benchmarks.exceptions import ProviderSkippedError
 from basic_memory_benchmarks.fairness import validate_fairness
@@ -224,7 +224,9 @@ def run_retrieval(
                     run_config=run_config,
                 )
 
-            summary = summarize_provider(provider_name, provider_rows)
+            summary = summarize_provider(
+                provider_name, provider_rows, dataset_id=run_config.dataset_id
+            )
             summaries.append(summary)
             retrieval_rows.extend(provider_rows)
             rows_by_provider[provider_name] = provider_rows
@@ -426,6 +428,72 @@ def run_diagnose_stage(
         encoding="utf-8",
     )
     return out_path
+
+
+def run_beam_score_stage(
+    *,
+    run_dir: Path,
+    judge_spec: str,
+    source: str = "auto",
+    max_workers: int = 4,
+) -> Path:
+    """Apply BEAM nugget/ordering scoring to a run's stored QA answers.
+
+    Joins per-query-qa[-rejudge].jsonl (the generated answers) with
+    per-query-retrieval.jsonl (rubric + ability in metadata) and writes
+    per-query-beam.jsonl, beam-summary.json, and beam-summary.md into the run
+    directory. ``source``: 'qa' | 'rejudge' | 'auto' (prefers re-judged), so a
+    re-generated answer set can be beam-scored too.
+    """
+    from basic_memory_benchmarks.llm.runners import create_runner
+    from basic_memory_benchmarks.scoring.beam import (
+        build_beam_summary_markdown,
+        score_beam_cases,
+    )
+
+    qa_cases, chosen = _load_qa_cases(run_dir, source)
+    retrieval_rows = _load_retrieval_rows(run_dir)
+
+    # Trigger: no retrieval row carries a rubric list.
+    # Why: only BEAM conversions put the nugget rubric in query metadata;
+    # scoring a non-BEAM run would just error case-by-case much later.
+    # Outcome: fail fast with a diagnosis instead of judging anything.
+    has_rubric = any(
+        isinstance(row.metadata.get("rubric"), list) and row.metadata["rubric"]
+        for row in retrieval_rows
+    )
+    if not has_rubric:
+        raise ValueError(
+            f"Run {run_dir} does not look like a BEAM run: no retrieval row "
+            "carries 'rubric' metadata (convert with `bm-bench convert beam`)"
+        )
+
+    judge = create_runner(judge_spec)
+    case_scores, summaries = score_beam_cases(
+        qa_cases, retrieval_rows, judge=judge, max_workers=max_workers
+    )
+
+    beam_jsonl = run_dir / "per-query-beam.jsonl"
+    with beam_jsonl.open("w", encoding="utf-8") as file:
+        for case in case_scores:
+            file.write(json.dumps(case.model_dump(mode="json"), sort_keys=True) + "\n")
+
+    (run_dir / "beam-summary.json").write_text(
+        json.dumps(
+            {
+                "judge": judge_spec,
+                "source": chosen.name,
+                "providers": [summary.model_dump(mode="json") for summary in summaries],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "beam-summary.md").write_text(
+        build_beam_summary_markdown(summaries, run_id=run_dir.name, source=chosen.name),
+        encoding="utf-8",
+    )
+    return run_dir
 
 
 def run_rejudge_stage(

--- a/benchmarks/src/basic_memory_benchmarks/scoring/beam.py
+++ b/benchmarks/src/basic_memory_benchmarks/scoring/beam.py
@@ -1,0 +1,534 @@
+"""BEAM nugget-methodology scoring over stored QA answers.
+
+Runs as a post-hoc stage (like rejudge/diagnose): it joins the stored QA
+answers (``per-query-qa.jsonl``) with the retrieval rows carrying each probe's
+rubric (``per-query-retrieval.jsonl``) on ``(provider, query_id)``, then
+applies BEAM's scoring:
+
+- every reference answer is pre-decomposed upstream into atomic nuggets (the
+  probe's ``rubric``); an LLM judge scores each nugget 0/0.5/1 against the
+  generated answer, and the per-question nugget score is the mean;
+- Event Ordering additionally aligns the answer's lines against the ordered
+  reference events with an LLM equivalence judge and scores Kendall tau-b over
+  the union rank vectors (``tau_norm = (tau_b + 1) / 2``);
+- the per-ability headline is the mean of ``tau_norm`` for event_ordering and
+  of the nugget score for the other nine abilities, mirroring upstream
+  ``src/evaluation/report_results.py`` (which aggregates ``tau_norm``, not
+  ``final_score``).
+
+Answer generation itself stays the untouched ``run qa`` stage — same fixed
+answer prompt, same context budget, same abstention sentinel for every
+provider (the fairness contract). Its binary verdict remains as a coarse
+cross-check and keeps review/diagnose/rejudge tooling functional on BEAM runs.
+
+Provenance: prompts and math are adapted from mohammadtavakoli78/BEAM
+(MIT-licensed code; ICLR 2026, arXiv 2510.27246) — see the per-constant and
+per-function comments for exact upstream locations and deliberate deviations.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from statistics import mean
+
+from basic_memory_benchmarks.datasets.beam import ABILITY_KEYS
+from basic_memory_benchmarks.llm.runners import LLMResult, LLMRunner, LLMRunnerError
+from basic_memory_benchmarks.models import (
+    BeamAbilitySummary,
+    BeamCaseScore,
+    BeamNuggetVerdict,
+    BeamOrderingScore,
+    BeamSummary,
+    PerQueryRetrievalResult,
+    QACaseResult,
+)
+from basic_memory_benchmarks.scoring.qa import question_display
+
+# Adapted from ``unified_llm_judge_base_prompt`` in BEAM ``src/prompts.py``
+# (line 11547 at the adapted revision). Kept verbatim: positive/negative
+# constraint handling, semantic tolerance, style neutrality, the 1.0/0.5/0.0
+# scale, and JSON output. Deliberate modifications:
+# 1. upstream's ``<rubric_item>``/``<llm_response>`` placeholders become
+#    ``{rubric_item}``/``{response}`` .format slots (JSON braces escaped);
+# 2. a QUESTION input line is added — upstream's RESPONSIVENESS section scores
+#    against "the QUESTION" but never injects it (an upstream bug); we supply
+#    it via the same question_display() rendering the answerer saw.
+BEAM_NUGGET_JUDGE_PROMPT = """\
+You are an expert evaluator tasked with judging whether the LLM's response demonstrates compliance with the specified RUBRIC CRITERION.
+
+## EVALUATION INPUTS
+- QUESTION (what the response was asked): {question}
+- RUBRIC CRITERION (what to check): {rubric_item}
+- RESPONSE TO EVALUATE: {response}
+
+## EVALUATION RUBRIC:
+The rubric defines a specific requirement, constraint, or expected behavior that the LLM response should demonstrate.
+
+**IMPORTANT**: Pay careful attention to whether the rubric specifies:
+- **Positive requirements** (things the response SHOULD include/do)
+- **Negative constraints** (things the response SHOULD NOT include/do, often indicated by "no", "not", "avoid", "absent")
+
+## RESPONSIVENESS REQUIREMENT
+A compliant response must be **on-topic** and attempt to answer it.
+- If the response does not address the QUESTION, score **0.0** and stop.
+- For negative constraints, both must hold: (a) the response is responsive to the QUESTION, and (b) the prohibited element is absent.
+
+## SEMANTIC TOLERANCE RULES:
+Judge by meaning, not exact wording.
+- Accept **paraphrases** and **synonyms** that preserve intent.
+- **Case/punctuation/whitespace** differences must be ignored.
+- **Numbers/currencies/dates** may appear in equivalent forms (e.g., "$68,000", "68k", "68,000 USD", or "sixty-eight thousand dollars"). Treat them as equal when numerically equivalent.
+- If the rubric expects a number or duration, prefer **normalized comparison** (extract and compare values) over string matching.
+
+## STYLE NEUTRALITY (prevents style contamination):
+Ignore tone, politeness, length, and flourish unless the rubric explicitly requires a format/structure (e.g., "itemized list", "no citations", "one sentence").
+- Do **not** penalize hedging, voice, or verbosity if content satisfies the rubric.
+- Only evaluate format when the rubric **explicitly** mandates it.
+
+## SCORING SCALE:
+- **1.0 (Complete Compliance)**: Fully complies with the rubric criterion.
+  - Positive: required element present, accurate, properly executed (allowing semantic equivalents).
+  - Negative: prohibited element **absent** AND response is **responsive**.
+
+- **0.5 (Partial Compliance)**: Partially complies.
+  - Positive: element present but minor inaccuracies/incomplete execution.
+  - Negative: generally responsive and mostly avoids the prohibited element but with minor/edge violations.
+
+- **0.0 (No Compliance)**: Fails to comply.
+  - Positive: required element missing or incorrect.
+  - Negative: prohibited element present **or** response is non-responsive/evasive even if the element is absent.
+
+## EVALUATION INSTRUCTIONS:
+1. **Understand the Requirement**: Determine if the rubric is asking for something to be present (positive) or absent (negative/constraint).
+
+2. **Parse Compound Statements**: If the rubric contains multiple elements connected by "and" or commas, evaluate whether:
+   - **All elements** must be present for full compliance (1.0)
+   - **Some elements** present indicates partial compliance (0.5)
+   - **No elements** present indicates no compliance (0.0)
+
+3. **Check Compliance**:
+   - For positive requirements: Look for the presence and quality of the required element
+   - For negative constraints: Look for the absence of the prohibited element
+
+4. **Assign Score**: Based on compliance with the specific rubric criterion according to the scoring scale above.
+
+5. **Provide Reasoning**: Explain whether the rubric criterion was satisfied and justify the score.
+
+## OUTPUT FORMAT:
+Return your evaluation in JSON format with two fields:
+
+{{
+   "score": [your score: 1.0, 0.5, or 0.0],
+   "reason": "[detailed explanation of whether the rubric criterion was satisfied and why this justified the assigned score]"
+}}
+
+NOTE: ONLY output the json object, without any explanation before or after that"""
+
+# Adapted from ``llm_equivalence`` in BEAM ``src/evaluation/compute_metrics.py``:
+# upstream sends a system+user message pair; our LLMRunner.complete is
+# single-prompt, so the two are merged into one prompt. The classifier text is
+# otherwise verbatim (including upstream's "exaplanation" typo) and the reply
+# is parsed upstream-style: "yes" in response.lower().
+BEAM_EQUIVALENCE_PROMPT = """\
+You are a binary classifier.
+If the TWO snippets describe the SAME event/fact, reply **YES**
+Otherwise reply **NO**. No extra words.
+DO NOT provide any exaplanation.
+
+First snippet: {first}
+
+Second snippet: {second}"""
+
+_ALLOWED_NUGGET_SCORES = (0.0, 0.5, 1.0)
+
+# Same first-JSON-object extraction the QA judge parser uses.
+_JSON_OBJECT_PATTERN = re.compile(r"\{.*\}", re.DOTALL)
+
+
+@dataclass
+class JudgeUsage:
+    """Accumulates judge-side token usage across a case's calls."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    calls: int = 0
+
+    def add(self, result: LLMResult) -> None:
+        self.input_tokens += result.input_tokens
+        self.output_tokens += result.output_tokens
+        self.calls += 1
+
+
+def parse_nugget_verdict(raw: str) -> tuple[float, str]:
+    """Extract a (score, reason) nugget verdict from judge output.
+
+    Like qa.parse_judge_verdict, takes the first JSON object found. The score
+    must be exactly one of {0.0, 0.5, 1.0}; anything else raises so the case
+    is recorded as an explicit error. Deviation from upstream: no json_repair
+    dependency — silent repair conflicts with the package's fail-fast rule, so
+    malformed verdicts become explicit per-case errors instead.
+    """
+    match = _JSON_OBJECT_PATTERN.search(raw)
+    if not match:
+        raise ValueError(f"Nugget judge returned no JSON object: {raw[:200]}")
+    payload = json.loads(match.group(0))
+    score = payload.get("score")
+    if not isinstance(score, (int, float)) or float(score) not in _ALLOWED_NUGGET_SCORES:
+        raise ValueError(f"Nugget judge score must be 0, 0.5 or 1: {raw[:200]}")
+    return float(score), str(payload.get("reason") or "")
+
+
+def score_nuggets(
+    question: str,
+    rubric: list[str],
+    response: str,
+    judge: LLMRunner,
+    usage: JudgeUsage,
+) -> list[BeamNuggetVerdict]:
+    """Judge each rubric item against the response (one call per nugget).
+
+    Serial within a case, mirroring the upstream loop; parallelism lives at
+    the case level so per-case token accounting stays simple.
+    """
+    verdicts: list[BeamNuggetVerdict] = []
+    for item in rubric:
+        result = judge.complete(
+            BEAM_NUGGET_JUDGE_PROMPT.format(question=question, rubric_item=item, response=response)
+        )
+        usage.add(result)
+        score, reason = parse_nugget_verdict(result.text)
+        verdicts.append(BeamNuggetVerdict(nugget=item, score=score, reason=reason))
+    return verdicts
+
+
+def kendall_tau_b(x: Sequence[int], y: Sequence[int]) -> float | None:
+    """Kendall tau-b with tie correction, pure Python.
+
+    Replaces upstream's scipy.stats.kendalltau(variant="b") — the rank vectors
+    here have <= ~10 entries, so the O(n^2) pair count is trivial and scipy is
+    not worth a dependency. Returns None when a tie-corrected denominator is
+    zero (scipy returns nan there).
+    """
+    if len(x) != len(y):
+        raise ValueError(f"Rank vectors differ in length: {len(x)} != {len(y)}")
+    n = len(x)
+    concordant = discordant = 0
+    ties_x = ties_y = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            dx = x[i] - x[j]
+            dy = y[i] - y[j]
+            if dx == 0:
+                ties_x += 1
+            if dy == 0:
+                ties_y += 1
+            if dx * dy > 0:
+                concordant += 1
+            elif dx * dy < 0:
+                discordant += 1
+    total_pairs = n * (n - 1) // 2
+    denominator = math.sqrt((total_pairs - ties_x) * (total_pairs - ties_y))
+    if denominator == 0:
+        return None
+    return (concordant - discordant) / denominator
+
+
+def _align_with_judge(
+    reference: list[str], system: list[str], judge: LLMRunner, usage: JudgeUsage
+) -> list[str]:
+    """Replicate BEAM ``align_with_llm``: greedy first-match canonicalisation.
+
+    Each system line is matched against the first unused reference item the
+    equivalence judge accepts; matched lines are REPLACED by the reference
+    string so downstream set/rank math operates on canonical labels.
+    """
+    used: set[int] = set()
+    system_out: list[str] = []
+    for system_item in system:
+        matched_index: int | None = None
+        for index, reference_item in enumerate(reference):
+            if index in used:
+                continue
+            result = judge.complete(
+                BEAM_EQUIVALENCE_PROMPT.format(first=reference_item, second=system_item)
+            )
+            usage.add(result)
+            if "yes" in result.text.lower():
+                matched_index = index
+                break
+        if matched_index is not None:
+            system_out.append(reference[matched_index])
+            used.add(matched_index)
+        else:
+            system_out.append(system_item)
+    return system_out
+
+
+def event_ordering_score(
+    reference: list[str], system: list[str], judge: LLMRunner, usage: JudgeUsage
+) -> BeamOrderingScore:
+    """Replicate BEAM ``event_ordering_score`` with align_type="llm".
+
+    Set precision/recall/F1 over canonicalised labels, then Kendall tau-b over
+    union rank vectors (missing items share the tie rank), normalised to
+    ``tau_norm = (tau_b + 1) / 2`` with ``final_score = tau_norm * f1`` —
+    the math mirrors upstream src/evaluation/compute_metrics.py exactly.
+    """
+    system_canon = _align_with_judge(reference, system, judge, usage)
+
+    reference_set = set(reference)
+    canon_set = set(system_canon)
+    true_positive = len(reference_set & canon_set)
+    false_positive = sum(1 for item in system_canon if item not in reference_set)
+    false_negative = sum(1 for item in reference if item not in canon_set)
+
+    precision = (
+        true_positive / (true_positive + false_positive) if true_positive + false_positive else 0.0
+    )
+    recall = (
+        true_positive / (true_positive + false_negative) if true_positive + false_negative else 0.0
+    )
+    f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+
+    union = list(dict.fromkeys(reference + system_canon))
+    tie_rank = len(union) + 1
+
+    def to_rank(sequence: list[str]) -> list[int]:
+        positions = {item: position + 1 for position, item in enumerate(sequence)}
+        return [positions.get(item, tie_rank) for item in union]
+
+    tau = kendall_tau_b(to_rank(reference), to_rank(system_canon))
+    tau_norm = (tau + 1) / 2 if tau is not None else 0.0
+
+    return BeamOrderingScore(
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        tau_norm=tau_norm,
+        final_score=tau_norm * f1,
+    )
+
+
+def _errored_case(
+    qa_case: QACaseResult, ability: str, question: str, judge_model: str, error: str
+) -> BeamCaseScore:
+    # Explicit-failure principle: errored cases are never silently
+    # zero-scored — they carry the error and are excluded from means.
+    return BeamCaseScore(
+        provider=qa_case.provider,
+        query_id=qa_case.query_id,
+        ability=ability,
+        question=question,
+        generated_answer=qa_case.generated_answer,
+        answer_input_tokens=qa_case.answer_input_tokens,
+        answer_output_tokens=qa_case.answer_output_tokens,
+        answer_prompt_chars=qa_case.answer_prompt_chars,
+        answer_latency_ms=qa_case.answer_latency_ms,
+        judge_model=judge_model,
+        error=error,
+    )
+
+
+def _score_case(
+    qa_case: QACaseResult,
+    retrieval_row: PerQueryRetrievalResult,
+    judge: LLMRunner,
+) -> BeamCaseScore:
+    ability = retrieval_row.metadata.get("ability")
+    if not isinstance(ability, str) or not ability:
+        raise ValueError(f"Retrieval row {qa_case.query_id} carries no 'ability' metadata")
+    rubric = retrieval_row.metadata.get("rubric")
+    if not isinstance(rubric, list) or not rubric:
+        raise ValueError(f"Retrieval row {qa_case.query_id} carries no 'rubric' metadata")
+
+    # Fairness guarantee: the judge sees the identical question rendering the
+    # answerer saw (including any ask-date framing).
+    question = question_display(retrieval_row)
+
+    if qa_case.error or not qa_case.generated_answer:
+        return _errored_case(
+            qa_case, ability, question, judge.spec, qa_case.error or "no generated answer"
+        )
+
+    usage = JudgeUsage()
+    try:
+        verdicts = score_nuggets(
+            question, [str(item) for item in rubric], qa_case.generated_answer, judge, usage
+        )
+        nugget_score = mean(verdict.score for verdict in verdicts)
+
+        ordering: BeamOrderingScore | None = None
+        if ability == "event_ordering":
+            # Upstream splits the raw response on newlines; dropping blank
+            # lines is a minimal commented cleanup (blank lines carry no
+            # event and would only inflate false positives).
+            system_lines = [line for line in qa_case.generated_answer.split("\n") if line.strip()]
+            ordering = event_ordering_score(
+                [str(item) for item in rubric], system_lines, judge, usage
+            )
+
+        # Aggregation rule (upstream report_results.py): event_ordering
+        # headlines on tau_norm; every other ability on the nugget score.
+        ability_score = ordering.tau_norm if ordering is not None else nugget_score
+
+        return BeamCaseScore(
+            provider=qa_case.provider,
+            query_id=qa_case.query_id,
+            ability=ability,
+            question=question,
+            generated_answer=qa_case.generated_answer,
+            nugget_verdicts=verdicts,
+            nugget_score=nugget_score,
+            ordering=ordering,
+            ability_score=ability_score,
+            answer_input_tokens=qa_case.answer_input_tokens,
+            answer_output_tokens=qa_case.answer_output_tokens,
+            answer_prompt_chars=qa_case.answer_prompt_chars,
+            answer_latency_ms=qa_case.answer_latency_ms,
+            judge_input_tokens=usage.input_tokens,
+            judge_output_tokens=usage.output_tokens,
+            judge_calls=usage.calls,
+            judge_model=judge.spec,
+        )
+    except (LLMRunnerError, ValueError, json.JSONDecodeError) as exc:
+        errored = _errored_case(qa_case, ability, question, judge.spec, str(exc))
+        return errored.model_copy(
+            update={
+                "judge_input_tokens": usage.input_tokens,
+                "judge_output_tokens": usage.output_tokens,
+                "judge_calls": usage.calls,
+            }
+        )
+
+
+def _summarize_ability(ability: str, cases: list[BeamCaseScore]) -> BeamAbilitySummary:
+    scored = [case for case in cases if case.error is None]
+    ordering_scores = [case.ordering for case in scored if case.ordering is not None]
+    return BeamAbilitySummary(
+        ability=ability,
+        question_count=len(cases),
+        error_count=len(cases) - len(scored),
+        mean_score=mean(case.ability_score for case in scored) if scored else 0.0,
+        mean_nugget_score=mean(case.nugget_score for case in scored) if scored else 0.0,
+        mean_f1=mean(item.f1 for item in ordering_scores) if ordering_scores else None,
+        # Token totals cover every case (errored calls still cost tokens).
+        total_answer_input_tokens=sum(case.answer_input_tokens for case in cases),
+        total_answer_output_tokens=sum(case.answer_output_tokens for case in cases),
+        total_judge_input_tokens=sum(case.judge_input_tokens for case in cases),
+        total_judge_output_tokens=sum(case.judge_output_tokens for case in cases),
+        mean_answer_prompt_chars=(
+            mean(case.answer_prompt_chars for case in cases) if cases else 0.0
+        ),
+    )
+
+
+def summarize_beam_cases(
+    provider: str, cases: list[BeamCaseScore], judge_model: str
+) -> BeamSummary:
+    by_ability_cases: dict[str, list[BeamCaseScore]] = {ability: [] for ability in ABILITY_KEYS}
+    for case in cases:
+        by_ability_cases.setdefault(case.ability, []).append(case)
+
+    by_ability = {
+        ability: _summarize_ability(ability, ability_cases)
+        for ability, ability_cases in by_ability_cases.items()
+    }
+    # Macro average over abilities that actually produced scores: including
+    # never-run abilities as 0.0 would silently deflate partial runs (a
+    # deviation from upstream, which always scores all ten).
+    scored_means = [
+        summary.mean_score
+        for summary in by_ability.values()
+        if summary.question_count - summary.error_count > 0
+    ]
+    return BeamSummary(
+        provider=provider,
+        judge_model=judge_model,
+        total_cases=len(cases),
+        error_count=sum(1 for case in cases if case.error is not None),
+        by_ability=by_ability,
+        macro_average=mean(scored_means) if scored_means else 0.0,
+    )
+
+
+def score_beam_cases(
+    qa_cases: list[QACaseResult],
+    retrieval_rows: list[PerQueryRetrievalResult],
+    *,
+    judge: LLMRunner,
+    max_workers: int = 4,
+) -> tuple[list[BeamCaseScore], list[BeamSummary]]:
+    """Join QA answers with their rubric-bearing retrieval rows and score them.
+
+    An unmatched join raises: a BEAM run always writes both artifacts, so a
+    missing row means the run dir is inconsistent, not a scoreable state.
+    """
+    rows_by_key = {(row.provider, row.query_id): row for row in retrieval_rows}
+    joined: list[tuple[QACaseResult, PerQueryRetrievalResult]] = []
+    for qa_case in qa_cases:
+        row = rows_by_key.get((qa_case.provider, qa_case.query_id))
+        if row is None:
+            raise ValueError(
+                f"No retrieval row for QA case ({qa_case.provider}, {qa_case.query_id})"
+            )
+        joined.append((qa_case, row))
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        case_scores = list(pool.map(lambda pair: _score_case(pair[0], pair[1], judge), joined))
+
+    providers: list[str] = []
+    cases_by_provider: dict[str, list[BeamCaseScore]] = {}
+    for case in case_scores:
+        if case.provider not in cases_by_provider:
+            providers.append(case.provider)
+            cases_by_provider[case.provider] = []
+        cases_by_provider[case.provider].append(case)
+
+    summaries = [
+        summarize_beam_cases(provider, cases_by_provider[provider], judge.spec)
+        for provider in providers
+    ]
+    return case_scores, summaries
+
+
+def build_beam_summary_markdown(summaries: list[BeamSummary], run_id: str, source: str) -> str:
+    """Render per-provider, per-ability tables — never just an overall average."""
+    lines: list[str] = [f"# BEAM Scoring — run `{run_id}`", ""]
+    lines.append(f"- Source answers: `{source}`")
+    if summaries:
+        lines.append(f"- Judge: `{summaries[0].judge_model}`")
+    lines.append("")
+
+    for summary in summaries:
+        lines.append(f"## {summary.provider}")
+        lines.append("")
+        lines.append(
+            "| Ability | Questions | Errors | Score | Nugget | F1 | "
+            "Answer tokens (in/out) | Judge tokens (in/out) |"
+        )
+        lines.append("| --- | --- | --- | --- | --- | --- | --- | --- |")
+        for ability, ability_summary in summary.by_ability.items():
+            f1_text = (
+                f"{ability_summary.mean_f1:.3f}" if ability_summary.mean_f1 is not None else ""
+            )
+            lines.append(
+                f"| {ability} | {ability_summary.question_count} | "
+                f"{ability_summary.error_count} | {ability_summary.mean_score:.3f} | "
+                f"{ability_summary.mean_nugget_score:.3f} | {f1_text} | "
+                f"{ability_summary.total_answer_input_tokens}/"
+                f"{ability_summary.total_answer_output_tokens} | "
+                f"{ability_summary.total_judge_input_tokens}/"
+                f"{ability_summary.total_judge_output_tokens} |"
+            )
+        lines.append(
+            f"| **Macro average** | {summary.total_cases} | {summary.error_count} | "
+            f"{summary.macro_average:.3f} |  |  |  |  |"
+        )
+        lines.append("")
+
+    return "\n".join(lines).strip() + "\n"

--- a/benchmarks/src/basic_memory_benchmarks/scoring/qa.py
+++ b/benchmarks/src/basic_memory_benchmarks/scoring/qa.py
@@ -165,6 +165,7 @@ def assemble_context(hits: list[SearchHit], max_chars: int = CONTEXT_MAX_CHARS) 
 
 
 def _row_context(row: PerQueryRetrievalResult, max_context_chars: int) -> str:
+    """Assemble a row's answering context exactly as the QA stage does."""
     # Prefer assembling from stored hits (richer, budget-controlled); fall
     # back to the legacy pre-joined context for old artifacts without hits.
     if row.hits:
@@ -174,12 +175,13 @@ def _row_context(row: PerQueryRetrievalResult, max_context_chars: int) -> str:
     return row.retrieved_context
 
 
-def _question_display(row: PerQueryRetrievalResult) -> str:
+def question_display(row: PerQueryRetrievalResult) -> str:
     """Render the question with its ask-date when the dataset provides one.
 
     Temporal-reasoning questions ("how many weeks ago...") are unanswerable
     without the reference date, and both the answerer and the judge need the
-    same framing.
+    same framing. Public because BEAM nugget scoring re-renders stored
+    questions and must show its judge the framing the answerer saw.
     """
     question_date = row.metadata.get("question_date")
     if question_date:
@@ -194,7 +196,7 @@ def _score_case(
     judge: LLMRunner,
     max_context_chars: int = CONTEXT_MAX_CHARS,
 ) -> QACaseResult:
-    question = _question_display(row)
+    question = question_display(row)
     answer_prompt = build_answer_prompt(question, _row_context(row, max_context_chars))
     try:
         answer_result = answerer.complete(answer_prompt)

--- a/benchmarks/src/basic_memory_benchmarks/scoring/retrieval.py
+++ b/benchmarks/src/basic_memory_benchmarks/scoring/retrieval.py
@@ -14,8 +14,13 @@ from basic_memory_benchmarks.models import (
     SearchHit,
 )
 
-
 OFFICIAL_HEADLINE_CATEGORIES = {"single_hop", "multi_hop", "temporal", "open_domain"}
+
+# BEAM datasets split the other way around: every ability except abstention is
+# headline-worthy, and abstention breaks out. Abstention rows have empty
+# ground truth, so their recall is 0 by construction and would poison the
+# headline — the same reason LoCoMo excludes its adversarial category.
+BEAM_BREAKOUT_CATEGORIES = {"abstention"}
 
 
 def _basename(identifier: str) -> str:
@@ -132,7 +137,19 @@ def _aggregate_metrics(rows: list[PerQueryRetrievalResult]) -> RetrievalMetrics:
     )
 
 
-def summarize_provider(provider: str, rows: list[PerQueryRetrievalResult]) -> RetrievalSummary:
+def summarize_provider(
+    provider: str,
+    rows: list[PerQueryRetrievalResult],
+    dataset_id: str | None = None,
+) -> RetrievalSummary:
+    """Aggregate one provider's rows, with a dataset-keyed headline split.
+
+    ``RetrievalSummary.official_headline`` / ``adversarial_breakout`` are the
+    generic headline/breakout containers (names kept for artifact-schema
+    stability): LoCoMo puts categories 1-4 in the headline and adversarial in
+    the breakout; BEAM datasets put the nine answerable abilities in the
+    headline and abstention in the breakout.
+    """
     by_category: dict[str, list[PerQueryRetrievalResult]] = {}
     for row in rows:
         by_category.setdefault(row.category, []).append(row)
@@ -141,14 +158,18 @@ def summarize_provider(provider: str, rows: list[PerQueryRetrievalResult]) -> Re
         category: _aggregate_metrics(group) for category, group in by_category.items()
     }
 
-    official_rows = [
-        row
-        for row in rows
-        if row.category in OFFICIAL_HEADLINE_CATEGORIES or row.category_id in {1, 2, 3, 4}
-    ]
-    adversarial_rows = [
-        row for row in rows if row.category == "adversarial" or row.category_id == 5
-    ]
+    if dataset_id is not None and dataset_id.startswith("beam"):
+        official_rows = [row for row in rows if row.category not in BEAM_BREAKOUT_CATEGORIES]
+        adversarial_rows = [row for row in rows if row.category in BEAM_BREAKOUT_CATEGORIES]
+    else:
+        official_rows = [
+            row
+            for row in rows
+            if row.category in OFFICIAL_HEADLINE_CATEGORIES or row.category_id in {1, 2, 3, 4}
+        ]
+        adversarial_rows = [
+            row for row in rows if row.category == "adversarial" or row.category_id == 5
+        ]
 
     return RetrievalSummary(
         provider=provider,

--- a/benchmarks/tests/beam_fixture.py
+++ b/benchmarks/tests/beam_fixture.py
@@ -1,0 +1,261 @@
+"""Hand-written miniature BEAM-format fixture builders.
+
+Mirrors the upstream mohammadtavakoli78/BEAM on-disk layout
+(``chats/<tier>/<N>/chat.json`` + ``probing_questions/probing_questions.json``)
+at toy scale: two conversations, all ten ability keys present, with real
+probes for information_extraction, knowledge_update, event_ordering, and
+abstention. Everything is built programmatically into tmp_path — no upstream
+data is vendored and no network is touched.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from basic_memory_benchmarks.datasets.beam import ABILITY_KEYS, REFERENCE_ANSWER_FIELDS
+
+# Phrasing chosen to trigger the binary QA judge's unanswerable branch, like
+# real upstream ideal_response values ("...there is no information related to...").
+ABSTENTION_IDEAL_RESPONSE = (
+    "Unfortunately, there is no information related to your car in our previous conversations."
+)
+
+
+def message(
+    role: str,
+    message_id: int,
+    content: str,
+    *,
+    question_type: str | None = None,
+    time_anchor: str | None = None,
+    index: str | None = None,
+) -> dict[str, Any]:
+    raw: dict[str, Any] = {"role": role, "id": message_id, "content": content}
+    if question_type is not None:
+        raw["question_type"] = question_type
+    if time_anchor is not None:
+        raw["time_anchor"] = time_anchor
+    if index is not None:
+        raw["index"] = index
+    return raw
+
+
+def probe(
+    ability: str,
+    question: str,
+    *,
+    rubric: list[str],
+    reference_answer: str,
+    source_chat_ids: object = None,
+    difficulty: str = "easy",
+    **extras: Any,
+) -> dict[str, Any]:
+    """Build one upstream-shaped probe record.
+
+    The reference answer lands in the per-ability field name
+    (answer/ideal_response/expected_compliance/...), exactly as upstream ships
+    it. ``source_chat_ids=None`` omits the field (the abstention shape).
+    """
+    record: dict[str, Any] = {
+        "question": question,
+        "difficulty": difficulty,
+        "rubric": rubric,
+        REFERENCE_ANSWER_FIELDS[ability]: reference_answer,
+    }
+    if source_chat_ids is not None:
+        record["source_chat_ids"] = source_chat_ids
+    record.update(extras)
+    return record
+
+
+def minimal_probes(source_chat_ids: list[int] | None = None) -> dict[str, list[dict[str, Any]]]:
+    """One minimal probe per ability (the loader requires all ten keys)."""
+    ids = [0] if source_chat_ids is None else source_chat_ids
+    probes: dict[str, list[dict[str, Any]]] = {}
+    for ability in ABILITY_KEYS:
+        if ability == "abstention":
+            probes[ability] = [
+                probe(
+                    ability,
+                    "Minimal abstention probe?",
+                    rubric=["abstention nugget"],
+                    reference_answer=ABSTENTION_IDEAL_RESPONSE,
+                )
+            ]
+        else:
+            probes[ability] = [
+                probe(
+                    ability,
+                    f"Minimal {ability} probe?",
+                    rubric=[f"{ability} nugget"],
+                    reference_answer=f"{ability} reference",
+                    source_chat_ids=list(ids),
+                )
+            ]
+    return probes
+
+
+def conversation_one_chat() -> list[dict[str, Any]]:
+    """Two batches: batch 1 anchored at batch level, batch 2 at message level.
+
+    Message ids are global and interleaved (0..5). Message 2 carries the
+    trailing ``->-> 1,2`` probe-index marker the converter must strip;
+    message 3 carries the non-numeric ``->-> 2,N/A`` variant observed in
+    upstream 100K/1/chat.json.
+    """
+    return [
+        {
+            "batch_number": 1,
+            "time_anchor": "March-15-2024",
+            "turns": [
+                [
+                    message("user", 0, "I adopted a puppy named Biscuit."),
+                    message("assistant", 1, "Congratulations on adopting Biscuit!"),
+                ],
+                [
+                    message(
+                        "user",
+                        2,
+                        "My dentist appointment is on March 29. ->-> 1,2",
+                        question_type="main_question",
+                        index="1,2",
+                    ),
+                    message(
+                        "assistant",
+                        3,
+                        "Noted: the dentist appointment is March 29. ->-> 2,N/A",
+                    ),
+                ],
+            ],
+        },
+        {
+            "batch_number": 2,
+            "time_anchor": None,
+            "turns": [
+                [
+                    message(
+                        "user",
+                        4,
+                        "Update: my salary is now $75,000.",
+                        time_anchor="April-02-2024",
+                    ),
+                    message("assistant", 5, "Got it, salary updated."),
+                ]
+            ],
+        },
+    ]
+
+
+def conversation_one_probes() -> dict[str, list[dict[str, Any]]]:
+    """All ten abilities; four carry real content used by converter tests."""
+    probes = minimal_probes()
+    probes["information_extraction"] = [
+        probe(
+            "information_extraction",
+            "When is the dentist appointment?",
+            rubric=["LLM response should state: March 29"],
+            reference_answer="March 29",
+            source_chat_ids=[2],
+        )
+    ]
+    probes["knowledge_update"] = [
+        probe(
+            "knowledge_update",
+            "What is my current salary?",
+            rubric=["States the salary is $75,000"],
+            reference_answer="$75,000",
+            # The verified upstream dict shape — exercises normalization.
+            source_chat_ids={"original_info": [1], "updated_info": [4]},
+            difficulty="medium",
+        )
+    ]
+    probes["event_ordering"] = [
+        probe(
+            "event_ordering",
+            "List the events we discussed in the order they happened.",
+            rubric=["Adopted Biscuit", "Dentist appointment", "Salary update"],
+            reference_answer="Adopted Biscuit -> Dentist appointment -> Salary update",
+            source_chat_ids=[0, 2, 4],
+            difficulty="hard",
+            ordering_type="full",
+        )
+    ]
+    probes["abstention"] = [
+        probe(
+            "abstention",
+            "What car do I drive?",
+            rubric=["Acknowledges there is no information about a car"],
+            reference_answer=ABSTENTION_IDEAL_RESPONSE,
+            abstention_type="never_mentioned",
+        )
+    ]
+    return probes
+
+
+def conversation_two_full_chat() -> list[dict[str, Any]]:
+    return [
+        {
+            "batch_number": 1,
+            "time_anchor": None,
+            "turns": [
+                [
+                    message("user", 0, "FULL VERSION: the meeting is on Friday."),
+                    message("assistant", 1, "Understood."),
+                ]
+            ],
+        }
+    ]
+
+
+def conversation_two_truncated_chat() -> list[dict[str, Any]]:
+    return [
+        {
+            "batch_number": 1,
+            "time_anchor": None,
+            "turns": [
+                [
+                    message("user", 0, "TRUNCATED VERSION: the meeting is on Friday."),
+                    message("assistant", 1, "Understood."),
+                ]
+            ],
+        }
+    ]
+
+
+def write_conversation(
+    conv_dir: Path,
+    chat: list[dict[str, Any]],
+    probes: dict[str, list[dict[str, Any]]],
+    *,
+    truncated_chat: list[dict[str, Any]] | None = None,
+) -> Path:
+    """Write one conversation dir in the upstream layout; returns the dir."""
+    conv_dir.mkdir(parents=True)
+    (conv_dir / "chat.json").write_text(json.dumps(chat), encoding="utf-8")
+    if truncated_chat is not None:
+        (conv_dir / "chat_trunecated.json").write_text(  # sic — upstream misspelling
+            json.dumps(truncated_chat), encoding="utf-8"
+        )
+    probing_dir = conv_dir / "probing_questions"
+    probing_dir.mkdir()
+    (probing_dir / "probing_questions.json").write_text(json.dumps(probes), encoding="utf-8")
+    return conv_dir
+
+
+def write_beam_tier(chats_root: Path, tier: str = "100K") -> Path:
+    """Write the two-conversation miniature tier; returns the chats root.
+
+    Conversation 1 has the anchored two-batch chat with real probes;
+    conversation 2 ships both chat.json and chat_trunecated.json so tests can
+    assert the loader prefers the truncated variant.
+    """
+    write_conversation(chats_root / tier / "1", conversation_one_chat(), conversation_one_probes())
+    write_conversation(
+        chats_root / tier / "2",
+        conversation_two_full_chat(),
+        minimal_probes(),
+        truncated_chat=conversation_two_truncated_chat(),
+    )
+    return chats_root

--- a/benchmarks/tests/converters/test_beam_converter.py
+++ b/benchmarks/tests/converters/test_beam_converter.py
@@ -1,0 +1,246 @@
+"""Tests for the BEAM grouped corpus converter (transcript -> notes + queries)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from basic_memory_benchmarks.converters.beam_to_corpus import convert_beam_to_corpus
+from basic_memory_benchmarks.datasets.beam import ABILITY_KEYS
+from basic_memory_benchmarks.models import QueryCase
+from basic_memory_benchmarks.utils import sha256_file
+from beam_fixture import (
+    ABSTENTION_IDEAL_RESPONSE,
+    conversation_two_full_chat,
+    message,
+    minimal_probes,
+    write_beam_tier,
+    write_conversation,
+)
+
+
+@pytest.fixture
+def chats_root(tmp_path: Path) -> Path:
+    return write_beam_tier(tmp_path / "chats")
+
+
+def _convert(chats_root: Path, output_dir: Path, **kwargs) -> tuple[Path, Path, int, int]:
+    return convert_beam_to_corpus(
+        dataset_root=chats_root, output_dir=output_dir, tier="100K", **kwargs
+    )
+
+
+def _queries_by_id(queries_path: Path) -> dict[str, dict]:
+    return {query["id"]: query for query in json.loads(queries_path.read_text())}
+
+
+class TestGroupedLayout:
+    def test_groups_docs_and_counts(self, chats_root: Path, tmp_path: Path) -> None:
+        groups_dir, queries_path, doc_count, query_count = _convert(chats_root, tmp_path / "out")
+
+        # Conversation 1: batch 1 has two sessions, batch 2 one; conv 2: one.
+        assert doc_count == 4
+        # Ten abilities x one probe x two conversations.
+        assert query_count == 20
+        assert (groups_dir / "beam-100k-c01" / "docs").is_dir()
+        assert (groups_dir / "beam-100k-c02" / "docs").is_dir()
+
+        doc_paths = sorted((groups_dir / "beam-100k-c01" / "docs").glob("*.md"))
+        assert [path.stem for path in doc_paths] == [
+            "beam-100k-c01-b01-s000",
+            "beam-100k-c01-b01-s001",
+            "beam-100k-c01-b02-s000",
+        ]
+
+    def test_filename_matches_source_doc_id(self, chats_root: Path, tmp_path: Path) -> None:
+        groups_dir, _, _, _ = _convert(chats_root, tmp_path / "out")
+
+        for path in groups_dir.rglob("*.md"):
+            assert f"source_doc_id: {path.stem}" in path.read_text()
+
+    def test_max_conversations(self, chats_root: Path, tmp_path: Path) -> None:
+        groups_dir, _, doc_count, query_count = _convert(
+            chats_root, tmp_path / "out", max_conversations=1
+        )
+
+        assert doc_count == 3
+        assert query_count == 10
+        assert not (groups_dir / "beam-100k-c02").exists()
+
+    def test_unsupported_mode_raises(self, chats_root: Path, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="ingestion mode"):
+            _convert(chats_root, tmp_path / "out", mode="curated")
+
+
+class TestTranscriptRendering:
+    def test_frontmatter_and_anchor_carry(self, chats_root: Path, tmp_path: Path) -> None:
+        groups_dir, _, _, _ = _convert(chats_root, tmp_path / "out")
+        docs = groups_dir / "beam-100k-c01" / "docs"
+
+        batch_one = (docs / "beam-100k-c01-b01-s000.md").read_text()
+        assert "title: beam-100k-c01-b01-s000 (March-15-2024)" in batch_one
+        assert "session_date: March-15-2024" in batch_one
+        assert "# Chat session (March-15-2024)" in batch_one
+        assert "- **User:** I adopted a puppy named Biscuit." in batch_one
+        assert "- **Assistant:** Congratulations on adopting Biscuit!" in batch_one
+
+        # Batch 2 has no batch-level anchor; the message-level anchor wins.
+        batch_two = (docs / "beam-100k-c01-b02-s000.md").read_text()
+        assert "session_date: April-02-2024" in batch_two
+        assert "# Chat session (April-02-2024)" in batch_two
+
+    def test_doc_without_anchor_uses_plain_heading(self, chats_root: Path, tmp_path: Path) -> None:
+        groups_dir, _, _, _ = _convert(chats_root, tmp_path / "out")
+        doc = (groups_dir / "beam-100k-c02" / "docs" / "beam-100k-c02-b01-s000.md").read_text()
+
+        assert "title: beam-100k-c02-b01-s000\n" in doc
+        assert "session_date:" not in doc
+        assert "# beam-100k-c02-b01-s000" in doc
+
+    def test_truncated_chat_variant_is_rendered(self, chats_root: Path, tmp_path: Path) -> None:
+        groups_dir, _, _, _ = _convert(chats_root, tmp_path / "out")
+        doc = (groups_dir / "beam-100k-c02" / "docs" / "beam-100k-c02-b01-s000.md").read_text()
+
+        assert "TRUNCATED VERSION" in doc
+        assert "FULL VERSION" not in doc
+
+    def test_index_marker_stripped(self, chats_root: Path, tmp_path: Path) -> None:
+        groups_dir, _, _, _ = _convert(chats_root, tmp_path / "out")
+
+        corpus_text = "".join(path.read_text() for path in groups_dir.rglob("*.md"))
+        assert "->->" not in corpus_text
+        assert "- **User:** My dentist appointment is on March 29." in corpus_text
+        # The non-numeric "->-> 2,N/A" variant is stripped too.
+        assert "- **Assistant:** Noted: the dentist appointment is March 29." in corpus_text
+
+    def test_surviving_marker_variant_fails_fast(self, tmp_path: Path) -> None:
+        # A non-trailing marker escapes the strip pattern; conversion must
+        # abort rather than leak probe indices into the rendered docs.
+        chat = [
+            {
+                "batch_number": 1,
+                "time_anchor": None,
+                "turns": [
+                    [
+                        message("user", 0, "As I said ->-> 3,7 earlier, the meeting moved."),
+                        message("assistant", 1, "Understood."),
+                    ]
+                ],
+            }
+        ]
+        write_conversation(tmp_path / "chats" / "100K" / "1", chat, minimal_probes())
+
+        with pytest.raises(ValueError, match="marker survived cleaning"):
+            _convert(tmp_path / "chats", tmp_path / "out")
+
+    def test_rubric_never_ingested(self, chats_root: Path, tmp_path: Path) -> None:
+        groups_dir, queries_path, _, _ = _convert(chats_root, tmp_path / "out")
+
+        corpus_text = "".join(path.read_text() for path in groups_dir.rglob("*.md"))
+        for query in json.loads(queries_path.read_text()):
+            for nugget in query["metadata"]["rubric"]:
+                assert nugget not in corpus_text
+
+
+class TestProbeToQueryMapping:
+    def test_queries_validate_as_query_cases(self, chats_root: Path, tmp_path: Path) -> None:
+        _, queries_path, _, _ = _convert(chats_root, tmp_path / "out")
+
+        for raw in json.loads(queries_path.read_text()):
+            case = QueryCase.model_validate(raw)
+            assert case.group in {"beam-100k-c01", "beam-100k-c02"}
+            assert case.category == case.metadata["ability"]
+            assert case.metadata["dataset_id"] == "beam-100k"
+            assert case.metadata["tier"] == "100K"
+
+    def test_probe_identity_and_fields(self, chats_root: Path, tmp_path: Path) -> None:
+        _, queries_path, _, _ = _convert(chats_root, tmp_path / "out")
+        queries = _queries_by_id(queries_path)
+
+        extraction = queries["beam-100k-c01-information_extraction-0"]
+        assert extraction["query"] == "When is the dentist appointment?"
+        assert extraction["category"] == "information_extraction"
+        assert extraction["expected_answer"] == "March 29"
+        assert extraction["metadata"]["probe_index"] == 0
+        assert extraction["metadata"]["rubric"] == ["LLM response should state: March 29"]
+        assert extraction["metadata"]["abstention"] is False
+
+    def test_ground_truth_maps_message_ids_to_session_docs(
+        self, chats_root: Path, tmp_path: Path
+    ) -> None:
+        _, queries_path, _, _ = _convert(chats_root, tmp_path / "out")
+        queries = _queries_by_id(queries_path)
+
+        # Message id 2 lives in batch 1, session 1.
+        assert queries["beam-100k-c01-information_extraction-0"]["ground_truth"] == [
+            "beam-100k-c01-b01-s001"
+        ]
+        # knowledge_update's dict ids (1 and 4) span two sessions.
+        assert queries["beam-100k-c01-knowledge_update-0"]["ground_truth"] == [
+            "beam-100k-c01-b01-s000",
+            "beam-100k-c01-b02-s000",
+        ]
+        assert queries["beam-100k-c01-event_ordering-0"]["ground_truth"] == [
+            "beam-100k-c01-b01-s000",
+            "beam-100k-c01-b01-s001",
+            "beam-100k-c01-b02-s000",
+        ]
+
+    def test_abstention_query_convention(self, chats_root: Path, tmp_path: Path) -> None:
+        _, queries_path, _, _ = _convert(chats_root, tmp_path / "out")
+        queries = _queries_by_id(queries_path)
+
+        abstention = queries["beam-100k-c01-abstention-0"]
+        assert abstention["ground_truth"] == []
+        assert abstention["metadata"]["abstention"] is True
+        assert abstention["expected_answer"] == ABSTENTION_IDEAL_RESPONSE
+
+    def test_all_abilities_covered_per_conversation(self, chats_root: Path, tmp_path: Path) -> None:
+        _, queries_path, _, _ = _convert(chats_root, tmp_path / "out")
+
+        queries = json.loads(queries_path.read_text())
+        for group in ("beam-100k-c01", "beam-100k-c02"):
+            categories = {q["category"] for q in queries if q["group"] == group}
+            assert categories == set(ABILITY_KEYS)
+
+    def test_cited_id_missing_from_chat_raises(self, tmp_path: Path) -> None:
+        probes = minimal_probes(source_chat_ids=[99])
+        write_conversation(tmp_path / "chats" / "100K" / "1", conversation_two_full_chat(), probes)
+
+        with pytest.raises(ValueError, match="cites chat id 99"):
+            _convert(tmp_path / "chats", tmp_path / "out")
+
+
+class TestConversionManifest:
+    def test_manifest_records_provenance(self, chats_root: Path, tmp_path: Path) -> None:
+        _convert(chats_root, tmp_path / "out")
+        manifest = json.loads((tmp_path / "out" / "conversion.json").read_text())
+
+        assert manifest["dataset_id"] == "beam-100k"
+        assert manifest["tier"] == "100K"
+        assert manifest["converter"] == {"mode": "raw", "max_conversations": None}
+
+        by_conv = {entry["conversation_id"]: entry for entry in manifest["conversations"]}
+        assert by_conv["1"]["chat_file"] == "chat.json"
+        assert by_conv["2"]["chat_file"] == "chat_trunecated.json"
+        # Checksums pin the exact files consumed (conv 2: the truncated one).
+        conv_two = chats_root / "100K" / "2"
+        assert by_conv["2"]["chat_sha256"] == sha256_file(conv_two / "chat_trunecated.json")
+        assert by_conv["2"]["probing_sha256"] == sha256_file(
+            conv_two / "probing_questions" / "probing_questions.json"
+        )
+
+    def test_conversion_is_deterministic(self, chats_root: Path, tmp_path: Path) -> None:
+        groups_one, queries_one, _, _ = _convert(chats_root, tmp_path / "out1")
+        groups_two, queries_two, _, _ = _convert(chats_root, tmp_path / "out2")
+
+        assert queries_one.read_text() == queries_two.read_text()
+        docs_one = sorted(groups_one.rglob("*.md"))
+        docs_two = sorted(groups_two.rglob("*.md"))
+        assert [path.relative_to(groups_one) for path in docs_one] == [
+            path.relative_to(groups_two) for path in docs_two
+        ]
+        for path_one, path_two in zip(docs_one, docs_two, strict=True):
+            assert path_one.read_text() == path_two.read_text()

--- a/benchmarks/tests/providers/test_baseline_providers.py
+++ b/benchmarks/tests/providers/test_baseline_providers.py
@@ -41,9 +41,10 @@ class TestFilesystemGrep:
 
         hits = provider.search("Where does Joanna live in Austin?", 5, _config(tmp_path))
 
-        assert hits[0].source_doc_id == "doc-a"
-        assert hits[0].score > 0
-        assert "Joanna" in (hits[0].text or "")
+        top = hits[0]
+        assert top.source_doc_id == "doc-a"
+        assert top.score is not None and top.score > 0
+        assert "Joanna" in (top.text or "")
 
     def test_coverage_beats_repetition(self, tmp_path):
         corpus = tmp_path / "docs"

--- a/benchmarks/tests/providers/test_mem0_normalization.py
+++ b/benchmarks/tests/providers/test_mem0_normalization.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import pytest
 
 from basic_memory_benchmarks.providers.mem0_local import Mem0LocalProvider
@@ -112,7 +114,9 @@ class TestTelemetryLockAvoidance:
 
         provider = Mem0LocalProvider()
         memory = FakeMemory()
-        provider._memory = memory
+        # The provider only needs the duck-typed cleanup surface; cast keeps
+        # the test double out of the provider's Memory | None annotation.
+        provider._memory = cast(Any, memory)
 
         from basic_memory_benchmarks.models import RunConfig
 

--- a/benchmarks/tests/test_beam_dataset.py
+++ b/benchmarks/tests/test_beam_dataset.py
@@ -1,0 +1,226 @@
+"""Tests for the BEAM dataset adapter (loading + tier filtering)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from basic_memory_benchmarks.datasets.beam import (
+    ABILITY_KEYS,
+    load_beam_conversation,
+    load_beam_tier,
+)
+from beam_fixture import (
+    ABSTENTION_IDEAL_RESPONSE,
+    conversation_two_full_chat,
+    minimal_probes,
+    probe,
+    write_beam_tier,
+    write_conversation,
+)
+
+
+@pytest.fixture
+def chats_root(tmp_path: Path) -> Path:
+    return write_beam_tier(tmp_path / "chats")
+
+
+class TestLoadConversation:
+    def test_batches_and_messages(self, chats_root: Path) -> None:
+        conv = load_beam_conversation(chats_root / "100K" / "1", "100K")
+
+        assert conv.conversation_id == "1"
+        assert conv.tier == "100K"
+        assert conv.source_chat_file == "chat.json"
+        assert [batch.batch_number for batch in conv.batches] == [1, 2]
+        assert conv.batches[0].time_anchor == "March-15-2024"
+        assert conv.batches[1].time_anchor is None
+        assert len(conv.batches[0].turns) == 2
+
+        first_session = conv.batches[0].turns[0]
+        assert [message.id for message in first_session] == [0, 1]
+        assert [message.role for message in first_session] == ["user", "assistant"]
+
+        marker_message = conv.batches[0].turns[1][0]
+        assert marker_message.question_type == "main_question"
+        assert marker_message.index == "1,2"
+
+        anchored_message = conv.batches[1].turns[0][0]
+        assert anchored_message.time_anchor == "April-02-2024"
+
+    def test_prefers_truncated_chat(self, chats_root: Path) -> None:
+        conv = load_beam_conversation(chats_root / "100K" / "2", "100K")
+
+        assert conv.source_chat_file == "chat_trunecated.json"
+        assert "TRUNCATED VERSION" in conv.batches[0].turns[0][0].content
+
+    def test_probes_flattened_ability_major(self, chats_root: Path) -> None:
+        conv = load_beam_conversation(chats_root / "100K" / "1", "100K")
+
+        # One probe per ability in the fixture, so the flattened order is
+        # exactly the upstream ability-key order.
+        assert [item.ability for item in conv.probes] == list(ABILITY_KEYS)
+        assert all(item.index == 0 for item in conv.probes)
+
+    def test_probe_index_enumerates_within_ability(self, tmp_path: Path) -> None:
+        probes = minimal_probes()
+        probes["information_extraction"] = [
+            probe(
+                "information_extraction",
+                "First probe?",
+                rubric=["first nugget"],
+                reference_answer="first",
+                source_chat_ids=[0],
+            ),
+            probe(
+                "information_extraction",
+                "Second probe?",
+                rubric=["second nugget"],
+                reference_answer="second",
+                source_chat_ids=[0],
+            ),
+        ]
+        conv_dir = write_conversation(tmp_path / "1", conversation_two_full_chat(), probes)
+
+        conv = load_beam_conversation(conv_dir, "100K")
+
+        extraction = [item for item in conv.probes if item.ability == "information_extraction"]
+        assert [(item.index, item.question) for item in extraction] == [
+            (0, "First probe?"),
+            (1, "Second probe?"),
+        ]
+
+    def test_reference_answer_field_resolution(self, chats_root: Path) -> None:
+        conv = load_beam_conversation(chats_root / "100K" / "1", "100K")
+        by_ability = {item.ability: item for item in conv.probes}
+
+        # answer / ideal_response / ideal_summary fields all resolve.
+        assert by_ability["information_extraction"].reference_answer == "March 29"
+        assert by_ability["abstention"].reference_answer == ABSTENTION_IDEAL_RESPONSE
+        assert by_ability["summarization"].reference_answer == "summarization reference"
+
+    def test_source_chat_ids_normalization(self, chats_root: Path) -> None:
+        conv = load_beam_conversation(chats_root / "100K" / "1", "100K")
+        by_ability = {item.ability: item for item in conv.probes}
+
+        # knowledge_update's dict shape flattens to the sorted union.
+        assert by_ability["knowledge_update"].source_chat_ids == [1, 4]
+        # abstention omits the field entirely.
+        assert by_ability["abstention"].source_chat_ids == []
+
+    def test_extras_passthrough(self, chats_root: Path) -> None:
+        conv = load_beam_conversation(chats_root / "100K" / "1", "100K")
+        by_ability = {item.ability: item for item in conv.probes}
+
+        assert by_ability["event_ordering"].extras == {"ordering_type": "full"}
+        assert by_ability["abstention"].extras == {"abstention_type": "never_mentioned"}
+        # Consumed fields never leak into extras.
+        assert "question" not in by_ability["event_ordering"].extras
+        assert "rubric" not in by_ability["event_ordering"].extras
+
+
+class TestLoadTier:
+    def test_loads_conversations_in_numeric_order(self, tmp_path: Path) -> None:
+        root = tmp_path / "chats"
+        write_conversation(root / "100K" / "2", conversation_two_full_chat(), minimal_probes())
+        write_conversation(root / "100K" / "10", conversation_two_full_chat(), minimal_probes())
+
+        conversations = load_beam_tier(root, "100K")
+
+        # Numeric ordering, not lexical ("10" would sort before "2" lexically).
+        assert [conv.conversation_id for conv in conversations] == ["2", "10"]
+
+    def test_tier_filtering_selects_tier_directory(self, chats_root: Path) -> None:
+        write_conversation(
+            chats_root / "500K" / "7", conversation_two_full_chat(), minimal_probes()
+        )
+
+        conversations = load_beam_tier(chats_root, "500K")
+
+        assert [conv.conversation_id for conv in conversations] == ["7"]
+        assert conversations[0].tier == "500K"
+
+    def test_max_conversations(self, chats_root: Path) -> None:
+        conversations = load_beam_tier(chats_root, "100K", max_conversations=1)
+        assert [conv.conversation_id for conv in conversations] == ["1"]
+
+    def test_unknown_tier_raises(self, chats_root: Path) -> None:
+        with pytest.raises(ValueError, match="Unknown BEAM tier"):
+            load_beam_tier(chats_root, "2M")
+
+    def test_10m_tier_rejected(self, chats_root: Path) -> None:
+        with pytest.raises(ValueError, match="plan-N"):
+            load_beam_tier(chats_root, "10M")
+
+    def test_missing_tier_directory_raises(self, chats_root: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="tier directory"):
+            load_beam_tier(chats_root, "1M")
+
+    def test_tier_without_numeric_dirs_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "chats" / "100K" / "not-a-number").mkdir(parents=True)
+        with pytest.raises(ValueError, match="no numeric conversation dirs"):
+            load_beam_tier(tmp_path / "chats", "100K")
+
+
+class TestFailFast:
+    def test_missing_ability_key_raises(self, tmp_path: Path) -> None:
+        probes = minimal_probes()
+        del probes["summarization"]
+        conv_dir = write_conversation(tmp_path / "1", conversation_two_full_chat(), probes)
+
+        with pytest.raises(ValueError, match="missing abilities"):
+            load_beam_conversation(conv_dir, "100K")
+
+    def test_empty_rubric_raises(self, tmp_path: Path) -> None:
+        probes = minimal_probes()
+        probes["information_extraction"][0]["rubric"] = []
+        conv_dir = write_conversation(tmp_path / "1", conversation_two_full_chat(), probes)
+
+        with pytest.raises(ValueError, match="no rubric"):
+            load_beam_conversation(conv_dir, "100K")
+
+    def test_missing_reference_answer_field_raises(self, tmp_path: Path) -> None:
+        probes = minimal_probes()
+        del probes["information_extraction"][0]["answer"]
+        conv_dir = write_conversation(tmp_path / "1", conversation_two_full_chat(), probes)
+
+        with pytest.raises(ValueError, match="missing reference answer field"):
+            load_beam_conversation(conv_dir, "100K")
+
+    def test_plan_layout_chat_raises(self, tmp_path: Path) -> None:
+        conv_dir = write_conversation(
+            tmp_path / "1", conversation_two_full_chat(), minimal_probes()
+        )
+        (conv_dir / "chat.json").write_text(json.dumps([{"plan-1": []}]), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="plan-N"):
+            load_beam_conversation(conv_dir, "100K")
+
+    def test_empty_chat_raises(self, tmp_path: Path) -> None:
+        conv_dir = write_conversation(
+            tmp_path / "1", conversation_two_full_chat(), minimal_probes()
+        )
+        (conv_dir / "chat.json").write_text("[]", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="non-empty list of batches"):
+            load_beam_conversation(conv_dir, "100K")
+
+    def test_missing_chat_file_raises(self, tmp_path: Path) -> None:
+        conv_dir = write_conversation(
+            tmp_path / "1", conversation_two_full_chat(), minimal_probes()
+        )
+        (conv_dir / "chat.json").unlink()
+
+        with pytest.raises(FileNotFoundError, match="no chat file"):
+            load_beam_conversation(conv_dir, "100K")
+
+    def test_missing_probing_questions_raises(self, tmp_path: Path) -> None:
+        conv_dir = write_conversation(
+            tmp_path / "1", conversation_two_full_chat(), minimal_probes()
+        )
+        (conv_dir / "probing_questions" / "probing_questions.json").unlink()
+
+        with pytest.raises(FileNotFoundError, match="no probing questions"):
+            load_beam_conversation(conv_dir, "100K")

--- a/benchmarks/tests/test_beam_scoring.py
+++ b/benchmarks/tests/test_beam_scoring.py
@@ -1,0 +1,620 @@
+"""Tests for BEAM nugget/ordering scoring, aggregation, and the score stage."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from statistics import mean
+
+import pytest
+
+from basic_memory_benchmarks.datasets.beam import ABILITY_KEYS
+from basic_memory_benchmarks.models import (
+    BeamCaseScore,
+    BeamOrderingScore,
+    PerQueryRetrievalResult,
+    QACaseResult,
+)
+from basic_memory_benchmarks.scoring.beam import (
+    JudgeUsage,
+    _align_with_judge,
+    event_ordering_score,
+    kendall_tau_b,
+    parse_nugget_verdict,
+    score_beam_cases,
+    score_nuggets,
+    summarize_beam_cases,
+)
+from basic_memory_benchmarks.scoring.retrieval import summarize_provider
+from test_qa_scoring import FakeRunner
+
+
+def _retrieval_row(
+    query_id: str,
+    ability: str,
+    rubric: list[str] | None,
+    question: str = "Q?",
+    provider: str = "bm-local",
+) -> PerQueryRetrievalResult:
+    metadata: dict[str, object] = {}
+    if rubric is not None:
+        metadata = {"ability": ability, "rubric": rubric}
+    return PerQueryRetrievalResult(
+        provider=provider,
+        query_id=query_id,
+        query_text=question,
+        category=ability,
+        ground_truth=[],
+        expected_answer="gold",
+        recall_at_5=0.0,
+        recall_at_10=0.0,
+        precision_at_5=0.0,
+        mrr=0.0,
+        content_hit=False,
+        latency_ms=1.0,
+        retrieved_context="ctx",
+        metadata=metadata,
+    )
+
+
+def _qa_case(
+    query_id: str,
+    generated: str,
+    error: str | None = None,
+    provider: str = "bm-local",
+    category: str = "information_extraction",
+) -> QACaseResult:
+    return QACaseResult(
+        provider=provider,
+        query_id=query_id,
+        category=category,
+        question="Q?",
+        expected_answer="gold",
+        generated_answer=generated,
+        abstained=False,
+        correct=False,
+        judge_reason="binary",
+        answer_model="fake:answerer",
+        judge_model="fake:judge",
+        answer_latency_ms=2.0,
+        answer_input_tokens=100,
+        answer_output_tokens=20,
+        answer_prompt_chars=500,
+        error=error,
+    )
+
+
+def _case_score(
+    query_id: str,
+    ability: str,
+    *,
+    ability_score: float = 0.0,
+    nugget_score: float = 0.0,
+    ordering: BeamOrderingScore | None = None,
+    error: str | None = None,
+) -> BeamCaseScore:
+    return BeamCaseScore(
+        provider="bm-local",
+        query_id=query_id,
+        ability=ability,
+        question="Q?",
+        generated_answer="answer",
+        nugget_score=nugget_score,
+        ordering=ordering,
+        ability_score=ability_score,
+        answer_input_tokens=100,
+        answer_output_tokens=20,
+        answer_prompt_chars=400,
+        answer_latency_ms=2.0,
+        judge_input_tokens=30,
+        judge_output_tokens=15,
+        judge_calls=3,
+        judge_model="fake:test",
+        error=error,
+    )
+
+
+class TestKendallTauB:
+    def test_perfect_agreement(self) -> None:
+        assert kendall_tau_b([1, 2, 3, 4], [1, 2, 3, 4]) == pytest.approx(1.0)
+
+    def test_perfect_reversal(self) -> None:
+        assert kendall_tau_b([1, 2, 3, 4], [4, 3, 2, 1]) == pytest.approx(-1.0)
+
+    def test_tie_correction_hand_computed(self) -> None:
+        # 5 concordant pairs, 0 discordant, 1 y-tie out of 6 pairs:
+        # tau_b = 5 / sqrt(6 * 5).
+        assert kendall_tau_b([1, 2, 3, 4], [1, 2, 2, 4]) == pytest.approx(5 / math.sqrt(30))
+
+    def test_scipy_documented_example(self) -> None:
+        # scipy.stats.kendalltau doc example: tau == -0.47140452079103173.
+        tau = kendall_tau_b([12, 2, 1, 12, 2], [1, 4, 7, 1, 0])
+        assert tau == pytest.approx(-0.47140452079103173)
+
+    def test_all_ties_returns_none(self) -> None:
+        assert kendall_tau_b([1, 1, 1], [1, 2, 3]) is None
+
+    def test_length_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="differ in length"):
+            kendall_tau_b([1, 2], [1, 2, 3])
+
+
+class TestParseNuggetVerdict:
+    def test_plain_json(self) -> None:
+        score, reason = parse_nugget_verdict('{"score": 0.5, "reason": "partial"}')
+        assert score == 0.5
+        assert reason == "partial"
+
+    def test_json_in_prose_and_fence(self) -> None:
+        raw = 'My verdict follows:\n```json\n{"score": 1.0, "reason": "stated"}\n```\nDone.'
+        score, reason = parse_nugget_verdict(raw)
+        assert score == 1.0
+        assert reason == "stated"
+
+    def test_integer_score_accepted(self) -> None:
+        score, _ = parse_nugget_verdict('{"score": 1, "reason": "ok"}')
+        assert score == 1.0
+
+    def test_score_outside_scale_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be 0, 0.5 or 1"):
+            parse_nugget_verdict('{"score": 0.7, "reason": "close"}')
+
+    def test_missing_score_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be 0, 0.5 or 1"):
+            parse_nugget_verdict('{"reason": "no score at all"}')
+
+    def test_no_json_raises(self) -> None:
+        with pytest.raises(ValueError, match="no JSON object"):
+            parse_nugget_verdict("The response satisfies the rubric.")
+
+
+class TestScoreNuggets:
+    def test_zero_half_one_averaging(self) -> None:
+        judge = FakeRunner(
+            {
+                "States March 29": '{"score": 1.0, "reason": "stated"}',
+                "States the salary": '{"score": 0.5, "reason": "partial"}',
+                "Mentions the puppy": '{"score": 0.0, "reason": "missing"}',
+            }
+        )
+        usage = JudgeUsage()
+
+        verdicts = score_nuggets(
+            "What happened?",
+            ["States March 29", "States the salary", "Mentions the puppy"],
+            "March 29 and some salary talk",
+            judge,
+            usage,
+        )
+
+        assert [verdict.score for verdict in verdicts] == [1.0, 0.5, 0.0]
+        assert [verdict.nugget for verdict in verdicts] == [
+            "States March 29",
+            "States the salary",
+            "Mentions the puppy",
+        ]
+        assert mean(verdict.score for verdict in verdicts) == 0.5
+        # One judge call per nugget; FakeRunner charges 10 in / 5 out per call.
+        assert usage.calls == 3
+        assert usage.input_tokens == 30
+        assert usage.output_tokens == 15
+
+    def test_question_rubric_and_response_reach_judge(self) -> None:
+        judge = FakeRunner({}, default='{"score": 1.0, "reason": "ok"}')
+        usage = JudgeUsage()
+
+        score_nuggets(
+            "When is the dentist appointment?",
+            ["States March 29"],
+            "It is on March 29.",
+            judge,
+            usage,
+        )
+
+        prompt = judge.prompts[0]
+        # The question is injected (upstream-bug fix in the adapted prompt).
+        assert "QUESTION (what the response was asked): When is the dentist appointment?" in prompt
+        assert "RUBRIC CRITERION (what to check): States March 29" in prompt
+        assert "RESPONSE TO EVALUATE: It is on March 29." in prompt
+
+
+class TestAlignWithJudge:
+    def test_greedy_first_unused_replacement(self) -> None:
+        reference = ["Alpha event", "Beta event", "Gamma event"]
+        system = ["The beta thing happened", "gamma occurred", "unrelated noise"]
+        judge = FakeRunner(
+            {
+                "First snippet: Beta event\n\nSecond snippet: The beta thing happened": "YES",
+                "First snippet: Gamma event\n\nSecond snippet: gamma occurred": "YES",
+            },
+            default="NO",
+        )
+        usage = JudgeUsage()
+
+        aligned = _align_with_judge(reference, system, judge, usage)
+
+        # Matched lines are replaced by the reference strings; unmatched pass
+        # through. Used reference items are skipped (greedy first-unused).
+        assert aligned == ["Beta event", "Gamma event", "unrelated noise"]
+        # sys0: Alpha NO + Beta YES; sys1: Alpha NO + Gamma YES (Beta used,
+        # skipped); sys2: Alpha NO (Beta/Gamma used) => 5 calls.
+        assert usage.calls == 5
+
+
+class TestEventOrderingScore:
+    def test_perfect_order(self) -> None:
+        reference = ["A rocket launched", "A satellite deployed"]
+        judge = FakeRunner(
+            {
+                "First snippet: A rocket launched\n\nSecond snippet: A rocket launched": "YES",
+                "First snippet: A satellite deployed\n\nSecond snippet: A satellite deployed": (
+                    "YES"
+                ),
+            },
+            default="NO",
+        )
+
+        result = event_ordering_score(reference, list(reference), judge, JudgeUsage())
+
+        assert result.precision == 1.0
+        assert result.recall == 1.0
+        assert result.f1 == 1.0
+        assert result.tau_norm == 1.0
+        assert result.final_score == 1.0
+
+    def test_reversed_order_zeroes_tau_norm(self) -> None:
+        reference = ["First event", "Second event"]
+        judge = FakeRunner(
+            {
+                "First snippet: First event\n\nSecond snippet: First event": "YES",
+                "First snippet: Second event\n\nSecond snippet: Second event": "YES",
+            },
+            default="NO",
+        )
+
+        result = event_ordering_score(
+            reference, ["Second event", "First event"], judge, JudgeUsage()
+        )
+
+        # All events found (f1 = 1) but fully reversed: tau = -1 -> tau_norm 0.
+        assert result.f1 == 1.0
+        assert result.tau_norm == 0.0
+        assert result.final_score == 0.0
+
+    def test_partial_alignment_math(self) -> None:
+        reference = ["Alpha event", "Beta event", "Gamma event"]
+        system = ["The beta thing happened", "gamma occurred", "unrelated noise"]
+        judge = FakeRunner(
+            {
+                "First snippet: Beta event\n\nSecond snippet: The beta thing happened": "YES",
+                "First snippet: Gamma event\n\nSecond snippet: gamma occurred": "YES",
+            },
+            default="NO",
+        )
+
+        result = event_ordering_score(reference, system, judge, JudgeUsage())
+
+        # tp=2 (Beta, Gamma), fp=1 (noise), fn=1 (Alpha) -> P = R = F1 = 2/3.
+        assert result.precision == pytest.approx(2 / 3)
+        assert result.recall == pytest.approx(2 / 3)
+        assert result.f1 == pytest.approx(2 / 3)
+        # Union [Alpha, Beta, Gamma, noise], tie rank 5: ref ranks [1,2,3,5],
+        # system ranks [5,1,2,3] -> 3 concordant, 3 discordant -> tau = 0.
+        assert result.tau_norm == pytest.approx(0.5)
+        assert result.final_score == pytest.approx(1 / 3)
+
+
+class TestScoreBeamCases:
+    def test_nugget_case_scoring_and_token_accounting(self) -> None:
+        rows = [
+            _retrieval_row(
+                "q1",
+                "information_extraction",
+                ["States March 29", "Mentions Biscuit"],
+                question="When is the dentist appointment?",
+            )
+        ]
+        qa_cases = [_qa_case("q1", "March 29, no pets discussed")]
+        judge = FakeRunner(
+            {
+                "States March 29": '{"score": 1.0, "reason": "stated"}',
+                "Mentions Biscuit": '{"score": 0.0, "reason": "absent"}',
+            }
+        )
+
+        cases, summaries = score_beam_cases(qa_cases, rows, judge=judge, max_workers=1)
+
+        case = cases[0]
+        assert case.ability == "information_extraction"
+        assert case.question == "When is the dentist appointment?"
+        assert case.nugget_score == 0.5
+        assert case.ability_score == 0.5
+        assert case.ordering is None
+        assert case.error is None
+        # Answer-side numbers copied from the QA case; judge-side summed here.
+        assert case.answer_input_tokens == 100
+        assert case.answer_output_tokens == 20
+        assert case.answer_prompt_chars == 500
+        assert case.answer_latency_ms == 2.0
+        assert case.judge_calls == 2
+        assert case.judge_input_tokens == 20
+        assert case.judge_output_tokens == 10
+        assert case.judge_model == "fake:test"
+        assert summaries[0].provider == "bm-local"
+
+    def test_event_ordering_ability_score_is_tau_norm(self) -> None:
+        rows = [_retrieval_row("q1", "event_ordering", ["First event", "Second event"])]
+        qa_cases = [_qa_case("q1", "Second event\nFirst event", category="event_ordering")]
+        judge = FakeRunner(
+            {
+                "what to check): First event": '{"score": 1.0, "reason": "present"}',
+                "what to check): Second event": '{"score": 1.0, "reason": "present"}',
+                "First snippet: First event\n\nSecond snippet: First event": "YES",
+                "First snippet: Second event\n\nSecond snippet: Second event": "YES",
+            },
+            default="NO",
+        )
+
+        cases, summaries = score_beam_cases(qa_cases, rows, judge=judge, max_workers=1)
+
+        case = cases[0]
+        assert case.nugget_score == 1.0  # both nuggets judged present
+        assert case.ordering is not None
+        assert case.ordering.f1 == 1.0
+        assert case.ordering.tau_norm == 0.0  # reversed order
+        # The ability headline is tau_norm, not the nugget score.
+        assert case.ability_score == 0.0
+        # 2 nugget calls + 3 alignment calls.
+        assert case.judge_calls == 5
+        assert summaries[0].by_ability["event_ordering"].mean_score == 0.0
+        assert summaries[0].by_ability["event_ordering"].mean_nugget_score == 1.0
+
+    def test_errored_qa_case_is_never_judged(self) -> None:
+        rows = [_retrieval_row("q1", "information_extraction", ["nugget"])]
+        qa_cases = [_qa_case("q1", "", error="answerer died")]
+        judge = FakeRunner({})  # would raise if called
+
+        cases, summaries = score_beam_cases(qa_cases, rows, judge=judge, max_workers=1)
+
+        assert cases[0].error == "answerer died"
+        assert cases[0].nugget_verdicts == []
+        assert cases[0].judge_calls == 0
+        assert judge.prompts == []
+        assert summaries[0].error_count == 1
+
+    def test_empty_answer_becomes_explicit_error(self) -> None:
+        rows = [_retrieval_row("q1", "information_extraction", ["nugget"])]
+        qa_cases = [_qa_case("q1", "")]
+        judge = FakeRunner({})
+
+        cases, _ = score_beam_cases(qa_cases, rows, judge=judge, max_workers=1)
+
+        assert cases[0].error == "no generated answer"
+
+    def test_malformed_verdict_recorded_as_case_error(self) -> None:
+        rows = [_retrieval_row("q1", "information_extraction", ["nugget"])]
+        qa_cases = [_qa_case("q1", "some answer")]
+        judge = FakeRunner({}, default="I refuse to emit JSON")
+
+        cases, summaries = score_beam_cases(qa_cases, rows, judge=judge, max_workers=1)
+
+        assert cases[0].error is not None
+        assert "no JSON object" in cases[0].error
+        # The failed call's tokens are still accounted for.
+        assert cases[0].judge_calls == 1
+        assert cases[0].judge_input_tokens == 10
+        assert summaries[0].error_count == 1
+
+    def test_unmatched_join_raises(self) -> None:
+        rows = [_retrieval_row("q1", "information_extraction", ["nugget"])]
+        qa_cases = [_qa_case("q-other", "answer")]
+        judge = FakeRunner({})
+
+        with pytest.raises(ValueError, match="No retrieval row"):
+            score_beam_cases(qa_cases, rows, judge=judge, max_workers=1)
+
+    def test_row_without_rubric_metadata_raises(self) -> None:
+        rows = [_retrieval_row("q1", "information_extraction", None)]
+        qa_cases = [_qa_case("q1", "answer")]
+        judge = FakeRunner({})
+
+        with pytest.raises(ValueError, match="ability"):
+            score_beam_cases(qa_cases, rows, judge=judge, max_workers=1)
+
+
+class TestSummarizeBeamCases:
+    def test_all_ten_abilities_always_present(self) -> None:
+        cases = [_case_score("q1", "information_extraction", ability_score=1.0)]
+
+        summary = summarize_beam_cases("bm-local", cases, "fake:test")
+
+        assert set(summary.by_ability) == set(ABILITY_KEYS)
+        assert summary.by_ability["temporal_reasoning"].question_count == 0
+
+    def test_event_ordering_headline_uses_tau_norm(self) -> None:
+        ordering = BeamOrderingScore(
+            precision=1.0, recall=0.8, f1=0.8, tau_norm=0.5, final_score=0.4
+        )
+        cases = [
+            _case_score(
+                "q1", "event_ordering", ability_score=0.5, nugget_score=1.0, ordering=ordering
+            )
+        ]
+
+        summary = summarize_beam_cases("bm-local", cases, "fake:test")
+        ability = summary.by_ability["event_ordering"]
+
+        assert ability.mean_score == 0.5  # tau_norm, not the nugget score
+        assert ability.mean_nugget_score == 1.0
+        assert ability.mean_f1 == 0.8
+
+    def test_errored_cases_excluded_from_means_but_counted(self) -> None:
+        cases = [
+            _case_score("q1", "information_extraction", ability_score=1.0, nugget_score=1.0),
+            _case_score("q2", "information_extraction", error="judge died"),
+        ]
+
+        summary = summarize_beam_cases("bm-local", cases, "fake:test")
+        ability = summary.by_ability["information_extraction"]
+
+        assert ability.question_count == 2
+        assert ability.error_count == 1
+        assert ability.mean_score == 1.0  # errored case excluded, not zero-scored
+        # Token totals cover every case, errored included.
+        assert ability.total_answer_input_tokens == 200
+        assert ability.total_judge_input_tokens == 60
+        assert summary.error_count == 1
+
+    def test_macro_average_over_scored_abilities_only(self) -> None:
+        cases = [
+            _case_score("q1", "information_extraction", ability_score=1.0),
+            _case_score("q2", "event_ordering", ability_score=0.5),
+        ]
+
+        summary = summarize_beam_cases("bm-local", cases, "fake:test")
+
+        # Mean of the two scored ability means; the eight never-run abilities
+        # do not deflate the average.
+        assert summary.macro_average == pytest.approx(0.75)
+        assert summary.total_cases == 2
+
+
+class TestBeamScoreStage:
+    def _write_rows(self, run_dir: Path, rows: list[PerQueryRetrievalResult]) -> None:
+        with (run_dir / "per-query-retrieval.jsonl").open("w", encoding="utf-8") as file:
+            for row in rows:
+                file.write(json.dumps(row.model_dump(mode="json")) + "\n")
+
+    def _write_qa(self, path: Path, cases: list[QACaseResult]) -> None:
+        with path.open("w", encoding="utf-8") as file:
+            for case in cases:
+                file.write(json.dumps(case.model_dump(mode="json")) + "\n")
+
+    def test_stage_writes_artifacts(self, tmp_path: Path, monkeypatch) -> None:
+        from basic_memory_benchmarks import runner as runner_module
+
+        rows = [
+            _retrieval_row(
+                "q1",
+                "information_extraction",
+                ["States March 29"],
+                question="When is the dentist appointment?",
+            )
+        ]
+        self._write_rows(tmp_path, rows)
+        self._write_qa(tmp_path / "per-query-qa.jsonl", [_qa_case("q1", "March 29")])
+
+        fake = FakeRunner({}, default='{"score": 1.0, "reason": "stated"}')
+        monkeypatch.setattr("basic_memory_benchmarks.llm.runners.create_runner", lambda spec: fake)
+
+        out = runner_module.run_beam_score_stage(
+            run_dir=tmp_path, judge_spec="fake:test", max_workers=1
+        )
+
+        assert out == tmp_path
+        beam_lines = (tmp_path / "per-query-beam.jsonl").read_text().splitlines()
+        scored = [BeamCaseScore.model_validate(json.loads(line)) for line in beam_lines]
+        assert len(scored) == 1
+        assert scored[0].ability_score == 1.0
+
+        summary = json.loads((tmp_path / "beam-summary.json").read_text())
+        assert summary["judge"] == "fake:test"
+        assert summary["source"] == "per-query-qa.jsonl"
+        provider_summary = summary["providers"][0]
+        assert provider_summary["provider"] == "bm-local"
+        assert set(provider_summary["by_ability"]) == set(ABILITY_KEYS)
+        assert provider_summary["by_ability"]["information_extraction"]["mean_score"] == 1.0
+
+        markdown = (tmp_path / "beam-summary.md").read_text()
+        assert "## bm-local" in markdown
+        assert "| information_extraction | 1 |" in markdown
+        assert "Macro average" in markdown
+
+    def test_non_beam_run_fails_fast(self, tmp_path: Path, monkeypatch) -> None:
+        from basic_memory_benchmarks import runner as runner_module
+
+        self._write_rows(tmp_path, [_retrieval_row("q1", "single_hop", None)])
+        self._write_qa(tmp_path / "per-query-qa.jsonl", [_qa_case("q1", "answer")])
+
+        fake = FakeRunner({})
+        monkeypatch.setattr("basic_memory_benchmarks.llm.runners.create_runner", lambda spec: fake)
+
+        with pytest.raises(ValueError, match="does not look like a BEAM run"):
+            runner_module.run_beam_score_stage(
+                run_dir=tmp_path, judge_spec="fake:test", max_workers=1
+            )
+        assert not (tmp_path / "per-query-beam.jsonl").exists()
+
+    def test_source_rejudge_selects_rejudged_answers(self, tmp_path: Path, monkeypatch) -> None:
+        from basic_memory_benchmarks import runner as runner_module
+
+        self._write_rows(
+            tmp_path, [_retrieval_row("q1", "information_extraction", ["States March 29"])]
+        )
+        self._write_qa(tmp_path / "per-query-qa.jsonl", [_qa_case("q1", "original answer")])
+        self._write_qa(tmp_path / "per-query-qa-rejudge.jsonl", [_qa_case("q1", "rejudged answer")])
+
+        fake = FakeRunner({}, default='{"score": 0.5, "reason": "partial"}')
+        monkeypatch.setattr("basic_memory_benchmarks.llm.runners.create_runner", lambda spec: fake)
+
+        runner_module.run_beam_score_stage(
+            run_dir=tmp_path, judge_spec="fake:test", source="rejudge", max_workers=1
+        )
+
+        summary = json.loads((tmp_path / "beam-summary.json").read_text())
+        assert summary["source"] == "per-query-qa-rejudge.jsonl"
+        beam_case = json.loads((tmp_path / "per-query-beam.jsonl").read_text().splitlines()[0])
+        assert beam_case["generated_answer"] == "rejudged answer"
+
+
+class TestBeamHeadlineSplit:
+    def _plain_row(self, query_id: str, category: str, recall: float) -> PerQueryRetrievalResult:
+        return PerQueryRetrievalResult(
+            provider="bm-local",
+            query_id=query_id,
+            query_text="Q?",
+            category=category,
+            ground_truth=[],
+            expected_answer=None,
+            recall_at_5=recall,
+            recall_at_10=recall,
+            precision_at_5=0.0,
+            mrr=0.0,
+            content_hit=False,
+            latency_ms=1.0,
+        )
+
+    def test_beam_dataset_puts_abstention_in_breakout(self) -> None:
+        rows = [
+            self._plain_row("q1", "information_extraction", 1.0),
+            self._plain_row("q2", "temporal_reasoning", 1.0),
+            self._plain_row("q3", "abstention", 0.0),
+        ]
+
+        summary = summarize_provider("bm-local", rows, dataset_id="beam-100k")
+
+        assert summary.official_headline.query_count == 2
+        assert summary.official_headline.recall_at_10 == 1.0
+        assert summary.adversarial_breakout.query_count == 1
+
+    def test_default_locomo_split_unchanged(self) -> None:
+        rows = [
+            self._plain_row("q1", "single_hop", 1.0),
+            self._plain_row("q2", "adversarial", 0.0),
+        ]
+
+        summary = summarize_provider("bm-local", rows)
+
+        assert summary.official_headline.query_count == 1
+        assert summary.adversarial_breakout.query_count == 1
+
+    def test_beam_categories_without_dataset_id_stay_out_of_headline(self) -> None:
+        # Regression guard: the split is keyed on dataset_id, never guessed
+        # from category names.
+        rows = [self._plain_row("q1", "information_extraction", 1.0)]
+
+        summary = summarize_provider("bm-local", rows)
+
+        assert summary.official_headline.query_count == 0
+        assert summary.adversarial_breakout.query_count == 0

--- a/benchmarks/tests/test_cli_surface.py
+++ b/benchmarks/tests/test_cli_surface.py
@@ -22,3 +22,22 @@ def test_full_command_has_no_legacy_judge_options() -> None:
 
     assert result.exit_code == 0
     assert "--judge-model" not in result.output
+
+
+def test_convert_beam_command_wired() -> None:
+    result = runner.invoke(app, ["convert", "beam", "--help"])
+
+    assert result.exit_code == 0
+    assert "--dataset-root" in result.output
+    assert "--output-dir" in result.output
+    assert "--tier" in result.output
+
+
+def test_run_beam_score_command_wired() -> None:
+    result = runner.invoke(app, ["run", "beam-score", "--help"])
+
+    assert result.exit_code == 0
+    assert "--run-dir" in result.output
+    assert "--judge" in result.output
+    assert "--source" in result.output
+    assert "--max-workers" in result.output

--- a/benchmarks/tests/test_concurrent_write.py
+++ b/benchmarks/tests/test_concurrent_write.py
@@ -249,7 +249,9 @@ def test_resolve_clean_checkout_sha_rejects_dirty_target(
     monkeypatch.setattr(
         concurrent_write,
         "run_command",
-        lambda *_args, **_kwargs: SimpleNamespace(stdout=" M src/basic_memory/app.py\n?? local.py\n"),
+        lambda *_args, **_kwargs: SimpleNamespace(
+            stdout=" M src/basic_memory/app.py\n?? local.py\n"
+        ),
     )
 
     with pytest.raises(ValueError, match="bm_resolved_sha.*dirty paths"):


### PR DESCRIPTION
## Why

Second slice of the POSIX tool surface + memory evals tracker (#1398). BEAM ([arXiv 2510.27246](https://arxiv.org/abs/2510.27246), ICLR 2026) joins LoCoMo as a second dataset so we can baseline current tools per memory ability — Contradiction Resolution and Temporal Reasoning are the external yardsticks for the SPEC-89/SPEC-82 roadmap (every published system is weakest there; ~60% SOTA per Exabase).

Closes #1400.

## What changed

- **`datasets/beam.py`** — path-based dataset adapter for the upstream JSON layout (never vendored; fetch command documented), tier selection (100K/500K; 10M explicitly excluded), knowledge-update record normalization.
- **`converters/beam_to_corpus.py`** — raw transcript-as-notes conversion with anti-leakage stripping of upstream probe-index markers (`->> i,j` and the real-world `->> 2,N/A` variant found in the live 100K data), **fail-fast** if any marker survives cleaning; sha256-recorded `conversion.json`. Seam designed so an agent-curated ingestion mode can be added without reshaping the adapter.
- **`scoring/beam.py`** — nugget scoring (upstream judge prompt adapted, provenance cited; 0/0.5/1 per nugget, per-question mean) and Event Ordering (LLM alignment + pure-Python Kendall tau-b, `final = tau_norm × f1`).
- **Reporting** — all ten abilities always shown, per-answer token accounting, macro average beside (never instead of) the per-ability rows; errored cases excluded from means and counted explicitly.
- **CLI** — beam run commands consistent with the LoCoMo invocation shape.
- **Provenance** — `docs/benchmarks.md` records exactly what was adapted from `mohammadtavakoli78/BEAM` (MIT code / CC BY-SA 4.0 data) and every deviation: the injected question input the upstream judge prompt references but never provides, the degenerate-tau NaN→0.0 mapping, the concise-answer/event-ordering interaction caveat, and why scipy/json_repair/the upstream judge model were not reused. Published numbers must note the judge differs from the paper's — absolute comparability to the paper's tables is explicitly disclaimed; the cross-provider comparison under our fairness contract is the product.
- Housekeeping: pinned the package's ruff lint selection (was implicitly tracking ruff's default, which changed in 0.16) and fixed two pre-existing pyright errors in untouched provider tests that blocked the typecheck gate.

## How it was built

Reviewed multi-agent workflow (map package + clone upstream + map ingestion → design → implement → offline fixture tests → verify loop → adversarial review). The review's should-fix — the `N/A` marker variant leaking through the anti-leakage strip, caught by checking the *live* upstream data rather than the fixture — was fixed with the widened pattern plus fail-fast, and two documentation-honesty nits (a falsely-justified publicized helper, the "replicated exactly" tau claim) were cleaned up before commit.

## Verification

- `uv run ruff check` / `ruff format --check` — clean
- `uv run pyright` — 0 errors
- Full package suite (`tests/` + `test-int/`) — all passing, fully offline (stubbed LLM runners, hand-written miniature BEAM fixture covering Information Extraction, Knowledge Update, and Event Ordering incl. the marker variants)

## Notes

- This PR ships the harness only — no paid benchmark runs. Baseline runs (BM + mem0-local at 100K) are the follow-up once merged, before the SPEC-82/89 work lands.
- Stacked work: #1401 (agent-task eval) will branch from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp
