### PR TITLE
feat(core): add section indexing and range reads

### DIFF
--- a/src/basic_memory/alembic/versions/t3n4o5t6e7s8_add_note_section_table.py
+++ b/src/basic_memory/alembic/versions/t3n4o5t6e7s8_add_note_section_table.py
@@ -1,0 +1,64 @@
+"""Add note_section table
+
+Revision ID: t3n4o5t6e7s8
+Revises: s2p3e4c5w6k7
+Create Date: 2026-08-30 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "t3n4o5t6e7s8"
+down_revision: Union[str, None] = "s2p3e4c5w6k7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create note_section: a per-generation index of heading-bounded note body spans.
+
+    Rows are coordinates into the canonical markdown (body-relative lines and utf-8 byte
+    offsets), never content copies; rebuilt under the note_content generation fence on
+    every (re)index and removed with the entity (SPEC-47 / #1403). The lookup index keys
+    on a sha256 digest of the heading path so arbitrary heading text cannot exceed
+    PostgreSQL's btree index-row limit.
+    """
+    op.create_table(
+        "note_section",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("project_id", sa.Integer(), nullable=False),
+        sa.Column("entity_id", sa.Integer(), nullable=False),
+        sa.Column("heading", sa.Text(), nullable=False),
+        sa.Column("level", sa.Integer(), nullable=False),
+        sa.Column("heading_path", sa.Text(), nullable=False),
+        sa.Column("heading_path_digest", sa.String(length=64), nullable=False),
+        sa.Column("duplicate_index", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("start_line", sa.Integer(), nullable=False),
+        sa.Column("end_line", sa.Integer(), nullable=False),
+        sa.Column("start_offset", sa.Integer(), nullable=False),
+        sa.Column("end_offset", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["project.id"]),
+        sa.ForeignKeyConstraint(["entity_id"], ["entity.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_note_section_project_id", "note_section", ["project_id"], unique=False)
+    op.create_index("ix_note_section_entity_id", "note_section", ["entity_id"], unique=False)
+    op.create_index(
+        "ix_note_section_entity_path",
+        "note_section",
+        ["entity_id", "heading_path_digest", "duplicate_index"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop note_section and its supporting indexes."""
+    op.drop_index("ix_note_section_entity_path", table_name="note_section")
+    op.drop_index("ix_note_section_entity_id", table_name="note_section")
+    op.drop_index("ix_note_section_project_id", table_name="note_section")
+    op.drop_table("note_section")

--- a/src/basic_memory/api/v2/routers/knowledge_router.py
+++ b/src/basic_memory/api/v2/routers/knowledge_router.py
@@ -17,7 +17,7 @@ import os
 import pathlib
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Response, Path, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, Path, status
 from loguru import logger
 
 import logfire
@@ -30,6 +30,14 @@ from basic_memory.ignore_utils import (
     IGNORED_PATH_REJECTION_DETAIL,
     load_gitignore_patterns,
     should_ignore_path,
+)
+from basic_memory.markdown.sections import (
+    LineRange,
+    NoteSliceError,
+    SectionSelector,
+    parse_line_range,
+    parse_section_selector,
+    slice_note_content,
 )
 from basic_memory.deps import (
     create_model_read_cache,
@@ -715,6 +723,80 @@ async def index_file(
 ## Read endpoints
 
 
+def _parse_note_slice_params(
+    *,
+    section: str | None,
+    lines: str | None,
+) -> tuple[SectionSelector | None, LineRange | None]:
+    """Validate raw slice query params into typed selectors, failing fast with 422s."""
+    if section is not None and lines is not None:
+        raise HTTPException(
+            status_code=422,
+            detail="section and lines are mutually exclusive; a section response carries "
+            "content_start_line/content_end_line for follow-up line reads",
+        )
+    selector: SectionSelector | None = None
+    if section is not None:
+        selector = parse_section_selector(section)
+        if selector is None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid section selector: '{section}'",
+            )
+    line_range: LineRange | None = None
+    if lines is not None:
+        line_range = parse_line_range(lines)
+        if line_range is None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid lines range: '{lines}' (expected 'N-M', 'N-', or 'N')",
+            )
+    return selector, line_range
+
+
+def _apply_note_slice(
+    result: EntityResponseV2,
+    *,
+    selector: SectionSelector | None,
+    line_range: LineRange | None,
+    max_tokens: int | None,
+) -> EntityResponseV2:
+    """Slice a full note response after cache retrieval.
+
+    Slice params are deliberately NOT part of the read-cache digest: the cache
+    keeps exactly one pristine full-note entry per entity and every slice is
+    computed from it per request, so differently-sliced reads share one entry
+    and the cached value is never a partial note.
+    """
+    if selector is None and line_range is None and max_tokens is None:
+        return result
+    if result.content is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Entity '{result.external_id}' has no markdown content to slice",
+        )
+    sliced = slice_note_content(
+        result.content,
+        section=selector,
+        lines=line_range,
+        max_tokens=max_tokens,
+        note_title=result.title,
+    )
+    if isinstance(sliced, NoteSliceError):
+        raise HTTPException(status_code=404, detail=sliced.message)
+    return result.model_copy(
+        update={
+            "content": sliced.content,
+            "section": sliced.section,
+            "content_start_line": sliced.start_line,
+            "content_end_line": sliced.end_line,
+            "content_total_lines": sliced.total_lines,
+            "content_truncated": sliced.truncated,
+            "content_continue_line": sliced.continue_line,
+        }
+    )
+
+
 @router.get("/entities/{entity_id}", response_model=EntityResponseV2)
 async def get_entity_by_id(
     project_id: ProjectExternalIdPathDep,
@@ -726,6 +808,22 @@ async def get_entity_by_id(
     session: SessionDep,
     read_cache: EntityReadCacheDep,
     entity_id: str = Path(..., description="Entity external ID (UUID)"),
+    section: str | None = Query(
+        None,
+        description="Return one section by heading text: 'Decisions', path form "
+        "'Auth/Decisions' to disambiguate, bracket form 'Heading[1]' for duplicate "
+        "headings. Mutually exclusive with lines.",
+    ),
+    lines: str | None = Query(
+        None,
+        description="Return a document-absolute line range: 'N-M', 'N-' (to end), or 'N'.",
+    ),
+    max_tokens: int | None = Query(
+        None,
+        ge=1,
+        description="Approximate token budget; longer content is truncated at a "
+        "section or paragraph boundary with an explicit marker and a continue line.",
+    ),
 ) -> EntityResponseV2:
     """Get an entity by its external ID (UUID).
 
@@ -734,12 +832,18 @@ async def get_entity_by_id(
 
     Args:
         entity_id: External ID (UUID string)
+        section: Optional heading selector returning one section slice
+        lines: Optional document-absolute line range slice
+        max_tokens: Optional token-budget truncation of the returned content
 
     Returns:
-        Complete entity with observations and relations
+        Complete entity with observations and relations; when a slice param is
+        set, `content` is the slice and the content_* fields carry its
+        document-absolute coordinates
 
     Raises:
-        HTTPException: 404 if entity not found
+        HTTPException: 404 if entity or requested section not found, 422 for
+            malformed or conflicting slice params
     """
     with logfire.span(
         "api.request.knowledge.get_entity",
@@ -748,6 +852,8 @@ async def get_entity_by_id(
         action="get_entity",
     ):
         logger.info(f"API v2 request: get_entity_by_id entity_id={entity_id}")
+
+        selector, line_range = _parse_note_slice_params(section=section, lines=lines)
 
         cache_key = ReadCacheKey(
             project_id=project_external_id,
@@ -761,7 +867,12 @@ async def get_entity_by_id(
         )
         async with cache_scope as cached:
             if cached.value is not None:
-                return cached.value
+                return _apply_note_slice(
+                    cached.value,
+                    selector=selector,
+                    line_range=line_range,
+                    max_tokens=max_tokens,
+                )
 
             note_payload = (
                 await note_content_query_service.get_note_entity_payload_with_read_repair(
@@ -775,7 +886,12 @@ async def get_entity_by_id(
                 result = entity_response_from_note_content_payload(note_payload)
                 logger.info(f"API v2 response: external_id={entity_id}, title='{result.title}'")
                 cached.value = result
-                return result
+                return _apply_note_slice(
+                    result,
+                    selector=selector,
+                    line_range=line_range,
+                    max_tokens=max_tokens,
+                )
 
             entity = await entity_repository.get_by_external_id(session, entity_id)
             if not entity:
@@ -787,7 +903,12 @@ async def get_entity_by_id(
             result = EntityResponseV2.model_validate(entity)
             logger.info(f"API v2 response: external_id={entity_id}, title='{result.title}'")
             cached.value = result
-            return result
+            return _apply_note_slice(
+                result,
+                selector=selector,
+                line_range=line_range,
+                max_tokens=max_tokens,
+            )
 
 
 ## Create endpoints

--- a/src/basic_memory/api/v2/routers/resource_router.py
+++ b/src/basic_memory/api/v2/routers/resource_router.py
@@ -10,10 +10,11 @@ storage-event indexing pipeline. No API endpoint writes resource files inline.
 """
 
 from contextlib import nullcontext
+from dataclasses import dataclass
 from pathlib import Path as PathLib
-from typing import Annotated
+from typing import Annotated, Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Response, Path
+from fastapi import APIRouter, Depends, Header, HTTPException, Response, Path
 from loguru import logger
 from pydantic import BaseModel, ConfigDict
 
@@ -66,6 +67,95 @@ def _is_markdown_resource(resource: CachedResourceResponse) -> bool:
     return resource.media_type.partition(";")[0].strip().lower() == "text/markdown"
 
 
+# --- HTTP Range support (RFC 9110, single bytes range) ---
+
+
+@dataclass(frozen=True, slots=True)
+class _SatisfiableByteRange:
+    """One satisfiable byte span, both bounds inclusive."""
+
+    start: int
+    end: int
+
+
+def _parse_byte_range(
+    header: str, total_bytes: int
+) -> _SatisfiableByteRange | Literal["ignored", "unsatisfiable"]:
+    """Parse a Range header against a body of ``total_bytes``.
+
+    Only the ``bytes`` unit and a single range are supported; anything else —
+    other units, multi-range, malformed specs — is "ignored" per RFC 9110 and
+    the full body is served with 200. A syntactically valid range that lies
+    entirely past the end of the body (or a zero-length suffix) is
+    "unsatisfiable" and maps to 416.
+    """
+    unit, separator, spec = header.partition("=")
+    if not separator or unit.strip().lower() != "bytes":
+        return "ignored"
+    spec = spec.strip()
+    if "," in spec:
+        return "ignored"
+    first, dash, last = spec.partition("-")
+    first = first.strip()
+    last = last.strip()
+    if not dash:
+        return "ignored"
+    if first:
+        if not first.isdigit() or (last and not last.isdigit()):
+            return "ignored"
+        start = int(first)
+        end = int(last) if last else total_bytes - 1
+        if last and end < start:
+            return "ignored"
+        if start >= total_bytes:
+            return "unsatisfiable"
+        return _SatisfiableByteRange(start=start, end=min(end, total_bytes - 1))
+    # Suffix form "bytes=-n": the final n bytes of the body.
+    if not last or not last.isdigit():
+        return "ignored"
+    suffix_length = int(last)
+    if suffix_length == 0 or total_bytes == 0:
+        return "unsatisfiable"
+    return _SatisfiableByteRange(start=max(0, total_bytes - suffix_length), end=total_bytes - 1)
+
+
+def _content_response(resource: CachedResourceResponse, range_header: str | None) -> Response:
+    """Serve one fully buffered resource, honoring a single-range Range header.
+
+    The cache always stores the full bytes; ranges are sliced per request after
+    retrieval, so the Range header is deliberately NOT part of the cache digest.
+    ``If-Range`` is not supported and is ignored.
+    """
+    total_bytes = len(resource.content)
+    if range_header is not None:
+        match _parse_byte_range(range_header, total_bytes):
+            case "unsatisfiable":
+                return Response(
+                    status_code=416,
+                    headers={
+                        "content-range": f"bytes */{total_bytes}",
+                        "accept-ranges": "bytes",
+                    },
+                )
+            case _SatisfiableByteRange(start=start, end=end):
+                return Response(
+                    status_code=206,
+                    content=resource.content[start : end + 1],
+                    media_type=resource.media_type,
+                    headers={
+                        "content-range": f"bytes {start}-{end}/{total_bytes}",
+                        "accept-ranges": "bytes",
+                    },
+                )
+            case "ignored":
+                pass
+    return Response(
+        content=resource.content,
+        media_type=resource.media_type,
+        headers={"accept-ranges": "bytes"},
+    )
+
+
 @router.get("/{entity_id}")
 async def get_resource_content(
     config: ProjectConfigV2ExternalDep,
@@ -76,8 +166,20 @@ async def get_resource_content(
     session_maker: SessionMakerDep,
     project_id: str = Path(..., description="Project external UUID"),
     entity_id: str = Path(..., description="Entity external UUID"),
+    range_header: Annotated[
+        str | None,
+        Header(
+            alias="Range",
+            description="Optional single bytes range, e.g. 'bytes=0-1023'; "
+            "served as 206 Partial Content",
+        ),
+    ] = None,
 ) -> Response:
     """Get raw resource content by entity external_id.
+
+    Supports single-range HTTP Range requests (``bytes=a-b``, ``bytes=a-``,
+    ``bytes=-n``) with 206/416 responses; multi-range and non-bytes units are
+    ignored and the full body is served. ``If-Range`` is not supported.
 
     Args:
         project_id: Project external UUID from URL path
@@ -85,6 +187,7 @@ async def get_resource_content(
         config: Project configuration
         entity_repository: Entity repository for fetching entity data
         file_service: File service for reading file content
+        range_header: Optional HTTP Range header for partial content
 
     Returns:
         Response with entity content
@@ -112,10 +215,7 @@ async def get_resource_content(
         )
         async with cache_scope as cached:
             if cached.value is not None:
-                return Response(
-                    content=cached.value.content,
-                    media_type=cached.value.media_type,
-                )
+                return _content_response(cached.value, range_header)
 
             # Keep the DB session open only for the lookups; close it before the
             # filesystem I/O below so large/slow resource reads don't pin a pooled
@@ -133,10 +233,7 @@ async def get_resource_content(
                         media_type=note_resource.content_type,
                     )
                     cached.value = resource
-                    return Response(
-                        content=resource.content,
-                        media_type=resource.media_type,
-                    )
+                    return _content_response(resource, range_header)
 
                 with logfire.span(
                     "api.resource.get_content.load_entity",
@@ -197,7 +294,4 @@ async def get_resource_content(
             )
             cached.cacheable = _is_markdown_resource(resource)
             cached.value = resource
-            return Response(
-                content=resource.content,
-                media_type=resource.media_type,
-            )
+            return _content_response(resource, range_header)

--- a/src/basic_memory/index/local_dependencies.py
+++ b/src/basic_memory/index/local_dependencies.py
@@ -470,6 +470,7 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
             content_type=synced.content_type,
             markdown_content=synced.markdown_content,
             observations=synced.observations,
+            sections=synced.sections,
             relations=synced.relations,
             resolve_relations=synced.resolve_relations,
         )
@@ -600,6 +601,7 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
             updated_at=file_metadata.modified_at,
             size=file_metadata.size,
             observations=indexed.observations,
+            sections=indexed.sections,
             relations=indexed.relations,
             resolve_relations=resolve_relations,
         )
@@ -669,6 +671,7 @@ class LocalMarkdownFileIndexer(IndexFileExecutor):
             updated_at=file_metadata.modified_at,
             size=file_metadata.size,
             observations=indexed.observations,
+            sections=indexed.sections,
             relations=indexed.relations,
             resolve_relations=resolve_relations,
         )

--- a/src/basic_memory/indexing/accepted_note_write_runner.py
+++ b/src/basic_memory/indexing/accepted_note_write_runner.py
@@ -15,17 +15,19 @@ from basic_memory.indexing.accepted_note_search import build_accepted_note_searc
 from basic_memory.indexing.external_file_delete_runner import (
     relation_cleanup_sources_for_deleted_entity,
 )
-from basic_memory.indexing.models import IndexedObservation, IndexedRelation
+from basic_memory.indexing.models import IndexedObservation, IndexedRelation, IndexedSection
 from basic_memory.indexing.relation_persistence import (
     ObservationGenerationStore,
     RelationGenerationPublication,
     RelationGenerationStore,
+    SectionGenerationStore,
 )
 from basic_memory.models import Entity, NoteContent
 from basic_memory.repository import (
     AcceptedNoteContentWrite,
     AcceptedObservationWrite,
     AcceptedRelationWrite,
+    AcceptedSectionWrite,
 )
 from basic_memory.repository.accepted_note_search_row import AcceptedNoteSearchRow
 from basic_memory.repository.entity_repository import AcceptedPendingEntityWrite
@@ -183,6 +185,10 @@ class AcceptedNoteObservationRepository(ObservationGenerationStore, Protocol):
     """Generation-fenced observation persistence for accepted note writes."""
 
 
+class AcceptedNoteSectionRepository(SectionGenerationStore, Protocol):
+    """Generation-fenced section persistence for accepted note writes."""
+
+
 class AcceptedNoteRelationRepository(RelationGenerationStore, Protocol):
     """Generation-fenced relation persistence for accepted note writes."""
 
@@ -210,6 +216,11 @@ class AcceptedNoteWriteRepositories(Protocol):
         project_id: ProjectId,
     ) -> AcceptedNoteObservationRepository: ...
 
+    def section_repository(
+        self,
+        project_id: ProjectId,
+    ) -> AcceptedNoteSectionRepository: ...
+
     def relation_repository(
         self,
         project_id: ProjectId,
@@ -234,6 +245,7 @@ class AcceptedPreparedNoteMove:
     permalink: str | None
     db_checksum: RuntimeNoteContentChecksum
     observations: tuple[AcceptedObservationWrite, ...]
+    sections: tuple[AcceptedSectionWrite, ...]
     relations: tuple[AcceptedRelationWrite, ...]
 
 
@@ -364,6 +376,7 @@ async def prepare_accepted_note_move(
         permalink=prepared.permalink,
         db_checksum=await file_utils.compute_checksum(prepared.markdown_content),
         observations=prepared.observations,
+        sections=prepared.sections,
         relations=prepared.relations,
     )
     entity.file_path = result.file_path
@@ -588,6 +601,7 @@ async def accepted_relation_generation_publication(
     entity: Entity,
     note_content: NoteContent,
     observations: Sequence[AcceptedObservationWrite],
+    sections: Sequence[AcceptedSectionWrite],
     relations: Sequence[AcceptedRelationWrite],
     self_relation_resolver: AcceptedNoteSelfRelationResolver,
 ) -> RelationGenerationPublication:
@@ -600,6 +614,19 @@ async def accepted_relation_generation_publication(
             tags=observation.tags,
         )
         for observation in observations
+    )
+    indexed_sections = tuple(
+        IndexedSection(
+            heading=section.heading,
+            level=section.level,
+            heading_path=section.heading_path,
+            duplicate_index=section.duplicate_index,
+            start_line=section.start_line,
+            end_line=section.end_line,
+            start_offset=section.start_offset,
+            end_offset=section.end_offset,
+        )
+        for section in sections
     )
     indexed_relations: list[IndexedRelation] = []
     for relation in relations:
@@ -628,6 +655,7 @@ async def accepted_relation_generation_publication(
         generation=note_content.db_version,
         relations=tuple(indexed_relations),
         observations=indexed_observations,
+        sections=indexed_sections,
     )
 
 
@@ -669,6 +697,7 @@ async def persist_accepted_note_snapshot(
             entity=entity,
             note_content=persisted.note_content,
             observations=prepared.observations,
+            sections=prepared.sections,
             relations=prepared.relations,
             self_relation_resolver=self_relation_resolver,
         ),
@@ -711,6 +740,7 @@ async def persist_accepted_note_move(
             entity=entity,
             note_content=persisted.note_content,
             observations=prepared.observations,
+            sections=prepared.sections,
             relations=prepared.relations,
             self_relation_resolver=self_relation_resolver,
         ),

--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -28,11 +28,13 @@ from basic_memory.indexing.models import (
     IndexedEntity,
     IndexedObservation,
     IndexedRelation,
+    IndexedSection,
     IndexFileWriter,
     IndexFrontmatterUpdate,
     IndexingBatchResult,
     IndexInputFile,
     RelationGenerationBatchResult,
+    indexed_sections_from_markdown,
 )
 from basic_memory.indexing.relation_resolution import (
     RelationSearchRefreshResult,
@@ -42,6 +44,7 @@ from basic_memory.indexing.relation_persistence import RelationGenerationPublish
 from basic_memory.models import Entity, NoteContent, Relation, RelationSearchRefresh
 from basic_memory.repository import EntityRepository, ObservationRepository, RelationRepository
 from basic_memory.repository.note_content_repository import NoteContentRepository
+from basic_memory.repository.note_section_repository import NoteSectionRepository
 from basic_memory.repository.semantic_errors import SemanticDependenciesMissingError
 from basic_memory.repository.relation_repository import lock_note_content_before_entity_mutation
 from basic_memory.runtime.storage import (
@@ -125,6 +128,7 @@ class _PreparedEntity:
     search_content: str | None
     markdown_content: str | None = None
     observations: tuple[IndexedObservation, ...] = ()
+    sections: tuple[IndexedSection, ...] = ()
     relations: tuple[IndexedRelation, ...] = ()
     resolve_relations: bool = True
     refresh_search: bool = True
@@ -158,12 +162,14 @@ class BatchIndexer:
         self.observation_repository = observation_repository
         self.relation_repository = relation_repository
         self.note_content_repository = NoteContentRepository(project_id=project_id)
+        self.section_repository = NoteSectionRepository(project_id=project_id)
         self.search_service = search_service
         self.file_writer = file_writer
         self.session_maker = session_maker
         self.relation_generation_publisher = RelationGenerationPublisher(
             relation_repository=relation_repository,
             observation_repository=observation_repository,
+            section_repository=self.section_repository,
             session_maker=session_maker,
         )
         self.relation_resolution = RepositoryRelationResolutionRuntime(
@@ -340,6 +346,7 @@ class BatchIndexer:
             content_type=prepared_entity.content_type,
             markdown_content=prepared_entity.markdown_content,
             observations=prepared_entity.observations,
+            sections=prepared_entity.sections,
             relations=prepared_entity.relations,
             resolve_relations=prepared_entity.resolve_relations,
         )
@@ -766,6 +773,7 @@ class BatchIndexer:
             relation.to_entity = None
 
         await self.observation_repository.delete_by_fields(session, entity_id=entity.id)
+        await self.section_repository.delete_by_fields(session, entity_id=entity.id)
         await self.relation_repository.delete_by_fields(session, from_id=entity.id)
         await self.note_content_repository.delete_by_entity_id(session, entity.id)
         await session.execute(
@@ -796,6 +804,7 @@ class BatchIndexer:
             generation=generation,
             relations=indexed.relations,
             observations=indexed.observations,
+            sections=indexed.sections,
         )
 
     async def publish_relation_generations(
@@ -896,6 +905,7 @@ class BatchIndexer:
             search_content=search_content,
             markdown_content=indexed.markdown_content,
             observations=indexed.observations,
+            sections=indexed.sections,
             relations=indexed.relations,
             resolve_relations=indexed.resolve_relations,
         )
@@ -977,6 +987,7 @@ class BatchIndexer:
             content_type=prepared.content_type,
             markdown_content=prepared.markdown_content,
             observations=prepared.observations,
+            sections=prepared.sections,
             relations=prepared.relations,
             resolve_relations=prepared.resolve_relations,
         )
@@ -1112,6 +1123,7 @@ class BatchIndexer:
             ),
             markdown_content=prepared.content,
             observations=indexed_observations,
+            sections=indexed_sections_from_markdown(prepared.markdown.sections),
             relations=tuple(indexed_relations),
             resolve_relations=resolve_relations,
         )

--- a/src/basic_memory/indexing/models.py
+++ b/src/basic_memory/indexing/models.py
@@ -16,6 +16,7 @@ from basic_memory.indexing.file_index_planning import (
     FileIndexDecision,
     FileIndexDecisionStatus,
 )
+from basic_memory.markdown.sections import MarkdownSection
 from basic_memory.indexing.project_index_progress import (
     ProjectIndexBatchCounterUpdate,
     ProjectIndexCounters,
@@ -124,6 +125,39 @@ class IndexedObservation:
     tags: list[str] | None
 
 
+@dataclass(frozen=True, slots=True)
+class IndexedSection:
+    """One heading-bounded body span waiting for generation-owned publication."""
+
+    heading: str
+    level: int
+    heading_path: str
+    duplicate_index: int
+    start_line: int
+    end_line: int
+    start_offset: int
+    end_offset: int
+
+
+def indexed_sections_from_markdown(
+    sections: Sequence[MarkdownSection],
+) -> tuple[IndexedSection, ...]:
+    """Flatten parsed section paths into the publishable projection shape."""
+    return tuple(
+        IndexedSection(
+            heading=section.heading,
+            level=section.level,
+            heading_path=section.heading_path,
+            duplicate_index=section.duplicate_index,
+            start_line=section.start_line,
+            end_line=section.end_line,
+            start_offset=section.start_offset,
+            end_offset=section.end_offset,
+        )
+        for section in sections
+    )
+
+
 @dataclass(slots=True)
 class IndexedEntity:
     """Stable output describing one file that finished indexing successfully."""
@@ -135,6 +169,7 @@ class IndexedEntity:
     content_type: str | None = None
     markdown_content: str | None = None
     observations: tuple[IndexedObservation, ...] = ()
+    sections: tuple[IndexedSection, ...] = ()
     relations: tuple[IndexedRelation, ...] = ()
     resolve_relations: bool = True
 
@@ -843,6 +878,7 @@ class SyncedMarkdownFile:
     updated_at: datetime
     size: int
     observations: tuple[IndexedObservation, ...] = ()
+    sections: tuple[IndexedSection, ...] = ()
     relations: tuple[IndexedRelation, ...] = ()
     resolve_relations: bool = True
 

--- a/src/basic_memory/indexing/relation_persistence.py
+++ b/src/basic_memory/indexing/relation_persistence.py
@@ -1,7 +1,7 @@
 """Publish a note's derived graph under one accepted content generation.
 
-The publication carries the complete observation and relation projections through one
-note_content fence lifecycle and one durable retry marker.
+The publication carries the complete observation, section, and relation projections
+through one note_content fence lifecycle and one durable retry marker.
 
 The graph tables are eventually consistent projections, not part of the accepted write's
 transaction. Publication runs after the content commit; a stale fence makes every statement
@@ -22,7 +22,11 @@ from typing import Protocol
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory import db
-from basic_memory.indexing.models import IndexedObservation, IndexedRelation
+from basic_memory.indexing.models import IndexedObservation, IndexedRelation, IndexedSection
+from basic_memory.repository.note_section_repository import (
+    AcceptedSectionWrite,
+    SectionGenerationWriteResult,
+)
 from basic_memory.repository.observation_repository import (
     AcceptedObservationWrite,
     ObservationGenerationWriteResult,
@@ -77,6 +81,19 @@ class ObservationGenerationStore(Protocol):
     ) -> ObservationGenerationWriteResult: ...
 
 
+class SectionGenerationStore(Protocol):
+    """Repository operation needed to replace one section generation."""
+
+    async def replace_sections_for_generation(
+        self,
+        session: AsyncSession,
+        *,
+        entity_id: int,
+        generation: int,
+        sections: Sequence[AcceptedSectionWrite],
+    ) -> SectionGenerationWriteResult: ...
+
+
 @dataclass(frozen=True, slots=True)
 class RelationGenerationPublication:
     """Derived graph intent authorized by one accepted note-content generation."""
@@ -86,14 +103,16 @@ class RelationGenerationPublication:
     generation: RuntimeNoteContentVersion
     relations: tuple[IndexedRelation, ...]
     observations: tuple[IndexedObservation, ...] = ()
+    sections: tuple[IndexedSection, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
 class RelationGenerationPublisher:
-    """Commit observations, relation chunks, and cleanup under repeated source fences."""
+    """Commit observations, sections, relation chunks, and cleanup under source fences."""
 
     relation_repository: RelationGenerationStore
     observation_repository: ObservationGenerationStore
+    section_repository: SectionGenerationStore
     session_maker: async_sessionmaker[AsyncSession]
 
     async def publish(
@@ -103,6 +122,7 @@ class RelationGenerationPublisher:
         generation: int,
         relations: Sequence[IndexedRelation],
         observations: Sequence[IndexedObservation] = (),
+        sections: Sequence[IndexedSection] = (),
     ) -> bool:
         """Return whether every statement retained ownership of ``generation``."""
         relations_by_identity: dict[tuple[str, str], IndexedRelation] = {}
@@ -164,6 +184,31 @@ class RelationGenerationPublisher:
                 )
             )
         if not observation_result.generation_is_current:
+            return False
+
+        # Sections mirror the observation projection: one fenced wipe-and-recreate in
+        # its own short transaction, where an empty desired set still wipes stale rows.
+        accepted_sections = tuple(
+            AcceptedSectionWrite(
+                heading=section.heading,
+                level=section.level,
+                heading_path=section.heading_path,
+                duplicate_index=section.duplicate_index,
+                start_line=section.start_line,
+                end_line=section.end_line,
+                start_offset=section.start_offset,
+                end_offset=section.end_offset,
+            )
+            for section in sections
+        )
+        async with db.scoped_session(self.session_maker) as session:
+            section_result = await self.section_repository.replace_sections_for_generation(
+                session,
+                entity_id=entity_id,
+                generation=generation,
+                sections=accepted_sections,
+            )
+        if not section_result.generation_is_current:
             return False
 
         for relation_chunk in batched(

--- a/src/basic_memory/markdown/__init__.py
+++ b/src/basic_memory/markdown/__init__.py
@@ -9,13 +9,33 @@ from basic_memory.markdown.schemas import (
     Observation,
     Relation,
 )
+from basic_memory.markdown.sections import (
+    LineRange,
+    MarkdownSection,
+    NoteSlice,
+    NoteSliceError,
+    SectionSelector,
+    parse_line_range,
+    parse_section_selector,
+    scan_sections,
+    slice_note_content,
+)
 
 __all__ = [
     "EntityMarkdown",
     "EntityFrontmatter",
     "EntityParser",
+    "LineRange",
     "MarkdownProcessor",
+    "MarkdownSection",
+    "NoteSlice",
+    "NoteSliceError",
     "Observation",
     "Relation",
     "ParseError",
+    "SectionSelector",
+    "parse_line_range",
+    "parse_section_selector",
+    "scan_sections",
+    "slice_note_content",
 ]

--- a/src/basic_memory/markdown/entity_parser.py
+++ b/src/basic_memory/markdown/entity_parser.py
@@ -21,6 +21,7 @@ from basic_memory.markdown.schemas import (
     Observation,
     Relation,
 )
+from basic_memory.markdown.sections import scan_sections
 from basic_memory.utils import parse_tags
 
 
@@ -334,6 +335,9 @@ class EntityParser:
         entity_content = (
             parse(post.content) if parse_semantics else EntityContent(content=post.content)
         )
+        # Sections are structural, not semantic: they index the body for range reads,
+        # so the bm_parse_semantics opt-out above must not suppress them.
+        sections = scan_sections(post.content)
 
         # Canonical frontmatter timestamps describe note semantics. File times are
         # only compatibility fallbacks for notes that do not declare them.
@@ -360,6 +364,7 @@ class EntityParser:
             content=post.content,
             observations=entity_content.observations,
             relations=entity_content.relations,
+            sections=list(sections),
             created=created,
             modified=modified,
         )

--- a/src/basic_memory/markdown/schemas.py
+++ b/src/basic_memory/markdown/schemas.py
@@ -5,6 +5,8 @@ from typing import override, TYPE_CHECKING, Any, List, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
+from basic_memory.markdown.sections import MarkdownSection
+
 
 class Observation(BaseModel):
     """An observation about an entity."""
@@ -90,6 +92,9 @@ class EntityMarkdown(BaseModel):
     content: Optional[str] = None
     observations: List[Observation] = []
     relations: List[Relation] = []
+    # Structural pass output: present even for graph-silent notes, unlike the
+    # semantic observations/relations above.
+    sections: List[MarkdownSection] = []
 
     # created, updated will have values after a read
     created: Optional[datetime] = None

--- a/src/basic_memory/markdown/sections.py
+++ b/src/basic_memory/markdown/sections.py
@@ -1,0 +1,483 @@
+"""Structural section scanning for markdown note bodies.
+
+A section is one heading-bounded span of a note body: the heading line through the
+line before the next heading of the same or higher level (subsections stay inside
+their parent, so spans nest). Sections are coordinates into canonical content —
+body-relative line numbers and utf-8 byte offsets — never a copy of it (SPEC-47 /
+issue #1403).
+
+The scan is structural, not semantic: it runs on every markdown parse regardless of
+the ``bm_parse_semantics`` opt-out, so graph-silent notes (e.g. PDF extraction text)
+are still section-addressable.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+import re
+
+from markdown_it import MarkdownIt
+
+# Path segments join on "/" for storage and selector matching. A heading whose text
+# itself contains "/" cannot be addressed by full-path selector; suffix matching and
+# duplicate indexes remain available for it.
+HEADING_PATH_SEPARATOR = "/"
+
+# Plain parser: heading boundaries need no observation/relation plugins, and the
+# token stream already skips fenced code blocks and handles setext headings.
+_md = MarkdownIt()
+
+# markdown-it normalizes "\r\n?|\n" to "\n" before assigning token line maps, so
+# every coordinate in this module must count lines by that same terminator rule.
+# str.split("\n") would fold a lone "\r" into its neighbouring line and shift
+# every later heading out of sync with the token stream.
+_LINE_TERMINATOR = re.compile(r"\r\n|\r|\n")
+
+
+def _split_lines(text: str) -> list[str]:
+    r"""Split text on markdown-it's line-terminator rule (``\r\n``, lone ``\r``, or ``\n``).
+
+    Mirrors ``str.split("\n")`` shape: a trailing terminator leaves one empty
+    artifact element. Returned lines carry no terminator characters, so joining
+    with ``"\n"`` and re-splitting round-trips the same list.
+    """
+    return _LINE_TERMINATOR.split(text)
+
+
+def _ends_with_terminator(text: str) -> bool:
+    """True when the text ends on a line terminator (so split() grew an artifact)."""
+    return text.endswith(("\n", "\r"))
+
+
+@dataclass(frozen=True, slots=True)
+class MarkdownSection:
+    """One heading-bounded span of a note body, addressed by its heading path.
+
+    Lines are 1-indexed and body-relative (frontmatter excluded); offsets are
+    utf-8 byte positions into the encoded body, with ``end_offset`` exclusive so
+    ``body.encode()[start_offset:end_offset]`` round-trips the section bytes.
+    """
+
+    heading: str
+    level: int
+    path: tuple[str, ...]
+    duplicate_index: int
+    start_line: int
+    end_line: int
+    start_offset: int
+    end_offset: int
+
+    @property
+    def heading_path(self) -> str:
+        """The joined ancestor path stored in the section index."""
+        return HEADING_PATH_SEPARATOR.join(self.path)
+
+
+@dataclass(frozen=True, slots=True)
+class _ScannedHeading:
+    """One heading token flattened out of the markdown-it stream."""
+
+    level: int
+    text: str
+    line_index: int
+
+
+def _scan_headings(body: str) -> list[_ScannedHeading]:
+    """Collect heading levels, inline text, and 0-indexed start lines in order."""
+    tokens = _md.parse(body)
+    headings: list[_ScannedHeading] = []
+    for index, token in enumerate(tokens):
+        if token.type != "heading_open" or token.map is None:
+            continue
+        # heading_open tags are always h1-h6; the following inline token carries the
+        # authored heading text (trailing ATX hashes already stripped).
+        headings.append(
+            _ScannedHeading(
+                level=int(token.tag[1:]),
+                text=tokens[index + 1].content.strip(),
+                line_index=token.map[0],
+            )
+        )
+    return headings
+
+
+def scan_sections(body: str) -> tuple[MarkdownSection, ...]:
+    """Scan a frontmatter-stripped note body into its heading-bounded sections.
+
+    The scan is pure and deterministic over the exact string given: read paths
+    re-run it on the content bytes being served instead of trusting stored rows,
+    so a section slice can never disagree with the text it slices.
+    """
+    if not body:
+        return ()
+
+    headings = _scan_headings(body)
+    if not headings:
+        return ()
+
+    lines = _split_lines(body)
+    # A trailing terminator yields one empty artifact element in the split; it is
+    # not a document line, but its start offset is exactly the body's byte length,
+    # which makes it the natural exclusive end for the final section.
+    line_count = len(lines) - 1 if _ends_with_terminator(body) else len(lines)
+
+    # Offsets index the ORIGINAL bytes, so each line advances by its own
+    # terminator's width ("\r\n" is two bytes; terminators are ASCII, so their
+    # str length is their utf-8 byte length). findall yields one terminator per
+    # split boundary, i.e. one for every line but the last.
+    terminators = _LINE_TERMINATOR.findall(body)
+    line_start_offsets: list[int] = []
+    offset = 0
+    for index, line in enumerate(lines):
+        line_start_offsets.append(offset)
+        offset += len(line.encode("utf-8"))
+        if index < len(terminators):
+            offset += len(terminators[index])
+    total_bytes = offset
+
+    def line_offset(line_index: int) -> int:
+        return line_start_offsets[line_index] if line_index < len(lines) else total_bytes
+
+    sections: list[MarkdownSection] = []
+    # Stack of (level, heading) ancestors: a new heading pops everything at its own
+    # level or deeper, so the stack always spells the open path down to it.
+    path_stack: list[tuple[int, str]] = []
+    duplicate_counts: dict[tuple[str, ...], int] = {}
+    for position, heading in enumerate(headings):
+        while path_stack and path_stack[-1][0] >= heading.level:
+            path_stack.pop()
+        path_stack.append((heading.level, heading.text))
+        path = tuple(text for _, text in path_stack)
+        duplicate_index = duplicate_counts.get(path, 0)
+        duplicate_counts[path] = duplicate_index + 1
+
+        # A section ends at the next heading of the same or higher level; the
+        # heading-level cap of 6 bounds this look-ahead to linear total work.
+        end_line_index = line_count
+        for later in headings[position + 1 :]:
+            if later.level <= heading.level:
+                end_line_index = later.line_index
+                break
+
+        sections.append(
+            MarkdownSection(
+                heading=heading.text,
+                level=heading.level,
+                path=path,
+                duplicate_index=duplicate_index,
+                start_line=heading.line_index + 1,
+                end_line=end_line_index,
+                start_offset=line_start_offsets[heading.line_index],
+                end_offset=line_offset(end_line_index),
+            )
+        )
+    return tuple(sections)
+
+
+# --- Read-time slicing (section=, lines=, max_tokens=) ---
+#
+# The note-read API re-runs scan_sections on the exact content it serves instead
+# of consulting stored note_section rows: derived rows are eventually consistent,
+# while these helpers are pure over the string in hand, so a slice can never
+# disagree with the text it slices.
+
+# Heuristic token budget: the repo carries no tokenizer dependency, so max_tokens
+# is charged in characters at ~4 chars/token (the common English-plus-markdown
+# approximation).
+_CHARS_PER_TOKEN = 4
+
+# The explicit truncation marker: appended as a final line, excluded from the
+# budget, and naming the exact document-absolute line to resume reading from.
+TRUNCATION_MARKER_TEMPLATE = (
+    "… [truncated at max_tokens={max_tokens}; continue with lines={continue_line}-]"
+)
+
+_DUPLICATE_INDEX_SUFFIX = re.compile(r"\[(\d+)\]\s*$")
+# ATX headings require the space after the hashes, so only "# Heading" forms are
+# stripped from selector segments; "#tag"-like text stays literal.
+_ATX_HEADING_PREFIX = re.compile(r"^#{1,6} ")
+
+
+@dataclass(frozen=True, slots=True)
+class SectionSelector:
+    """A parsed ``section=`` selector: path segments plus a duplicate index.
+
+    ``raw`` keeps the caller's original spelling for error messages. Bare
+    selectors address duplicate index 0 (the first section with that path).
+    """
+
+    raw: str
+    segments: tuple[str, ...]
+    duplicate_index: int
+
+
+def parse_section_selector(selector: str) -> SectionSelector | None:
+    """Parse a section selector, or return None when it is malformed.
+
+    Accepted forms: ``"Decisions"``, ``"Auth/Decisions"`` (path form),
+    ``"Heading[1]"`` (duplicate index on the last segment), and heading-styled
+    segments like ``"## Auth"`` (leading hashes plus one space are stripped).
+    """
+    text = selector.strip()
+    duplicate_index = 0
+    suffix = _DUPLICATE_INDEX_SUFFIX.search(text)
+    if suffix:
+        duplicate_index = int(suffix.group(1))
+        text = text[: suffix.start()].rstrip()
+
+    segments: list[str] = []
+    for segment in text.split(HEADING_PATH_SEPARATOR):
+        cleaned = _ATX_HEADING_PREFIX.sub("", segment.strip()).strip()
+        if not cleaned:
+            return None
+        segments.append(cleaned)
+    return SectionSelector(raw=selector, segments=tuple(segments), duplicate_index=duplicate_index)
+
+
+@dataclass(frozen=True, slots=True)
+class LineRange:
+    """A 1-indexed inclusive document-absolute line range; ``end=None`` reads to EOF."""
+
+    start: int
+    end: int | None
+
+
+def parse_line_range(value: str) -> LineRange | None:
+    """Parse ``"N-M"``, ``"N-"`` (to end), or ``"N"``; return None when malformed."""
+    first, dash, last = (part.strip() for part in value.strip().partition("-"))
+    if not first.isdigit():
+        return None
+    start = int(first)
+    if start < 1:
+        return None
+    if not dash:
+        return LineRange(start=start, end=start)
+    if not last:
+        return LineRange(start=start, end=None)
+    if not last.isdigit():
+        return None
+    end = int(last)
+    if end < start:
+        return None
+    return LineRange(start=start, end=end)
+
+
+@dataclass(frozen=True, slots=True)
+class NoteSlice:
+    """One served slice of a note, with document-absolute coordinates.
+
+    ``content`` never carries a frontmatter block unless an explicit line range
+    covered it; line numbers always count over the full stored document
+    (frontmatter included), matching line-range follow-up reads.
+    """
+
+    content: str
+    section: str | None
+    start_line: int
+    end_line: int
+    total_lines: int
+    truncated: bool
+    continue_line: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class NoteSliceError:
+    """A section lookup failure: unknown, ambiguous, or out-of-range selector."""
+
+    message: str
+
+
+def _frontmatter_line_count(full_text: str) -> int:
+    """Count the leading lines occupied by a well-formed opening frontmatter block.
+
+    Structural, delimiter-only rule (top-of-file ``---`` fence pairs, matching
+    ``mcp.note_reads.parse_opening_frontmatter``); YAML validity is deliberately
+    not checked here — the markdown layer stays free of YAML parsing. Returns 0
+    when no terminated block opens the document.
+    """
+    lines = _split_lines(full_text)
+    if not lines or lines[0].strip() != "---":
+        return 0
+    for index in range(1, len(lines)):
+        if lines[index].strip() == "---":
+            return index + 1
+    return 0
+
+
+def _section_labels(sections: tuple[MarkdownSection, ...]) -> list[str]:
+    """Render heading paths in document order, bracket-suffixed for duplicates."""
+    path_counts = Counter(section.heading_path for section in sections)
+    return [
+        f"{section.heading_path}[{section.duplicate_index}]"
+        if path_counts[section.heading_path] > 1
+        else section.heading_path
+        for section in sections
+    ]
+
+
+def _find_section(
+    sections: tuple[MarkdownSection, ...],
+    selector: SectionSelector,
+    note_title: str | None,
+) -> tuple[MarkdownSection, str] | NoteSliceError:
+    """Match a selector against scanned sections, returning the section and its label.
+
+    A selector matches when a section's full path ends with the selector segments
+    (suffix match), so ``"Decisions"`` finds ``("Auth", "Decisions")`` and
+    ``"Auth/Decisions"`` disambiguates. Comparison is exact and case-sensitive.
+    """
+    note_label = f" in note '{note_title}'" if note_title else ""
+    matches = [
+        section
+        for section in sections
+        if section.path[-len(selector.segments) :] == selector.segments
+    ]
+    if not matches:
+        available = ", ".join(_section_labels(sections)) or "(note has no headings)"
+        return NoteSliceError(
+            f"Section '{selector.raw}' not found{note_label}. Available sections: {available}"
+        )
+
+    distinct_paths = list(dict.fromkeys(section.heading_path for section in matches))
+    if len(distinct_paths) > 1:
+        return NoteSliceError(
+            f"Section '{selector.raw}' is ambiguous{note_label}. "
+            f"Qualify it: {', '.join(distinct_paths)}"
+        )
+
+    # All matches share one full path; document order equals duplicate_index order.
+    for section in matches:
+        if section.duplicate_index == selector.duplicate_index:
+            label = (
+                f"{section.heading_path}[{section.duplicate_index}]"
+                if len(matches) > 1
+                else section.heading_path
+            )
+            return section, label
+    return NoteSliceError(
+        f"Section '{selector.raw}' not found{note_label}: {len(matches)} section(s) share "
+        f"the path '{distinct_paths[0]}' (duplicate indexes 0-{len(matches) - 1})."
+    )
+
+
+def _token_budget_line_count(text: str, text_lines: list[str], budget_chars: int) -> int | None:
+    """Return how many leading lines of ``text`` to keep, or None when no cut applies.
+
+    Cut preference: section boundary first, then paragraph (blank-line) boundary,
+    then the last full line within budget. Never cuts mid-line, and always keeps
+    at least one line so a continue-loop makes forward progress. A single line
+    over budget is served whole — there is no boundary to cut at.
+    """
+    if len(text) <= budget_chars:
+        return None
+    line_count = len(text_lines)
+    if line_count <= 1:
+        return None
+
+    # prefix_lengths[k] == len("\n".join(text_lines[:k]))
+    prefix_lengths = [0]
+    for index, line in enumerate(text_lines):
+        separator = 1 if index > 0 else 0
+        prefix_lengths.append(prefix_lengths[-1] + separator + len(line))
+
+    def fits(kept: int) -> bool:
+        return prefix_lengths[kept] <= budget_chars
+
+    # Section boundaries strictly after the slice start (its own heading, when the
+    # slice begins with one, is never a cut point).
+    section_cuts = [
+        section.start_line - 1 for section in scan_sections(text) if section.start_line > 1
+    ]
+    fitting = [kept for kept in section_cuts if kept >= 1 and fits(kept)]
+    if fitting:
+        return max(fitting)
+
+    paragraph_cuts = [
+        index for index, line in enumerate(text_lines) if index >= 1 and not line.strip()
+    ]
+    fitting = [kept for kept in paragraph_cuts if fits(kept)]
+    if fitting:
+        return max(fitting)
+
+    # Line backstop: the largest whole-line prefix within budget; when even the
+    # first line exceeds the budget, keep it anyway — forward progress beats an
+    # empty slice.
+    for kept in range(line_count - 1, 0, -1):
+        if fits(kept):
+            return kept
+    return 1
+
+
+def slice_note_content(
+    full_text: str,
+    *,
+    section: SectionSelector | None = None,
+    lines: LineRange | None = None,
+    max_tokens: int | None = None,
+    note_title: str | None = None,
+) -> NoteSlice | NoteSliceError:
+    """Slice a full stored note document by section, line range, and/or token budget.
+
+    ``full_text`` is the exact content being served (frontmatter included). Section
+    and token-budget slices exclude the frontmatter block; an explicit line range
+    addresses the full document so continue-reads and cat coordinates agree. All
+    returned coordinates are document-absolute 1-indexed lines; served content
+    joins lines with "\\n", so CR/CRLF terminators come back normalized.
+    """
+    if section is not None and lines is not None:
+        raise ValueError("section and lines are mutually exclusive")
+    if section is None and lines is None and max_tokens is None:
+        raise ValueError("slice_note_content requires section, lines, or max_tokens")
+
+    doc_lines = _split_lines(full_text)
+    total_lines = 0
+    if full_text:
+        total_lines = len(doc_lines) - 1 if _ends_with_terminator(full_text) else len(doc_lines)
+
+    section_label: str | None = None
+    if section is not None:
+        frontmatter_lines = _frontmatter_line_count(full_text)
+        # _split_lines strips terminators, so this join is the terminator-
+        # normalized document suffix: re-splitting it yields these exact lines,
+        # and scanned coordinates translate by the frontmatter offset.
+        body = "\n".join(doc_lines[frontmatter_lines:])
+        found = _find_section(scan_sections(body), section, note_title)
+        if isinstance(found, NoteSliceError):
+            return found
+        matched, section_label = found
+        start_line = frontmatter_lines + matched.start_line
+        end_line = frontmatter_lines + matched.end_line
+    elif lines is not None:
+        start_line = lines.start
+        end_line = min(lines.end, total_lines) if lines.end is not None else total_lines
+    else:
+        # max_tokens alone budgets the whole body: slices never carry frontmatter.
+        frontmatter_lines = _frontmatter_line_count(full_text)
+        start_line = frontmatter_lines + 1
+        end_line = total_lines
+
+    selected = doc_lines[start_line - 1 : end_line]
+    content = "\n".join(selected)
+    truncated = False
+    continue_line: int | None = None
+    if max_tokens is not None:
+        kept = _token_budget_line_count(content, selected, max_tokens * _CHARS_PER_TOKEN)
+        if kept is not None:
+            continue_line = start_line + kept
+            end_line = start_line + kept - 1
+            marker = TRUNCATION_MARKER_TEMPLATE.format(
+                max_tokens=max_tokens, continue_line=continue_line
+            )
+            content = "\n".join(selected[:kept]) + "\n" + marker
+            truncated = True
+
+    return NoteSlice(
+        content=content,
+        section=section_label,
+        start_line=start_line,
+        end_line=end_line,
+        total_lines=total_lines,
+        truncated=truncated,
+        continue_line=continue_line,
+    )

--- a/src/basic_memory/mcp/clients/knowledge.py
+++ b/src/basic_memory/mcp/clients/knowledge.py
@@ -112,19 +112,40 @@ class KnowledgeClient:
             )
         return EntityResponse.model_validate(response.json())
 
-    async def get_entity(self, entity_id: str) -> EntityResponseV2:
-        """Get an entity by ID.
+    async def get_entity(
+        self,
+        entity_id: str,
+        *,
+        section: str | None = None,
+        lines: str | None = None,
+        max_tokens: int | None = None,
+    ) -> EntityResponseV2:
+        """Get an entity by ID, optionally sliced server-side.
 
         Args:
             entity_id: Entity external_id (UUID)
+            section: Optional heading selector ("Decisions", "Auth/Decisions",
+                "Heading[1]") returning one section slice
+            lines: Optional document-absolute line range ("N-M", "N-", or "N")
+            max_tokens: Optional token budget truncating the returned content
 
         Returns:
-            EntityResponseV2 with accepted note content and entity metadata
+            EntityResponseV2 with accepted note content and entity metadata;
+            sliced responses carry the content_* slice coordinates
 
         Raises:
-            ToolError: If the entity is not found or request fails
+            ToolError: If the entity or requested section is not found or the
+                request fails
         """
         from basic_memory.mcp.tools.utils import call_get
+
+        params: dict[str, str | int] = {}
+        if section is not None:
+            params["section"] = section
+        if lines is not None:
+            params["lines"] = lines
+        if max_tokens is not None:
+            params["max_tokens"] = max_tokens
 
         with logfire.span(
             "mcp.client.knowledge.get_entity",
@@ -137,6 +158,7 @@ class KnowledgeClient:
                 client_name="knowledge",
                 operation="get_entity",
                 path_template="/v2/projects/{project_id}/knowledge/entities/{entity_id}",
+                params=params or None,
             )
         return EntityResponseV2.model_validate(response.json())
 

--- a/src/basic_memory/mcp/note_reads.py
+++ b/src/basic_memory/mcp/note_reads.py
@@ -1,6 +1,6 @@
 """Reusable typed note-read shaping for MCP adapters."""
 
-from typing import Any, Protocol, TypedDict
+from typing import Any, NotRequired, Protocol, TypedDict
 
 import logfire
 import yaml
@@ -10,20 +10,38 @@ from basic_memory.schemas.v2 import EntityResponseV2
 
 
 class ReadNoteJsonPayload(TypedDict):
-    """Existing successful ``read_note(output_format="json")`` payload."""
+    """Successful ``read_note(output_format="json")`` payload.
+
+    The slice keys appear only on sliced reads (section/lines/max_tokens), whose
+    ``content`` is the server-computed slice with document-absolute coordinates;
+    ``truncated``/``continue_line`` appear only when max_tokens cut the content.
+    """
 
     title: str
     permalink: str | None
     file_path: str
     content: str
     frontmatter: dict[str, Any] | None
+    section: NotRequired[str | None]
+    start_line: NotRequired[int]
+    end_line: NotRequired[int]
+    total_lines: NotRequired[int]
+    truncated: NotRequired[bool]
+    continue_line: NotRequired[int]
 
 
 class KnowledgeEntityReader(Protocol):
     """Entity-read capability required by exact-ID note reads."""
 
-    async def get_entity(self, entity_id: str) -> EntityResponseV2:
-        """Return the entity response for one exact external ID."""
+    async def get_entity(
+        self,
+        entity_id: str,
+        *,
+        section: str | None = None,
+        lines: str | None = None,
+        max_tokens: int | None = None,
+    ) -> EntityResponseV2:
+        """Return the entity response for one exact external ID, optionally sliced."""
 
 
 class NoteResourceReader(Protocol):
@@ -74,6 +92,9 @@ async def read_note_json_by_external_id(
     resource_client: NoteResourceReader,
     entity_external_id: str,
     include_frontmatter: bool = False,
+    section: str | None = None,
+    lines: str | None = None,
+    max_tokens: int | None = None,
 ) -> ReadNoteJsonPayload:
     """Read and shape one note by exact external ID without identifier resolution.
 
@@ -81,6 +102,10 @@ async def read_note_json_by_external_id(
     non-note entities may not carry content, so only that explicit ``None`` state falls back to
     the raw resource route. Empty accepted Markdown remains a valid response and never triggers
     a speculative resource read.
+
+    A sliced read (``section``/``lines``/``max_tokens``) never falls back: the server 404s
+    content-less entities and returns the slice with its document-absolute coordinates. Slices
+    carry no frontmatter block, so ``include_frontmatter`` does not apply to them.
     """
     with logfire.span(
         "mcp.read_note.shape_response",
@@ -88,6 +113,40 @@ async def read_note_json_by_external_id(
         action="read_note",
         phase="shape_response",
     ) as span:
+        # Plain reads keep the bare positional call so the unsliced path stays
+        # byte-for-byte identical (and existing duck-typed readers unaffected).
+        slice_requested = section is not None or lines is not None or max_tokens is not None
+        if slice_requested:
+            entity = await knowledge_client.get_entity(
+                entity_external_id, section=section, lines=lines, max_tokens=max_tokens
+            )
+            span.set_attribute("read_note.resource_fallback", False)
+            if (
+                entity.content is None
+                or entity.content_start_line is None
+                or entity.content_end_line is None
+                or entity.content_total_lines is None
+            ):  # pragma: no cover — the server always returns coordinates for sliced reads
+                raise ValueError("sliced note read response is missing slice coordinates")
+            payload: ReadNoteJsonPayload = {
+                "title": entity.title,
+                "permalink": entity.permalink,
+                "file_path": entity.file_path,
+                "content": entity.content,
+                "frontmatter": None,
+                "section": entity.section,
+                "start_line": entity.content_start_line,
+                "end_line": entity.content_end_line,
+                "total_lines": entity.content_total_lines,
+            }
+            # The server sets continue_line exactly when max_tokens truncated the
+            # content, so one narrowing check carries both keys.
+            continue_line = entity.content_continue_line
+            if continue_line is not None:
+                payload["truncated"] = True
+                payload["continue_line"] = continue_line
+            return payload
+
         entity = await knowledge_client.get_entity(entity_external_id)
         content_text = entity.content
         resource_fallback = content_text is None

--- a/src/basic_memory/mcp/tools/posix_tools.py
+++ b/src/basic_memory/mcp/tools/posix_tools.py
@@ -58,31 +58,71 @@ async def cat(
     project_id: Optional[str] = None,
     context: Context | None = None,
 ) -> dict[str, Any]:
-    """Print a note's full content, optionally sliced to a 1-indexed line range.
+    """Print a note's content, optionally sliced by line range, section, or token budget.
 
     Args:
         identifier: Note title, permalink, or memory:// URL (resolved exactly).
         start_line: First line to include (1-indexed, inclusive).
         end_line: Last line to include (inclusive). Defaults to the last line.
-        section: Reserved; not yet supported.
-        max_tokens: Reserved; not yet supported.
+        section: Heading to slice to: "Decisions", path form "Auth/Decisions"
+            to disambiguate by parent, or bracket form "Heading[1]" for the
+            second duplicate heading. Cannot combine with start_line/end_line;
+            the response's start_line/end_line support follow-up range reads.
+        max_tokens: Approximate token budget. Longer content is truncated at a
+            section or paragraph boundary with an explicit ellipsis marker; the
+            response carries truncated/continue_line for resuming.
         include_frontmatter: Include the YAML frontmatter block in `content`.
+            Ignored for section/max_tokens reads — those slices never carry a
+            frontmatter block. A start_line/end_line range combined with
+            max_tokens addresses the full document (frontmatter included) and
+            therefore requires include_frontmatter=True.
         project: Project name. Optional - the server resolves the default.
         project_id: Project external_id (UUID); takes precedence over `project`.
         context: Optional FastMCP context.
 
     Returns:
         The read_note JSON payload (title, permalink, file_path, content,
-        frontmatter), plus start_line/end_line/total_lines when a range applied.
+        frontmatter), plus start_line/end_line/total_lines when a slice applied,
+        `section` for section reads, and truncated/continue_line when max_tokens
+        cut the content.
     """
-    if section is not None:
-        raise ValueError("cat: 'section' is not yet supported; use start_line/end_line")
-    if max_tokens is not None:
-        raise ValueError("cat: 'max_tokens' is not yet supported; use start_line/end_line")
+    if section is not None and (start_line is not None or end_line is not None):
+        raise ValueError(
+            "cat: 'section' cannot be combined with start_line/end_line; use the "
+            "returned start_line/end_line for follow-up range reads"
+        )
+    if max_tokens is not None and max_tokens < 1:
+        raise ValueError(f"max_tokens must be >= 1, got {max_tokens}")
     if start_line is not None and start_line < 1:
         raise ValueError(f"start_line must be >= 1, got {start_line}")
     if end_line is not None and end_line < (start_line or 1):
         raise ValueError(f"end_line must be >= start_line, got {end_line}")
+    # Trigger: a line range rides along with max_tokens while frontmatter is opted out.
+    # Why: server-side line ranges are document-absolute (frontmatter included), but
+    #      include_frontmatter=False range reads slice the frontmatter-stripped body —
+    #      the same numbers would address different lines, and the served range could
+    #      carry frontmatter text despite the explicit opt-out.
+    # Outcome: the combination is rejected so every read keeps one coordinate system.
+    if (
+        max_tokens is not None
+        and not include_frontmatter
+        and (start_line is not None or end_line is not None)
+    ):
+        raise ValueError(
+            "cat: max_tokens with start_line/end_line requires include_frontmatter=True — "
+            "those ranges address the full document (frontmatter included); drop max_tokens "
+            "for a body-relative range, or keep include_frontmatter=True"
+        )
+
+    # Trigger: section or max_tokens is set.
+    # Why: those slices need the server-side section scan and token budgeting;
+    #      plain line ranges keep their original client-side slicing untouched.
+    # Outcome: the read carries the slice params (line bounds ride along as a
+    #          lines= range) and the server-supplied payload returns as-is.
+    server_side_slice = section is not None or max_tokens is not None
+    lines_param: Optional[str] = None
+    if server_side_slice and (start_line is not None or end_line is not None):
+        lines_param = f"{start_line or 1}-{'' if end_line is None else end_line}"
 
     async with get_project_client(project, context=context, project_id=project_id) as (
         client,
@@ -99,10 +139,13 @@ async def cat(
                 resource_client=ResourceClient(client, active_project.external_id),
                 entity_external_id=entity_id,
                 include_frontmatter=include_frontmatter,
+                section=section,
+                lines=lines_param,
+                max_tokens=max_tokens,
             )
         )
 
-    if start_line is None and end_line is None:
+    if server_side_slice or (start_line is None and end_line is None):
         return payload
 
     lines = str(payload["content"]).splitlines()

--- a/src/basic_memory/models/__init__.py
+++ b/src/basic_memory/models/__init__.py
@@ -6,6 +6,7 @@ from basic_memory.models.knowledge import (
     Entity,
     NoteContent,
     NoteFileVacate,
+    NoteSection,
     Observation,
     Relation,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "Entity",
     "NoteContent",
     "NoteFileVacate",
+    "NoteSection",
     "Observation",
     "Relation",
     "RelationSearchRefresh",

--- a/src/basic_memory/models/knowledge.py
+++ b/src/basic_memory/models/knowledge.py
@@ -131,6 +131,7 @@ class Entity(Base):
         cascade="all, delete-orphan",
         uselist=False,
     )
+    sections = relationship("NoteSection", back_populates="entity", cascade="all, delete-orphan")
 
     @validates("created_at", "updated_at")
     def _normalize_semantic_timestamp(self, attribute_name: str, value: datetime) -> datetime:
@@ -278,6 +279,58 @@ class NoteFileVacate(Base):
         return (
             f"NoteFileVacate(project_id={self.project_id}, entity_id={self.entity_id}, "
             f"file_path='{self.file_path}')"
+        )
+
+
+class NoteSection(Base):
+    """One heading-bounded span of a note body.
+
+    Sections are an index into canonical markdown, never a copy of it: rows carry
+    body-relative line numbers and utf-8 byte offsets plus the heading path that
+    addresses the span. Like observations, they are a derived projection rebuilt
+    under the note_content generation fence on every (re)index and removed with
+    the entity (SPEC-47 / #1403).
+    """
+
+    __tablename__ = "note_section"
+    __table_args__ = (
+        Index("ix_note_section_entity_id", "entity_id"),
+        Index(
+            "ix_note_section_entity_path",
+            "entity_id",
+            "heading_path_digest",
+            "duplicate_index",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)  # pyright: ignore [reportIncompatibleVariableOverride]
+    project_id: Mapped[int] = mapped_column(Integer, ForeignKey("project.id"), index=True)
+    entity_id: Mapped[int] = mapped_column(Integer, ForeignKey("entity.id", ondelete="CASCADE"))
+    heading: Mapped[str] = mapped_column(Text)
+    level: Mapped[int] = mapped_column(Integer)
+    # Full "Parent/Child" path kept as un-indexed text for display; the lookup
+    # index keys on its fixed-width digest because arbitrary heading text can
+    # exceed PostgreSQL's 2704-byte btree index-row limit (same guard as
+    # Observation.permalink below).
+    heading_path: Mapped[str] = mapped_column(Text)
+    heading_path_digest: Mapped[str] = mapped_column(String(64))
+    duplicate_index: Mapped[int] = mapped_column(Integer, default=0, server_default=text("0"))
+    # Body-relative coordinates: 1-indexed inclusive lines, utf-8 byte offsets
+    # with end_offset exclusive. Body-relative keeps rows valid when frontmatter
+    # normalization rewrites the file head without touching the body (#1090).
+    start_line: Mapped[int] = mapped_column(Integer)
+    end_line: Mapped[int] = mapped_column(Integer)
+    start_offset: Mapped[int] = mapped_column(Integer)
+    end_offset: Mapped[int] = mapped_column(Integer)
+
+    entity = relationship("Entity", back_populates="sections")
+
+    @override
+    def __repr__(self) -> str:  # pragma: no cover
+        return (
+            f"NoteSection(id={self.id}, entity_id={self.entity_id}, "
+            f"heading_path='{self.heading_path}[{self.duplicate_index}]', "
+            f"lines={self.start_line}-{self.end_line})"
         )
 
 

--- a/src/basic_memory/repository/__init__.py
+++ b/src/basic_memory/repository/__init__.py
@@ -4,6 +4,7 @@ from .note_content_repository import (
     NoteContentRepository,
     NoteContentVersionConflict,
 )
+from .note_section_repository import AcceptedSectionWrite, NoteSectionRepository
 from .observation_repository import AcceptedObservationWrite, ObservationRepository
 from .project_repository import ProjectRepository
 from .relation_repository import AcceptedRelationWrite, RelationRepository
@@ -15,6 +16,8 @@ __all__ = [
     "NoteContentVersionConflict",
     "AcceptedObservationWrite",
     "ObservationRepository",
+    "AcceptedSectionWrite",
+    "NoteSectionRepository",
     "ProjectRepository",
     "AcceptedRelationWrite",
     "RelationRepository",

--- a/src/basic_memory/repository/accepted_note_repositories.py
+++ b/src/basic_memory/repository/accepted_note_repositories.py
@@ -3,7 +3,12 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from basic_memory.repository import NoteContentRepository, ObservationRepository, RelationRepository
+from basic_memory.repository import (
+    NoteContentRepository,
+    NoteSectionRepository,
+    ObservationRepository,
+    RelationRepository,
+)
 from basic_memory.repository.accepted_note_search_repository import AcceptedNoteSearchRepository
 from basic_memory.repository.accepted_note_vector_cleanup import (
     ProjectIndexExternalVectorCleaner,
@@ -42,6 +47,9 @@ class AcceptedNoteRepositories:
 
     def observation_repository(self, project_id: ProjectId) -> ObservationRepository:
         return ObservationRepository(project_id=project_id)
+
+    def section_repository(self, project_id: ProjectId) -> NoteSectionRepository:
+        return NoteSectionRepository(project_id=project_id)
 
     def relation_repository(self, project_id: ProjectId) -> RelationRepository:
         return RelationRepository(project_id=project_id)

--- a/src/basic_memory/repository/note_section_repository.py
+++ b/src/basic_memory/repository/note_section_repository.py
@@ -1,0 +1,121 @@
+"""Repository for managing NoteSection rows."""
+
+import hashlib
+from dataclasses import dataclass
+from typing import Sequence
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from basic_memory.models import NoteSection
+from basic_memory.repository.relation_repository import current_relation_generation_statement
+from basic_memory.repository.repository import Repository
+
+
+def heading_path_digest(heading_path: str) -> str:
+    """Digest keyed by the section lookup index in place of the raw path.
+
+    Arbitrary heading text can exceed PostgreSQL's 2704-byte btree index-row
+    limit (same constraint as Observation.permalink), so the lookup index keys
+    on this fixed-width digest while the full path stays as un-indexed text.
+
+    Known ambiguity: the path joins heading segments with "/", so a heading
+    whose text literally contains "/" collides with the equivalent nested path
+    ("# A/B" and "# A" > "## B" both digest as "A/B"). The section read path is
+    immune (it matches in-memory path tuples), but a future consumer of this
+    table must not assume the key distinguishes those shapes without escaping
+    the separator first.
+    """
+    return hashlib.sha256(heading_path.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class AcceptedSectionWrite:
+    """One heading-bounded body span parsed from accepted markdown, ready to persist.
+
+    Mirrors the markdown ``MarkdownSection`` fields with the path already joined,
+    so the accepted-write path can persist the section index without constructing
+    ORM rows in the storage-neutral runner (matching AcceptedObservationWrite).
+    """
+
+    heading: str
+    level: int
+    heading_path: str
+    duplicate_index: int
+    start_line: int
+    end_line: int
+    start_offset: int
+    end_offset: int
+
+
+@dataclass(frozen=True, slots=True)
+class SectionGenerationWriteResult:
+    """Whether a guarded section replacement still owned its source generation."""
+
+    generation_is_current: bool
+
+
+class NoteSectionRepository(Repository[NoteSection]):
+    """Repository for the NoteSection projection of accepted note bodies."""
+
+    project_id: int
+
+    def __init__(self, project_id: int):
+        """Initialize with project_id filter.
+
+        Args:
+            project_id: Project ID to filter all operations by
+        """
+        super().__init__(NoteSection, project_id=project_id)
+
+    async def find_by_entity(self, session: AsyncSession, entity_id: int) -> Sequence[NoteSection]:
+        """Find all sections for one entity in document order."""
+        query = (
+            self.select()
+            .filter(NoteSection.entity_id == entity_id)
+            .order_by(NoteSection.start_line)
+        )
+        result = await self.execute_query(session, query)
+        return result.scalars().all()
+
+    async def replace_sections_for_generation(
+        self,
+        session: AsyncSession,
+        *,
+        entity_id: int,
+        generation: int,
+        sections: Sequence[AcceptedSectionWrite],
+    ) -> SectionGenerationWriteResult:
+        """Replace sections only while the accepted content generation is current."""
+        # This helper is a shared note_content fence despite its historical relation name.
+        current_generation = await session.scalar(
+            current_relation_generation_statement(
+                project_id=self.project_id,
+                entity_id=entity_id,
+                generation=generation,
+            )
+        )
+        # Trigger: a newer accepted note generation won before this transaction acquired the row.
+        # Why: replacing here would publish stale coordinates over the newer note body.
+        # Outcome: leave every existing section untouched and let the current writer publish.
+        if current_generation is None:
+            return SectionGenerationWriteResult(generation_is_current=False)
+
+        await self.delete_by_fields(session, entity_id=entity_id)
+        rows = [
+            NoteSection(
+                project_id=self.project_id,
+                entity_id=entity_id,
+                heading=section.heading,
+                level=section.level,
+                heading_path=section.heading_path,
+                heading_path_digest=heading_path_digest(section.heading_path),
+                duplicate_index=section.duplicate_index,
+                start_line=section.start_line,
+                end_line=section.end_line,
+                start_offset=section.start_offset,
+                end_offset=section.end_offset,
+            )
+            for section in sections
+        ]
+        await self.add_all_no_return(session, rows)
+        return SectionGenerationWriteResult(generation_is_current=True)

--- a/src/basic_memory/schemas/v2/entity.py
+++ b/src/basic_memory/schemas/v2/entity.py
@@ -216,6 +216,32 @@ class EntityResponseV2(BaseModel):
     )
     sync_error: Optional[str] = Field(None, description="Current note sync error")
 
+    # Slice metadata (SPEC-47 / #1403). Set only when the request asked for a
+    # section=, lines=, or max_tokens= slice, in which case `content` is the
+    # slice and line numbers count over the full stored document, frontmatter
+    # included. All None on unsliced responses, so every other producer of this
+    # model is untouched.
+    section: Optional[str] = Field(
+        None,
+        description="Canonical heading path of the returned section slice "
+        "(bracket-suffixed when a duplicate heading was addressed)",
+    )
+    content_start_line: Optional[int] = Field(
+        None, description="Document-absolute 1-indexed first line of the returned content"
+    )
+    content_end_line: Optional[int] = Field(
+        None, description="Document-absolute 1-indexed last line of the returned content"
+    )
+    content_total_lines: Optional[int] = Field(
+        None, description="Total line count of the full stored document"
+    )
+    content_truncated: Optional[bool] = Field(
+        None, description="Whether max_tokens truncated the returned content"
+    )
+    content_continue_line: Optional[int] = Field(
+        None, description="First line omitted by truncation; resume line reads here"
+    )
+
     # V2-specific metadata
     api_version: Literal["v2"] = Field(
         default="v2", description="API version (always 'v2' for this response)"

--- a/src/basic_memory/services/entity_service.py
+++ b/src/basic_memory/services/entity_service.py
@@ -12,7 +12,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from basic_memory import db
 from basic_memory.config import ProjectConfig, BasicMemoryConfig
 from basic_memory.file_utils import remove_frontmatter
-from basic_memory.indexing.models import IndexedObservation, IndexedRelation
+from basic_memory.indexing.models import (
+    IndexedObservation,
+    IndexedRelation,
+    indexed_sections_from_markdown,
+)
 from basic_memory.indexing.note_content_reconciliation import NoteContentReconciliationAnchor
 from basic_memory.indexing.note_content_reconciler import NoteContentReconciler
 from basic_memory.indexing.relation_persistence import RelationGenerationPublisher
@@ -26,6 +30,7 @@ from basic_memory.models import Entity as EntityModel
 from basic_memory.repository import ObservationRepository, RelationRepository
 from basic_memory.repository.entity_repository import EntityRepository
 from basic_memory.repository.note_content_repository import NoteContentRepository
+from basic_memory.repository.note_section_repository import NoteSectionRepository
 from basic_memory.read_cache import ReadCache, invalidate_cache
 from basic_memory.runtime.note_move import normalize_note_move_destination_path
 from basic_memory.schemas import Entity as EntitySchema
@@ -246,6 +251,7 @@ class EntityService(BaseService[EntityModel]):
         publisher = RelationGenerationPublisher(
             relation_repository=self.relation_repository,
             observation_repository=self.observation_repository,
+            section_repository=NoteSectionRepository(project_id=self.repository.project_id),
             session_maker=self.session_maker,
         )
         published = await publisher.publish(
@@ -253,6 +259,7 @@ class EntityService(BaseService[EntityModel]):
             generation=reconciliation.generation,
             relations=indexed_relations,
             observations=indexed_observations,
+            sections=indexed_sections_from_markdown(markdown.sections),
         )
         if not published:
             return entity

--- a/src/basic_memory/services/note_content_writes.py
+++ b/src/basic_memory/services/note_content_writes.py
@@ -172,9 +172,13 @@ class NoteContentMutationService:
                 publication.project_id
             )
         )
+        section_repository = self.mutation_dependencies.write_repositories.section_repository(
+            publication.project_id
+        )
         publisher = RelationGenerationPublisher(
             relation_repository=repository,
             observation_repository=observation_repository,
+            section_repository=section_repository,
             session_maker=self.session_maker,
         )
         await publisher.publish(
@@ -182,6 +186,7 @@ class NoteContentMutationService:
             generation=publication.generation,
             relations=publication.relations,
             observations=publication.observations,
+            sections=publication.sections,
         )
 
     async def _finish_mutation(

--- a/src/basic_memory/services/note_preparation.py
+++ b/src/basic_memory/services/note_preparation.py
@@ -30,7 +30,11 @@ from basic_memory.markdown.entity_parser import (
 )
 from basic_memory.markdown.utils import schema_to_markdown
 from basic_memory.models import Entity
-from basic_memory.repository import AcceptedObservationWrite, AcceptedRelationWrite
+from basic_memory.repository import (
+    AcceptedObservationWrite,
+    AcceptedRelationWrite,
+    AcceptedSectionWrite,
+)
 from basic_memory.repository.entity_repository import EntityMetadata, EntityRepository
 from basic_memory.repository.project_repository import ProjectRepository
 from basic_memory.runtime.note_move import normalize_note_move_destination_path
@@ -40,6 +44,23 @@ from basic_memory.services.exceptions import EntityAlreadyExistsError
 from basic_memory.services.file_service import FileService
 from basic_memory.utils import build_canonical_permalink
 from basic_memory.workspace_context import workspace_slug_for_canonical_permalinks
+
+
+def accepted_section_writes(entity_markdown: EntityMarkdown) -> tuple[AcceptedSectionWrite, ...]:
+    """Flatten parsed section paths into generation-fenced persistence writes."""
+    return tuple(
+        AcceptedSectionWrite(
+            heading=section.heading,
+            level=section.level,
+            heading_path=section.heading_path,
+            duplicate_index=section.duplicate_index,
+            start_line=section.start_line,
+            end_line=section.end_line,
+            start_offset=section.start_offset,
+            end_offset=section.end_offset,
+        )
+        for section in entity_markdown.sections
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -89,6 +110,10 @@ class PreparedEntityWrite:
             for relation in self.entity_markdown.relations
         ]
 
+    @property
+    def sections(self) -> tuple[AcceptedSectionWrite, ...]:
+        return accepted_section_writes(self.entity_markdown)
+
 
 @dataclass(frozen=True, slots=True)
 class PreparedEntityMove:
@@ -99,6 +124,7 @@ class PreparedEntityMove:
     search_content: str
     permalink: str | None
     observations: tuple[AcceptedObservationWrite, ...] = ()
+    sections: tuple[AcceptedSectionWrite, ...] = ()
     relations: tuple[AcceptedRelationWrite, ...] = ()
 
 
@@ -852,6 +878,7 @@ async def prepare_move_entity_content(
             )
             for observation in entity_markdown.observations
         ),
+        sections=accepted_section_writes(entity_markdown),
         relations=tuple(
             AcceptedRelationWrite(
                 relation_type=relation.type,

--- a/tests/api/v2/conftest.py
+++ b/tests/api/v2/conftest.py
@@ -85,3 +85,51 @@ def v2_project_url(test_project: Project) -> str:
 def v2_projects_url() -> str:
     """Base URL for v2 project management endpoints."""
     return "/v2/projects"
+
+
+@pytest.fixture
+def fake_read_cache(app: FastAPI):
+    """Install an in-memory ReadCache backend so cached-read branches execute.
+
+    The real backend is Redis and absent in tests (get_read_cache returns None,
+    disabling read-through). Tests that pin cache semantics — a cached full note
+    sliced per request, a cached resource sliced by Range — opt in with this
+    fixture and can inspect the stored payloads.
+    """
+    from basic_memory.deps import get_read_cache
+    from basic_memory.read_cache import (
+        ReadCacheInvalidationStatus,
+        ReadCacheKey,
+        ReadCacheLookup,
+        ReadCacheStoreStatus,
+    )
+
+    class InMemoryReadCache:
+        def __init__(self) -> None:
+            self.payloads: dict[ReadCacheKey, bytes] = {}
+            self.invalidated_projects: list[str] = []
+
+        async def lookup(self, key: ReadCacheKey) -> ReadCacheLookup:
+            return ReadCacheLookup(generation="test-generation", payload=self.payloads.get(key))
+
+        async def store(
+            self,
+            key: ReadCacheKey,
+            lookup: ReadCacheLookup,
+            payload: bytes,
+            *,
+            ttl_seconds: int,
+        ) -> ReadCacheStoreStatus:
+            del lookup, ttl_seconds
+            self.payloads[key] = payload
+            return ReadCacheStoreStatus.stored
+
+        async def invalidate_project(self, project_id: str) -> ReadCacheInvalidationStatus:
+            self.invalidated_projects.append(project_id)
+            self.payloads.clear()
+            return ReadCacheInvalidationStatus.invalidated
+
+    cache = InMemoryReadCache()
+    app.dependency_overrides[get_read_cache] = lambda: cache
+    yield cache
+    app.dependency_overrides.pop(get_read_cache, None)

--- a/tests/api/v2/test_knowledge_router.py
+++ b/tests/api/v2/test_knowledge_router.py
@@ -2292,3 +2292,361 @@ async def test_index_file_rejects_non_markdown(
     )
     assert response.status_code == 400
     assert "Only markdown files" in response.json()["detail"]
+
+
+# --- Note read slicing: section=, lines=, max_tokens= (SPEC-47 / #1403) ---
+
+_SLICEABLE_DOC = (
+    "---\ntitle: Sliceable\n---\n\n# Auth\nline a\n## Decisions\nd1\nd2\n## Ops\no1\n# Tail\nz"
+)
+
+
+async def _seed_sliceable_note(
+    client: AsyncClient,
+    v2_project_url: str,
+    test_project: Project,
+    session_maker,
+    *,
+    title: str,
+    content: str,
+) -> str:
+    """Create a note and pin its accepted content to an exact known document."""
+    create_response = await client.post(
+        f"{v2_project_url}/knowledge/entities",
+        json={"title": title, "directory": "test", "content": "placeholder"},
+    )
+    assert create_response.status_code == 202
+    created = EntityResponseV2.model_validate(create_response.json())
+
+    repository = NoteContentRepository(project_id=test_project.id)
+    async with db.scoped_session(session_maker) as session:
+        await repository.upsert(
+            session,
+            {
+                "entity_id": created.id,
+                "markdown_content": content,
+                "db_version": 42,
+                "db_checksum": "sliceable-checksum",
+                "file_write_status": "pending",
+                "last_source": "test",
+            },
+        )
+    assert created.external_id is not None
+    return created.external_id
+
+
+@pytest.mark.asyncio
+async def test_get_entity_section_slice_returns_span_and_coordinates(
+    client: AsyncClient, test_project: Project, v2_project_url, session_maker
+):
+    external_id = await _seed_sliceable_note(
+        client,
+        v2_project_url,
+        test_project,
+        session_maker,
+        title="SectionSlice",
+        content=_SLICEABLE_DOC,
+    )
+
+    response = await client.get(
+        f"{v2_project_url}/knowledge/entities/{external_id}",
+        params={"section": "Decisions"},
+    )
+
+    assert response.status_code == 200
+    entity = EntityResponseV2.model_validate(response.json())
+    assert entity.content == "## Decisions\nd1\nd2"
+    assert entity.section == "Auth/Decisions"
+    assert entity.content_start_line == 7
+    assert entity.content_end_line == 9
+    assert entity.content_total_lines == 13
+    assert entity.content_truncated is False
+    assert entity.content_continue_line is None
+    # The returned coordinates address the same lines in the full document.
+    assert "\n".join(_SLICEABLE_DOC.split("\n")[6:9]) == entity.content
+
+
+@pytest.mark.asyncio
+async def test_get_entity_section_slice_path_and_bracket_forms(
+    client: AsyncClient, test_project: Project, v2_project_url, session_maker
+):
+    external_id = await _seed_sliceable_note(
+        client,
+        v2_project_url,
+        test_project,
+        session_maker,
+        title="SectionForms",
+        content="# Spec\n## Auth\nfirst\n## Auth\nsecond",
+    )
+
+    path_response = await client.get(
+        f"{v2_project_url}/knowledge/entities/{external_id}",
+        params={"section": "Spec/Auth"},
+    )
+    assert path_response.status_code == 200
+    first = EntityResponseV2.model_validate(path_response.json())
+    assert first.content == "## Auth\nfirst"
+    assert first.section == "Spec/Auth[0]"
+
+    bracket_response = await client.get(
+        f"{v2_project_url}/knowledge/entities/{external_id}",
+        params={"section": "Auth[1]"},
+    )
+    assert bracket_response.status_code == 200
+    second = EntityResponseV2.model_validate(bracket_response.json())
+    assert second.content == "## Auth\nsecond"
+    assert second.section == "Spec/Auth[1]"
+    assert (second.content_start_line, second.content_end_line) == (4, 5)
+
+
+@pytest.mark.asyncio
+async def test_get_entity_unknown_section_404_lists_available_headings(
+    client: AsyncClient, test_project: Project, v2_project_url, session_maker
+):
+    external_id = await _seed_sliceable_note(
+        client,
+        v2_project_url,
+        test_project,
+        session_maker,
+        title="SectionMissing",
+        content=_SLICEABLE_DOC,
+    )
+
+    response = await client.get(
+        f"{v2_project_url}/knowledge/entities/{external_id}",
+        params={"section": "Nope"},
+    )
+
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert "'Nope' not found" in detail
+    assert "Available sections: Auth, Auth/Decisions, Auth/Ops, Tail" in detail
+
+
+@pytest.mark.asyncio
+async def test_get_entity_ambiguous_section_404_lists_qualified_paths(
+    client: AsyncClient, test_project: Project, v2_project_url, session_maker
+):
+    external_id = await _seed_sliceable_note(
+        client,
+        v2_project_url,
+        test_project,
+        session_maker,
+        title="SectionAmbiguous",
+        content="# Auth\n## Decisions\na\n# Ops\n## Decisions\nb",
+    )
+
+    response = await client.get(
+        f"{v2_project_url}/knowledge/entities/{external_id}",
+        params={"section": "Decisions"},
+    )
+
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert "is ambiguous" in detail
+    assert "Auth/Decisions, Ops/Decisions" in detail
+
+
+@pytest.mark.asyncio
+async def test_get_entity_lines_slice_forms(
+    client: AsyncClient, test_project: Project, v2_project_url, session_maker
+):
+    external_id = await _seed_sliceable_note(
+        client,
+        v2_project_url,
+        test_project,
+        session_maker,
+        title="LineSlices",
+        content=_SLICEABLE_DOC,
+    )
+    url = f"{v2_project_url}/knowledge/entities/{external_id}"
+
+    ranged = EntityResponseV2.model_validate(
+        (await client.get(url, params={"lines": "5-6"})).json()
+    )
+    assert ranged.content == "# Auth\nline a"
+    assert (ranged.content_start_line, ranged.content_end_line) == (5, 6)
+    assert ranged.content_total_lines == 13
+    assert ranged.section is None
+
+    open_ended = EntityResponseV2.model_validate(
+        (await client.get(url, params={"lines": "12-"})).json()
+    )
+    assert open_ended.content == "# Tail\nz"
+    assert (open_ended.content_start_line, open_ended.content_end_line) == (12, 13)
+
+    single = EntityResponseV2.model_validate((await client.get(url, params={"lines": "5"})).json())
+    assert single.content == "# Auth"
+    assert (single.content_start_line, single.content_end_line) == (5, 5)
+
+    clamped = EntityResponseV2.model_validate(
+        (await client.get(url, params={"lines": "13-999"})).json()
+    )
+    assert clamped.content == "z"
+    assert (clamped.content_start_line, clamped.content_end_line) == (13, 13)
+
+
+@pytest.mark.asyncio
+async def test_get_entity_slice_param_validation_422(
+    client: AsyncClient, test_project: Project, v2_project_url, session_maker
+):
+    external_id = await _seed_sliceable_note(
+        client,
+        v2_project_url,
+        test_project,
+        session_maker,
+        title="SliceValidation",
+        content=_SLICEABLE_DOC,
+    )
+    url = f"{v2_project_url}/knowledge/entities/{external_id}"
+
+    both = await client.get(url, params={"section": "Auth", "lines": "1-3"})
+    assert both.status_code == 422
+    assert "mutually exclusive" in both.json()["detail"]
+
+    bad_lines = await client.get(url, params={"lines": "3-1"})
+    assert bad_lines.status_code == 422
+    assert "Invalid lines range" in bad_lines.json()["detail"]
+
+    bad_selector = await client.get(url, params={"section": "A//B"})
+    assert bad_selector.status_code == 422
+    assert "Invalid section selector" in bad_selector.json()["detail"]
+
+    bad_budget = await client.get(url, params={"max_tokens": 0})
+    assert bad_budget.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_get_entity_max_tokens_truncates_with_marker(
+    client: AsyncClient, test_project: Project, v2_project_url, session_maker
+):
+    content = "# One\n" + "a" * 40 + "\n# Two\n" + "b" * 400
+    external_id = await _seed_sliceable_note(
+        client,
+        v2_project_url,
+        test_project,
+        session_maker,
+        title="TokenBudget",
+        content=content,
+    )
+
+    response = await client.get(
+        f"{v2_project_url}/knowledge/entities/{external_id}",
+        params={"max_tokens": 20},
+    )
+
+    assert response.status_code == 200
+    entity = EntityResponseV2.model_validate(response.json())
+    assert entity.content is not None
+    kept_lines = entity.content.split("\n")
+    assert kept_lines[:-1] == ["# One", "a" * 40]
+    assert kept_lines[-1] == "… [truncated at max_tokens=20; continue with lines=3-]"
+    assert entity.content_truncated is True
+    assert entity.content_continue_line == 3
+    assert (entity.content_start_line, entity.content_end_line) == (1, 2)
+    assert entity.content_total_lines == 4
+
+
+@pytest.mark.asyncio
+async def test_get_entity_without_slice_params_has_no_slice_metadata(
+    client: AsyncClient, test_project: Project, v2_project_url, session_maker
+):
+    external_id = await _seed_sliceable_note(
+        client,
+        v2_project_url,
+        test_project,
+        session_maker,
+        title="NoSliceMeta",
+        content=_SLICEABLE_DOC,
+    )
+
+    response = await client.get(f"{v2_project_url}/knowledge/entities/{external_id}")
+
+    assert response.status_code == 200
+    entity = EntityResponseV2.model_validate(response.json())
+    assert entity.content == _SLICEABLE_DOC
+    assert entity.section is None
+    assert entity.content_start_line is None
+    assert entity.content_end_line is None
+    assert entity.content_total_lines is None
+    assert entity.content_truncated is None
+    assert entity.content_continue_line is None
+
+
+@pytest.mark.asyncio
+async def test_get_entity_slices_apply_after_cache_retrieval(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url,
+    session_maker,
+    fake_read_cache,
+):
+    """The read cache stores the pristine full note; every slice is per-request."""
+    external_id = await _seed_sliceable_note(
+        client,
+        v2_project_url,
+        test_project,
+        session_maker,
+        title="SliceCache",
+        content=_SLICEABLE_DOC,
+    )
+    url = f"{v2_project_url}/knowledge/entities/{external_id}"
+
+    # Warm the cache with a full read, then request two different slices: both
+    # are computed from the one stored full-note entry (slice params are not in
+    # the cache digest).
+    full_first = EntityResponseV2.model_validate((await client.get(url)).json())
+    assert full_first.content == _SLICEABLE_DOC
+    assert len(fake_read_cache.payloads) == 1
+    (stored_payload,) = fake_read_cache.payloads.values()
+
+    section_slice = EntityResponseV2.model_validate(
+        (await client.get(url, params={"section": "Ops"})).json()
+    )
+    assert section_slice.content == "## Ops\no1"
+
+    line_slice = EntityResponseV2.model_validate(
+        (await client.get(url, params={"lines": "8-9"})).json()
+    )
+    assert line_slice.content == "d1\nd2"
+
+    # The sliced reads shared the warm entry: no new key, and the stored value
+    # is still the pristine full note.
+    assert list(fake_read_cache.payloads.values()) == [stored_payload]
+    cached_entity = EntityResponseV2.model_validate_json(stored_payload)
+    assert cached_entity.content == _SLICEABLE_DOC
+
+    # A later full read still serves the complete document, not a cached slice.
+    full_after = EntityResponseV2.model_validate((await client.get(url)).json())
+    assert full_after.content == _SLICEABLE_DOC
+    assert full_after.section is None
+
+
+@pytest.mark.asyncio
+async def test_get_entity_slice_without_content_404(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url,
+    entity_repository,
+    session_maker,
+):
+    """A content-less legacy entity cannot be sliced."""
+    entity = EntityModel(
+        title="legacy.txt",
+        note_type="file",
+        content_type="text/plain",
+        file_path="legacy/legacy.txt",
+        checksum="seeded",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    async with db.scoped_session(session_maker) as session:
+        entity = await entity_repository.add(session, entity)
+
+    response = await client.get(
+        f"{v2_project_url}/knowledge/entities/{entity.external_id}",
+        params={"section": "Anything"},
+    )
+
+    assert response.status_code == 404
+    assert "no markdown content to slice" in response.json()["detail"]

--- a/tests/api/v2/test_resource_router.py
+++ b/tests/api/v2/test_resource_router.py
@@ -159,3 +159,258 @@ async def test_resource_write_methods_removed(
         json={"content": "test"},
     )
     assert put_response.status_code == 405
+
+
+# --- HTTP Range support (SPEC-47 / #1403) ---
+
+_RANGE_CONTENT = "0123456789abcdefghij"  # 20 bytes, every offset addressable
+
+
+async def _seed_range_file(
+    test_project: Project,
+    entity_repository: EntityRepository,
+    session_maker,
+) -> str:
+    """Seed a plain-text file entity whose bytes are position-addressable."""
+    file_path = "test-resources/range.txt"
+    disk_path = Path(test_project.path) / file_path
+    disk_path.parent.mkdir(parents=True, exist_ok=True)
+    disk_path.write_text(_RANGE_CONTENT)
+
+    entity = Entity(
+        title="range.txt",
+        note_type="file",
+        content_type="text/plain",
+        file_path=file_path,
+        checksum="seeded-range",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    async with db.scoped_session(session_maker) as session:
+        entity = await entity_repository.add(session, entity)
+    return entity.external_id
+
+
+@pytest.mark.asyncio
+async def test_resource_without_range_serves_full_body_with_accept_ranges(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    entity_repository: EntityRepository,
+    session_maker,
+):
+    external_id = await _seed_range_file(test_project, entity_repository, session_maker)
+
+    response = await client.get(f"{v2_project_url}/resource/{external_id}")
+
+    assert response.status_code == 200
+    assert response.text == _RANGE_CONTENT
+    assert response.headers["accept-ranges"] == "bytes"
+
+
+@pytest.mark.asyncio
+async def test_resource_bounded_range_returns_206_with_content_range(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    entity_repository: EntityRepository,
+    session_maker,
+):
+    external_id = await _seed_range_file(test_project, entity_repository, session_maker)
+
+    response = await client.get(
+        f"{v2_project_url}/resource/{external_id}",
+        headers={"Range": "bytes=0-4"},
+    )
+
+    assert response.status_code == 206
+    assert response.text == "01234"
+    assert response.headers["content-range"] == "bytes 0-4/20"
+    assert response.headers["accept-ranges"] == "bytes"
+
+
+@pytest.mark.asyncio
+async def test_resource_open_ended_range_runs_to_end(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    entity_repository: EntityRepository,
+    session_maker,
+):
+    external_id = await _seed_range_file(test_project, entity_repository, session_maker)
+
+    response = await client.get(
+        f"{v2_project_url}/resource/{external_id}",
+        headers={"Range": "bytes=15-"},
+    )
+
+    assert response.status_code == 206
+    assert response.text == "fghij"
+    assert response.headers["content-range"] == "bytes 15-19/20"
+
+
+@pytest.mark.asyncio
+async def test_resource_range_end_clamps_to_body_length(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    entity_repository: EntityRepository,
+    session_maker,
+):
+    external_id = await _seed_range_file(test_project, entity_repository, session_maker)
+
+    response = await client.get(
+        f"{v2_project_url}/resource/{external_id}",
+        headers={"Range": "bytes=10-9999"},
+    )
+
+    assert response.status_code == 206
+    assert response.text == "abcdefghij"
+    assert response.headers["content-range"] == "bytes 10-19/20"
+
+
+@pytest.mark.asyncio
+async def test_resource_suffix_range_serves_final_bytes(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    entity_repository: EntityRepository,
+    session_maker,
+):
+    external_id = await _seed_range_file(test_project, entity_repository, session_maker)
+
+    response = await client.get(
+        f"{v2_project_url}/resource/{external_id}",
+        headers={"Range": "bytes=-4"},
+    )
+
+    assert response.status_code == 206
+    assert response.text == "ghij"
+    assert response.headers["content-range"] == "bytes 16-19/20"
+
+
+@pytest.mark.asyncio
+async def test_resource_oversized_suffix_serves_whole_body_as_206(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    entity_repository: EntityRepository,
+    session_maker,
+):
+    external_id = await _seed_range_file(test_project, entity_repository, session_maker)
+
+    response = await client.get(
+        f"{v2_project_url}/resource/{external_id}",
+        headers={"Range": "bytes=-500"},
+    )
+
+    assert response.status_code == 206
+    assert response.text == _RANGE_CONTENT
+    assert response.headers["content-range"] == "bytes 0-19/20"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("range_header", ["bytes=20-", "bytes=99-100", "bytes=-0"])
+async def test_resource_unsatisfiable_range_returns_416(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    entity_repository: EntityRepository,
+    session_maker,
+    range_header: str,
+):
+    external_id = await _seed_range_file(test_project, entity_repository, session_maker)
+
+    response = await client.get(
+        f"{v2_project_url}/resource/{external_id}",
+        headers={"Range": range_header},
+    )
+
+    assert response.status_code == 416
+    assert response.headers["content-range"] == "bytes */20"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "range_header",
+    [
+        "bytes=0-1,3-4",  # multi-range: ignored per RFC 9110
+        "items=0-4",  # non-bytes unit
+        "bytes=abc-def",  # malformed bounds
+        "bytes=5-2",  # inverted bounds
+        "bytes",  # no '=' separator
+        "bytes=5",  # no '-' in the range spec
+        "bytes=-",  # empty suffix
+    ],
+)
+async def test_resource_unsupported_range_forms_serve_full_body(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    entity_repository: EntityRepository,
+    session_maker,
+    range_header: str,
+):
+    external_id = await _seed_range_file(test_project, entity_repository, session_maker)
+
+    response = await client.get(
+        f"{v2_project_url}/resource/{external_id}",
+        headers={"Range": range_header},
+    )
+
+    assert response.status_code == 200
+    assert response.text == _RANGE_CONTENT
+
+
+@pytest.mark.asyncio
+async def test_resource_range_served_from_cached_markdown_response(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    session_maker,
+    fake_read_cache,
+):
+    """The cache stores full bytes; ranges slice per request after retrieval."""
+    create_response = await client.post(
+        f"{v2_project_url}/knowledge/entities",
+        json={
+            "title": "RangedNote",
+            "directory": "test",
+            "content": "Original file content",
+        },
+    )
+    assert create_response.status_code == 202
+    created = create_response.json()
+
+    accepted_content = "# RangedNote\n\nRange me.\n"
+    repository = NoteContentRepository(project_id=test_project.id)
+    async with db.scoped_session(session_maker) as session:
+        await repository.upsert(
+            session,
+            {
+                "entity_id": created["id"],
+                "markdown_content": accepted_content,
+                "db_version": 42,
+                "db_checksum": "ranged-checksum",
+                "file_write_status": "pending",
+                "last_source": "test",
+            },
+        )
+    url = f"{v2_project_url}/resource/{created['external_id']}"
+
+    # First read warms the markdown read cache with the full body.
+    warm = await client.get(url)
+    assert warm.status_code == 200
+    assert warm.text == accepted_content
+    assert len(fake_read_cache.payloads) == 1
+
+    total = len(accepted_content.encode("utf-8"))
+    ranged = await client.get(url, headers={"Range": "bytes=2-11"})
+    assert ranged.status_code == 206
+    assert ranged.content == accepted_content.encode("utf-8")[2:12]
+    assert ranged.headers["content-range"] == f"bytes 2-11/{total}"
+
+    # And a later full read still serves the complete cached body.
+    full_after = await client.get(url)
+    assert full_after.status_code == 200
+    assert full_after.text == accepted_content

--- a/tests/cloud/test_cloud_services.py
+++ b/tests/cloud/test_cloud_services.py
@@ -522,6 +522,7 @@ async def test_note_content_mutation_service_publishes_graph_after_commit(monkey
             return RecordingSession()
 
     observation_repository = object()
+    section_repository = object()
     relation_repository = object()
 
     class WriteRepositories:
@@ -529,6 +530,11 @@ async def test_note_content_mutation_service_publishes_graph_after_commit(monkey
             assert project_id == publication.project_id
             events.append("observation_repository")
             return observation_repository
+
+        def section_repository(self, project_id: int) -> object:
+            assert project_id == publication.project_id
+            events.append("section_repository")
+            return section_repository
 
         def relation_repository(self, project_id: int) -> object:
             assert project_id == publication.project_id
@@ -558,10 +564,12 @@ async def test_note_content_mutation_service_publishes_graph_after_commit(monkey
             self,
             *,
             observation_repository: object,
+            section_repository: object,
             relation_repository: object,
             session_maker: object,
         ) -> None:
             assert observation_repository is not None
+            assert section_repository is not None
             assert relation_repository is not None
             assert session_maker is not None
 
@@ -571,11 +579,13 @@ async def test_note_content_mutation_service_publishes_graph_after_commit(monkey
             entity_id: int,
             generation: int,
             observations: object,
+            sections: object,
             relations: object,
         ) -> bool:
             assert entity_id == publication.entity_id
             assert generation == publication.generation
             assert observations == publication.observations
+            assert sections == publication.sections
             assert relations == publication.relations
             events.append("publish")
             return True
@@ -604,6 +614,7 @@ async def test_note_content_mutation_service_publishes_graph_after_commit(monkey
         "session_exit",
         "relation_repository",
         "observation_repository",
+        "section_repository",
         "publish",
     ]
 
@@ -623,6 +634,10 @@ async def test_note_content_mutation_service_continues_after_graph_publication_f
 
     class WriteRepositories:
         def observation_repository(self, project_id: int) -> object:
+            assert project_id == publication.project_id
+            return object()
+
+        def section_repository(self, project_id: int) -> object:
             assert project_id == publication.project_id
             return object()
 
@@ -647,10 +662,12 @@ async def test_note_content_mutation_service_continues_after_graph_publication_f
             self,
             *,
             observation_repository: object,
+            section_repository: object,
             relation_repository: object,
             session_maker: object,
         ) -> None:
             assert observation_repository is not None
+            assert section_repository is not None
             assert relation_repository is not None
             assert session_maker is not None
 

--- a/tests/index/test_local_project_index.py
+++ b/tests/index/test_local_project_index.py
@@ -61,7 +61,7 @@ from basic_memory.indexing.relation_resolution import (
 )
 from basic_memory.indexing.relation_persistence import RelationGenerationPublisher
 from basic_memory.models import Entity, Project, Relation
-from basic_memory.repository import EntityRepository
+from basic_memory.repository import EntityRepository, NoteSectionRepository
 from basic_memory.repository.note_content_repository import (
     AcceptedNoteContentWrite,
     NoteContentRepository,
@@ -1802,6 +1802,7 @@ async def test_local_relation_resolution_refreshes_pending_source_without_markdo
     generation_is_current = await RelationGenerationPublisher(
         observation_repository=observation_repository,
         relation_repository=relation_repository,
+        section_repository=NoteSectionRepository(project_id=observation_repository.project_id),
         session_maker=session_maker,
     ).publish(
         entity_id=source_id,

--- a/tests/indexing/test_accepted_note_mutation_runner.py
+++ b/tests/indexing/test_accepted_note_mutation_runner.py
@@ -40,13 +40,16 @@ from basic_memory.markdown.schemas import (
     Observation as MarkdownObservation,
     Relation as MarkdownRelation,
 )
+from basic_memory.markdown.sections import MarkdownSection
 from basic_memory.models import Entity, NoteContent, Project
 from basic_memory.repository import (
     AcceptedNoteContentWrite,
     AcceptedObservationWrite,
     AcceptedRelationWrite,
+    AcceptedSectionWrite,
 )
 from basic_memory.repository.entity_repository import AcceptedPendingEntityWrite
+from basic_memory.repository.note_section_repository import SectionGenerationWriteResult
 from basic_memory.repository.observation_repository import ObservationGenerationWriteResult
 from basic_memory.repository.relation_repository import RelationGenerationWriteResult
 from basic_memory.runtime.note_content import RuntimeAcceptedNoteResponse
@@ -77,6 +80,7 @@ def _prepared_write(
     entity_fields: PreparedEntityFields,
     observations: Sequence[AcceptedObservationWrite] = (),
     relations: Sequence[AcceptedRelationWrite] = (),
+    sections: Sequence[MarkdownSection] = (),
 ) -> PreparedEntityWrite:
     entity_markdown = EntityMarkdown(
         frontmatter=EntityFrontmatter(
@@ -104,6 +108,7 @@ def _prepared_write(
             )
             for relation in relations
         ],
+        sections=list(sections),
     )
     return PreparedEntityWrite(
         file_path=Path(entity_fields.file_path),
@@ -534,6 +539,18 @@ class _ObservationRepository:
         )
 
 
+class _SectionRepository:
+    async def replace_sections_for_generation(
+        self,
+        session: AsyncSession,
+        *,
+        entity_id: int,
+        generation: int,
+        sections: Sequence[AcceptedSectionWrite],
+    ) -> SectionGenerationWriteResult:
+        raise AssertionError("section publication was not expected inside the accepted transaction")
+
+
 class _RelationRepository:
     def __init__(self) -> None:
         self.calls: list[tuple[int, Sequence[AcceptedRelationWrite]]] = []
@@ -577,6 +594,7 @@ class _MutationWriteRepositories:
     note_content_accept_repository_result: _NoteContentAcceptRepository
     search_repository_result: _SearchRepository
     observation_repository_result: _ObservationRepository
+    section_repository_result: _SectionRepository
     relation_repository_result: _RelationRepository
 
     def pending_entity_repository(self, project_id: int) -> _PendingEntityRepository:
@@ -594,6 +612,10 @@ class _MutationWriteRepositories:
     def observation_repository(self, project_id: int) -> _ObservationRepository:
         _ = project_id
         return self.observation_repository_result
+
+    def section_repository(self, project_id: int) -> _SectionRepository:
+        _ = project_id
+        return self.section_repository_result
 
     def relation_repository(self, project_id: int) -> _RelationRepository:
         _ = project_id
@@ -657,6 +679,18 @@ def _prepared_move() -> PreparedEntityMove:
         markdown_content="# Moved\n",
         search_content="Moved",
         permalink="archive/accepted",
+        sections=(
+            AcceptedSectionWrite(
+                heading="Moved",
+                level=1,
+                heading_path="Moved",
+                duplicate_index=0,
+                start_line=1,
+                end_line=1,
+                start_offset=0,
+                end_offset=8,
+            ),
+        ),
     )
 
 
@@ -728,6 +762,7 @@ def _dependencies(
             note_content_accept_repository_result=note_content_accept_repository,
             search_repository_result=search_repository,
             observation_repository_result=observation_repository or _ObservationRepository(),
+            section_repository_result=_SectionRepository(),
             relation_repository_result=relation_repository or _RelationRepository(),
         ),
         move_policy=move_policy
@@ -1773,6 +1808,8 @@ async def test_run_accepted_note_move_carries_previous_path_and_materialized_cle
     assert persistence_calls[1].await_count == 1
     assert result.relation_publication is not None
     assert result.relation_publication.generation == note_content.db_version
+    # The move republishes the freshly parsed section index for the moved body.
+    assert [section.heading_path for section in result.relation_publication.sections] == ["Moved"]
 
 
 @pytest.mark.asyncio
@@ -2205,10 +2242,23 @@ async def test_run_accepted_note_delete_stays_idempotent_after_concurrent_delete
     assert search_repository.deleted_vector_entity_ids == []
 
 
+_ACCEPTED_SECTION = MarkdownSection(
+    heading="Accepted",
+    level=1,
+    path=("Accepted",),
+    duplicate_index=0,
+    start_line=1,
+    end_line=1,
+    start_offset=0,
+    end_offset=11,
+)
+
+
 def _prepared_with_graph(
     *,
     observations: Sequence[AcceptedObservationWrite],
     relations: Sequence[AcceptedRelationWrite],
+    sections: Sequence[MarkdownSection] = (),
 ) -> PreparedEntityWrite:
     """A prepared accepted write carrying a parsed observation/relation graph."""
     return _prepared_write(
@@ -2226,6 +2276,7 @@ def _prepared_with_graph(
         ),
         observations=observations,
         relations=relations,
+        sections=sections,
     )
 
 
@@ -2242,7 +2293,11 @@ async def test_run_accepted_note_create_returns_graph_publication() -> None:
     relations = [
         AcceptedRelationWrite(relation_type="works_at", target_name="XSYS Target", context=None)
     ]
-    prepared = _prepared_with_graph(observations=observations, relations=relations)
+    prepared = _prepared_with_graph(
+        observations=observations,
+        relations=relations,
+        sections=[_ACCEPTED_SECTION],
+    )
     entity = _entity()
     note_content = _note_content(entity)
     preparer_factory = _PreparerFactory(_CreatePreparer(prepared))
@@ -2280,6 +2335,10 @@ async def test_run_accepted_note_create_returns_graph_publication() -> None:
         "Engineer",
     ]
     assert result.relation_publication.relations[0].target_name == "XSYS Target"
+    (published_section,) = result.relation_publication.sections
+    assert published_section.heading_path == "Accepted"
+    assert (published_section.start_line, published_section.end_line) == (1, 1)
+    assert (published_section.start_offset, published_section.end_offset) == (0, 11)
 
 
 @pytest.mark.asyncio
@@ -2302,6 +2361,7 @@ async def test_run_accepted_note_create_can_suppress_derived_graph_facts() -> No
                 context=None,
             )
         ],
+        sections=[_ACCEPTED_SECTION],
     )
     entity = _entity()
     note_content = _note_content(entity)
@@ -2331,6 +2391,11 @@ async def test_run_accepted_note_create_can_suppress_derived_graph_facts() -> No
     assert result.relation_publication is not None
     assert result.relation_publication.observations == ()
     assert result.relation_publication.relations == ()
+    # Sections are structural, not semantic: the graph-silent policy blanks only
+    # observations and relations, so the section index still publishes.
+    assert [section.heading_path for section in result.relation_publication.sections] == [
+        "Accepted"
+    ]
 
 
 @pytest.mark.asyncio
@@ -2401,7 +2466,11 @@ async def test_run_accepted_note_update_returns_replacement_graph() -> None:
     relations = [
         AcceptedRelationWrite(relation_type="relates_to", target_name="Other", context=None)
     ]
-    prepared = _prepared_with_graph(observations=observations, relations=relations)
+    prepared = _prepared_with_graph(
+        observations=observations,
+        relations=relations,
+        sections=[_ACCEPTED_SECTION],
+    )
     entity = _entity(file_path="notes/accepted.md")
     note_content = _note_content(entity)
     observation_repository = _ObservationRepository()
@@ -2435,6 +2504,9 @@ async def test_run_accepted_note_update_returns_replacement_graph() -> None:
     assert result.relation_publication is not None
     assert result.relation_publication.observations[0].content == "Replaced"
     assert result.relation_publication.relations[0].target_name == "Other"
+    assert [section.heading_path for section in result.relation_publication.sections] == [
+        "Accepted"
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_accepted_note_write_runner.py
+++ b/tests/indexing/test_accepted_note_write_runner.py
@@ -43,7 +43,9 @@ from basic_memory.repository import (
     AcceptedNoteContentWrite,
     AcceptedObservationWrite,
     AcceptedRelationWrite,
+    AcceptedSectionWrite,
 )
+from basic_memory.repository.note_section_repository import SectionGenerationWriteResult
 from basic_memory.repository.observation_repository import ObservationGenerationWriteResult
 from basic_memory.repository.relation_repository import RelationGenerationWriteResult
 from basic_memory.repository.entity_repository import AcceptedPendingEntityWrite
@@ -148,6 +150,22 @@ class _ObservationRepository:
         return ObservationGenerationWriteResult(generation_is_current=True)
 
 
+class _SectionRepository:
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, Sequence[AcceptedSectionWrite]]] = []
+
+    async def replace_sections_for_generation(
+        self,
+        session: AsyncSession,
+        *,
+        entity_id: int,
+        generation: int,
+        sections: Sequence[AcceptedSectionWrite],
+    ) -> SectionGenerationWriteResult:
+        self.calls.append((entity_id, sections))
+        return SectionGenerationWriteResult(generation_is_current=True)
+
+
 class _RelationRepository:
     def __init__(self) -> None:
         self.calls: list[tuple[int, Sequence[AcceptedRelationWrite]]] = []
@@ -205,6 +223,10 @@ def test_accepted_note_write_repositories_name_persistence_behavior() -> None:
             assert project_id == 7
             return _ObservationRepository()
 
+        def section_repository(self, project_id: int) -> _SectionRepository:
+            assert project_id == 7
+            return _SectionRepository()
+
         def relation_repository(self, project_id: int) -> _RelationRepository:
             assert project_id == 7
             return _RelationRepository()
@@ -215,6 +237,7 @@ def test_accepted_note_write_repositories_name_persistence_behavior() -> None:
     assert isinstance(repositories.note_content_repository(7), _NoteContentRepository)
     assert isinstance(repositories.search_repository(7), _SearchRepository)
     assert isinstance(repositories.observation_repository(7), _ObservationRepository)
+    assert isinstance(repositories.section_repository(7), _SectionRepository)
     assert isinstance(repositories.relation_repository(7), _RelationRepository)
 
 
@@ -407,12 +430,17 @@ def _unexpected_relation_repository(_project_id: int) -> _RelationRepository:
     raise AssertionError("relation repository was not expected")
 
 
+def _unexpected_section_repository(_project_id: int) -> _SectionRepository:
+    raise AssertionError("section repository was not expected")
+
+
 @dataclass(frozen=True, slots=True)
 class _RepositoryProvider:
     pending_entity_repository_result: _PendingEntityRepository | None = None
     note_content_repository_result: _NoteContentRepository | None = None
     search_repository_result: _SearchRepository | None = None
     observation_repository_result: _ObservationRepository | None = None
+    section_repository_result: _SectionRepository | None = None
     relation_repository_result: _RelationRepository | None = None
 
     def pending_entity_repository(self, project_id: int) -> _PendingEntityRepository:
@@ -435,6 +463,11 @@ class _RepositoryProvider:
             return _unexpected_observation_repository(project_id)
         return self.observation_repository_result
 
+    def section_repository(self, project_id: int) -> _SectionRepository:
+        if self.section_repository_result is None:
+            return _unexpected_section_repository(project_id)
+        return self.section_repository_result
+
     def relation_repository(self, project_id: int) -> _RelationRepository:
         if self.relation_repository_result is None:
             return _unexpected_relation_repository(project_id)
@@ -447,12 +480,14 @@ def _repository_provider(
     note_content_repository: _NoteContentRepository | None = None,
     search_repository: _SearchRepository | None = None,
     observation_repository: _ObservationRepository | None = None,
+    section_repository: _SectionRepository | None = None,
     relation_repository: _RelationRepository | None = None,
 ) -> AcceptedNoteWriteRepositories:
     """Build a fail-fast fake repository provider for one focused test."""
     return _RepositoryProvider(
         pending_entity_repository_result=pending_entity_repository,
         observation_repository_result=observation_repository,
+        section_repository_result=section_repository,
         relation_repository_result=relation_repository,
         note_content_repository_result=note_content_repository,
         search_repository_result=search_repository,

--- a/tests/indexing/test_regular_file_classification.py
+++ b/tests/indexing/test_regular_file_classification.py
@@ -14,8 +14,8 @@ from basic_memory.indexing.batch_indexer import (
     regular_file_content_type,
 )
 from basic_memory.indexing.models import IndexInputFile, StorageIndexFileWriter
-from basic_memory.models import Entity, Observation, Relation, RelationSearchRefresh
-from basic_memory.repository import NoteContentRepository
+from basic_memory.models import Entity, NoteSection, Observation, Relation, RelationSearchRefresh
+from basic_memory.repository import NoteContentRepository, NoteSectionRepository
 
 
 def test_markdown_mime_without_note_basename_is_persisted_as_resource() -> None:
@@ -88,6 +88,21 @@ async def test_poison_markdown_reclassification_clears_note_only_state(
                 content="stale observation",
                 category="note",
             ),
+        )
+        session.add(
+            NoteSection(
+                project_id=project_id,
+                entity_id=poison.id,
+                heading="Poison note",
+                level=1,
+                heading_path="Poison note",
+                heading_path_digest="0" * 64,
+                duplicate_index=0,
+                start_line=1,
+                end_line=1,
+                start_offset=0,
+                end_offset=13,
+            )
         )
         await relation_repository.add(
             session,
@@ -215,6 +230,10 @@ async def test_poison_markdown_reclassification_clears_note_only_state(
             session,
             poison.id,
         )
+        sections = await NoteSectionRepository(project_id=project_id).find_by_entity(
+            session,
+            poison.id,
+        )
         refreshed_inbound = await relation_repository.select_by_id(session, inbound.id)
         poison_refreshes = await relation_repository.list_pending_search_refreshes(
             session,
@@ -234,6 +253,7 @@ async def test_poison_markdown_reclassification_clears_note_only_state(
     assert repaired.entity_metadata == {}
     assert note_content is None
     assert observations == []
+    assert sections == []
     assert repaired.outgoing_relations == []
     assert refreshed_inbound is not None
     assert refreshed_inbound.to_id is None

--- a/tests/indexing/test_relation_persistence.py
+++ b/tests/indexing/test_relation_persistence.py
@@ -16,13 +16,18 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from basic_memory import db
 from basic_memory.indexing.change_detector import ChangeDetector
 import basic_memory.indexing.relation_persistence as relation_persistence_module
-from basic_memory.indexing.models import IndexedObservation, IndexedRelation
+from basic_memory.indexing.models import IndexedObservation, IndexedRelation, IndexedSection
 from basic_memory.indexing.relation_persistence import RelationGenerationPublisher
 from basic_memory.models import Entity, Relation, RelationSearchRefresh
 from basic_memory.repository.entity_repository import EntityRepository
 from basic_memory.repository.note_content_repository import (
     AcceptedNoteContentWrite,
     NoteContentRepository,
+)
+from basic_memory.repository.note_section_repository import (
+    AcceptedSectionWrite,
+    NoteSectionRepository,
+    SectionGenerationWriteResult,
 )
 from basic_memory.repository.observation_repository import (
     AcceptedObservationWrite,
@@ -105,6 +110,28 @@ class RecordingObservationGenerationStore:
         return ObservationGenerationWriteResult(generation_is_current=self.generation_is_current)
 
 
+@dataclass(slots=True)
+class RecordingSectionGenerationStore:
+    """Record the fenced section replacement produced by the publisher."""
+
+    generation_is_current: bool = True
+    events: list[str] = field(default_factory=list)
+    calls: list[tuple[int, tuple[AcceptedSectionWrite, ...]]] = field(default_factory=list)
+
+    async def replace_sections_for_generation(
+        self,
+        session: AsyncSession,
+        *,
+        entity_id: int,
+        generation: int,
+        sections: Sequence[AcceptedSectionWrite],
+    ) -> SectionGenerationWriteResult:
+        assert session is not None
+        self.events.append("sections")
+        self.calls.append((generation, tuple(sections)))
+        return SectionGenerationWriteResult(generation_is_current=self.generation_is_current)
+
+
 @pytest.mark.asyncio
 async def test_relation_generation_publisher_commits_sorted_chunks_before_cleanup(
     monkeypatch: pytest.MonkeyPatch,
@@ -128,9 +155,11 @@ async def test_relation_generation_publisher_commits_sorted_chunks_before_cleanu
     )
     store = RecordingRelationGenerationStore()
     observation_store = RecordingObservationGenerationStore(events=store.events)
+    section_store = RecordingSectionGenerationStore(events=store.events)
     publisher = RelationGenerationPublisher(
         relation_repository=store,
         observation_repository=observation_store,
+        section_repository=section_store,
         session_maker=cast(async_sessionmaker[AsyncSession], object()),
     )
     relations = [
@@ -142,21 +171,37 @@ async def test_relation_generation_publisher_commits_sorted_chunks_before_cleanu
         )
         for index in reversed(range(251))
     ]
+    indexed_section = IndexedSection(
+        heading="Decisions",
+        level=2,
+        heading_path="Auth/Decisions",
+        duplicate_index=0,
+        start_line=3,
+        end_line=9,
+        start_offset=12,
+        end_offset=140,
+    )
 
     generation_is_current = await publisher.publish(
         entity_id=42,
         generation=7,
         relations=relations,
         observations=[IndexedObservation("Observed", "note", None, ["graph"])],
+        sections=[indexed_section],
     )
 
     assert generation_is_current
-    assert store.events == ["begin", "observations", "upsert", "upsert", "cleanup"]
+    assert store.events == ["begin", "observations", "sections", "upsert", "upsert", "cleanup"]
     assert observation_store.calls == [
         (7, (AcceptedObservationWrite("Observed", "note", None, ["graph"]),))
     ]
+    assert section_store.calls == [
+        (7, (AcceptedSectionWrite("Decisions", 2, "Auth/Decisions", 0, 3, 9, 12, 140),))
+    ]
     assert [call[0] for call in store.calls] == ["begin", "upsert", "upsert", "cleanup"]
     assert [len(call[2]) for call in store.calls] == [0, 250, 1, 0]
+    assert len(sessions) == 6
+    assert len({id(session) for session in sessions}) == 6
     published_names = [
         relation.target_name
         for operation, _, relation_chunk in store.calls
@@ -171,8 +216,6 @@ async def test_relation_generation_publisher_commits_sorted_chunks_before_cleanu
         for relation in relation_chunk
     ]
     assert published_targets.count(42) == 1
-    assert len(sessions) == 5
-    assert len({id(session) for session in sessions}) == 5
 
 
 @pytest.mark.asyncio
@@ -198,9 +241,11 @@ async def test_relation_generation_publisher_stops_when_source_fence_is_stale(
     )
     store = RecordingRelationGenerationStore(generation_is_current=False)
     observation_store = RecordingObservationGenerationStore(events=store.events)
+    section_store = RecordingSectionGenerationStore(events=store.events)
     publisher = RelationGenerationPublisher(
         relation_repository=store,
         observation_repository=observation_store,
+        section_repository=section_store,
         session_maker=cast(async_sessionmaker[AsyncSession], object()),
     )
 
@@ -211,9 +256,9 @@ async def test_relation_generation_publisher_stops_when_source_fence_is_stale(
     )
 
     assert not generation_is_current
-    assert store.events == ["begin", "observations", "upsert"]
+    assert store.events == ["begin", "observations", "sections", "upsert"]
     assert [call[0] for call in store.calls] == ["begin", "upsert"]
-    assert transaction_count == 3
+    assert transaction_count == 4
 
 
 @pytest.mark.asyncio
@@ -239,9 +284,11 @@ async def test_relation_generation_publisher_stops_when_publication_cannot_begin
     )
     store = RecordingRelationGenerationStore(begin_is_current=False)
     observation_store = RecordingObservationGenerationStore(events=store.events)
+    section_store = RecordingSectionGenerationStore(events=store.events)
     publisher = RelationGenerationPublisher(
         relation_repository=store,
         observation_repository=observation_store,
+        section_repository=section_store,
         session_maker=cast(async_sessionmaker[AsyncSession], object()),
     )
 
@@ -252,6 +299,7 @@ async def test_relation_generation_publisher_stops_when_publication_cannot_begin
     )
     assert [call[0] for call in store.calls] == ["begin"]
     assert observation_store.calls == []
+    assert section_store.calls == []
     assert transaction_count == 1
 
 
@@ -281,9 +329,11 @@ async def test_relation_generation_publisher_stops_when_observation_fence_is_sta
         generation_is_current=False,
         events=store.events,
     )
+    section_store = RecordingSectionGenerationStore(events=store.events)
     publisher = RelationGenerationPublisher(
         relation_repository=store,
         observation_repository=observation_store,
+        section_repository=section_store,
         session_maker=cast(async_sessionmaker[AsyncSession], object()),
     )
 
@@ -296,7 +346,54 @@ async def test_relation_generation_publisher_stops_when_observation_fence_is_sta
     assert store.events == ["begin", "observations"]
     assert [call[0] for call in store.calls] == ["begin"]
     assert observation_store.calls == [(6, ())]
+    assert section_store.calls == []
     assert transaction_count == 2
+
+
+@pytest.mark.asyncio
+async def test_relation_generation_publisher_stops_when_section_fence_is_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale section replace stops before relation chunks or cleanup."""
+    transaction_count = 0
+
+    @asynccontextmanager
+    async def fake_scoped_session(
+        session_maker: async_sessionmaker[AsyncSession],
+    ) -> AsyncIterator[AsyncSession]:
+        nonlocal transaction_count
+        assert session_maker is not None
+        transaction_count += 1
+        yield cast(AsyncSession, object())
+
+    monkeypatch.setattr(
+        relation_persistence_module.db,
+        "scoped_session",
+        fake_scoped_session,
+    )
+    store = RecordingRelationGenerationStore()
+    observation_store = RecordingObservationGenerationStore(events=store.events)
+    section_store = RecordingSectionGenerationStore(
+        generation_is_current=False,
+        events=store.events,
+    )
+    publisher = RelationGenerationPublisher(
+        relation_repository=store,
+        observation_repository=observation_store,
+        section_repository=section_store,
+        session_maker=cast(async_sessionmaker[AsyncSession], object()),
+    )
+
+    assert not await publisher.publish(
+        entity_id=42,
+        generation=6,
+        relations=[IndexedRelation("links_to", "Target", None)],
+        sections=[],
+    )
+    assert store.events == ["begin", "observations", "sections"]
+    assert [call[0] for call in store.calls] == ["begin"]
+    assert section_store.calls == [(6, ())]
+    assert transaction_count == 3
 
 
 @pytest.mark.asyncio
@@ -319,9 +416,11 @@ async def test_relation_generation_publisher_deduplicates_pre_resolved_aliases(
     )
     store = RecordingRelationGenerationStore()
     observation_store = RecordingObservationGenerationStore(events=store.events)
+    section_store = RecordingSectionGenerationStore(events=store.events)
     publisher = RelationGenerationPublisher(
         relation_repository=store,
         observation_repository=observation_store,
+        section_repository=section_store,
         session_maker=cast(async_sessionmaker[AsyncSession], object()),
     )
 
@@ -337,6 +436,7 @@ async def test_relation_generation_publisher_deduplicates_pre_resolved_aliases(
 
     assert generation_is_current
     assert observation_store.calls == [(7, ())]
+    assert section_store.calls == [(7, ())]
     assert store.calls == [
         ("begin", 7, ()),
         (
@@ -356,9 +456,11 @@ async def test_relation_generation_publisher_rejects_non_self_pre_resolved_targe
     """Ordinary targets remain resolver-owned even when a caller supplies an ID."""
     store = RecordingRelationGenerationStore()
     observation_store = RecordingObservationGenerationStore(events=store.events)
+    section_store = RecordingSectionGenerationStore(events=store.events)
     publisher = RelationGenerationPublisher(
         relation_repository=store,
         observation_repository=observation_store,
+        section_repository=section_store,
         session_maker=cast(async_sessionmaker[AsyncSession], object()),
     )
 
@@ -442,6 +544,7 @@ async def test_failed_relation_publication_forces_change_detection_retry(
     failing_publisher = RelationGenerationPublisher(
         relation_repository=_FailAfterPublicationBegins(),
         observation_repository=observation_repository,
+        section_repository=NoteSectionRepository(project_id=sample_entity.project_id),
         session_maker=session_maker,
     )
     with pytest.raises(OSError, match="relation chunk write failed"):
@@ -470,6 +573,7 @@ async def test_failed_relation_publication_forces_change_detection_retry(
     retry_publisher = RelationGenerationPublisher(
         relation_repository=relation_repository,
         observation_repository=observation_repository,
+        section_repository=NoteSectionRepository(project_id=sample_entity.project_id),
         session_maker=session_maker,
     )
     assert await retry_publisher.publish(
@@ -537,6 +641,7 @@ async def test_generation_zero_relation_forces_generation_publication(
     publisher = RelationGenerationPublisher(
         relation_repository=relation_repository,
         observation_repository=observation_repository,
+        section_repository=NoteSectionRepository(project_id=sample_entity.project_id),
         session_maker=session_maker,
     )
     assert await publisher.publish(

--- a/tests/markdown/test_entity_parser.py
+++ b/tests/markdown/test_entity_parser.py
@@ -353,6 +353,81 @@ async def test_non_scalar_semantic_setting_does_not_crash(
     assert [relation.target for relation in entity.relations] == ["Target"]
 
 
+@pytest.mark.asyncio
+async def test_parse_file_scans_sections(project_config, entity_parser):
+    """parse_file carries body-relative section spans on the parsed entity."""
+    content = dedent("""\
+        ---
+        title: Sectioned
+        type: note
+        ---
+
+        # Spec
+        intro
+        ## Auth
+        first
+        ## Auth
+        second
+        # Tail
+        z
+        """)
+    test_file = project_config.home / "sectioned.md"
+    test_file.write_text(content)
+
+    entity = await entity_parser.parse_file(test_file)
+
+    assert [section.heading_path for section in entity.sections] == [
+        "Spec",
+        "Spec/Auth",
+        "Spec/Auth",
+        "Tail",
+    ]
+    assert [section.duplicate_index for section in entity.sections] == [0, 0, 1, 0]
+    # Coordinates are body-relative (frontmatter stripped): the parsed content
+    # is the exact string the spans index into.
+    spec = entity.sections[0]
+    body_lines = entity.content.split("\n")
+    assert body_lines[spec.start_line - 1] == "# Spec"
+    encoded = entity.content.encode("utf-8")
+    for section in entity.sections:
+        section_text = "\n".join(body_lines[section.start_line - 1 : section.end_line])
+        assert (
+            encoded[section.start_offset : section.end_offset].decode("utf-8").rstrip("\n")
+            == section_text
+        )
+
+
+@pytest.mark.asyncio
+async def test_parse_note_with_lone_carriage_returns_scans_sections(entity_parser):
+    """Stray \\r terminators (pasted terminal/Excel output) must not break parsing.
+
+    Regression for issue #1403 review: scan_sections counted lines by
+    split("\\n") while markdown-it treats a lone \\r as a newline, so this note
+    raised IndexError and could not be written or indexed at all.
+    """
+    entity = await entity_parser.parse_markdown_content(
+        Path("stray-cr.md"), "# One\ralpha\r# Two\rbeta"
+    )
+
+    assert [
+        (section.heading, section.start_line, section.end_line) for section in entity.sections
+    ] == [("One", 1, 2), ("Two", 3, 4)]
+
+
+@pytest.mark.asyncio
+async def test_graph_silent_note_still_gets_sections(entity_parser):
+    """bm_parse_semantics: false suppresses the graph but never the section index."""
+    entity = await entity_parser.parse_markdown_content(
+        Path("graph-silent.md"),
+        "---\nbm_parse_semantics: false\n---\n# Extracted\n- [note] Not an observation\n"
+        "- references [[Not A Relation]]\n",
+    )
+
+    assert entity.observations == []
+    assert entity.relations == []
+    assert [section.heading for section in entity.sections] == ["Extracted"]
+
+
 # @pytest.mark.asyncio
 # async def test_parse_file_invalid_yaml(test_config, entity_parser):
 #     """Test parsing file with invalid YAML frontmatter."""

--- a/tests/markdown/test_sections.py
+++ b/tests/markdown/test_sections.py
@@ -1,0 +1,574 @@
+"""Tests for structural section scanning and read-time slicing (SPEC-47 / #1403).
+
+Pure-function tests over dedented strings: no fixtures, no I/O. The scanner and
+slicers are re-run at read time on the exact content being served, so these
+boundary cases pin canonical-content correctness.
+"""
+
+from textwrap import dedent
+
+import pytest
+
+from basic_memory.markdown.sections import (
+    LineRange,
+    NoteSlice,
+    NoteSliceError,
+    TRUNCATION_MARKER_TEMPLATE,
+    _frontmatter_line_count,
+    _token_budget_line_count,
+    parse_line_range,
+    parse_section_selector,
+    scan_sections,
+    slice_note_content,
+)
+
+# --- scan_sections ---
+
+
+def test_scan_empty_body_returns_no_sections():
+    assert scan_sections("") == ()
+
+
+def test_scan_body_without_headings_returns_no_sections():
+    assert scan_sections("just prose\n\nmore prose\n") == ()
+
+
+def test_scan_nested_headings_build_paths_and_nested_spans():
+    body = dedent("""\
+        # Top
+        intro
+        ## Sub
+        sub body
+        ## Sub2
+        more
+        # Next
+        tail""")
+
+    sections = scan_sections(body)
+
+    by_heading = {section.heading: section for section in sections}
+    assert [section.heading for section in sections] == ["Top", "Sub", "Sub2", "Next"]
+
+    top = by_heading["Top"]
+    assert top.level == 1
+    assert top.path == ("Top",)
+    assert top.heading_path == "Top"
+    assert (top.start_line, top.end_line) == (1, 6)
+
+    sub = by_heading["Sub"]
+    assert sub.level == 2
+    assert sub.path == ("Top", "Sub")
+    assert sub.heading_path == "Top/Sub"
+    assert (sub.start_line, sub.end_line) == (3, 4)
+
+    sub2 = by_heading["Sub2"]
+    assert sub2.path == ("Top", "Sub2")
+    assert (sub2.start_line, sub2.end_line) == (5, 6)
+
+    nxt = by_heading["Next"]
+    assert nxt.path == ("Next",)
+    assert (nxt.start_line, nxt.end_line) == (7, 8)
+
+    # Subsections nest inside their parent: overlapping spans are correct.
+    assert top.start_line <= sub.start_line and sub.end_line <= top.end_line
+
+
+def test_scan_skipped_heading_level_keeps_ancestor_path():
+    body = "# A\n### Deep\ncontent\n"
+
+    sections = scan_sections(body)
+
+    assert sections[1].path == ("A", "Deep")
+    assert sections[1].level == 3
+
+
+def test_scan_duplicate_headings_same_path_count_duplicate_index():
+    body = dedent("""\
+        # Spec
+        ## Auth
+        first
+        ## Auth
+        second""")
+
+    sections = scan_sections(body)
+
+    auths = [section for section in sections if section.heading == "Auth"]
+    assert [section.duplicate_index for section in auths] == [0, 1]
+    assert [section.path for section in auths] == [("Spec", "Auth"), ("Spec", "Auth")]
+    assert (auths[0].start_line, auths[0].end_line) == (2, 3)
+    assert (auths[1].start_line, auths[1].end_line) == (4, 5)
+
+
+def test_scan_same_heading_under_different_parents_gets_distinct_paths():
+    body = dedent("""\
+        # Auth
+        ## Decisions
+        a
+        # Ops
+        ## Decisions
+        b""")
+
+    sections = scan_sections(body)
+
+    decisions = [section for section in sections if section.heading == "Decisions"]
+    assert [section.heading_path for section in decisions] == ["Auth/Decisions", "Ops/Decisions"]
+    assert [section.duplicate_index for section in decisions] == [0, 0]
+
+
+def test_scan_ignores_headings_inside_fenced_code_blocks():
+    body = dedent("""\
+        # Real
+        ```
+        # not a heading
+        ```
+        ~~~
+        ## also not one
+        ~~~
+        done""")
+
+    sections = scan_sections(body)
+
+    assert [section.heading for section in sections] == ["Real"]
+    assert sections[0].end_line == 8
+
+
+def test_scan_setext_headings_span_their_underline():
+    body = dedent("""\
+        Title
+        =====
+        body
+
+        Sub
+        ---
+        more""")
+
+    sections = scan_sections(body)
+
+    assert [(section.heading, section.level) for section in sections] == [("Title", 1), ("Sub", 2)]
+    title, sub = sections
+    assert (title.start_line, title.end_line) == (1, 7)
+    assert title.path == ("Title",)
+    assert (sub.start_line, sub.end_line) == (5, 7)
+    assert sub.path == ("Title", "Sub")
+
+
+def test_scan_empty_section_ends_on_its_own_heading_line():
+    body = "# A\n# B"
+
+    sections = scan_sections(body)
+
+    a, b = sections
+    assert (a.start_line, a.end_line) == (1, 1)
+    assert (b.start_line, b.end_line) == (2, 2)
+
+
+def test_scan_byte_offsets_round_trip_unicode_content():
+    body = "# Héllo ☕\ncafé costs 5€\n# End\nfin"
+
+    sections = scan_sections(body)
+
+    encoded = body.encode("utf-8")
+    hello, end = sections
+    assert encoded[hello.start_offset : hello.end_offset].decode("utf-8") == (
+        "# Héllo ☕\ncafé costs 5€\n"
+    )
+    assert encoded[end.start_offset : end.end_offset].decode("utf-8") == "# End\nfin"
+    assert end.end_offset == len(encoded)
+
+
+def test_scan_trailing_newline_is_included_in_final_section_bytes():
+    body = "# Only\ntext\n"
+
+    (only,) = scan_sections(body)
+
+    assert (only.start_line, only.end_line) == (1, 2)
+    assert body.encode("utf-8")[only.start_offset : only.end_offset].decode("utf-8") == body
+
+
+def test_scan_lone_carriage_returns_count_as_line_boundaries():
+    # markdown-it normalizes "\r\n?|\n" to "\n" before assigning token line maps,
+    # so a lone \r is a line boundary; counting by split("\n") shifted every later
+    # heading and indexed past the line table (issue #1403 review).
+    body = "# One\ralpha\r# Two\rbeta"
+
+    one, two = scan_sections(body)
+
+    assert (one.start_line, one.end_line) == (1, 2)
+    assert (two.start_line, two.end_line) == (3, 4)
+    encoded = body.encode("utf-8")
+    assert encoded[one.start_offset : one.end_offset].decode("utf-8") == "# One\ralpha\r"
+    assert encoded[two.start_offset : two.end_offset].decode("utf-8") == "# Two\rbeta"
+    assert two.end_offset == len(encoded)
+
+
+def test_scan_crlf_terminators_round_trip_original_bytes():
+    body = "# A\r\nbody\r\n# B\r\ntail\r\n"
+
+    a, b = scan_sections(body)
+
+    assert (a.start_line, a.end_line) == (1, 2)
+    assert (b.start_line, b.end_line) == (3, 4)
+    encoded = body.encode("utf-8")
+    assert encoded[a.start_offset : a.end_offset].decode("utf-8") == "# A\r\nbody\r\n"
+    assert encoded[b.start_offset : b.end_offset].decode("utf-8") == "# B\r\ntail\r\n"
+    assert b.end_offset == len(encoded)
+
+
+# --- parse_section_selector ---
+
+
+@pytest.mark.parametrize(
+    ("selector", "segments", "duplicate_index"),
+    [
+        ("Decisions", ("Decisions",), 0),
+        ("Auth/Decisions", ("Auth", "Decisions"), 0),
+        ("Heading[1]", ("Heading",), 1),
+        ("Auth/Decisions[2]", ("Auth", "Decisions"), 2),
+        ("## Auth", ("Auth",), 0),
+        ("# Auth / ### Decisions ", ("Auth", "Decisions"), 0),
+        ("#tag", ("#tag",), 0),
+    ],
+)
+def test_parse_section_selector_accepted_forms(selector, segments, duplicate_index):
+    parsed = parse_section_selector(selector)
+
+    assert parsed is not None
+    assert parsed.raw == selector
+    assert parsed.segments == segments
+    assert parsed.duplicate_index == duplicate_index
+
+
+@pytest.mark.parametrize("selector", ["", "   ", "A//B", "/Auth", "Auth/", "[2]", "A/ /B"])
+def test_parse_section_selector_rejects_malformed_forms(selector):
+    assert parse_section_selector(selector) is None
+
+
+# --- parse_line_range ---
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2-4", LineRange(start=2, end=4)),
+        ("3-", LineRange(start=3, end=None)),
+        ("5", LineRange(start=5, end=5)),
+        (" 2 - 4 ", LineRange(start=2, end=4)),
+        ("7-7", LineRange(start=7, end=7)),
+    ],
+)
+def test_parse_line_range_accepted_forms(value, expected):
+    assert parse_line_range(value) == expected
+
+
+@pytest.mark.parametrize("value", ["", "0", "-5", "a", "2-1", "1-b", "1.5-2", "0-"])
+def test_parse_line_range_rejects_malformed_forms(value):
+    assert parse_line_range(value) is None
+
+
+# --- _frontmatter_line_count ---
+
+
+def test_frontmatter_line_count_counts_well_formed_block():
+    text = "---\ntitle: T\ntags: [a]\n---\n\nbody"
+    assert _frontmatter_line_count(text) == 4
+
+
+def test_frontmatter_line_count_zero_without_opening_fence():
+    assert _frontmatter_line_count("# Heading\n---\n") == 0
+    assert _frontmatter_line_count("") == 0
+
+
+def test_frontmatter_line_count_zero_for_unterminated_block():
+    assert _frontmatter_line_count("---\ntitle: T\nbody without closing fence") == 0
+
+
+def test_frontmatter_line_count_counts_carriage_return_terminated_block():
+    # Lone \r terminators count as line boundaries, matching the document line
+    # table the count indexes into.
+    assert _frontmatter_line_count("---\rtitle: T\r---\rbody") == 3
+
+
+# --- slice_note_content: section selection ---
+
+_DOC = dedent("""\
+    ---
+    title: Spec
+    ---
+
+    # Auth
+    line a
+    ## Decisions
+    d1
+    d2
+    ## Ops
+    o1
+    # Tail
+    z""")
+
+
+def _slice(full_text: str, **kwargs) -> NoteSlice:
+    result = slice_note_content(full_text, **kwargs)
+    assert isinstance(result, NoteSlice)
+    return result
+
+
+def _slice_error(full_text: str, **kwargs) -> NoteSliceError:
+    result = slice_note_content(full_text, **kwargs)
+    assert isinstance(result, NoteSliceError)
+    return result
+
+
+def test_slice_by_section_returns_document_absolute_span():
+    selector = parse_section_selector("Decisions")
+    assert selector is not None
+
+    sliced = _slice(_DOC, section=selector, note_title="Spec")
+
+    assert sliced.content == "## Decisions\nd1\nd2"
+    assert sliced.section == "Auth/Decisions"
+    assert (sliced.start_line, sliced.end_line) == (7, 9)
+    assert sliced.total_lines == 13
+    assert not sliced.truncated
+    assert sliced.continue_line is None
+    # The returned coordinates address the same lines in the full document.
+    assert "\n".join(_DOC.split("\n")[6:9]) == sliced.content
+
+
+def test_slice_by_qualified_path_disambiguates():
+    doc = dedent("""\
+        # Auth
+        ## Decisions
+        a
+        # Ops
+        ## Decisions
+        b""")
+    selector = parse_section_selector("Ops/Decisions")
+    assert selector is not None
+
+    sliced = _slice(doc, section=selector)
+
+    assert sliced.content == "## Decisions\nb"
+    assert sliced.section == "Ops/Decisions"
+    assert (sliced.start_line, sliced.end_line) == (5, 6)
+
+
+def test_slice_ambiguous_suffix_lists_qualified_paths():
+    doc = "# Auth\n## Decisions\na\n# Ops\n## Decisions\nb"
+    selector = parse_section_selector("Decisions")
+    assert selector is not None
+
+    error = _slice_error(doc, section=selector, note_title="Spec")
+
+    assert "'Decisions' is ambiguous in note 'Spec'" in error.message
+    assert "Auth/Decisions, Ops/Decisions" in error.message
+
+
+def test_slice_duplicate_headings_addressed_by_bracket_index():
+    doc = dedent("""\
+        # Spec
+        ## Auth
+        first
+        ## Auth
+        second""")
+    selector = parse_section_selector("Auth[1]")
+    assert selector is not None
+
+    sliced = _slice(doc, section=selector)
+
+    assert sliced.content == "## Auth\nsecond"
+    assert sliced.section == "Spec/Auth[1]"
+    assert (sliced.start_line, sliced.end_line) == (4, 5)
+
+
+def test_slice_duplicate_index_out_of_range_reports_count():
+    doc = "# Spec\n## Auth\nfirst\n## Auth\nsecond"
+    selector = parse_section_selector("Auth[5]")
+    assert selector is not None
+
+    error = _slice_error(doc, section=selector)
+
+    assert "2 section(s) share the path 'Spec/Auth'" in error.message
+    assert "duplicate indexes 0-1" in error.message
+
+
+def test_slice_unknown_section_lists_available_headings_with_duplicates_bracketed():
+    doc = "# Spec\n## Auth\nfirst\n## Auth\nsecond\n## Ops\nz"
+    selector = parse_section_selector("Nope")
+    assert selector is not None
+
+    error = _slice_error(doc, section=selector, note_title="Spec")
+
+    assert "'Nope' not found in note 'Spec'" in error.message
+    assert "Available sections: Spec, Spec/Auth[0], Spec/Auth[1], Spec/Ops" in error.message
+
+
+def test_slice_unknown_section_in_heading_less_note():
+    selector = parse_section_selector("Anything")
+    assert selector is not None
+
+    error = _slice_error("plain prose only", section=selector)
+
+    assert "(note has no headings)" in error.message
+    assert " in note " not in error.message
+
+
+def test_slice_by_section_after_stray_carriage_return_serves_the_heading():
+    # Regression: split("\n") counting let a stray \r shift the section span so
+    # this selector silently served only "tail" (issue #1403 review).
+    selector = parse_section_selector("H")
+    assert selector is not None
+
+    sliced = _slice("one\rtwo\n# H\ntail", section=selector)
+
+    assert sliced.content == "# H\ntail"
+    assert (sliced.start_line, sliced.end_line) == (3, 4)
+    assert sliced.total_lines == 4
+
+
+# --- slice_note_content: line ranges ---
+
+
+def test_slice_by_line_range_addresses_full_document():
+    sliced = _slice(_DOC, lines=LineRange(start=2, end=4))
+
+    assert sliced.content == "title: Spec\n---\n"
+    assert (sliced.start_line, sliced.end_line) == (2, 4)
+    assert sliced.total_lines == 13
+    assert sliced.section is None
+
+
+def test_slice_open_ended_line_range_runs_to_end():
+    sliced = _slice(_DOC, lines=LineRange(start=12, end=None))
+
+    assert sliced.content == "# Tail\nz"
+    assert (sliced.start_line, sliced.end_line) == (12, 13)
+
+
+def test_slice_line_range_end_clamps_to_total_lines():
+    sliced = _slice(_DOC, lines=LineRange(start=13, end=999))
+
+    assert sliced.content == "z"
+    assert (sliced.start_line, sliced.end_line) == (13, 13)
+
+
+def test_slice_single_line_range():
+    sliced = _slice(_DOC, lines=LineRange(start=5, end=5))
+
+    assert sliced.content == "# Auth"
+
+
+def test_slice_empty_document_yields_empty_slice():
+    sliced = _slice("", lines=LineRange(start=1, end=None))
+
+    assert sliced.content == ""
+    assert sliced.total_lines == 0
+
+
+def test_slice_section_and_lines_are_mutually_exclusive():
+    selector = parse_section_selector("Auth")
+    assert selector is not None
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        slice_note_content(_DOC, section=selector, lines=LineRange(start=1, end=2))
+
+
+def test_slice_requires_at_least_one_slice_parameter():
+    with pytest.raises(ValueError, match="requires section, lines, or max_tokens"):
+        slice_note_content(_DOC)
+
+
+# --- slice_note_content: max_tokens ---
+
+
+def test_slice_max_tokens_alone_serves_body_after_frontmatter():
+    sliced = _slice(_DOC, max_tokens=10_000)
+
+    assert sliced.content == "\n".join(_DOC.split("\n")[3:])
+    assert (sliced.start_line, sliced.end_line) == (4, 13)
+    assert not sliced.truncated
+    assert sliced.continue_line is None
+
+
+def test_slice_max_tokens_cuts_at_section_boundary_with_marker():
+    # Body: one small section, then a second section; a budget that fits the
+    # first section but not both must cut exactly at the second heading.
+    doc = "# One\n" + "a" * 40 + "\n# Two\n" + "b" * 400
+    sliced = _slice(doc, max_tokens=20)  # budget: 80 chars
+
+    kept_lines = sliced.content.split("\n")
+    assert kept_lines[-1] == TRUNCATION_MARKER_TEMPLATE.format(max_tokens=20, continue_line=3)
+    assert kept_lines[:-1] == ["# One", "a" * 40]
+    assert sliced.truncated
+    assert sliced.continue_line == 3
+    assert (sliced.start_line, sliced.end_line) == (1, 2)
+
+
+def test_slice_max_tokens_continue_read_reconstructs_document():
+    doc = "# One\n" + "a" * 40 + "\n# Two\n" + "b" * 40
+    sliced = _slice(doc, max_tokens=20)
+    assert sliced.truncated and sliced.continue_line is not None
+
+    remainder = _slice(doc, lines=LineRange(start=sliced.continue_line, end=None))
+
+    kept = "\n".join(sliced.content.split("\n")[:-1])
+    assert kept + "\n" + remainder.content == doc
+
+
+def test_slice_max_tokens_falls_back_to_paragraph_boundary():
+    # No section boundary after the start: the cut lands on the blank line
+    # between paragraphs instead.
+    doc = "# Only\n" + "a" * 40 + "\n\n" + "b" * 400
+    sliced = _slice(doc, max_tokens=20)  # budget: 80 chars
+
+    kept_lines = sliced.content.split("\n")
+    assert kept_lines[:-1] == ["# Only", "a" * 40]
+    assert sliced.truncated
+    assert sliced.continue_line == 3
+
+
+def test_slice_max_tokens_line_backstop_within_one_paragraph():
+    # One giant paragraph: the backstop cuts at the last whole line in budget.
+    doc = "x" * 30 + "\n" + "y" * 30 + "\n" + "z" * 30
+    sliced = _slice(doc, max_tokens=20)  # budget: 80 chars, fits two lines (61)
+
+    kept_lines = sliced.content.split("\n")
+    assert kept_lines[:-1] == ["x" * 30, "y" * 30]
+    assert sliced.continue_line == 3
+
+
+def test_slice_max_tokens_applies_after_section_selection():
+    doc = "# Big\n" + "a" * 40 + "\n\n" + "b" * 400 + "\n# Other\nz"
+    selector = parse_section_selector("Big")
+    assert selector is not None
+
+    sliced = _slice(doc, section=selector, max_tokens=20)
+
+    kept_lines = sliced.content.split("\n")
+    assert kept_lines[:-1] == ["# Big", "a" * 40]
+    assert sliced.section == "Big"
+    assert sliced.truncated
+    assert sliced.continue_line == 3
+    assert sliced.end_line == 2
+
+
+def test_slice_max_tokens_within_budget_is_not_truncated():
+    sliced = _slice("# A\nshort", max_tokens=100)
+
+    assert sliced.content == "# A\nshort"
+    assert not sliced.truncated
+
+
+# --- _token_budget_line_count backstops ---
+
+
+def test_token_budget_no_cut_when_text_fits():
+    assert _token_budget_line_count("short", ["short"], budget_chars=100) is None
+
+
+def test_token_budget_single_over_budget_line_is_served_whole():
+    text = "x" * 500
+    assert _token_budget_line_count(text, [text], budget_chars=10) is None
+
+
+def test_token_budget_keeps_first_line_even_when_it_exceeds_budget():
+    lines = ["x" * 500, "tail"]
+    assert _token_budget_line_count("\n".join(lines), lines, budget_chars=10) == 1

--- a/tests/mcp/test_read_note_request_counts.py
+++ b/tests/mcp/test_read_note_request_counts.py
@@ -270,7 +270,15 @@ async def test_exact_id_helper_does_not_read_resource_for_present_content(
     class EntityReader:
         calls = 0
 
-        async def get_entity(self, entity_id: str) -> EntityResponseV2:
+        async def get_entity(
+            self,
+            entity_id: str,
+            *,
+            section: str | None = None,
+            lines: str | None = None,
+            max_tokens: int | None = None,
+        ) -> EntityResponseV2:
+            assert section is None and lines is None and max_tokens is None
             self.calls += 1
             assert entity_id == ENTITY_ID
             return _entity(content=accepted_content)
@@ -301,7 +309,15 @@ async def test_exact_id_helper_reads_resource_once_only_when_content_is_absent()
     class EntityReader:
         calls = 0
 
-        async def get_entity(self, entity_id: str) -> EntityResponseV2:
+        async def get_entity(
+            self,
+            entity_id: str,
+            *,
+            section: str | None = None,
+            lines: str | None = None,
+            max_tokens: int | None = None,
+        ) -> EntityResponseV2:
+            assert section is None and lines is None and max_tokens is None
             self.calls += 1
             assert entity_id == ENTITY_ID
             return _entity(content=None)
@@ -331,7 +347,15 @@ async def test_exact_id_helper_reads_resource_once_only_when_content_is_absent()
 @pytest.mark.asyncio
 async def test_exact_id_helper_does_not_fabricate_frontmatter_from_entity_metadata() -> None:
     class EntityReader:
-        async def get_entity(self, entity_id: str) -> EntityResponseV2:
+        async def get_entity(
+            self,
+            entity_id: str,
+            *,
+            section: str | None = None,
+            lines: str | None = None,
+            max_tokens: int | None = None,
+        ) -> EntityResponseV2:
+            assert section is None and lines is None and max_tokens is None
             assert entity_id == ENTITY_ID
             return _entity(content="plain body\n")
 

--- a/tests/mcp/test_tool_posix.py
+++ b/tests/mcp/test_tool_posix.py
@@ -130,15 +130,155 @@ async def test_cat_end_line_clamped_to_total(client, test_project):
 
 
 @pytest.mark.asyncio
-async def test_cat_section_not_supported():
-    with pytest.raises(ValueError, match="'section' is not yet supported"):
-        await cat("anything", section="Overview")
+async def test_cat_section_returns_exact_span(client, test_project):
+    await write_note(
+        title="Cat Section Note",
+        directory="test",
+        content="# Guide\nintro\n## First\nalpha\n## Second\nbeta",
+        project=test_project.name,
+    )
+    full = await cat("Cat Section Note", project=test_project.name)
+    full_lines = full["content"].splitlines()
+
+    result = await cat("Cat Section Note", project=test_project.name, section="First")
+
+    assert result["section"] == "Guide/First"
+    assert result["content"].splitlines() == ["## First", "alpha"]
+    assert result["total_lines"] == len(full_lines)
+    # Coordinates are document-absolute: they address the same lines in a
+    # frontmatter-included follow-up range read.
+    assert result["content"] == "\n".join(full_lines[result["start_line"] - 1 : result["end_line"]])
+    # Slices never carry a frontmatter block.
+    assert result["frontmatter"] is None
+    assert "truncated" not in result
+    assert "continue_line" not in result
 
 
 @pytest.mark.asyncio
-async def test_cat_max_tokens_not_supported():
-    with pytest.raises(ValueError, match="'max_tokens' is not yet supported"):
-        await cat("anything", max_tokens=100)
+async def test_cat_section_path_form_disambiguates(client, test_project):
+    await write_note(
+        title="Cat Section Paths",
+        directory="test",
+        content="# Auth\n## Decisions\na\n# Ops\n## Decisions\nb",
+        project=test_project.name,
+    )
+
+    result = await cat("Cat Section Paths", project=test_project.name, section="Ops/Decisions")
+
+    assert result["section"] == "Ops/Decisions"
+    assert result["content"].splitlines() == ["## Decisions", "b"]
+
+
+@pytest.mark.asyncio
+async def test_cat_section_bracket_form_addresses_duplicates(client, test_project):
+    await write_note(
+        title="Cat Section Duplicates",
+        directory="test",
+        content="# Spec\n## Auth\nfirst\n## Auth\nsecond",
+        project=test_project.name,
+    )
+
+    result = await cat("Cat Section Duplicates", project=test_project.name, section="Auth[1]")
+
+    assert result["section"] == "Spec/Auth[1]"
+    assert result["content"].splitlines() == ["## Auth", "second"]
+
+
+@pytest.mark.asyncio
+async def test_cat_unknown_section_lists_available_headings(client, test_project):
+    await write_note(
+        title="Cat Section Missing",
+        directory="test",
+        content="# Guide\n## First\nalpha",
+        project=test_project.name,
+    )
+
+    with pytest.raises(ToolError, match="Available sections") as excinfo:
+        await cat("Cat Section Missing", project=test_project.name, section="Nope")
+    assert "Guide/First" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"section": "A", "start_line": 2}, "cannot be combined with start_line/end_line"),
+        ({"section": "A", "end_line": 3}, "cannot be combined with start_line/end_line"),
+        ({"max_tokens": 0}, "max_tokens must be >= 1"),
+        ({"max_tokens": -5}, "max_tokens must be >= 1"),
+        # A line range with max_tokens is document-absolute (frontmatter included);
+        # include_frontmatter=False ranges are body-relative — mixing the two would
+        # serve frontmatter text despite the opt-out, so the combination is rejected.
+        (
+            {"max_tokens": 5, "start_line": 2, "include_frontmatter": False},
+            "requires include_frontmatter=True",
+        ),
+        (
+            {"max_tokens": 5, "end_line": 3, "include_frontmatter": False},
+            "requires include_frontmatter=True",
+        ),
+    ],
+)
+async def test_cat_rejects_bad_slice_arguments_before_io(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        await cat("anything", **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_cat_max_tokens_truncates_and_resumes(client, test_project):
+    await write_note(
+        title="Cat Token Budget",
+        directory="test",
+        content="# One\n" + "a" * 40 + "\n# Two\n" + "b" * 40,
+        project=test_project.name,
+    )
+    full = await cat("Cat Token Budget", project=test_project.name)
+    full_lines = full["content"].splitlines()
+
+    truncated = await cat("Cat Token Budget", project=test_project.name, max_tokens=20)
+
+    assert truncated["truncated"] is True
+    marker = truncated["content"].splitlines()[-1]
+    assert "truncated at max_tokens=20" in marker
+    assert f"continue with lines={truncated['continue_line']}-" in marker
+    kept_lines = truncated["content"].splitlines()[:-1]
+
+    # Resume flow: a follow-up range read from continue_line returns exactly
+    # the remainder, reconstructing the document body.
+    rest = await cat(
+        "Cat Token Budget",
+        project=test_project.name,
+        start_line=truncated["continue_line"],
+    )
+    assert kept_lines + rest["content"].splitlines() == (full_lines[truncated["start_line"] - 1 :])
+
+
+@pytest.mark.asyncio
+async def test_cat_max_tokens_with_line_range_routes_server_side(client, test_project):
+    await write_note(
+        title="Cat Combined Slice",
+        directory="test",
+        content="alpha\nbravo\ncharlie\ndelta",
+        project=test_project.name,
+    )
+    full = await cat("Cat Combined Slice", project=test_project.name)
+    full_lines = full["content"].splitlines()
+
+    result = await cat(
+        "Cat Combined Slice",
+        project=test_project.name,
+        start_line=2,
+        max_tokens=1000,
+    )
+
+    assert result["content"] == "\n".join(full_lines[1:])
+    assert result["start_line"] == 2
+    assert result["end_line"] == len(full_lines)
+    assert result["total_lines"] == len(full_lines)
+    assert "truncated" not in result
+    # The server-side slice agrees with the client-side range read byte for byte.
+    client_side = await cat("Cat Combined Slice", project=test_project.name, start_line=2)
+    assert result["content"] == client_side["content"]
 
 
 @pytest.mark.asyncio

--- a/tests/repository/test_note_section_repository.py
+++ b/tests/repository/test_note_section_repository.py
@@ -1,0 +1,462 @@
+"""Tests for the NoteSectionRepository and the section index lifecycle."""
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from basic_memory import db
+from basic_memory.index.local_project import (
+    LocalProjectIndexRuntimeFactory,
+    run_local_project_index_for_project,
+)
+from basic_memory.models import Entity, NoteContent, NoteSection, Project
+from basic_memory.repository.note_section_repository import (
+    AcceptedSectionWrite,
+    NoteSectionRepository,
+    heading_path_digest,
+)
+
+
+def _section(
+    heading: str,
+    *,
+    level: int = 2,
+    heading_path: str | None = None,
+    duplicate_index: int = 0,
+    start_line: int = 1,
+    end_line: int = 2,
+    start_offset: int = 0,
+    end_offset: int = 10,
+) -> AcceptedSectionWrite:
+    return AcceptedSectionWrite(
+        heading=heading,
+        level=level,
+        heading_path=heading_path or heading,
+        duplicate_index=duplicate_index,
+        start_line=start_line,
+        end_line=end_line,
+        start_offset=start_offset,
+        end_offset=end_offset,
+    )
+
+
+async def _add_note_content_generation(
+    session_maker: async_sessionmaker[AsyncSession],
+    entity: Entity,
+    *,
+    generation: int,
+) -> None:
+    async with db.scoped_session(session_maker) as session:
+        session.add(
+            NoteContent(
+                entity_id=entity.id,
+                project_id=entity.project_id,
+                external_id=f"content-{entity.external_id}",
+                file_path=entity.file_path,
+                markdown_content="# Current\n",
+                db_version=generation,
+                db_checksum=f"checksum-{generation}",
+                file_write_status="synced",
+            )
+        )
+
+
+def test_heading_path_digest_is_sha256_hex():
+    assert heading_path_digest("Auth/Decisions") == (hashlib.sha256(b"Auth/Decisions").hexdigest())
+
+
+@pytest.mark.asyncio
+async def test_replace_sections_for_current_generation_inserts_rows(
+    sample_entity: Entity,
+    session_maker: async_sessionmaker[AsyncSession],
+):
+    """The current generation replaces the complete scanned section set."""
+    repository = NoteSectionRepository(project_id=sample_entity.project_id)
+    await _add_note_content_generation(session_maker, sample_entity, generation=7)
+
+    writes = [
+        _section("Spec", level=1, start_line=1, end_line=6, start_offset=0, end_offset=60),
+        _section(
+            "Auth",
+            heading_path="Spec/Auth",
+            start_line=2,
+            end_line=6,
+            start_offset=7,
+            end_offset=60,
+        ),
+    ]
+    async with db.scoped_session(session_maker) as session:
+        result = await repository.replace_sections_for_generation(
+            session,
+            entity_id=sample_entity.id,
+            generation=7,
+            sections=writes,
+        )
+
+    assert result.generation_is_current
+    async with db.scoped_session(session_maker) as session:
+        sections = await repository.find_by_entity(session, sample_entity.id)
+
+    assert [section.heading_path for section in sections] == ["Spec", "Spec/Auth"]
+    spec, auth = sections
+    assert spec.project_id == sample_entity.project_id
+    assert (spec.level, spec.start_line, spec.end_line) == (1, 1, 6)
+    assert (spec.start_offset, spec.end_offset) == (0, 60)
+    assert spec.duplicate_index == 0
+    assert spec.heading_path_digest == heading_path_digest("Spec")
+    assert auth.heading_path_digest == heading_path_digest("Spec/Auth")
+
+
+@pytest.mark.asyncio
+async def test_replace_sections_wipes_and_recreates(
+    sample_entity: Entity,
+    session_maker: async_sessionmaker[AsyncSession],
+):
+    """A later replace under the same fence discards every prior row."""
+    repository = NoteSectionRepository(project_id=sample_entity.project_id)
+    await _add_note_content_generation(session_maker, sample_entity, generation=3)
+
+    async with db.scoped_session(session_maker) as session:
+        await repository.replace_sections_for_generation(
+            session,
+            entity_id=sample_entity.id,
+            generation=3,
+            sections=[_section("Old")],
+        )
+    async with db.scoped_session(session_maker) as session:
+        result = await repository.replace_sections_for_generation(
+            session,
+            entity_id=sample_entity.id,
+            generation=3,
+            sections=[_section("New A"), _section("New B", start_line=4, end_line=5)],
+        )
+
+    assert result.generation_is_current
+    async with db.scoped_session(session_maker) as session:
+        sections = await repository.find_by_entity(session, sample_entity.id)
+    assert [section.heading for section in sections] == ["New A", "New B"]
+
+
+@pytest.mark.asyncio
+async def test_replace_sections_empty_set_wipes_stale_rows(
+    sample_entity: Entity,
+    session_maker: async_sessionmaker[AsyncSession],
+):
+    """An empty desired set is a legitimate current-generation wipe."""
+    repository = NoteSectionRepository(project_id=sample_entity.project_id)
+    await _add_note_content_generation(session_maker, sample_entity, generation=5)
+    async with db.scoped_session(session_maker) as session:
+        await repository.replace_sections_for_generation(
+            session,
+            entity_id=sample_entity.id,
+            generation=5,
+            sections=[_section("Stale")],
+        )
+
+    async with db.scoped_session(session_maker) as session:
+        result = await repository.replace_sections_for_generation(
+            session,
+            entity_id=sample_entity.id,
+            generation=5,
+            sections=[],
+        )
+
+    assert result.generation_is_current
+    async with db.scoped_session(session_maker) as session:
+        assert await repository.find_by_entity(session, sample_entity.id) == []
+
+
+@pytest.mark.asyncio
+async def test_replace_sections_for_stale_generation_is_noop(
+    sample_entity: Entity,
+    session_maker: async_sessionmaker[AsyncSession],
+):
+    """A stale fence cannot delete the current rows or insert its desired set."""
+    repository = NoteSectionRepository(project_id=sample_entity.project_id)
+    await _add_note_content_generation(session_maker, sample_entity, generation=8)
+    async with db.scoped_session(session_maker) as session:
+        await repository.replace_sections_for_generation(
+            session,
+            entity_id=sample_entity.id,
+            generation=8,
+            sections=[_section("Current")],
+        )
+
+    async with db.scoped_session(session_maker) as session:
+        result = await repository.replace_sections_for_generation(
+            session,
+            entity_id=sample_entity.id,
+            generation=7,
+            sections=[_section("Stale")],
+        )
+
+    assert not result.generation_is_current
+    async with db.scoped_session(session_maker) as session:
+        sections = await repository.find_by_entity(session, sample_entity.id)
+    assert [section.heading for section in sections] == ["Current"]
+
+
+@pytest.mark.asyncio
+async def test_find_by_entity_orders_by_start_line(
+    sample_entity: Entity,
+    session_maker: async_sessionmaker[AsyncSession],
+):
+    repository = NoteSectionRepository(project_id=sample_entity.project_id)
+    await _add_note_content_generation(session_maker, sample_entity, generation=2)
+
+    async with db.scoped_session(session_maker) as session:
+        await repository.replace_sections_for_generation(
+            session,
+            entity_id=sample_entity.id,
+            generation=2,
+            sections=[
+                _section("Late", start_line=9, end_line=10),
+                _section("Early", start_line=1, end_line=8),
+                _section("Middle", start_line=4, end_line=8),
+            ],
+        )
+
+    async with db.scoped_session(session_maker) as session:
+        sections = await repository.find_by_entity(session, sample_entity.id)
+    assert [section.heading for section in sections] == ["Early", "Middle", "Late"]
+
+
+@pytest.mark.asyncio
+async def test_lookup_by_digest_and_duplicate_index(
+    sample_entity: Entity,
+    session_maker: async_sessionmaker[AsyncSession],
+):
+    """The lookup index addresses one span by (entity, path digest, duplicate)."""
+    repository = NoteSectionRepository(project_id=sample_entity.project_id)
+    await _add_note_content_generation(session_maker, sample_entity, generation=4)
+
+    async with db.scoped_session(session_maker) as session:
+        await repository.replace_sections_for_generation(
+            session,
+            entity_id=sample_entity.id,
+            generation=4,
+            sections=[
+                _section("Auth", heading_path="Spec/Auth", start_line=2, end_line=3),
+                _section(
+                    "Auth",
+                    heading_path="Spec/Auth",
+                    duplicate_index=1,
+                    start_line=4,
+                    end_line=5,
+                ),
+            ],
+        )
+
+    async with db.scoped_session(session_maker) as session:
+        query = repository.select().filter(
+            NoteSection.entity_id == sample_entity.id,
+            NoteSection.heading_path_digest == heading_path_digest("Spec/Auth"),
+            NoteSection.duplicate_index == 1,
+        )
+        result = await repository.execute_query(session, query)
+        second_auth = result.scalar_one()
+
+    assert (second_auth.start_line, second_auth.end_line) == (4, 5)
+
+
+@pytest.mark.asyncio
+async def test_replace_sections_is_project_scoped(
+    sample_entity: Entity,
+    session_maker: async_sessionmaker[AsyncSession],
+):
+    """A repository cannot claim another project's note_content fence."""
+    del sample_entity
+    async with db.scoped_session(session_maker) as session:
+        other_project = Project(
+            name="other-section-project",
+            permalink="other-section-project",
+            path="/other-section-project",
+        )
+        session.add(other_project)
+        await session.flush()
+        other_entity = Entity(
+            project_id=other_project.id,
+            title="Other",
+            note_type="note",
+            permalink="other-sectioned",
+            file_path="other-sectioned.md",
+            content_type="text/markdown",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        session.add(other_entity)
+        await session.flush()
+        session.add(
+            NoteContent(
+                entity_id=other_entity.id,
+                project_id=other_project.id,
+                external_id=f"content-{other_entity.external_id}",
+                file_path=other_entity.file_path,
+                markdown_content="# Other\n",
+                db_version=2,
+                db_checksum="other-checksum",
+                file_write_status="synced",
+            )
+        )
+        other_project_id = other_project.id
+        other_entity_id = other_entity.id
+
+    foreign_repository = NoteSectionRepository(project_id=other_project_id + 1000)
+    async with db.scoped_session(session_maker) as session:
+        result = await foreign_repository.replace_sections_for_generation(
+            session,
+            entity_id=other_entity_id,
+            generation=2,
+            sections=[_section("Hijack")],
+        )
+
+    assert not result.generation_is_current
+    owning_repository = NoteSectionRepository(project_id=other_project_id)
+    async with db.scoped_session(session_maker) as session:
+        assert await owning_repository.find_by_entity(session, other_entity_id) == []
+
+
+@pytest.mark.asyncio
+async def test_entity_delete_cascades_section_rows(
+    sample_entity: Entity,
+    entity_repository,
+    session_maker: async_sessionmaker[AsyncSession],
+):
+    """Sections are removed with their entity (ORM cascade + DB FK)."""
+    repository = NoteSectionRepository(project_id=sample_entity.project_id)
+    await _add_note_content_generation(session_maker, sample_entity, generation=1)
+    async with db.scoped_session(session_maker) as session:
+        await repository.replace_sections_for_generation(
+            session,
+            entity_id=sample_entity.id,
+            generation=1,
+            sections=[_section("Doomed")],
+        )
+
+    async with db.scoped_session(session_maker) as session:
+        assert await entity_repository.delete(session, sample_entity.id)
+
+    async with db.scoped_session(session_maker) as session:
+        rows = (
+            (
+                await session.execute(
+                    select(NoteSection).where(NoteSection.entity_id == sample_entity.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_long_heading_path_row_inserts_under_digest_guard(
+    sample_entity: Entity,
+    session_maker: async_sessionmaker[AsyncSession],
+):
+    """Arbitrary heading text persists: only the fixed-width digest is indexed.
+
+    A >3KB path would overflow PostgreSQL's btree index-row limit if the lookup
+    index keyed on the raw path (the Observation.permalink incident class).
+    """
+    repository = NoteSectionRepository(project_id=sample_entity.project_id)
+    await _add_note_content_generation(session_maker, sample_entity, generation=6)
+    long_heading = "H" * 3200
+    long_path = f"Parent/{long_heading}"
+
+    async with db.scoped_session(session_maker) as session:
+        result = await repository.replace_sections_for_generation(
+            session,
+            entity_id=sample_entity.id,
+            generation=6,
+            sections=[_section(long_heading, heading_path=long_path, start_line=2, end_line=3)],
+        )
+
+    assert result.generation_is_current
+    async with db.scoped_session(session_maker) as session:
+        sections = await repository.find_by_entity(session, sample_entity.id)
+    assert sections[0].heading_path == long_path
+    assert len(sections[0].heading_path_digest) == 64
+
+
+# --- Index lifecycle: rows appear on index, rebuild on reindex ---
+
+_SECTIONED_NOTE_V1 = """---
+type: note
+title: Sectioned
+---
+# Spec
+intro
+## Auth
+first
+## Auth
+second
+"""
+
+_SECTIONED_NOTE_V2 = """---
+type: note
+title: Sectioned
+---
+# Spec
+intro
+## Ops
+runbook
+"""
+
+
+@pytest.mark.asyncio
+async def test_project_index_builds_and_rebuilds_section_rows(
+    app_config,
+    session_maker: async_sessionmaker[AsyncSession],
+    test_project,
+    project_config,
+    entity_repository,
+):
+    """A full project index populates note_section; reindexing rebuilds it."""
+    del app_config
+    note_path = Path(project_config.home) / "sectioned.md"
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+    note_path.write_text(_SECTIONED_NOTE_V1, encoding="utf-8")
+
+    indexed = await run_local_project_index_for_project(
+        test_project,
+        runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+        force_full=True,
+    )
+    assert indexed.enqueued_files == 1
+
+    repository = NoteSectionRepository(project_id=test_project.id)
+    async with db.scoped_session(session_maker) as session:
+        entity = await entity_repository.get_by_file_path(session, "sectioned.md")
+        assert entity is not None
+        sections = await repository.find_by_entity(session, entity.id)
+
+    assert [(section.heading_path, section.duplicate_index) for section in sections] == [
+        ("Spec", 0),
+        ("Spec/Auth", 0),
+        ("Spec/Auth", 1),
+    ]
+    spec = sections[0]
+    assert spec.level == 1
+    assert spec.start_line == 1
+    assert spec.start_offset == 0
+    assert spec.end_offset > spec.start_offset
+
+    # Reindex after an edit: the derived rows converge to the new body.
+    note_path.write_text(_SECTIONED_NOTE_V2, encoding="utf-8")
+    await run_local_project_index_for_project(
+        test_project,
+        runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+        force_full=True,
+    )
+
+    async with db.scoped_session(session_maker) as session:
+        entity = await entity_repository.get_by_file_path(session, "sectioned.md")
+        assert entity is not None
+        sections = await repository.find_by_entity(session, entity.id)
+
+    assert [section.heading_path for section in sections] == ["Spec", "Spec/Ops"]

--- a/tests/test_note_section_migration.py
+++ b/tests/test_note_section_migration.py
@@ -1,0 +1,90 @@
+"""Migration tests for the note_section table (SPEC-47 / #1403)."""
+
+import sqlite3
+
+from alembic import command
+
+from tests.test_note_content_migration import sqlite_alembic_config
+
+
+def test_alembic_upgrade_creates_note_section_table(tmp_path, monkeypatch):
+    """Running Alembic head creates note_section with its expected contract."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BASIC_MEMORY_HOME", str(tmp_path / "basic-memory"))
+
+    database_path = tmp_path / "note-section-migration.db"
+    command.upgrade(sqlite_alembic_config(database_path), "head")
+
+    connection = sqlite3.connect(database_path)
+    try:
+        columns = {
+            row[1] for row in connection.execute("PRAGMA table_info(note_section)").fetchall()
+        }
+        assert columns == {
+            "id",
+            "project_id",
+            "entity_id",
+            "heading",
+            "level",
+            "heading_path",
+            "heading_path_digest",
+            "duplicate_index",
+            "start_line",
+            "end_line",
+            "start_offset",
+            "end_offset",
+        }
+
+        foreign_keys = connection.execute("PRAGMA foreign_key_list(note_section)").fetchall()
+        entity_fk = next(row for row in foreign_keys if row[3] == "entity_id")
+        project_fk = next(row for row in foreign_keys if row[3] == "project_id")
+        assert entity_fk[2] == "entity"
+        assert entity_fk[4] == "id"
+        # Sections are removed with their entity at the database level.
+        assert entity_fk[6].upper() == "CASCADE"
+        assert project_fk[2] == "project"
+        assert project_fk[4] == "id"
+
+        indexes = {
+            row[1] for row in connection.execute("PRAGMA index_list(note_section)").fetchall()
+        }
+        assert "ix_note_section_project_id" in indexes
+        assert "ix_note_section_entity_id" in indexes
+        assert "ix_note_section_entity_path" in indexes
+        lookup_columns = [
+            row[2]
+            for row in connection.execute(
+                "PRAGMA index_info(ix_note_section_entity_path)"
+            ).fetchall()
+        ]
+        assert lookup_columns == ["entity_id", "heading_path_digest", "duplicate_index"]
+
+        duplicate_default = next(
+            row
+            for row in connection.execute("PRAGMA table_info(note_section)").fetchall()
+            if row[1] == "duplicate_index"
+        )
+        assert duplicate_default[4] == "0"
+    finally:
+        connection.close()
+
+
+def test_alembic_downgrade_drops_note_section_table(tmp_path, monkeypatch):
+    """Downgrading one revision removes the table and its indexes."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BASIC_MEMORY_HOME", str(tmp_path / "basic-memory"))
+
+    database_path = tmp_path / "note-section-downgrade.db"
+    config = sqlite_alembic_config(database_path)
+    command.upgrade(config, "head")
+    command.downgrade(config, "-1")
+
+    connection = sqlite3.connect(database_path)
+    try:
+        table_exists = connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'note_section'"
+        ).fetchone()
+    finally:
+        connection.close()
+
+    assert table_exists is None


### PR DESCRIPTION
## Why

SPEC-47 component 1 — the highest-leverage piece of the POSIX surface (#1398): section indexing makes `cat --section` / `max_tokens` real, so the token-savings claim becomes measurable instead of assumed. Stacked on #1406 (`1399-posix-tools`), whose `cat` shipped these params as a clear not-yet-supported error.

Closes #1403.

## What changed

- **`markdown/sections.py`** — section-boundary scanner: heading text/level/path, start/end line **and byte offsets** against the original bytes, duplicate index; a section ends at the next heading of same-or-higher level. Line boundaries follow markdown-it's terminator rule (`\r\n | \r | \n`) so scanner and tokenizer can never disagree on line numbers.
- **`models/knowledge.py` + migration** — `note_section` table keyed `(entity_id, heading_path_digest, duplicate_index)`; sha256 digest keys the lookup index because arbitrary heading text can exceed Postgres's btree index-row limit (same constraint as `Observation.permalink`). Content is not duplicated — sections are an index into the canonical file. Rows rebuild on every (re)index and die with the entity.
- **Indexing wiring** — sections persist through the accepted-write path (`AcceptedSectionWrite`, matching the observation-write shape) and the file indexer.
- **API** — note reads gain `section=` (path form `Parent/Child`, bracket form `Heading[1]` for duplicates; unknown section → error listing available headings), `lines=N-M`, and `max_tokens=` (truncation at section > paragraph boundary with an explicit ellipsis marker).
- **MCP** — `cat`'s `section`/`max_tokens` go live, replacing the stub error; tests updated.

## Review catches worth knowing about

The adversarial review found a genuine **must-fix**: lone `\r` line endings (real-world pasted terminal/Excel content) desynced the scanner from markdown-it's token line map — notes like `"# One\ralpha\r# Two"` raised `IndexError` on *every* parse, making them unwritable and unindexable, and near-miss cases served the wrong section silently. Fixed by adopting markdown-it's own terminator rule, with regression tests for the crash path, the silent-wrong-section path, and CRLF byte-offset round-tripping.

Also fixed (should-fix): `cat` with `include_frontmatter=False` + `max_tokens` + a line range mixed two coordinate systems (body-relative client slicing vs document-absolute server ranges) and could serve frontmatter despite the opt-out — now rejected explicitly with a clear error, keeping one coordinate system per read.

## Known follow-ups (not in this PR)

- `scan_sections` adds a second markdown-it tokenization per parse in the sync hot path (linear; the sync benchmark should confirm it's noise — flagged for a benchmark run before/after merge).
- Headings literally containing `/` collide with the equivalent nested path in the stored digest key; the read path is immune, and the limitation is documented at the digest function for future table consumers.
- Deep links (`memory://note#section`), schema `required_sections`, and section-aware search snippets are the free wins that land separately per the tracker.

## Verification

- ruff check / format — clean; `ty check` (milvus extra) — clean
- `tests/markdown` + `tests/repository` — 1081 passed; `tests/mcp` — 986 passed; changed API test files — 103 passed; migration + indexing + cloud/index tests — 142 passed
- Migration applies on both SQLite and Postgres paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp
