### PR TITLE
feat(core): add agent-task eval harness for tool-surface comparison

### DIFF
--- a/benchmarks/AGENTS.md
+++ b/benchmarks/AGENTS.md
@@ -44,6 +44,10 @@ Run end-to-end QA scoring:
 BEAM nugget scoring (post-hoc, after `run qa` on a BEAM run):
 - `uv run bm-bench run beam-score --run-dir benchmarks/runs/<run-id> --judge claude:claude-sonnet-4-6`
 
+Agent-task eval (rich vs POSIX tool surfaces, issue #1401; see docs/benchmarks.md 6c):
+- `uv run bm-bench run agent-tasks --surfaces rich,posix --model openai-compat:<model>@<base_url> --bm-local-path <bm-checkout>`
+- `BM_LOCAL_PATH=.. just bench-agent-smoke` (LLM-free scripted smoke)
+
 Validate and publish:
 - `uv run bm-bench validate-artifacts --run-dir benchmarks/runs/<run-id>`
 - `uv run bm-bench publish --run-dir benchmarks/runs/<run-id> --destination benchmarks/results/public`

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/architecture/api-design-decisions.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/architecture/api-design-decisions.md
@@ -1,0 +1,21 @@
+---
+title: API Design Decisions
+type: note
+tags: [api, architecture]
+status: published
+priority: high
+confidence: 0.3
+---
+
+# API Design Decisions
+
+Running record of decisions that shape the public API.
+
+## Observations
+
+- [decision] All list endpoints paginate with opaque cursors
+- [decision] Cache invalidation is event-driven, not TTL-only
+
+## Relations
+
+- depends_on [[Redis Cache Architecture]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/architecture/oauth-migration-plan.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/architecture/oauth-migration-plan.md
@@ -1,0 +1,22 @@
+---
+title: OAuth Migration Plan
+type: note
+tags: [oauth, migration]
+status: draft
+review:
+  status: done
+---
+
+# OAuth Migration Plan
+
+Cutover plan from the legacy session cookies to OAuth. Review finished;
+waiting on the token design to settle before scheduling.
+
+## Observations
+
+- [plan] Dual-issue cookies and tokens for two release cycles
+- [risk] Mobile clients pin the old auth host
+
+## Relations
+
+- relates_to [[OAuth Token Design]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/architecture/oauth-token-design.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/architecture/oauth-token-design.md
@@ -1,0 +1,23 @@
+---
+title: OAuth Token Design
+type: note
+tags: [oauth, security, architecture]
+status: draft
+priority: high
+confidence: 0.85
+review:
+  status: pending
+---
+
+# OAuth Token Design
+
+Token lifetimes and rotation for the OAuth flow. Still in review.
+
+## Observations
+
+- [design] Access tokens are 15-minute JWTs; refresh tokens rotate on use
+- [security] Refresh token reuse triggers whole-family revocation
+
+## Relations
+
+- relates_to [[API Design Decisions]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/architecture/redis-cache-architecture.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/architecture/redis-cache-architecture.md
@@ -1,0 +1,22 @@
+---
+title: Redis Cache Architecture
+type: note
+tags: [redis, architecture, caching]
+status: published
+priority: high
+confidence: 0.6
+---
+
+# Redis Cache Architecture
+
+How the read-through Redis cache fronts the entity API.
+
+## Observations
+
+- [design] Read-through cache with a 15 minute TTL on entity payloads
+- [constraint] Eviction must never outlive the session token lifetime
+- [metric] Cache hit rate holds at 92 percent in staging
+
+## Relations
+
+- relates_to [[API Design Decisions]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/man3/edit-note-3.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/man3/edit-note-3.md
@@ -1,0 +1,47 @@
+---
+title: edit-note(3)
+type: manpage
+section: 3
+name: edit-note
+summary: 'edit a note in place: append, prepend, find/replace, or section surgery'
+---
+
+# edit-note(3)
+
+## NAME
+
+**edit-note** — edit a note in place: append, prepend, find/replace, or
+section surgery. This is the tool for incremental note edits.
+
+## SYNOPSIS
+
+```
+edit_note(identifier, operation, content, project=None, section=None,
+          find_text=None, expected_replacements=None)
+```
+
+## DESCRIPTION
+
+Modifies an existing note without rewriting the whole file. Operations:
+
+- **append** / **prepend** — add content at the end or start
+- **find_replace** — replace occurrences of `find_text` with `content`
+- **replace_section** — replace everything under a markdown heading
+- **insert_before_section** / **insert_after_section** — insert around a heading
+
+Unlike read-note(3), the identifier must be an **exact** title, permalink, or
+memory:// URL — there is no fuzzy fallback for edits.
+
+## EXAMPLES
+
+Append an observation (this example carries the token BMEVAL-man-edit-7f3e):
+
+```
+edit_note("notes/redis-cache-tuning", operation="append",
+          content="- [tuning] observed hit rate after the change")
+```
+
+## Relations
+
+- see_also [[search-notes(3)]]
+- see_also [[read-note(3)]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/man3/read-note-3.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/man3/read-note-3.md
@@ -1,0 +1,36 @@
+---
+title: read-note(3)
+type: manpage
+section: 3
+name: read-note
+summary: read a note by title, permalink, or memory:// URL
+---
+
+# read-note(3)
+
+## NAME
+
+**read-note** — read a note by title, permalink, or memory:// URL.
+
+## SYNOPSIS
+
+```
+read_note(identifier, project=None, page=1, page_size=10)
+```
+
+## DESCRIPTION
+
+Returns the full markdown of one note with knowledge-graph context. The
+identifier resolves fuzzily: an exact permalink wins, then title match.
+For in-place changes use edit-note(3); for discovery use search-notes(3).
+
+## EXAMPLES
+
+```
+read_note("specs/spec-9-search-rework")
+```
+
+## Relations
+
+- see_also [[edit-note(3)]]
+- see_also [[search-notes(3)]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/man3/search-notes-3.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/man3/search-notes-3.md
@@ -1,0 +1,38 @@
+---
+title: search-notes(3)
+type: manpage
+section: 3
+name: search-notes
+summary: full-text and metadata search across the knowledge base
+---
+
+# search-notes(3)
+
+## NAME
+
+**search-notes** — full-text and metadata search across the knowledge base.
+
+## SYNOPSIS
+
+```
+search_notes(query, project=None, page=1, page_size=10,
+             search_type="text", metadata_filters=None, after_date=None)
+```
+
+## DESCRIPTION
+
+Searches note titles, content, observations, and frontmatter metadata.
+`metadata_filters` accepts equality, `$in`, `$gt`/`$gte`/`$lt`/`$lte`,
+`$between`, and dot-notation nested keys. Whole-note reads belong to
+read-note(3); this page only finds them.
+
+## EXAMPLES
+
+```
+search_notes(query="cache", metadata_filters={"status": "active"})
+```
+
+## Relations
+
+- see_also [[edit-note(3)]]
+- see_also [[read-note(3)]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/coffee-brewing-log.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/coffee-brewing-log.md
@@ -1,0 +1,14 @@
+---
+title: Coffee Brewing Log
+type: note
+tags: [coffee, personal]
+---
+
+# Coffee Brewing Log
+
+Personal brewing experiments; nothing to do with the codebase.
+
+## Observations
+
+- [method] The 1:16 pour-over ratio beat last month's 1:15 batch BMEVAL-oldnote2-8e7d
+- [preference] Ethiopian naturals taste best around day 12 off roast

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/feature-x.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/feature-x.md
@@ -1,0 +1,19 @@
+---
+title: Feature X
+type: note
+tags: [feature, planning]
+status: active
+priority: low
+---
+
+# Feature X
+
+Planned burst-quota feature for the public API. Depends on the limiter chain.
+
+## Observations
+
+- [plan] Ship behind a flag once the limiter chain is proven in staging
+
+## Relations
+
+- relates_to [[Rate Limiter]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/kubernetes-migration.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/kubernetes-migration.md
@@ -1,0 +1,21 @@
+---
+title: Kubernetes Migration
+type: note
+tags: [infra, kubernetes]
+status: active
+priority: high
+confidence: 0.7
+---
+
+# Kubernetes Migration
+
+Move the API workloads from the legacy VMs onto the managed cluster.
+
+## Observations
+
+- [plan] Stateless services move first; the index workers follow
+- [risk] Node-local disk assumptions in the sync watcher
+
+## Relations
+
+- relates_to [[2026-08-27 Infra Notes]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/oauth-rollout-notes.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/oauth-rollout-notes.md
@@ -1,0 +1,19 @@
+---
+title: OAuth Rollout Notes
+type: note
+tags: [oauth, rollout]
+status: published
+---
+
+# OAuth Rollout Notes
+
+Field notes from the staged OAuth rollout.
+
+## Observations
+
+- [note] Staging tenants migrated without a single forced re-login
+- [note] Token refresh volume peaks at the top of each hour
+
+## Relations
+
+- relates_to [[OAuth Migration Plan]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/postgres-vacuum-notes.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/postgres-vacuum-notes.md
@@ -1,0 +1,17 @@
+---
+title: Postgres Vacuum Notes
+type: note
+tags: [postgres, maintenance]
+status: active
+priority: low
+---
+
+# Postgres Vacuum Notes
+
+The old tracker labelled this "priority: high" in its free-text field, but the
+frontmatter above records the real triage priority after we measured the bloat.
+
+## Observations
+
+- [note] Autovacuum stalls on the events table during bulk imports
+- [note] A manual VACUUM ANALYZE after imports keeps bloat under 10 percent

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/rate-limiter.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/rate-limiter.md
@@ -1,0 +1,17 @@
+---
+title: Rate Limiter
+type: note
+tags: [api, limits]
+---
+
+# Rate Limiter
+
+Sliding-window limiter in front of the public API.
+
+## Observations
+
+- [design] Sliding window keyed by API token, evaluated at the edge
+
+## Relations
+
+- depends_on [[Redis Quota Store]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/redis-cache-tuning.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/redis-cache-tuning.md
@@ -1,0 +1,17 @@
+---
+title: Redis Cache Tuning
+type: note
+tags: [redis, caching, performance]
+status: active
+priority: low
+---
+
+# Redis Cache Tuning
+
+Tuning follow-ups for the Redis cache described in the cache architecture
+document. Not yet linked into the graph.
+
+## Observations
+
+- [tuning] maxmemory-policy allkeys-lru beat volatile-lru in the replay test
+- [tuning] Raising the TTL past 15 minutes gave no additional hit-rate gain

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/redis-quota-store.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/notes/redis-quota-store.md
@@ -1,0 +1,18 @@
+---
+title: Redis Quota Store
+type: note
+tags: [redis, quotas]
+---
+
+# Redis Quota Store
+
+Counter storage backing the rate limiter.
+
+## Observations
+
+- [constraint] Quota counters must fit a single Redis hash slot BMEVAL-quota-fa11
+- [design] A Lua script increments and expires each counter atomically
+
+## Relations
+
+- relates_to [[Redis Cache Architecture]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/schemas/task.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/schemas/task.md
@@ -1,0 +1,32 @@
+---
+title: Task
+type: schema
+entity: Task
+version: 1
+schema:
+  description: string, what needs to be done
+  status?(enum, current state): [active, blocked, done, abandoned]
+  assigned_to?: string, who is working on this
+  steps?(array): string, ordered steps to complete
+  current_step?: integer, which step number we're on (1-indexed)
+  context?: string, key context needed to resume after memory loss
+  started?: string, when work began
+  completed?: string, when work finished
+  blockers?(array): string, what's preventing progress
+  parent_task?: Task, parent task if this is a subtask
+settings:
+  validation: warn
+---
+
+# Task
+
+A **Task** is work-in-progress tracked as a note, so it survives context
+compaction and shows up in the next session's brief.
+
+Put queryable fields (`status`, `current_step`) in frontmatter so metadata
+filters can find them. `type` is stored as lowercase `task` in frontmatter.
+New tasks start at `current_step: 1` with `status: active`.
+
+## Relations
+
+- example [[Migrate CI to uv]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/specs/spec-8-sync-rework.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/specs/spec-8-sync-rework.md
@@ -1,0 +1,23 @@
+---
+title: SPEC-8 Sync Rework
+type: note
+tags: [sync, spec]
+status: active
+priority: low
+confidence: 0.55
+---
+
+# SPEC-8 Sync Rework
+
+Earlier rework of the file-sync loop. Parked while SPEC-9 lands; the open
+items below are stale but intentionally kept for the record.
+
+## Observations
+
+- [open] Sync conflict banner still flickers on slow volumes BMEVAL-s8open-1f2e
+- [next] Draft the debounce redesign note BMEVAL-s8next-c9a4
+- [status] Parked in favor of the search rework; untouched for a month BMEVAL-oldnote1-2b3c
+
+## Relations
+
+- superseded_by [[SPEC-9 Search Rework]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/specs/spec-9-search-rework.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/specs/spec-9-search-rework.md
@@ -1,0 +1,24 @@
+---
+title: SPEC-9 Search Rework
+type: note
+tags: [search, spec]
+status: active
+priority: critical
+confidence: 0.92
+---
+
+# SPEC-9 Search Rework
+
+Rework the search pipeline so ranking quality stops depending on FTS5 quirks.
+This is the active spec; session worklogs carry the running state.
+
+## Observations
+
+- [goal] Replace the legacy FTS query planner with a two-stage ranking pass
+- [decision] Keep SQLite FTS5 as the first stage; rescoring happens in Python
+- [status] Session 2 captured the current open items and the next step
+
+## Relations
+
+- has_session [[2026-08-20 SPEC-9 Session 1]]
+- has_session [[2026-08-27 SPEC-9 Session 2]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/tasks/migrate-ci-to-uv.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/tasks/migrate-ci-to-uv.md
@@ -1,0 +1,23 @@
+---
+title: Migrate CI to uv
+type: task
+status: active
+steps:
+  - Inventory pip usages across the workflows
+  - Rewrite the test workflow around uv sync BMEVAL-ci-step2-51aa
+  - Delete the requirements lockfiles and verify deploy
+current_step: 2
+context: CI migration to uv; wheel cache is keyed on uv.lock BMEVAL-ci-ctx-90bf
+started: '2026-08-25'
+---
+
+# Migrate CI to uv
+
+## Observations
+
+- [status] Step 1 complete; the workflow rewrite is in review
+
+## Relations
+
+- instance_of [[Task]]
+- relates_to [[2026-08-27 Infra Notes]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/tasks/refactor-search-index.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/tasks/refactor-search-index.md
@@ -1,0 +1,21 @@
+---
+title: Refactor Search Index
+type: task
+status: active
+steps:
+  - Extract the index writer behind a protocol BMEVAL-rsi-step1-6d21
+  - Move the FTS triggers into migrations
+current_step: 1
+context: Search index refactor groundwork for the search rework BMEVAL-rsi-ctx-33cd
+started: '2026-07-30'
+---
+
+# Refactor Search Index
+
+## Observations
+
+- [status] Not started beyond groundwork reading
+
+## Relations
+
+- relates_to [[SPEC-9 Search Rework]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/tasks/upgrade-flyio.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/tasks/upgrade-flyio.md
@@ -1,0 +1,19 @@
+---
+title: Upgrade Fly.io Runtime
+type: task
+status: blocked
+context: Fly.io machine runtime upgrade for the workers
+blockers:
+  - Waiting on the platform capacity review BMEVAL-blocked-cd34
+started: '2026-08-10'
+---
+
+# Upgrade Fly.io Runtime
+
+## Observations
+
+- [status] Blocked on the platform team
+
+## Relations
+
+- relates_to [[2026-08-27 Infra Notes]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/tasks/write-release-notes.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/tasks/write-release-notes.md
@@ -1,0 +1,18 @@
+---
+title: Write Release Notes
+type: task
+status: done
+context: Release notes for the v2.4 release BMEVAL-done-ab12
+started: '2026-08-18'
+completed: '2026-08-20'
+---
+
+# Write Release Notes
+
+## Observations
+
+- [status] Shipped with the v2.4 tag
+
+## Relations
+
+- relates_to [[Migrate CI to uv]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/worklog/2026-08-20-spec-9-session-1.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/worklog/2026-08-20-spec-9-session-1.md
@@ -1,0 +1,21 @@
+---
+title: 2026-08-20 SPEC-9 Session 1
+type: note
+tags: [worklog, spec-9]
+status: draft
+---
+
+# 2026-08-20 SPEC-9 Session 1
+
+First working session on the search rework.
+
+## Observations
+
+- [progress] Mapped the legacy query planner call graph end to end
+- [blocker] Rescoring prototype was slower than raw FTS5 on long queries
+- [context] Infra scheduling may collide with the cluster move
+
+## Relations
+
+- part_of [[SPEC-9 Search Rework]]
+- mentions [[Kubernetes Migration]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/worklog/2026-08-27-infra-notes.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/worklog/2026-08-27-infra-notes.md
@@ -1,0 +1,18 @@
+---
+title: 2026-08-27 Infra Notes
+type: note
+tags: [worklog, infra]
+---
+
+# 2026-08-27 Infra Notes
+
+Infra housekeeping from the same working day as the SPEC-9 session.
+
+## Observations
+
+- [note] CI runners moved to the larger instance size
+- [note] Search index rebuild time dropped 40 percent after the runner upgrade
+
+## Relations
+
+- relates_to [[SPEC-9 Search Rework]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/corpus/worklog/2026-08-27-spec-9-session-2.md
+++ b/benchmarks/benchmarks/datasets/agent-tasks/corpus/worklog/2026-08-27-spec-9-session-2.md
@@ -1,0 +1,21 @@
+---
+title: 2026-08-27 SPEC-9 Session 2
+type: note
+tags: [worklog, spec-9]
+status: draft
+---
+
+# 2026-08-27 SPEC-9 Session 2
+
+Latest session on the search rework; this note carries the live state.
+
+## Observations
+
+- [open] Rescoring pass still misses quoted phrases BMEVAL-s9open1-4c1a
+- [open] Snippet highlighting drops emphasis inside code spans BMEVAL-s9open2-9d2b
+- [open] Benchmark harness needs a cold-cache mode BMEVAL-s9open3-77e0
+- [next] Wire the rescorer behind the search flag and rerun the suite BMEVAL-s9next-b881
+
+## Relations
+
+- part_of [[SPEC-9 Search Rework]]

--- a/benchmarks/benchmarks/datasets/agent-tasks/smoke-script.json
+++ b/benchmarks/benchmarks/datasets/agent-tasks/smoke-script.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "LLM-free smoke script for `just bench-agent-smoke`. It deliberately knows the curate-orphans answer: the smoke proves harness plumbing (session, dispatch, settle, grading, artifacts), not model quality.",
+  "tasks": {
+    "orphan notes": [
+      {
+        "tool_calls": [
+          {
+            "name": "search_notes",
+            "arguments": {"query": "redis", "project": "{project}"}
+          }
+        ]
+      },
+      {
+        "text": "The orphan notes are listed below.\n```json\n{\"permalinks\": [\"notes/redis-cache-tuning\", \"notes/postgres-vacuum-notes\", \"notes/coffee-brewing-log\"]}\n```"
+      }
+    ]
+  }
+}

--- a/benchmarks/docs/benchmarks.md
+++ b/benchmarks/docs/benchmarks.md
@@ -322,6 +322,116 @@ Adapted from `mohammadtavakoli78/BEAM` (MIT code / CC BY-SA 4.0 data):
   paper's tables); the HF materialization script and `chat.pickle` (the
   repo's JSON layout is read directly); the 10M tier.
 
+## 6c) Agent-task eval (rich vs POSIX tool surfaces, issue #1401)
+
+An AGENT-IN-THE-LOOP run kind: the same model, budget, task set, and seeded
+corpus, with the TOOL SURFACE as the provider axis — `rich` (today's MCP
+tools) vs `posix` (the `cat`/`grep`/`ls`/`find`/`tail`/`man` read surface from
+#1399/#1406). The model proposes tool calls; the harness dispatches them
+against an ephemeral per-surface `bm mcp` stdio instance, feeds results back,
+and grades the final answer plus the resulting project state.
+
+### Headline: tokens per completed task (xAFS framing)
+
+The question is not "which surface is more accurate" but "what does a
+completed memory task COST through each surface". The headline is
+`(total agent tokens over ALL attempted tasks) / (tasks completed)` — `n/a`
+(never 0) when nothing completed. Accuracy (pass rate), tool-call count,
+turns, and wall time are always reported alongside; the report renders them
+in one table so accuracy can never appear alone. Judge tokens (if a judge is
+configured) are accounted separately and never enter the headline.
+
+### Tasks and grading
+
+Twelve declarative tasks (`agent_tasks/tasks.py`) derived from the shipped
+skills — memory-continue (resume SPEC-9, recency window, two-hop chain),
+memory-curate (find orphans, connect an orphan), memory-metadata-search
+(status+priority, `$gt` boundary, nested review field), memory-tasks (create,
+resume, complete) — plus SPEC-47's manual chain (search the man3/ pages, read
+the right section). Each runs against a fresh copy of the hand-written seed
+corpus (`benchmarks/datasets/agent-tasks/corpus`, ~25 notes with realistic
+frontmatter/observations/relations, three orphans, three manpage-typed
+notes); file mtimes are aged deterministically so the recency task has a
+stable gold set. All twelve grade deterministically (planted `BMEVAL-*`
+markers, fenced-JSON answer sets, frontmatter/observation/relation-row
+predicates against the settled project and the run's SQLite index); a
+`judge_rubric` grader type exists through the package judge seam but no v1
+task uses it. Errored tasks (model transport, dead MCP session) are recorded
+explicitly and excluded from means — never zero-scored, never dropped — and
+keep the partial token/turn accounting already spent, so the cost columns and
+`per-turn.jsonl` never under-report real model calls.
+
+### Fairness contract additions
+
+Same tasks, same model spec, same budgets (`--max-turns`, `--max-total-tokens`,
+`--task-timeout`; the wall clock is also re-checked between tool dispatches so
+one many-call assistant turn cannot overrun it), same corpus snapshot
+(checksummed into the manifest), one
+fixed prompt preamble, a fixed tool-result truncation cap
+(`TOOL_RESULT_MAX_CHARS`), and deterministic tool-schema ordering (the
+surface allowlist order). Only the surface definition varies, and both
+definitions — config overrides, allowlist, and the tool list actually
+observed from the server — are echoed into `manifest.json` as the audit
+trail. `validate_surface_fairness` warns when surfaces attempted different
+task sets. Note one structural asymmetry, by design: posix v1 (#1399) is
+read-side only, so both surfaces share the rich write verbs (`write_note`,
+`edit_note`, `move_note`, `delete_note`) and the A/B isolates the read-side
+surface.
+
+### POSIX surface gating (important)
+
+This branch does NOT contain the posix tools — they live on the 1399/1403
+stack. The surface is data (`agent_tasks/surfaces.py`): selecting it applies
+`BASIC_MEMORY_ENABLE_POSIX_TOOLS=true` to the ephemeral BM env and requires
+the six read tools in the server's advertised tool list. Because an older
+BM silently ignores the unknown env var, the tool list is the authoritative
+check: a missing tool raises `SurfaceUnavailableError` naming the missing
+tools, the flag, and the branch requirement. Under the default
+`--allow-surface-skip` the surface is recorded as `skipped` in
+`surface-status.json` and the run continues; `--strict-surfaces` aborts.
+Point `--bm-local-path` at a checkout with the flag for live posix runs; the
+six tool names in `surfaces.py` are the single place to reconcile if names
+drift on that branch.
+
+### Model transports
+
+The agent under test speaks `openai-compat:<model>@<base_url>` (any
+`/chat/completions` endpoint implementing the `tools` parameter — Ollama,
+vLLM, LM Studio, OpenAI, or an Anthropic model behind a LiteLLM proxy) or
+`scripted:<path.json>` (canned turns for offline tests/smoke). An
+`openai-compat` response must carry a `usage` block: omitting it would
+silently zero the headline token accounting and disarm the tokens budget, so
+it raises an explicit task error instead.
+`claude:<model>` is rejected for the agent under test: `claude -p` runs its
+own loop and cannot hand a `tool_use` block back to the harness — noted as
+future work (Claude Agent SDK or an MCP-proxy recorder). The optional
+`--judge` still accepts `claude:<model>` through the existing judge seam.
+
+### Workflow
+
+```bash
+BM_LOCAL_PATH=.. just bench-agent-smoke     # LLM-free: scripted model, rich surface, strict
+BM_LOCAL_PATH=.. just bench-agent-tasks     # rich,posix A/B with a local openai-compat model
+uv run bm-bench run agent-tasks --surfaces rich,posix \
+  --model openai-compat:qwen3@http://localhost:11434/v1 \
+  --bm-local-path <bm-checkout>
+```
+
+The smoke script deliberately "knows" the curate-orphans answer: it proves
+harness plumbing (session, dispatch, settle, grading, artifacts), not model
+quality.
+
+### Artifacts
+
+`benchmarks/runs/<run-id>/`: `manifest.json` (BM SHA/version, model + judge
+specs, budget, corpus checksum + file count, full surface echoes),
+`surface-status.json` (ok/skipped/error per surface, explicit reasons),
+`per-turn.jsonl` (per model turn and tool dispatch: tokens, tool name,
+latency, result size), `per-task-agent.jsonl`, `agent-tasks-summary.json`,
+`summary.md` (which repeats any skipped surface so the report cannot be
+misread as a completed A/B). `validate-artifacts` remains retrieval-only for now (as for
+concurrent-write); a kind-aware variant is a follow-up.
+
 ## 7) Commit-to-Commit Comparison (Current Manual Method)
 
 Use this workflow today to compare BM revisions while keeping benchmark tooling fixed.

--- a/benchmarks/justfile
+++ b/benchmarks/justfile
@@ -245,6 +245,37 @@ bench-concurrent-write-load writers="8" notes="200":
       --writers {{writers}} --notes-per-writer {{notes}} \
       --bm-local-path "{{bm_local_path}}"
 
+# --- Agent-task eval: rich vs POSIX tool surfaces (basic-memory#1401) ---
+
+# LLM-free plumbing smoke: scripted model, rich surface, one read-only task, strict
+bench-agent-smoke:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ -z "{{bm_local_path}}" ]]; then
+        echo "BM_LOCAL_PATH must point to the Basic Memory git checkout under test" >&2
+        exit 2
+    fi
+    uv run bm-bench run agent-tasks \
+      --surfaces rich \
+      --model scripted:benchmarks/datasets/agent-tasks/smoke-script.json \
+      --tasks curate-orphans \
+      --bm-local-path "{{bm_local_path}}" \
+      --strict
+
+# Full A/B: same tasks, model, budgets, corpus; only the tool surface varies.
+# The posix surface needs a checkout with enable_posix_tools (#1399/#1406 stack).
+bench-agent-tasks surfaces="rich,posix" model="openai-compat:qwen3@http://localhost:11434/v1":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ -z "{{bm_local_path}}" ]]; then
+        echo "BM_LOCAL_PATH must point to the Basic Memory git checkout under test" >&2
+        exit 2
+    fi
+    uv run bm-bench run agent-tasks \
+      --surfaces "{{surfaces}}" \
+      --model "{{model}}" \
+      --bm-local-path "{{bm_local_path}}"
+
 # --- Artifacts and comparison ---
 
 bench-latest-run:

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/__init__.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/__init__.py
@@ -1,0 +1,60 @@
+"""Agent-in-the-loop task eval: rich vs POSIX tool surfaces (basic-memory#1401)."""
+
+from basic_memory_benchmarks.agent_tasks.driver import (
+    AgentSession,
+    McpAgentSession,
+    SessionTerminatedError,
+    SurfaceRuntime,
+    run_agent_tasks,
+)
+from basic_memory_benchmarks.agent_tasks.loop import (
+    TOOL_RESULT_MAX_CHARS,
+    AgentLoopResult,
+    ToolDispatch,
+    ToolOutcome,
+    run_agent_loop,
+)
+from basic_memory_benchmarks.agent_tasks.models import (
+    AgentBudget,
+    AgentTaskResult,
+    AgentTasksConfig,
+    AgentTasksManifest,
+    SurfaceSummary,
+)
+from basic_memory_benchmarks.agent_tasks.spec import AgentTaskSpec, Grader
+from basic_memory_benchmarks.agent_tasks.surfaces import (
+    SURFACES,
+    SurfaceUnavailableError,
+    ToolSurface,
+    surface_env,
+    verify_surface_tools,
+)
+from basic_memory_benchmarks.agent_tasks.tasks import TASKS, TASKS_BY_ID, select_tasks
+
+__all__ = [
+    "SURFACES",
+    "TASKS",
+    "TASKS_BY_ID",
+    "TOOL_RESULT_MAX_CHARS",
+    "AgentBudget",
+    "AgentLoopResult",
+    "AgentSession",
+    "AgentTaskResult",
+    "AgentTaskSpec",
+    "AgentTasksConfig",
+    "AgentTasksManifest",
+    "Grader",
+    "McpAgentSession",
+    "SessionTerminatedError",
+    "SurfaceRuntime",
+    "SurfaceSummary",
+    "SurfaceUnavailableError",
+    "ToolDispatch",
+    "ToolOutcome",
+    "ToolSurface",
+    "run_agent_loop",
+    "run_agent_tasks",
+    "select_tasks",
+    "surface_env",
+    "verify_surface_tools",
+]

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/corpus.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/corpus.py
@@ -1,0 +1,75 @@
+"""Seed-corpus handling: checksum, per-task copies, timestamps, baseline.
+
+The corpus is a hand-written fixture checked into
+``benchmarks/datasets/agent-tasks/corpus``. Every task gets a fresh copy of
+the full corpus (one snapshot — the fairness contract), with file mtimes aged
+deterministically so recency-window tasks have a stable gold set.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import time
+from pathlib import Path
+from types import MappingProxyType
+
+DEFAULT_AGE_DAYS = 30
+RECENT_AGE_DAYS = 1
+SECONDS_PER_DAY = 86_400
+
+# File age in days, applied via os.utime after each per-task copy and before
+# `bm project add`, so BM's sync derives updated_at from a controlled mtime.
+# Exactly these three files sit inside the recency window that
+# `continue-recent-window` grades on; everything else is DEFAULT_AGE_DAYS old.
+TIMESTAMPS: MappingProxyType[str, int] = MappingProxyType(
+    {
+        "worklog/2026-08-27-spec-9-session-2.md": RECENT_AGE_DAYS,
+        "worklog/2026-08-27-infra-notes.md": RECENT_AGE_DAYS,
+        "tasks/migrate-ci-to-uv.md": RECENT_AGE_DAYS,
+    }
+)
+
+
+def corpus_files(corpus_dir: Path) -> list[str]:
+    """Sorted relpaths of every markdown note in the corpus."""
+    return sorted(
+        str(path.relative_to(corpus_dir)) for path in corpus_dir.rglob("*.md") if path.is_file()
+    )
+
+
+def corpus_checksum(corpus_dir: Path) -> tuple[str, int]:
+    """Content fingerprint over (relpath, bytes) pairs; pins the corpus snapshot."""
+    digest = hashlib.sha256()
+    relpaths = corpus_files(corpus_dir)
+    for relpath in relpaths:
+        digest.update(relpath.encode("utf-8"))
+        digest.update(b"\x00")
+        digest.update((corpus_dir / relpath).read_bytes())
+        digest.update(b"\x00")
+    return digest.hexdigest(), len(relpaths)
+
+
+def copy_corpus(corpus_dir: Path, project_dir: Path, *, now: float | None = None) -> None:
+    """Copy the corpus into a fresh project dir and apply the aged mtimes."""
+    if project_dir.exists():
+        raise RuntimeError(f"Project dir already exists: {project_dir}")
+    shutil.copytree(corpus_dir, project_dir)
+    apply_timestamps(project_dir, now=now)
+
+
+def apply_timestamps(project_dir: Path, *, now: float | None = None) -> None:
+    resolved_now = time.time() if now is None else now
+    for relpath in corpus_files(project_dir):
+        age_days = TIMESTAMPS.get(relpath, DEFAULT_AGE_DAYS)
+        stamp = resolved_now - age_days * SECONDS_PER_DAY
+        os.utime(project_dir / relpath, (stamp, stamp))
+
+
+def snapshot_baseline(project_dir: Path) -> dict[str, str]:
+    """relpath -> file text for every markdown note (taken after seed settle)."""
+    return {
+        relpath: (project_dir / relpath).read_text(encoding="utf-8")
+        for relpath in corpus_files(project_dir)
+    }

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/driver.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/driver.py
@@ -1,0 +1,666 @@
+"""Agent-task run driver: rich vs POSIX tool surfaces (basic-memory#1401).
+
+Standalone fresh-run driver modeled on ``concurrent_write.run_concurrent_write``:
+isolated benchmark home, pinned clean BM checkout, per-surface warm ``bm mcp``
+session, per-task fresh corpus copy, settle, grade, artifacts. Only the tool
+surface varies between providers; tasks, model, budgets, corpus snapshot, and
+prompt preamble are identical (the fairness contract).
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean
+from typing import Any, Protocol
+
+from mcp.types import CallToolResult
+from rich.console import Console
+
+from basic_memory_benchmarks.agent_tasks.corpus import (
+    copy_corpus,
+    corpus_checksum,
+    snapshot_baseline,
+)
+from basic_memory_benchmarks.agent_tasks.grading import GradingContext, grade_task
+from basic_memory_benchmarks.agent_tasks.loop import (
+    AgentLoopError,
+    AgentLoopResult,
+    ToolOutcome,
+    run_agent_loop,
+)
+from basic_memory_benchmarks.agent_tasks.models import (
+    AgentTaskResult,
+    AgentTasksConfig,
+    AgentTasksManifest,
+    SkillBreakdown,
+    SurfaceEcho,
+    SurfaceSummary,
+)
+from basic_memory_benchmarks.agent_tasks.spec import AgentTaskSpec
+from basic_memory_benchmarks.agent_tasks.surfaces import (
+    SURFACES,
+    SurfaceUnavailableError,
+    ToolSurface,
+    surface_env,
+    verify_surface_tools,
+)
+from basic_memory_benchmarks.agent_tasks.tasks import select_tasks
+from basic_memory_benchmarks.bm_runtime import (
+    WarmMcpClient,
+    isolated_bm_env,
+    resolve_bm_command_prefix,
+    settle_index,
+)
+from basic_memory_benchmarks.concurrent_write import (
+    _tool_result_payload,
+    resolve_clean_checkout_sha,
+)
+from basic_memory_benchmarks.fairness import validate_surface_fairness
+from basic_memory_benchmarks.llm.runners import LLMRunner, LLMRunnerError, create_runner
+from basic_memory_benchmarks.llm.tool_agent import (
+    ToolAgentModel,
+    ToolDef,
+    create_tool_agent_model,
+    substitute_placeholders,
+)
+from basic_memory_benchmarks.models import ProviderStatus, RuntimeInfo
+from basic_memory_benchmarks.utils import git_sha, run_command, runtime_info, utc_now_iso
+
+console = Console()
+
+# One fixed preamble for every task on every surface (fairness contract). The
+# harness does NOT inject the project argument into tool calls — naming the
+# project and passing it correctly is part of the measured agent behavior.
+TASK_PROMPT_TEMPLATE = """\
+You are completing a task in the Basic Memory project "{project}".
+Use the available tools to inspect and modify that project's notes.
+When you are finished, reply WITHOUT tool calls and end your reply with a fenced
+```json code block containing the answer fields the task asks for (or {{}} if none).
+
+Task:
+{task_prompt}"""
+
+
+class SessionTerminatedError(RuntimeError):
+    """The MCP session is unusable; remaining tasks on this surface are errored."""
+
+
+class AgentSession(Protocol):
+    """Seam over the per-surface BM MCP session (faked in offline tests)."""
+
+    def start(self) -> None: ...
+    def tools(self) -> list[ToolDef]: ...
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> ToolOutcome: ...
+    def stop(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class SurfaceRuntime:
+    """Everything a session factory needs to spin up one surface's BM."""
+
+    surface: ToolSurface
+    command: str
+    args: list[str]
+    env: dict[str, str]
+    tool_timeout_seconds: float
+
+
+def tool_outcome_from_result(result: CallToolResult) -> ToolOutcome:
+    """Convert an MCP result into loop feedback text plus an error flag.
+
+    Unlike concurrent_write's JSON-only contract, agent tool calls may return
+    plain text, so a non-JSON body is NOT an error here; only MCP ``isError``
+    and an explicit JSON ``error`` field are.
+    """
+    texts = [
+        text for item in result.content if isinstance(text := getattr(item, "text", None), str)
+    ]
+    text = "\n".join(texts)
+    if result.isError:
+        return ToolOutcome(text=text or "Unknown MCP tool error", is_error=True)
+    if not text and result.structuredContent is not None:
+        text = json.dumps(result.structuredContent)
+    payload = _tool_result_payload(result)
+    error = payload.get("error") if payload else None
+    if error:
+        return ToolOutcome(text=text or str(error), is_error=True)
+    return ToolOutcome(text=text, is_error=False)
+
+
+class McpAgentSession:
+    """AgentSession over a warm ``bm mcp`` stdio subprocess."""
+
+    def __init__(self, runtime: SurfaceRuntime) -> None:
+        # required_tool is a verb shared by BOTH surfaces so the session comes
+        # up on any BM build; the authoritative surface check happens in
+        # verify_surface_tools against the advertised tool list, which is the
+        # only way to produce the informative missing-tools message.
+        self._client = WarmMcpClient(
+            command=runtime.command,
+            args=runtime.args,
+            env=runtime.env,
+            request_timeout_seconds=runtime.tool_timeout_seconds,
+            required_tool="write_note",
+        )
+
+    def start(self) -> None:
+        self._client.start()
+
+    def tools(self) -> list[ToolDef]:
+        return [
+            ToolDef(
+                name=tool.name,
+                description=tool.description or "",
+                input_schema=dict(tool.inputSchema),
+            )
+            for tool in self._client.tools()
+        ]
+
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> ToolOutcome:
+        try:
+            result = self._client.call_tool(name, arguments)
+        except TimeoutError as exc:
+            # A timed-out call leaves the single-slot session with a request in
+            # flight; the session cannot be reused.
+            raise SessionTerminatedError(f"tool call timed out: {name}") from exc
+        except RuntimeError as exc:
+            if "not running" in str(exc) or "stopped" in str(exc):
+                raise SessionTerminatedError(str(exc)) from exc
+            raise
+        return tool_outcome_from_result(result)
+
+    def stop(self) -> None:
+        self._client.stop()
+
+
+def _bm_version(prefix: list[str], env: dict[str, str]) -> str | None:
+    try:
+        result = run_command(prefix + ["--version"], env=env)
+    except Exception:
+        return None
+    return result.stdout.strip() or None
+
+
+def _errored_result(
+    surface: str,
+    task: AgentTaskSpec,
+    error: str,
+    partial: AgentLoopResult | None = None,
+) -> AgentTaskResult:
+    # Explicit-failure principle: errored tasks carry the error and are
+    # excluded from means — never silently zero-scored. When the failure
+    # happened after real model calls, the partial loop accounting (tokens,
+    # per-turn records) is kept so per-turn.jsonl and the cost columns never
+    # under-report spent cost.
+    if partial is None:
+        return AgentTaskResult(
+            surface=surface, task_id=task.id, skill=task.skill, passed=False, error=error
+        )
+    return AgentTaskResult(
+        surface=surface,
+        task_id=task.id,
+        skill=task.skill,
+        passed=False,
+        error=error,
+        stopped_reason=partial.stopped_reason,
+        turns=partial.turns,
+        tool_calls=partial.tool_call_count,
+        total_input_tokens=partial.total_input_tokens,
+        total_output_tokens=partial.total_output_tokens,
+        wall_seconds=round(partial.wall_seconds, 2),
+        turn_records=partial.turn_records,
+    )
+
+
+def _run_one_task(
+    *,
+    surface: ToolSurface,
+    task: AgentTaskSpec,
+    config: AgentTasksConfig,
+    model: ToolAgentModel,
+    judge: LLMRunner | None,
+    session: AgentSession,
+    tool_defs: list[ToolDef],
+    prefix: list[str],
+    env: dict[str, str],
+    surface_home: Path,
+) -> AgentTaskResult:
+    project_name = f"at-{config.run_id}-{task.id}"
+    project_dir = surface_home / "projects" / task.id
+    copy_corpus(Path(config.corpus_dir), project_dir)
+    run_command(prefix + ["project", "add", project_name, str(project_dir)], env=env)
+    settle_index(
+        prefix=prefix,
+        env=env,
+        project_name=project_name,
+        timeout_seconds=config.settle_timeout_seconds,
+    )
+    baseline = snapshot_baseline(project_dir)
+    prompt = TASK_PROMPT_TEMPLATE.format(project=project_name, task_prompt=task.prompt)
+
+    def dispatch(name: str, arguments: dict[str, Any]) -> ToolOutcome:
+        # {project} placeholders come from the scripted transport, which cannot
+        # know per-run project names; a no-op for real model output.
+        resolved = substitute_placeholders(arguments, {"project": project_name})
+        return session.call_tool(name, resolved)
+
+    loop_result = run_agent_loop(
+        model=model,
+        dispatch=dispatch,
+        tools=tool_defs,
+        prompt=prompt,
+        budget=config.budget,
+    )
+    settle_index(
+        prefix=prefix,
+        env=env,
+        project_name=project_name,
+        timeout_seconds=config.settle_timeout_seconds,
+    )
+    ctx = GradingContext(
+        final_answer=loop_result.final_answer,
+        project_dir=project_dir,
+        baseline=baseline,
+        db_path=surface_home / "config" / "memory.db",
+        project_name=project_name,
+        turn_records=loop_result.turn_records,
+        judge=judge,
+    )
+    try:
+        passed, predicates, judge_usage = grade_task(task, ctx)
+    except LLMRunnerError as exc:
+        # Judge transport failure after a completed loop: the agent's spent
+        # tokens are real cost — keep them on the errored row.
+        return _errored_result(surface.name, task, f"grading failed: {exc}", partial=loop_result)
+    return AgentTaskResult(
+        surface=surface.name,
+        task_id=task.id,
+        skill=task.skill,
+        passed=passed,
+        stopped_reason=loop_result.stopped_reason,
+        turns=loop_result.turns,
+        tool_calls=loop_result.tool_call_count,
+        total_input_tokens=loop_result.total_input_tokens,
+        total_output_tokens=loop_result.total_output_tokens,
+        wall_seconds=round(loop_result.wall_seconds, 2),
+        final_answer=loop_result.final_answer,
+        predicates=predicates,
+        judge_input_tokens=judge_usage.input_tokens,
+        judge_output_tokens=judge_usage.output_tokens,
+        judge_calls=judge_usage.calls,
+        turn_records=loop_result.turn_records,
+    )
+
+
+def build_surface_summary(
+    surface: str, model_spec: str, results: Sequence[AgentTaskResult]
+) -> SurfaceSummary:
+    graded = [row for row in results if row.error is None]
+    passed_rows = [row for row in graded if row.passed]
+    total_input = sum(row.total_input_tokens for row in results)
+    total_output = sum(row.total_output_tokens for row in results)
+    total_tokens = total_input + total_output
+    budget_stops = Counter(
+        row.stopped_reason
+        for row in graded
+        if row.stopped_reason is not None and row.stopped_reason != "final"
+    )
+
+    per_skill: dict[str, SkillBreakdown] = {}
+    for skill in sorted({row.skill for row in results}):
+        skill_rows = [row for row in results if row.skill == skill]
+        skill_passed = [row for row in skill_rows if row.error is None and row.passed]
+        skill_tokens = sum(row.total_input_tokens + row.total_output_tokens for row in skill_rows)
+        per_skill[skill] = SkillBreakdown(
+            total=len(skill_rows),
+            passed=len(skill_passed),
+            tokens_per_completed=round(skill_tokens / len(skill_passed), 1)
+            if skill_passed
+            else None,
+        )
+
+    return SurfaceSummary(
+        surface=surface,
+        model=model_spec,
+        tasks_total=len(results),
+        tasks_passed=len(passed_rows),
+        tasks_errored=len(results) - len(graded),
+        budget_stops={str(reason): count for reason, count in sorted(budget_stops.items())},
+        pass_rate=round(len(passed_rows) / len(graded), 3) if graded else 0.0,
+        total_input_tokens=total_input,
+        total_output_tokens=total_output,
+        # Headline: tokens over ALL attempted tasks per completed task; None
+        # (rendered "n/a"), never 0, when nothing completed.
+        tokens_per_completed_task=round(total_tokens / len(passed_rows), 1)
+        if passed_rows
+        else None,
+        tokens_per_attempted_task=round(total_tokens / len(results), 1) if results else 0.0,
+        mean_tool_calls=round(mean(row.tool_calls for row in graded), 2) if graded else 0.0,
+        mean_turns=round(mean(row.turns for row in graded), 2) if graded else 0.0,
+        mean_wall_seconds=round(mean(row.wall_seconds for row in graded), 2) if graded else 0.0,
+        per_skill=per_skill,
+        judge_input_tokens=sum(row.judge_input_tokens for row in results),
+        judge_output_tokens=sum(row.judge_output_tokens for row in results),
+        judge_calls=sum(row.judge_calls for row in results),
+    )
+
+
+def _format_tokens_per_completed(value: float | None) -> str:
+    return f"{value}" if value is not None else "n/a — 0 tasks completed"
+
+
+def build_agent_summary_markdown(
+    manifest: AgentTasksManifest,
+    summaries: Sequence[SurfaceSummary],
+    results: Sequence[AgentTaskResult],
+    fairness_warnings: Sequence[str],
+    statuses: Sequence[ProviderStatus],
+) -> str:
+    lines = [
+        f"# Agent-Task Run `{manifest.run_id}`",
+        "",
+        "## Provenance",
+        "",
+        f"- Benchmark SHA: `{manifest.benchmark_git_sha}`",
+        f"- BM source: `{manifest.bm_source}`",
+        f"- BM resolved SHA: `{manifest.bm_resolved_sha or 'unknown'}`",
+        f"- BM version: `{manifest.bm_version or 'unknown'}`",
+        f"- Model: `{manifest.model_spec}` — Judge: `{manifest.judge_spec or 'none'}`",
+        f"- Corpus: `{manifest.corpus_checksum[:12]}` ({manifest.corpus_file_count} notes)",
+        f"- Budget: {manifest.budget.max_turns} turns,"
+        f" {manifest.budget.max_total_tokens} tokens,"
+        f" {manifest.budget.max_task_seconds}s per task",
+        "",
+        # The headline column comes first and never appears without the
+        # accompanying accuracy/cost columns — reporting must never show
+        # accuracy alone.
+        "## Results by surface",
+        "",
+        "| Surface | Tokens/completed | Pass rate | Passed/total | Mean tool calls |"
+        " Mean turns | Mean wall s | Total tokens |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for summary in summaries:
+        total_tokens = summary.total_input_tokens + summary.total_output_tokens
+        lines.append(
+            f"| {summary.surface} | {_format_tokens_per_completed(summary.tokens_per_completed_task)} |"
+            f" {summary.pass_rate} | {summary.tasks_passed}/{summary.tasks_total} |"
+            f" {summary.mean_tool_calls} | {summary.mean_turns} |"
+            f" {summary.mean_wall_seconds} | {total_tokens} |"
+        )
+
+    # A skipped surface must be visible in the human-facing report, not just
+    # surface-status.json — otherwise a rich-only run of `--surfaces rich,posix`
+    # reads like a completed A/B.
+    skipped = [status for status in statuses if status.state != "ok"]
+    if skipped:
+        lines += ["", "## Surfaces not run (the table above is NOT a complete A/B)", ""]
+        for status in skipped:
+            lines.append(f"- {status.provider} ({status.state}): {status.reason or 'no reason'}")
+
+    lines += ["", "## Per skill", ""]
+    lines += [
+        "| Surface | Skill | Passed/total | Tokens/completed |",
+        "| --- | --- | --- | --- |",
+    ]
+    for summary in summaries:
+        for skill, breakdown in summary.per_skill.items():
+            lines.append(
+                f"| {summary.surface} | {skill} | {breakdown.passed}/{breakdown.total} |"
+                f" {_format_tokens_per_completed(breakdown.tokens_per_completed)} |"
+            )
+
+    stops = [(s.surface, s.budget_stops) for s in summaries if s.budget_stops]
+    if stops:
+        lines += ["", "## Budget stops", ""]
+        for surface, reasons in stops:
+            rendered = ", ".join(f"{reason}: {count}" for reason, count in reasons.items())
+            lines.append(f"- {surface}: {rendered}")
+
+    errored = [row for row in results if row.error is not None]
+    if errored:
+        lines += ["", "## Errored tasks (excluded from means, never zero-scored)", ""]
+        for row in errored:
+            lines.append(f"- {row.surface}/{row.task_id}: {row.error}")
+
+    if fairness_warnings:
+        lines += ["", "## Fairness warnings", ""]
+        lines += [f"- {warning}" for warning in fairness_warnings]
+
+    judge_totals = [
+        (s.surface, s.judge_input_tokens + s.judge_output_tokens, s.judge_calls)
+        for s in summaries
+        if s.judge_calls
+    ]
+    if judge_totals:
+        lines += ["", "## Judge usage (never part of the headline)", ""]
+        for surface, tokens, calls in judge_totals:
+            lines.append(f"- {surface}: {tokens} tokens over {calls} calls")
+
+    return "\n".join(lines).strip() + "\n"
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as file:
+        for row in rows:
+            file.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def run_agent_tasks(
+    config: AgentTasksConfig,
+    *,
+    model_factory: Callable[[str], ToolAgentModel] = create_tool_agent_model,
+    session_factory: Callable[[SurfaceRuntime], AgentSession] | None = None,
+    judge_factory: Callable[[str], LLMRunner] = create_runner,
+) -> Path:
+    """Execute the full agent-task eval and write run artifacts; returns run dir."""
+    bm_checkout = Path(config.bm_local_path).expanduser().resolve()
+    prefix = resolve_bm_command_prefix(str(bm_checkout))
+    bm_resolved_sha = resolve_clean_checkout_sha(bm_checkout)
+    config = config.model_copy(update={"bm_local_path": str(bm_checkout)})
+
+    corpus_dir = Path(config.corpus_dir)
+    if not corpus_dir.is_dir():
+        raise ValueError(f"Corpus dir not found: {corpus_dir}")
+    checksum, corpus_file_count = corpus_checksum(corpus_dir)
+    tasks = select_tasks(config.task_ids)
+
+    # Model and judge parse before any on-disk state is created, so a bad spec
+    # fails fast without leaving an empty benchmark home behind.
+    model = model_factory(config.model_spec)
+    judge = judge_factory(config.judge_spec) if config.judge_spec else None
+    build_session = session_factory or (lambda runtime: McpAgentSession(runtime))
+
+    home = Path("benchmarks/.bm-homes") / f"agent-tasks-{config.run_id}"
+    if home.exists():
+        raise RuntimeError(f"Home already exists (re-running a run_id is not supported): {home}")
+    home.mkdir(parents=True)
+
+    console.print(
+        f"[bold]agent-tasks[/bold] run_id={config.run_id} surfaces={config.surfaces}"
+        f" tasks={len(tasks)} model={model.spec}"
+    )
+
+    statuses: list[ProviderStatus] = []
+    echoes: list[SurfaceEcho] = []
+    results: list[AgentTaskResult] = []
+    bm_version: str | None = None
+
+    for surface_name in config.surfaces:
+        surface = SURFACES[surface_name]
+        surface_home = home / surface.name
+        (surface_home / "default-home").mkdir(parents=True)
+        env = surface_env(surface, isolated_bm_env(surface_home))
+        if bm_version is None:
+            bm_version = _bm_version(prefix, env)
+        runtime = SurfaceRuntime(
+            surface=surface,
+            command=prefix[0],
+            args=prefix[1:] + ["mcp"],
+            env=env,
+            tool_timeout_seconds=config.tool_timeout_seconds,
+        )
+        session = build_session(runtime)
+        console.print(f"Starting `bm mcp` session for surface [cyan]{surface.name}[/cyan]...")
+        session.start()
+        try:
+            available = session.tools()
+            observed_names = sorted(tool.name for tool in available)
+            echoes.append(
+                SurfaceEcho(
+                    name=surface.name,
+                    config_overrides=dict(surface.config_overrides),
+                    tool_allowlist=list(surface.tool_allowlist),
+                    observed_tools=observed_names,
+                )
+            )
+            try:
+                verify_surface_tools(surface, observed_names, bm_version=bm_version)
+            except SurfaceUnavailableError as exc:
+                # Never silently dropped: the surface is recorded as skipped
+                # (default) or aborts the run (--strict-surfaces).
+                if not config.allow_surface_skip:
+                    raise
+                console.print(f"[yellow]Skipping surface {surface.name}[/yellow]: {exc}")
+                statuses.append(
+                    ProviderStatus(provider=surface.name, state="skipped", reason=str(exc))
+                )
+                continue
+
+            by_name = {tool.name: tool for tool in available}
+            # Deterministic order: schemas reach the model in allowlist order.
+            tool_defs = [by_name[name] for name in surface.tool_allowlist]
+
+            session_error: str | None = None
+            for task in tasks:
+                if session_error is not None:
+                    results.append(
+                        _errored_result(
+                            surface.name, task, f"mcp session terminated: {session_error}"
+                        )
+                    )
+                    continue
+                console.print(f"  [{surface.name}] task [cyan]{task.id}[/cyan]...")
+                try:
+                    result = _run_one_task(
+                        surface=surface,
+                        task=task,
+                        config=config,
+                        model=model,
+                        judge=judge,
+                        session=session,
+                        tool_defs=tool_defs,
+                        prefix=prefix,
+                        env=env,
+                        surface_home=surface_home,
+                    )
+                except AgentLoopError as exc:
+                    # The loop wraps every mid-task failure with the partial
+                    # accounting; the cause decides task-level vs surface-level
+                    # handling. Anything else is a harness bug: abort loudly.
+                    if isinstance(exc.cause, SessionTerminatedError):
+                        session_error = str(exc.cause)
+                        results.append(
+                            _errored_result(
+                                surface.name,
+                                task,
+                                f"mcp session terminated: {session_error}",
+                                partial=exc.partial,
+                            )
+                        )
+                        continue
+                    if isinstance(exc.cause, LLMRunnerError):
+                        results.append(
+                            _errored_result(surface.name, task, str(exc.cause), partial=exc.partial)
+                        )
+                        continue
+                    raise
+                results.append(result)
+            statuses.append(ProviderStatus(provider=surface.name, state="ok"))
+        finally:
+            session.stop()
+
+    ok_surfaces = {status.provider for status in statuses if status.state == "ok"}
+    fairness_warnings = validate_surface_fairness(
+        {surface: [row for row in results if row.surface == surface] for surface in ok_surfaces}
+    )
+    summaries = [
+        build_surface_summary(
+            surface, model.spec, [row for row in results if row.surface == surface]
+        )
+        for surface in config.surfaces
+        if surface in ok_surfaces
+    ]
+
+    manifest = AgentTasksManifest(
+        run_id=config.run_id,
+        created_at_utc=utc_now_iso(),
+        benchmark_git_sha=git_sha(Path(".")) or "unknown",
+        bm_source=config.bm_source,
+        bm_resolved_sha=bm_resolved_sha,
+        bm_version=bm_version,
+        home_dir=str(home),
+        model_spec=model.spec,
+        judge_spec=judge.spec if judge is not None else None,
+        budget=config.budget,
+        corpus_checksum=checksum,
+        corpus_file_count=corpus_file_count,
+        task_ids=[task.id for task in tasks],
+        surfaces=echoes,
+        runtime=RuntimeInfo(
+            os=runtime_info()[0],
+            python_version=runtime_info()[1],
+            started_at_utc=utc_now_iso(),
+        ),
+        config=config,
+    )
+
+    run_dir = Path(config.output_root) / config.run_id
+    _write_json(run_dir / "manifest.json", manifest.model_dump(mode="json"))
+    _write_json(
+        run_dir / "surface-status.json",
+        [status.model_dump(mode="json") for status in statuses],
+    )
+    _write_jsonl(
+        run_dir / "per-turn.jsonl",
+        [
+            {"surface": row.surface, "task_id": row.task_id, **record.model_dump(mode="json")}
+            for row in results
+            for record in row.turn_records
+        ],
+    )
+    _write_jsonl(
+        run_dir / "per-task-agent.jsonl",
+        [row.model_dump(mode="json", exclude={"turn_records"}) for row in results],
+    )
+    _write_json(
+        run_dir / "agent-tasks-summary.json",
+        {
+            "surfaces": [summary.model_dump(mode="json") for summary in summaries],
+            "fairness_warnings": list(fairness_warnings),
+        },
+    )
+    (run_dir / "summary.md").write_text(
+        build_agent_summary_markdown(manifest, summaries, results, fairness_warnings, statuses),
+        encoding="utf-8",
+    )
+
+    for summary in summaries:
+        console.print(
+            f"[bold]{summary.surface}[/bold]: {summary.tasks_passed}/{summary.tasks_total} passed,"
+            f" tokens/completed = {_format_tokens_per_completed(summary.tokens_per_completed_task)},"
+            f" mean tool calls {summary.mean_tool_calls}"
+        )
+    for warning in fairness_warnings:
+        console.print(f"[yellow]fairness[/yellow]: {warning}")
+    return run_dir

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/grading.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/grading.py
@@ -1,0 +1,410 @@
+"""Deterministic and judge grading for agent tasks.
+
+Deterministic predicates read the final answer, the settled project directory,
+and the run's isolated SQLite index; ``JudgeRubric`` goes through the package's
+existing ``LLMRunner`` judge seam. A malformed final answer is a task failure
+(failed predicates with detail), never a harness error; judge/model transport
+failures raise and become explicit task errors in the driver.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import frontmatter
+
+from basic_memory_benchmarks.agent_tasks.models import PredicateResult, TurnRecord
+from basic_memory_benchmarks.agent_tasks.spec import (
+    NEW_FILE_SELECTOR,
+    AgentTaskSpec,
+    AnswerContains,
+    AnswerMatches,
+    AnswerSetEquals,
+    FileLineDiff,
+    FrontmatterEquals,
+    FrontmatterListLen,
+    FrontmatterMatches,
+    Grader,
+    JudgeRubric,
+    MarkerAbsent,
+    MarkerPresent,
+    NewNoteUnder,
+    NoteCountDelta,
+    NotesUntouched,
+    ObservationLines,
+    RelationResolves,
+    ToolCalled,
+)
+from basic_memory_benchmarks.llm.runners import LLMResult, LLMRunner
+
+_FENCED_JSON_PATTERN = re.compile(r"```json\s*\n(.*?)```", re.DOTALL)
+
+AGENT_JUDGE_PROMPT_TEMPLATE = """\
+You are grading an agent's final answer against a rubric.
+
+Rubric:
+{rubric}
+
+Final answer:
+{answer}
+
+Reply with exactly one line: CORRECT or INCORRECT, followed by " - " and a
+one-sentence reason."""
+
+
+@dataclass
+class JudgeUsage:
+    """Accumulates judge-side token usage across a task's judge calls."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    calls: int = 0
+
+    def add(self, result: LLMResult) -> None:
+        self.input_tokens += result.input_tokens
+        self.output_tokens += result.output_tokens
+        self.calls += 1
+
+
+@dataclass
+class GradingContext:
+    final_answer: str | None
+    project_dir: Path
+    # Baseline snapshot taken after seed settle: relpath -> full file text.
+    # (Content, not just a checksum, so line-diff predicates need no second
+    # directory copy — the corpus is tiny.)
+    baseline: Mapping[str, str]
+    db_path: Path
+    project_name: str
+    turn_records: Sequence[TurnRecord] = field(default_factory=tuple)
+    judge: LLMRunner | None = None
+
+
+# --- Answer helpers ---
+
+
+def extract_final_json(final_answer: str | None) -> dict[str, object] | None:
+    """The LAST fenced ```json block of the final answer, parsed; None if absent."""
+    if not final_answer:
+        return None
+    blocks = _FENCED_JSON_PATTERN.findall(final_answer)
+    if not blocks:
+        return None
+    try:
+        payload = json.loads(blocks[-1])
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def normalize_answer_item(value: str) -> str:
+    """Comparable form for permalinks/titles: strip, drop leading '/' and '.md'."""
+    return value.strip().lstrip("/").removesuffix(".md").lower()
+
+
+# --- File helpers ---
+
+
+def _markdown_relpaths(project_dir: Path) -> list[str]:
+    return sorted(
+        str(path.relative_to(project_dir)) for path in project_dir.rglob("*.md") if path.is_file()
+    )
+
+
+def _select_files(ctx: GradingContext, selector: str) -> list[str]:
+    current = _markdown_relpaths(ctx.project_dir)
+    if selector == NEW_FILE_SELECTOR:
+        return [relpath for relpath in current if relpath not in ctx.baseline]
+    return [relpath for relpath in current if Path(relpath).match(selector)]
+
+
+def _single_file(ctx: GradingContext, selector: str) -> tuple[str | None, str]:
+    matches = _select_files(ctx, selector)
+    if len(matches) == 1:
+        return matches[0], ""
+    return None, f"selector '{selector}' matched {len(matches)} files: {matches[:5]}"
+
+
+def _frontmatter_value(text: str, dotted_key: str) -> object | None:
+    metadata: object = frontmatter.loads(text).metadata
+    for part in dotted_key.split("."):
+        if not isinstance(metadata, dict) or part not in metadata:
+            return None
+        metadata = metadata[part]
+    return metadata
+
+
+# --- Predicate evaluation ---
+
+
+def _result(grader: Grader, passed: bool, detail: str) -> PredicateResult:
+    kind = type(grader).__name__
+    return PredicateResult(
+        name=f"{kind}({_grader_label(grader)})",
+        kind=kind,
+        passed=passed,
+        required=grader.required,
+        detail=detail,
+    )
+
+
+def _grader_label(grader: Grader) -> str:
+    match grader:
+        case AnswerSetEquals(key=key):
+            return key
+        case MarkerPresent(marker=marker) | MarkerAbsent(marker=marker):
+            return marker
+        case AnswerContains(needle=needle):
+            return needle
+        case AnswerMatches(pattern=pattern):
+            return pattern
+        case NoteCountDelta(delta=delta):
+            return f"{delta:+d}"
+        case NewNoteUnder(prefix=prefix):
+            return prefix
+        case NotesUntouched():
+            return "*"
+        case FrontmatterEquals(path=path, key=key) | FrontmatterMatches(path=path, key=key):
+            return f"{path}:{key}"
+        case FrontmatterListLen(path=path, key=key):
+            return f"{path}:{key}"
+        case ObservationLines(path=path):
+            return path
+        case RelationResolves(source_permalink=source):
+            return source
+        case FileLineDiff(path=path):
+            return path
+        case ToolCalled(name_pattern=pattern):
+            return pattern
+        case JudgeRubric():
+            return "rubric"
+
+
+def _eval_answer_set(grader: AnswerSetEquals, ctx: GradingContext) -> PredicateResult:
+    payload = extract_final_json(ctx.final_answer)
+    if payload is None:
+        return _result(grader, False, "no parseable fenced JSON block in the final answer")
+    raw = payload.get(grader.key)
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        return _result(grader, False, f"answer key '{grader.key}' is not a list of strings")
+    got = {normalize_answer_item(item) for item in raw}
+    gold = {normalize_answer_item(item) for item in grader.gold}
+    if got == gold:
+        return _result(grader, True, f"{len(gold)} items match")
+    missing = sorted(gold - got)
+    extra = sorted(got - gold)
+    return _result(grader, False, f"missing={missing[:5]} extra={extra[:5]}")
+
+
+def _eval_new_note_under(grader: NewNoteUnder, ctx: GradingContext) -> PredicateResult:
+    new_files = _select_files(ctx, NEW_FILE_SELECTOR)
+    if not new_files:
+        return _result(grader, False, "no new notes since baseline")
+    # is_relative_to gives directory semantics regardless of a trailing slash:
+    # "tasks" and "tasks/" both contain "tasks/x.md" and neither contains
+    # "tasks-archive/x.md", which a bare startswith("tasks") would accept.
+    misplaced = [
+        relpath for relpath in new_files if not Path(relpath).is_relative_to(grader.prefix)
+    ]
+    if misplaced:
+        return _result(grader, False, f"new notes outside {grader.prefix}: {misplaced[:5]}")
+    return _result(grader, True, f"{len(new_files)} new note(s) under {grader.prefix}")
+
+
+def _eval_notes_untouched(grader: NotesUntouched, ctx: GradingContext) -> PredicateResult:
+    changed: list[str] = []
+    for relpath, baseline_text in ctx.baseline.items():
+        if any(Path(relpath).match(glob) for glob in grader.except_globs):
+            continue
+        current = ctx.project_dir / relpath
+        if not current.is_file() or current.read_text(encoding="utf-8") != baseline_text:
+            changed.append(relpath)
+    if changed:
+        return _result(grader, False, f"{len(changed)} baseline notes changed: {changed[:5]}")
+    return _result(grader, True, "baseline notes untouched")
+
+
+def _eval_frontmatter(
+    grader: FrontmatterEquals | FrontmatterMatches | FrontmatterListLen,
+    ctx: GradingContext,
+) -> PredicateResult:
+    relpath, problem = _single_file(ctx, grader.path)
+    if relpath is None:
+        return _result(grader, False, problem)
+    text = (ctx.project_dir / relpath).read_text(encoding="utf-8")
+    actual = _frontmatter_value(text, grader.key)
+    if actual is None:
+        return _result(grader, False, f"{relpath} has no frontmatter key '{grader.key}'")
+    match grader:
+        case FrontmatterEquals(value=value):
+            # str-comparison fallback absorbs YAML type drift (e.g. quoted ints).
+            passed = actual == value or str(actual) == str(value)
+            return _result(grader, passed, f"{relpath}: {grader.key}={actual!r}")
+        case FrontmatterMatches(pattern=pattern):
+            passed = re.search(pattern, str(actual)) is not None
+            return _result(grader, passed, f"{relpath}: {grader.key}={actual!r}")
+        case FrontmatterListLen(length=length):
+            if not isinstance(actual, list):
+                return _result(grader, False, f"{relpath}: {grader.key} is not a list")
+            return _result(
+                grader,
+                len(actual) == length,
+                f"{relpath}: len({grader.key})={len(actual)}, expected {length}",
+            )
+
+
+def _eval_relation_resolves(grader: RelationResolves, ctx: GradingContext) -> PredicateResult:
+    if not ctx.db_path.exists():
+        raise RuntimeError(f"Index database not found: {ctx.db_path}")
+    # Plain connection issuing SELECTs only; the BM process is idle post-settle.
+    connection = sqlite3.connect(ctx.db_path)
+    try:
+        row = connection.execute(
+            "SELECT id FROM project WHERE name = ?", (ctx.project_name,)
+        ).fetchone()
+        if row is None:
+            raise RuntimeError(f"Project '{ctx.project_name}' not found in {ctx.db_path}")
+        project_id = int(row[0])
+        query = (
+            "SELECT target.permalink, r.relation_type"
+            " FROM relation r"
+            " JOIN entity source ON r.from_id = source.id"
+            " JOIN entity target ON r.to_id = target.id"
+            " WHERE source.project_id = ? AND source.permalink = ?"
+            " AND r.to_id IS NOT NULL"
+        )
+        rows = connection.execute(query, (project_id, grader.source_permalink)).fetchall()
+    finally:
+        connection.close()
+
+    targets = {normalize_answer_item(item) for item in grader.targets}
+    for target_permalink, relation_type in rows:
+        if normalize_answer_item(str(target_permalink)) not in targets:
+            continue
+        if grader.relation_type is not None and relation_type != grader.relation_type:
+            continue
+        return _result(
+            grader, True, f"{grader.source_permalink} -{relation_type}-> {target_permalink}"
+        )
+    return _result(
+        grader,
+        False,
+        f"no resolved relation from {grader.source_permalink} to {sorted(targets)}"
+        f" (found {len(rows)} resolved relations)",
+    )
+
+
+def _eval_file_line_diff(grader: FileLineDiff, ctx: GradingContext) -> PredicateResult:
+    relpath, problem = _single_file(ctx, grader.path)
+    if relpath is None:
+        return _result(grader, False, problem)
+    baseline_text = ctx.baseline.get(relpath)
+    if baseline_text is None:
+        return _result(grader, False, f"{relpath} has no baseline to diff against")
+    current_lines = Counter((ctx.project_dir / relpath).read_text(encoding="utf-8").splitlines())
+    baseline_lines = Counter(baseline_text.splitlines())
+    removed = list((baseline_lines - current_lines).elements())
+    added = list((current_lines - baseline_lines).elements())
+    if len(removed) != 1 or len(added) != 1:
+        return _result(
+            grader, False, f"{relpath}: {len(removed)} lines removed, {len(added)} added"
+        )
+    removed_ok = re.search(grader.removed_pattern, removed[0]) is not None
+    added_ok = re.search(grader.added_pattern, added[0]) is not None
+    return _result(
+        grader,
+        removed_ok and added_ok,
+        f"removed={removed[0]!r} added={added[0]!r}",
+    )
+
+
+def _parse_judge_line(raw: str) -> tuple[bool, str]:
+    upper = raw.upper()
+    if re.search(r"\bINCORRECT\b", upper):
+        return False, raw.strip().splitlines()[0][:200]
+    if re.search(r"\bCORRECT\b", upper):
+        return True, raw.strip().splitlines()[0][:200]
+    raise ValueError(f"Judge returned neither CORRECT nor INCORRECT: {raw[:200]}")
+
+
+def _eval_judge(grader: JudgeRubric, ctx: GradingContext, usage: JudgeUsage) -> PredicateResult:
+    if ctx.judge is None:
+        # Fail fast: the CLI refuses judge-graded tasks without --judge, so
+        # reaching here is a harness bug, not a task outcome.
+        raise RuntimeError("JudgeRubric grader requires a judge runner")
+    if not ctx.final_answer:
+        return _result(grader, False, "no final answer to judge")
+    prompt = AGENT_JUDGE_PROMPT_TEMPLATE.format(rubric=grader.rubric, answer=ctx.final_answer)
+    result = ctx.judge.complete(prompt)
+    usage.add(result)
+    passed, reason = _parse_judge_line(result.text)
+    return _result(grader, passed, reason)
+
+
+def evaluate_grader(
+    grader: Grader, ctx: GradingContext, usage: JudgeUsage | None = None
+) -> PredicateResult:
+    match grader:
+        case AnswerSetEquals():
+            return _eval_answer_set(grader, ctx)
+        case MarkerPresent(marker=marker):
+            present = ctx.final_answer is not None and marker in ctx.final_answer
+            return _result(grader, present, "marker present" if present else "marker missing")
+        case MarkerAbsent(marker=marker):
+            present = ctx.final_answer is not None and marker in ctx.final_answer
+            return _result(
+                grader, not present, "decoy marker present" if present else "decoy absent"
+            )
+        case AnswerContains(needle=needle):
+            found = ctx.final_answer is not None and needle.lower() in ctx.final_answer.lower()
+            return _result(grader, found, f"'{needle}' {'found' if found else 'missing'}")
+        case AnswerMatches(pattern=pattern):
+            found = ctx.final_answer is not None and (
+                re.search(pattern, ctx.final_answer, re.IGNORECASE) is not None
+            )
+            return _result(grader, found, f"/{pattern}/ {'found' if found else 'missing'}")
+        case NoteCountDelta(delta=delta):
+            actual = len(_markdown_relpaths(ctx.project_dir)) - len(ctx.baseline)
+            return _result(grader, actual == delta, f"note count delta {actual:+d}")
+        case NewNoteUnder():
+            return _eval_new_note_under(grader, ctx)
+        case NotesUntouched():
+            return _eval_notes_untouched(grader, ctx)
+        case FrontmatterEquals() | FrontmatterMatches() | FrontmatterListLen():
+            return _eval_frontmatter(grader, ctx)
+        case ObservationLines(path=path, pattern=pattern, min_count=min_count):
+            relpath, problem = _single_file(ctx, path)
+            if relpath is None:
+                return _result(grader, False, problem)
+            text = (ctx.project_dir / relpath).read_text(encoding="utf-8")
+            count = sum(1 for line in text.splitlines() if re.search(pattern, line))
+            return _result(grader, count >= min_count, f"{relpath}: {count} matching lines")
+        case RelationResolves():
+            return _eval_relation_resolves(grader, ctx)
+        case FileLineDiff():
+            return _eval_file_line_diff(grader, ctx)
+        case ToolCalled(name_pattern=pattern):
+            called = any(
+                record.kind == "tool"
+                and record.tool_name is not None
+                and re.search(pattern, record.tool_name)
+                for record in ctx.turn_records
+            )
+            return _result(grader, called, "matching tool called" if called else "not called")
+        case JudgeRubric():
+            return _eval_judge(grader, ctx, usage if usage is not None else JudgeUsage())
+
+
+def grade_task(
+    spec: AgentTaskSpec, ctx: GradingContext
+) -> tuple[bool, list[PredicateResult], JudgeUsage]:
+    usage = JudgeUsage()
+    predicates = [evaluate_grader(grader, ctx, usage) for grader in spec.graders]
+    passed = all(predicate.passed for predicate in predicates if predicate.required)
+    return passed, predicates, usage

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/loop.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/loop.py
@@ -1,0 +1,200 @@
+"""The minimal agent loop: model proposes tool calls, the harness dispatches.
+
+Budgets (turns, total tokens, wall clock) are enforced before each model call,
+and the wall clock is re-checked between tool dispatches — one assistant turn
+can carry many calls, each worth up to the tool timeout. Per-turn accounting
+is recorded for both model turns and tool dispatches. The loop never swallows
+model or dispatch errors: a mid-loop failure raises ``AgentLoopError`` wrapping
+the cause plus the partial accounting, so the driver records the task as an
+explicit error (never a silent zero score) without discarding tokens already
+spent on real model calls.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+
+from basic_memory_benchmarks.agent_tasks.models import AgentBudget, StopReason, TurnRecord
+from basic_memory_benchmarks.llm.tool_agent import (
+    AssistantTurn,
+    ToolAgentModel,
+    ToolDef,
+    ToolReturn,
+    TranscriptItem,
+    UserMessage,
+)
+
+# Fixed for both surfaces — part of the fairness contract (disclosed in docs).
+TOOL_RESULT_MAX_CHARS = 8_000
+TRUNCATION_SUFFIX = "\n…[tool result truncated]"
+
+
+@dataclass(frozen=True)
+class ToolOutcome:
+    """What a dispatched tool call produced: text to feed back, error flag."""
+
+    text: str
+    is_error: bool
+
+
+class ToolDispatch(Protocol):
+    def __call__(self, name: str, arguments: dict[str, Any]) -> ToolOutcome: ...
+
+
+@dataclass
+class AgentLoopResult:
+    final_answer: str | None
+    stopped_reason: StopReason
+    turns: int
+    tool_call_count: int
+    total_input_tokens: int
+    total_output_tokens: int
+    wall_seconds: float
+    turn_records: list[TurnRecord] = field(default_factory=list)
+
+
+class AgentLoopError(RuntimeError):
+    """A model call or tool dispatch failed mid-loop.
+
+    Carries the partial ``AgentLoopResult`` (``stopped_reason="error"``) so the
+    driver can keep the tokens and per-turn records already spent on the
+    errored task — real cost is never discarded just because the task died.
+    """
+
+    def __init__(self, cause: Exception, partial: AgentLoopResult) -> None:
+        super().__init__(str(cause))
+        self.cause = cause
+        self.partial = partial
+
+
+def _truncate_result(text: str) -> str:
+    if len(text) <= TOOL_RESULT_MAX_CHARS:
+        return text
+    return text[:TOOL_RESULT_MAX_CHARS] + TRUNCATION_SUFFIX
+
+
+def run_agent_loop(
+    *,
+    model: ToolAgentModel,
+    dispatch: ToolDispatch,
+    tools: Sequence[ToolDef],
+    prompt: str,
+    budget: AgentBudget,
+    clock: Callable[[], float] = time.monotonic,
+) -> AgentLoopResult:
+    allowed_names = {tool.name for tool in tools}
+    transcript: list[TranscriptItem] = [UserMessage(text=prompt)]
+    turn_records: list[TurnRecord] = []
+    model_turns = 0
+    tool_call_count = 0
+    total_input_tokens = 0
+    total_output_tokens = 0
+    started = clock()
+
+    def stop(reason: StopReason, final_answer: str | None) -> AgentLoopResult:
+        return AgentLoopResult(
+            final_answer=final_answer,
+            stopped_reason=reason,
+            turns=model_turns,
+            tool_call_count=tool_call_count,
+            total_input_tokens=total_input_tokens,
+            total_output_tokens=total_output_tokens,
+            wall_seconds=clock() - started,
+            turn_records=turn_records,
+        )
+
+    budget_stop: Literal["turns", "tokens", "wall_clock"] | None = None
+    while True:
+        # Budget gate BEFORE each model call: a breach returns without a final
+        # answer, so budget-stopped tasks fail their answer predicates honestly.
+        if clock() - started >= budget.max_task_seconds:
+            budget_stop = "wall_clock"
+        elif model_turns >= budget.max_turns:
+            budget_stop = "turns"
+        elif total_input_tokens + total_output_tokens >= budget.max_total_tokens:
+            budget_stop = "tokens"
+        if budget_stop is not None:
+            return stop(budget_stop, None)
+
+        try:
+            turn = model.propose(transcript, tools)
+        except Exception as exc:
+            raise AgentLoopError(exc, stop("error", None)) from exc
+        model_turns += 1
+        total_input_tokens += turn.input_tokens
+        total_output_tokens += turn.output_tokens
+        finalized = not turn.tool_calls
+        turn_records.append(
+            TurnRecord(
+                turn_index=len(turn_records),
+                kind="model",
+                input_tokens=turn.input_tokens,
+                output_tokens=turn.output_tokens,
+                latency_ms=round(turn.latency_ms, 2),
+                tool_call_count=len(turn.tool_calls),
+                finalized=finalized,
+            )
+        )
+        transcript.append(AssistantTurn(text=turn.text, tool_calls=turn.tool_calls))
+        if finalized:
+            return stop("final", turn.text)
+
+        for call in turn.tool_calls:
+            # Trigger: wall clock exhausted between tool dispatches.
+            # Why: gating only before model calls would let one assistant turn
+            # carrying many calls overrun the budget by n_calls x tool_timeout.
+            # Outcome: stop with 'wall_clock' and no final answer, exactly like
+            # the pre-model-call gate.
+            if clock() - started >= budget.max_task_seconds:
+                return stop("wall_clock", None)
+            tool_call_count += 1
+            if call.name not in allowed_names:
+                # Hallucinated or off-surface tool: never reaches BM; the error
+                # is fed back so the model can self-correct within budget.
+                outcome = ToolOutcome(
+                    text=f"tool '{call.name}' is not available on this surface",
+                    is_error=True,
+                )
+                latency_ms = 0.0
+            else:
+                dispatch_started = time.perf_counter()
+                try:
+                    outcome = dispatch(call.name, call.arguments)
+                except Exception as exc:
+                    # Record the call that was in flight when the dispatch died
+                    # so per-turn.jsonl shows where the failure happened.
+                    turn_records.append(
+                        TurnRecord(
+                            turn_index=len(turn_records),
+                            kind="tool",
+                            latency_ms=round((time.perf_counter() - dispatch_started) * 1000.0, 2),
+                            tool_name=call.name,
+                            arguments_chars=len(str(call.arguments)),
+                            is_error=True,
+                        )
+                    )
+                    raise AgentLoopError(exc, stop("error", None)) from exc
+                latency_ms = (time.perf_counter() - dispatch_started) * 1000.0
+            fed_back = _truncate_result(outcome.text)
+            turn_records.append(
+                TurnRecord(
+                    turn_index=len(turn_records),
+                    kind="tool",
+                    latency_ms=round(latency_ms, 2),
+                    tool_name=call.name,
+                    arguments_chars=len(str(call.arguments)),
+                    result_chars=len(fed_back),
+                    is_error=outcome.is_error,
+                )
+            )
+            transcript.append(
+                ToolReturn(
+                    call_id=call.call_id,
+                    name=call.name,
+                    text=fed_back,
+                    is_error=outcome.is_error,
+                )
+            )

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/models.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/models.py
@@ -1,0 +1,142 @@
+"""Configuration and artifact schemas for the agent-task eval (basic-memory#1401)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from basic_memory_benchmarks.models import RuntimeInfo
+
+# "error" marks a loop that died mid-task (model or dispatch failure): the
+# partial accounting is kept on the errored row, never counted as a budget stop.
+StopReason = Literal["final", "turns", "tokens", "wall_clock", "error"]
+
+
+class AgentBudget(BaseModel):
+    """Per-task budgets; identical across surfaces (fairness contract)."""
+
+    max_turns: int = Field(default=20, ge=1)
+    max_total_tokens: int = Field(default=200_000, ge=1)
+    max_task_seconds: float = Field(default=300.0, gt=0.0)
+
+
+class AgentTasksConfig(BaseModel):
+    run_id: str
+    surfaces: list[str] = Field(default_factory=lambda: ["rich"])
+    task_ids: list[str] = Field(default_factory=list)  # empty = all shipped tasks
+    model_spec: str
+    judge_spec: str | None = None
+    corpus_dir: str = "benchmarks/datasets/agent-tasks/corpus"
+    output_root: str = "benchmarks/runs"
+    bm_source: str = "local-checkout"
+    bm_local_path: str
+    budget: AgentBudget = Field(default_factory=AgentBudget)
+    tool_timeout_seconds: float = Field(default=120.0, gt=0.0)
+    settle_timeout_seconds: float = Field(default=180.0, gt=0.0)
+    allow_surface_skip: bool = True
+
+
+class TurnRecord(BaseModel):
+    """One model turn or one tool dispatch inside a task's agent loop."""
+
+    turn_index: int
+    kind: Literal["model", "tool"]
+    input_tokens: int = 0
+    output_tokens: int = 0
+    latency_ms: float = 0.0
+    tool_call_count: int = 0
+    finalized: bool = False
+    tool_name: str | None = None
+    arguments_chars: int = 0
+    result_chars: int = 0
+    is_error: bool = False
+
+
+class PredicateResult(BaseModel):
+    name: str
+    kind: str
+    passed: bool
+    required: bool
+    detail: str
+
+
+class AgentTaskResult(BaseModel):
+    surface: str
+    task_id: str
+    skill: str
+    passed: bool
+    stopped_reason: StopReason | None = None
+    turns: int = 0
+    tool_calls: int = 0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    wall_seconds: float = 0.0
+    final_answer: str | None = None
+    predicates: list[PredicateResult] = Field(default_factory=list)
+    judge_input_tokens: int = 0
+    judge_output_tokens: int = 0
+    judge_calls: int = 0
+    # Harness/model/session failure: errored tasks are excluded from means and
+    # never zero-scored (the scoring/beam.py explicit-failure principle).
+    error: str | None = None
+    # Per-turn accounting; serialized into per-turn.jsonl, excluded from the
+    # per-task rows to keep them scannable.
+    turn_records: list[TurnRecord] = Field(default_factory=list)
+
+
+class SkillBreakdown(BaseModel):
+    total: int
+    passed: int
+    tokens_per_completed: float | None = None
+
+
+class SurfaceSummary(BaseModel):
+    surface: str
+    model: str
+    tasks_total: int
+    tasks_passed: int
+    tasks_errored: int
+    budget_stops: dict[str, int] = Field(default_factory=dict)
+    pass_rate: float
+    total_input_tokens: int
+    total_output_tokens: int
+    # The headline: total agent tokens over ALL attempted tasks divided by
+    # completed tasks. None (never 0) when nothing completed.
+    tokens_per_completed_task: float | None
+    tokens_per_attempted_task: float
+    mean_tool_calls: float
+    mean_turns: float
+    mean_wall_seconds: float
+    per_skill: dict[str, SkillBreakdown] = Field(default_factory=dict)
+    judge_input_tokens: int = 0
+    judge_output_tokens: int = 0
+    judge_calls: int = 0
+
+
+class SurfaceEcho(BaseModel):
+    """Full surface definition echoed into the manifest — the fairness audit trail."""
+
+    name: str
+    config_overrides: dict[str, str]
+    tool_allowlist: list[str]
+    observed_tools: list[str] = Field(default_factory=list)
+
+
+class AgentTasksManifest(BaseModel):
+    run_id: str
+    created_at_utc: str
+    benchmark_git_sha: str
+    bm_source: str
+    bm_resolved_sha: str
+    bm_version: str | None = None
+    home_dir: str
+    model_spec: str
+    judge_spec: str | None = None
+    budget: AgentBudget
+    corpus_checksum: str
+    corpus_file_count: int
+    task_ids: list[str]
+    surfaces: list[SurfaceEcho]
+    runtime: RuntimeInfo
+    config: AgentTasksConfig

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/spec.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/spec.py
@@ -1,0 +1,179 @@
+"""Declarative task-spec and grader types for the agent-task eval.
+
+Specs are pure frozen data (house style: data before behavior); evaluation
+lives in ``grading.py``. A task passes iff every ``required=True`` predicate
+passes; non-required predicates (e.g. ``ToolCalled``) are diagnostics only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# A file selector: a glob relative to the project dir, or the sentinel "new"
+# meaning "the file(s) added since the baseline snapshot".
+type PathSel = str
+
+NEW_FILE_SELECTOR = "new"
+
+
+@dataclass(frozen=True)
+class AnswerSetEquals:
+    """The final answer's fenced-JSON ``key`` list equals ``gold`` as a set."""
+
+    key: str
+    gold: frozenset[str]
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class MarkerPresent:
+    marker: str
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class MarkerAbsent:
+    marker: str
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class AnswerContains:
+    needle: str
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class AnswerMatches:
+    """The final answer matches ``pattern`` (case-insensitive, like AnswerContains)."""
+
+    pattern: str
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class NoteCountDelta:
+    """Markdown file count changed by exactly ``delta`` vs the baseline."""
+
+    delta: int
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class NewNoteUnder:
+    """Every file added since the baseline snapshot lives under ``prefix``."""
+
+    prefix: str
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class NotesUntouched:
+    """Every baseline file is byte-identical, except paths matching the globs."""
+
+    except_globs: tuple[str, ...] = ()
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class FrontmatterEquals:
+    """Dot-notation frontmatter key equals ``value`` in the selected file."""
+
+    path: PathSel
+    key: str
+    value: str | int | float | bool
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class FrontmatterMatches:
+    path: PathSel
+    key: str
+    pattern: str
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class FrontmatterListLen:
+    path: PathSel
+    key: str
+    length: int
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class ObservationLines:
+    """At least ``min_count`` lines matching ``pattern`` in the selected file."""
+
+    path: PathSel
+    pattern: str
+    min_count: int
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class RelationResolves:
+    """A resolved relation row exists from source to one of ``targets`` in the DB."""
+
+    source_permalink: str
+    targets: frozenset[str]
+    relation_type: str | None = None
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class FileLineDiff:
+    """Exactly one line changed vs baseline, matching the given patterns."""
+
+    path: PathSel
+    removed_pattern: str
+    added_pattern: str
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class ToolCalled:
+    """Diagnostic: some dispatched tool call's name matches ``name_pattern``."""
+
+    name_pattern: str
+    required: bool = False
+
+
+@dataclass(frozen=True)
+class JudgeRubric:
+    """LLM-judged rubric over the final answer (via the package judge seam)."""
+
+    rubric: str
+    required: bool = True
+
+
+type Grader = (
+    AnswerSetEquals
+    | MarkerPresent
+    | MarkerAbsent
+    | AnswerContains
+    | AnswerMatches
+    | NoteCountDelta
+    | NewNoteUnder
+    | NotesUntouched
+    | FrontmatterEquals
+    | FrontmatterMatches
+    | FrontmatterListLen
+    | ObservationLines
+    | RelationResolves
+    | FileLineDiff
+    | ToolCalled
+    | JudgeRubric
+)
+
+
+@dataclass(frozen=True)
+class AgentTaskSpec:
+    id: str
+    # "memory-continue" | "memory-curate" | "memory-metadata-search" |
+    # "memory-tasks" | "manual"
+    skill: str
+    # Attribution, e.g. "skills/memory-continue/SKILL.md" or "SPEC-47 manual chain".
+    source: str
+    prompt: str
+    graders: tuple[Grader, ...]

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/surfaces.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/surfaces.py
@@ -1,0 +1,100 @@
+"""Tool surfaces as data: rich (today's MCP tools) vs posix (#1399/#1406).
+
+This branch does NOT contain the posix tools — they live on the 1399/1403
+stack — so the surface is pure data: config overrides applied to the ephemeral
+BM instance's environment plus a tool allowlist. Selecting the posix surface
+against a BM build that lacks the flag fails fast (or is recorded as an
+explicit skip) via ``verify_surface_tools``; the six posix tool names below
+are the single place to reconcile against that branch if names drift.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+
+class SurfaceUnavailableError(RuntimeError):
+    """The running BM build does not expose the tools this surface needs."""
+
+
+@dataclass(frozen=True)
+class ToolSurface:
+    name: str
+    # BasicMemoryConfig field -> env value string, applied as
+    # BASIC_MEMORY_<FIELD_UPPER>=<value> (BaseSettings env_prefix contract).
+    config_overrides: Mapping[str, str]
+    # Deterministic order: this is the order tool schemas reach the model.
+    tool_allowlist: tuple[str, ...]
+    # Human hint for the fail-fast message.
+    requires: str
+
+
+RICH_SURFACE = ToolSurface(
+    name="rich",
+    config_overrides={},
+    tool_allowlist=(
+        "search_notes",
+        "read_note",
+        "read_content",
+        "list_directory",
+        "recent_activity",
+        "build_context",
+        "write_note",
+        "edit_note",
+        "move_note",
+        "delete_note",
+    ),
+    requires="any current basic-memory build",
+)
+
+# Read verbs swapped per #1399; write verbs shared — posix v1 is read-side
+# only ("later issue if the read-side A/B justifies it"), so the A/B isolates
+# the read-side surface while every task stays runnable on both surfaces.
+POSIX_SURFACE = ToolSurface(
+    name="posix",
+    config_overrides={"enable_posix_tools": "true"},
+    tool_allowlist=(
+        "cat",
+        "grep",
+        "ls",
+        "find",
+        "tail",
+        "man",
+        "write_note",
+        "edit_note",
+        "move_note",
+        "delete_note",
+    ),
+    requires="a basic-memory checkout with the enable_posix_tools flag (#1399/#1406 stack)",
+)
+
+SURFACES: dict[str, ToolSurface] = {"rich": RICH_SURFACE, "posix": POSIX_SURFACE}
+
+
+def surface_env(surface: ToolSurface, base_env: dict[str, str]) -> dict[str, str]:
+    """Apply the surface's config overrides on top of an isolated BM env."""
+    env = dict(base_env)
+    for setting, value in surface.config_overrides.items():
+        env[f"BASIC_MEMORY_{setting.upper()}"] = value
+    return env
+
+
+def verify_surface_tools(
+    surface: ToolSurface, available: Iterable[str], *, bm_version: str | None = None
+) -> None:
+    """Authoritative surface check against the tools the server actually exposes.
+
+    The env override alone is not a check: an old BM's pydantic settings ignore
+    the unknown key silently, so only the advertised tool list proves the
+    surface exists on this build.
+    """
+    available_names = set(available)
+    missing = [name for name in surface.tool_allowlist if name not in available_names]
+    if not missing:
+        return
+    raise SurfaceUnavailableError(
+        f"surface '{surface.name}' needs tools not exposed by this basic-memory "
+        f"(bm --version: {bm_version or 'unknown'}): missing {', '.join(missing)}. "
+        f"Requires {surface.requires}; point --bm-local-path at it."
+    )

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/tasks.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/tasks.py
@@ -1,0 +1,249 @@
+"""The shipped agent tasks, derived from the Basic Memory skills.
+
+Each task is declarative data (see ``spec.py``); grading is deterministic for
+all twelve (the judge seam exists but no shipped task uses it, so judge tokens
+never touch the headline). Gold values are pinned to the seed corpus in
+``benchmarks/datasets/agent-tasks/corpus`` and enforced by the fixture
+integrity tests.
+"""
+
+from __future__ import annotations
+
+from basic_memory_benchmarks.agent_tasks.spec import (
+    NEW_FILE_SELECTOR,
+    AgentTaskSpec,
+    AnswerMatches,
+    AnswerSetEquals,
+    FrontmatterEquals,
+    FrontmatterListLen,
+    FrontmatterMatches,
+    MarkerAbsent,
+    MarkerPresent,
+    NewNoteUnder,
+    NoteCountDelta,
+    NotesUntouched,
+    ObservationLines,
+    RelationResolves,
+    ToolCalled,
+)
+
+ORPHAN_PERMALINKS = frozenset(
+    {
+        "notes/redis-cache-tuning",
+        "notes/postgres-vacuum-notes",
+        "notes/coffee-brewing-log",
+    }
+)
+
+RECENT_TITLES = frozenset(
+    {
+        "2026-08-27 SPEC-9 Session 2",
+        "2026-08-27 Infra Notes",
+        "Migrate CI to uv",
+    }
+)
+
+ACTIVE_HIGH_PRIORITY_PERMALINKS = frozenset(
+    {"specs/spec-9-search-rework", "notes/kubernetes-migration"}
+)
+
+HIGH_CONFIDENCE_PERMALINKS = frozenset(
+    {"specs/spec-9-search-rework", "architecture/oauth-token-design"}
+)
+
+PENDING_OAUTH_REVIEW_PERMALINKS = frozenset({"architecture/oauth-token-design"})
+
+TASKS: tuple[AgentTaskSpec, ...] = (
+    AgentTaskSpec(
+        id="continue-spec9",
+        skill="memory-continue",
+        source="skills/memory-continue/SKILL.md",
+        prompt=(
+            "Where were we on SPEC-9? List every open item and the next step, quoting "
+            "each item's text verbatim (including any tracking tokens)."
+        ),
+        graders=(
+            MarkerPresent(marker="BMEVAL-s9open1-4c1a"),
+            MarkerPresent(marker="BMEVAL-s9open2-9d2b"),
+            MarkerPresent(marker="BMEVAL-s9open3-77e0"),
+            MarkerPresent(marker="BMEVAL-s9next-b881"),
+            MarkerAbsent(marker="BMEVAL-s8open-1f2e"),
+            MarkerAbsent(marker="BMEVAL-s8next-c9a4"),
+            ToolCalled(name_pattern=r"search_notes|build_context|read_note|grep|cat"),
+        ),
+    ),
+    AgentTaskSpec(
+        id="continue-recent-window",
+        skill="memory-continue",
+        source="skills/memory-continue/SKILL.md",
+        prompt=(
+            "What did we work on in the last three days? Answer with the note titles "
+            'as {"titles": [...]}.'
+        ),
+        graders=(
+            AnswerSetEquals(key="titles", gold=RECENT_TITLES),
+            MarkerAbsent(marker="BMEVAL-oldnote1-2b3c"),
+            MarkerAbsent(marker="BMEVAL-oldnote2-8e7d"),
+        ),
+    ),
+    AgentTaskSpec(
+        id="continue-two-hop",
+        skill="memory-continue",
+        source="skills/memory-continue/SKILL.md",
+        prompt=(
+            "Continue work on Feature X: what constraint does its dependency chain "
+            "impose on the storage layer? Quote the constraint's tracking token "
+            "verbatim."
+        ),
+        graders=(MarkerPresent(marker="BMEVAL-quota-fa11"),),
+    ),
+    AgentTaskSpec(
+        id="curate-orphans",
+        skill="memory-curate",
+        source="skills/memory-curate/SKILL.md",
+        prompt=(
+            "Find all orphan notes in this project (notes with no relations to or "
+            'from any other note). Answer with {"permalinks": [...]}.'
+        ),
+        graders=(AnswerSetEquals(key="permalinks", gold=ORPHAN_PERMALINKS),),
+    ),
+    AgentTaskSpec(
+        id="curate-connect",
+        skill="memory-curate",
+        source="skills/memory-curate/SKILL.md",
+        prompt=(
+            "The note 'Redis Cache Tuning' is unlinked. Connect it to the single most "
+            "relevant existing note by adding one typed relation to its Relations "
+            "section. Do not modify any other note and do not create new notes."
+        ),
+        graders=(
+            RelationResolves(
+                source_permalink="notes/redis-cache-tuning",
+                targets=frozenset({"architecture/redis-cache-architecture"}),
+            ),
+            NotesUntouched(except_globs=("notes/redis-cache-tuning.md",)),
+            NoteCountDelta(delta=0),
+        ),
+    ),
+    AgentTaskSpec(
+        id="meta-status-priority",
+        skill="memory-metadata-search",
+        source="skills/memory-metadata-search/SKILL.md",
+        prompt=(
+            "Using the notes' frontmatter metadata, which notes are active (status) "
+            "with high or critical priority? Answer with their permalinks as "
+            '{"permalinks": [...]}.'
+        ),
+        graders=(AnswerSetEquals(key="permalinks", gold=ACTIVE_HIGH_PRIORITY_PERMALINKS),),
+    ),
+    AgentTaskSpec(
+        id="meta-confidence-gt",
+        skill="memory-metadata-search",
+        source="skills/memory-metadata-search/SKILL.md",
+        prompt=(
+            "Which notes have a frontmatter confidence strictly greater than 0.7? "
+            'Answer with their permalinks as {"permalinks": [...]}.'
+        ),
+        graders=(AnswerSetEquals(key="permalinks", gold=HIGH_CONFIDENCE_PERMALINKS),),
+    ),
+    AgentTaskSpec(
+        id="meta-nested-review",
+        skill="memory-metadata-search",
+        source="skills/memory-metadata-search/SKILL.md",
+        prompt=(
+            "Find the draft notes about OAuth whose review status is still pending "
+            '(a nested frontmatter field). Answer with {"permalinks": [...]}.'
+        ),
+        graders=(AnswerSetEquals(key="permalinks", gold=PENDING_OAUTH_REVIEW_PERMALINKS),),
+    ),
+    AgentTaskSpec(
+        id="tasks-create",
+        skill="memory-tasks",
+        source="skills/memory-tasks/SKILL.md",
+        prompt=(
+            "Track this work: migrate the docs build to uv — (1) audit pip usage, "
+            "(2) rewrite the CI workflow, (3) verify the deploy. Create a task note "
+            "in tasks/ following this project's Task schema (see the schemas/ "
+            "directory), starting at the first step."
+        ),
+        graders=(
+            NoteCountDelta(delta=1),
+            NewNoteUnder(prefix="tasks/"),
+            FrontmatterEquals(path=NEW_FILE_SELECTOR, key="type", value="task"),
+            FrontmatterEquals(path=NEW_FILE_SELECTOR, key="status", value="active"),
+            FrontmatterListLen(path=NEW_FILE_SELECTOR, key="steps", length=3),
+            FrontmatterEquals(path=NEW_FILE_SELECTOR, key="current_step", value=1),
+            ObservationLines(path=NEW_FILE_SELECTOR, pattern=r"^- \[[a-z-]+\] ", min_count=1),
+        ),
+    ),
+    AgentTaskSpec(
+        id="tasks-resume",
+        skill="memory-tasks",
+        source="skills/memory-tasks/SKILL.md",
+        prompt=(
+            "You've lost all context. Find your active tasks and report, for each "
+            "one, its context field and the step it is currently on — quote both "
+            "verbatim (including any tracking tokens). Skip tasks that are not "
+            "active."
+        ),
+        graders=(
+            MarkerPresent(marker="BMEVAL-ci-ctx-90bf"),
+            MarkerPresent(marker="BMEVAL-ci-step2-51aa"),
+            MarkerPresent(marker="BMEVAL-rsi-ctx-33cd"),
+            MarkerPresent(marker="BMEVAL-rsi-step1-6d21"),
+            MarkerAbsent(marker="BMEVAL-done-ab12"),
+            MarkerAbsent(marker="BMEVAL-blocked-cd34"),
+        ),
+    ),
+    AgentTaskSpec(
+        id="tasks-complete",
+        skill="memory-tasks",
+        source="skills/memory-tasks/SKILL.md",
+        prompt=(
+            "Mark the task 'Migrate CI to uv' as done, recording today's completion "
+            "date in its frontmatter. Do not modify any other note."
+        ),
+        graders=(
+            FrontmatterEquals(path="tasks/migrate-ci-to-uv.md", key="status", value="done"),
+            FrontmatterMatches(
+                path="tasks/migrate-ci-to-uv.md",
+                key="completed",
+                pattern=r"^\d{4}-\d{2}-\d{2}",
+            ),
+            NotesUntouched(except_globs=("tasks/migrate-ci-to-uv.md",)),
+            NoteCountDelta(delta=0),
+        ),
+    ),
+    AgentTaskSpec(
+        id="man-chain",
+        skill="manual",
+        source="SPEC-47 manual chain (search manual -> read man page section)",
+        prompt=(
+            "Manual pages for the memory tools live in man3/. Which page documents "
+            "the tool for incremental note edits? Read that page and report the "
+            "exact token from its EXAMPLES section that starts with BMEVAL-."
+        ),
+        graders=(
+            MarkerPresent(marker="BMEVAL-man-edit-7f3e"),
+            # Both tool spellings are substantively correct: the man page is
+            # edit-note(3) while the MCP tool itself is edit_note.
+            AnswerMatches(pattern=r"edit[-_]note"),
+            ToolCalled(name_pattern=r"read_note|read_content|search_notes|cat|man|grep"),
+        ),
+    ),
+)
+
+TASKS_BY_ID: dict[str, AgentTaskSpec] = {task.id: task for task in TASKS}
+
+
+def select_tasks(task_ids: list[str]) -> list[AgentTaskSpec]:
+    """Resolve a task-id filter (empty = all), rejecting unknown ids loudly."""
+    if not task_ids:
+        return sorted(TASKS, key=lambda task: task.id)
+    unknown = [task_id for task_id in task_ids if task_id not in TASKS_BY_ID]
+    if unknown:
+        raise ValueError(f"Unknown task ids: {unknown}. Known: {sorted(TASKS_BY_ID)}")
+    # dict.fromkeys dedupes while preserving input order; a duplicated id must
+    # not create two same-named per-task projects.
+    unique_ids = dict.fromkeys(task_ids)
+    return sorted((TASKS_BY_ID[task_id] for task_id in unique_ids), key=lambda task: task.id)

--- a/benchmarks/src/basic_memory_benchmarks/bm_runtime.py
+++ b/benchmarks/src/basic_memory_benchmarks/bm_runtime.py
@@ -9,16 +9,23 @@ same code runs unchanged against any BM version under comparison (installed
 from __future__ import annotations
 
 import asyncio
+import json
+import os
 import threading
+import time
 from concurrent.futures import Future
 from dataclasses import dataclass
 from pathlib import Path
 from queue import Empty, Queue
-from typing import Any
+from typing import Any, Literal
 
 from mcp.client.session import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
-from mcp.types import CallToolResult
+from mcp.types import CallToolResult, Tool
+
+from basic_memory_benchmarks.utils import run_command
+
+FALLBACK_SETTLE_SECONDS = 10.0
 
 
 @dataclass
@@ -60,6 +67,7 @@ class WarmMcpClient:
         self._state_lock = threading.Lock()
         self._loop: asyncio.AbstractEventLoop | None = None
         self._serve_task: asyncio.Task[None] | None = None
+        self._tools: list[Tool] = []
 
     async def _serve(self) -> None:
         loop = asyncio.get_running_loop()
@@ -79,6 +87,9 @@ class WarmMcpClient:
                 if self._required_tool not in tool_names:
                     raise RuntimeError(f"bm mcp server does not expose '{self._required_tool}'")
 
+                # Captured before _ready so tools() is populated as soon as
+                # start() returns; consumers use it for surface verification.
+                self._tools = list(tools.tools)
                 self._ready.set()
 
                 while True:
@@ -142,6 +153,12 @@ class WarmMcpClient:
             startup_error = self._startup_error
             self.stop()
             raise RuntimeError("Failed to start bm mcp session") from startup_error
+
+    def tools(self) -> list[Tool]:
+        """Tool definitions the server advertised at session start."""
+        if self._thread is None or not self._thread.is_alive():
+            raise RuntimeError("bm mcp session is not running")
+        return list(self._tools)
 
     def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
         if self._thread is None or not self._thread.is_alive():
@@ -232,3 +249,56 @@ def status_json_is_ready(payload: dict[str, Any]) -> bool | None:
                 return False
 
     return True if recognized_signal else None
+
+
+def isolated_bm_env(home: Path) -> dict[str, str]:
+    """Benchmark-owned env: fresh config dir AND fresh default-project home.
+
+    BASIC_MEMORY_HOME points inside the sandbox so the auto-created default
+    project indexes an empty directory instead of the operator's personal
+    notes (which would add noise to settle timing and DB contents).
+    """
+    env = dict(os.environ)
+    env.pop("BASIC_MEMORY_CLOUD_MODE", None)
+    env["BASIC_MEMORY_CONFIG_DIR"] = str(home / "config")
+    env["BASIC_MEMORY_HOME"] = str(home / "default-home")
+    return env
+
+
+def settle_index(
+    *,
+    prefix: list[str],
+    env: dict[str, str],
+    project_name: str,
+    timeout_seconds: float,
+) -> tuple[float, Literal["status-json", "fixed-delay"]]:
+    """Wait until the index reports no pending work; returns (seconds, mode)."""
+    start = time.monotonic()
+    probe = run_command(prefix + ["status", "--json", "--local"], check=False, env=env)
+    merged = ((probe.stdout or "") + "\n" + (probe.stderr or "")).lower()
+    if "no such option: --json" in merged:
+        # Old BM without --json: no readiness signal exists; give the watcher a
+        # fixed grace period and record the mode so the artifact is explicit.
+        time.sleep(FALLBACK_SETTLE_SECONDS)
+        return time.monotonic() - start, "fixed-delay"
+
+    deadline = start + timeout_seconds
+    delay = 0.25
+    while True:
+        completed = run_command(
+            prefix + ["status", "--project", project_name, "--json", "--local"], env=env
+        )
+        payload = json.loads(completed.stdout.strip() or "{}")
+        if isinstance(payload, dict):
+            readiness = status_json_is_ready(payload)
+            if readiness is None:
+                time.sleep(FALLBACK_SETTLE_SECONDS)
+                return time.monotonic() - start, "fixed-delay"
+            if readiness:
+                return time.monotonic() - start, "status-json"
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"Index did not settle within {timeout_seconds}s for project '{project_name}'"
+            )
+        time.sleep(delay)
+        delay = min(delay * 2, 2.0)

--- a/benchmarks/src/basic_memory_benchmarks/cli.py
+++ b/benchmarks/src/basic_memory_benchmarks/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 import uuid
 from pathlib import Path
@@ -9,6 +10,11 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
+from basic_memory_benchmarks.agent_tasks.driver import run_agent_tasks
+from basic_memory_benchmarks.agent_tasks.models import AgentBudget, AgentTasksConfig
+from basic_memory_benchmarks.agent_tasks.spec import JudgeRubric
+from basic_memory_benchmarks.agent_tasks.surfaces import SURFACES
+from basic_memory_benchmarks.agent_tasks.tasks import select_tasks
 from basic_memory_benchmarks.concurrent_write import (
     ConcurrentWriteConfig,
     run_concurrent_write,
@@ -24,6 +30,7 @@ from basic_memory_benchmarks.datasets.longmemeval import (
     LONGMEMEVAL_S_URL,
     fetch_longmemeval_dataset,
 )
+from basic_memory_benchmarks.llm.tool_agent import create_tool_agent_model
 from basic_memory_benchmarks.models import DatasetProvenance, RunConfig
 from basic_memory_benchmarks.reporting.compare import (
     compare_provider_metric,
@@ -352,13 +359,130 @@ def run_concurrent_write_command(
     console.print(f"Concurrent-write run complete: [green]{run_dir}[/green]")
 
     if strict:
-        import json
-
         summary = json.loads(
             (run_dir / "concurrent-write-summary.json").read_text(encoding="utf-8")
         )
         if not summary["converged"]:
             console.print("[red]Convergence checks failed (--strict)[/red]")
+            raise typer.Exit(code=1)
+
+
+@run_app.command("agent-tasks")
+def run_agent_tasks_command(
+    surfaces: str = typer.Option(
+        "rich", "--surfaces", help="Comma-separated tool surfaces: rich,posix (issue #1401)"
+    ),
+    model: str = typer.Option(
+        ...,
+        "--model",
+        help="Agent under test: openai-compat:<model>@<base_url> | scripted:<path.json>",
+    ),
+    judge: str | None = typer.Option(
+        None,
+        "--judge",
+        help="Judge runner spec (claude:<model> or openai-compat:...); required only "
+        "when a selected task uses a judge_rubric grader",
+    ),
+    tasks: str = typer.Option(
+        "", "--tasks", help="Comma-separated task ids; empty runs all shipped tasks"
+    ),
+    corpus_dir: Path = typer.Option(Path("benchmarks/datasets/agent-tasks/corpus"), "--corpus-dir"),
+    output_root: Path = typer.Option(Path("benchmarks/runs"), "--output-root"),
+    run_id: str | None = typer.Option(None, "--run-id"),
+    bm_source: str = typer.Option("local-checkout", "--bm-source"),
+    bm_local_path: Path = typer.Option(
+        ...,
+        "--bm-local-path",
+        exists=True,
+        file_okay=False,
+        resolve_path=True,
+        help="Pinned Basic Memory git checkout to benchmark",
+    ),
+    max_turns: int = typer.Option(20, "--max-turns"),
+    max_total_tokens: int = typer.Option(200_000, "--max-total-tokens"),
+    task_timeout: float = typer.Option(300.0, "--task-timeout"),
+    tool_timeout: float = typer.Option(120.0, "--tool-timeout"),
+    settle_timeout: float = typer.Option(180.0, "--settle-timeout"),
+    allow_surface_skip: bool = typer.Option(
+        True,
+        "--allow-surface-skip/--strict-surfaces",
+        help="Record an unavailable surface as skipped (default) or abort the run",
+    ),
+    strict: bool = typer.Option(
+        False,
+        "--strict/--no-strict",
+        help="Exit nonzero when any surface is not ok or any task errored; the pass "
+        "rate itself is never a gate",
+    ),
+) -> None:
+    """Agent-in-the-loop eval: same tasks/model/budget, tool surface varies (#1401)."""
+    # dict.fromkeys dedupes while preserving input order (mirroring select_tasks);
+    # a duplicated surface must not create the same surface home twice mid-run.
+    surface_list = list(dict.fromkeys(item.strip() for item in surfaces.split(",") if item.strip()))
+    if not surface_list:
+        raise typer.BadParameter("--surfaces must name at least one surface")
+    unknown_surfaces = [name for name in surface_list if name not in SURFACES]
+    if unknown_surfaces:
+        raise typer.BadParameter(f"Unknown surfaces: {unknown_surfaces}. Known: {sorted(SURFACES)}")
+
+    task_ids = [item.strip() for item in tasks.split(",") if item.strip()]
+    try:
+        selected = select_tasks(task_ids)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    # Fail fast at parse time: a bad model spec (including claude:) and a
+    # missing judge for judge-graded tasks must not survive to mid-run.
+    try:
+        create_tool_agent_model(model)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    judged = [
+        task.id
+        for task in selected
+        if any(isinstance(grader, JudgeRubric) for grader in task.graders)
+    ]
+    if judged and judge is None:
+        raise typer.BadParameter(f"Tasks {judged} use judge_rubric graders; pass --judge")
+
+    resolved_run_id = run_id or f"at-{uuid.uuid4().hex[:12]}"
+    config = AgentTasksConfig(
+        run_id=resolved_run_id,
+        surfaces=surface_list,
+        task_ids=task_ids,
+        model_spec=model,
+        judge_spec=judge,
+        corpus_dir=str(corpus_dir),
+        output_root=str(output_root),
+        bm_source=bm_source,
+        bm_local_path=str(bm_local_path),
+        budget=AgentBudget(
+            max_turns=max_turns,
+            max_total_tokens=max_total_tokens,
+            max_task_seconds=task_timeout,
+        ),
+        tool_timeout_seconds=tool_timeout,
+        settle_timeout_seconds=settle_timeout,
+        allow_surface_skip=allow_surface_skip,
+    )
+    run_dir = run_agent_tasks(config)
+    console.print(f"Agent-task run complete: [green]{run_dir}[/green]")
+    console.print(f"See [cyan]{run_dir / 'summary.md'}[/cyan]")
+
+    if strict:
+        statuses = json.loads((run_dir / "surface-status.json").read_text(encoding="utf-8"))
+        not_ok = [status for status in statuses if status["state"] != "ok"]
+        task_rows = [
+            json.loads(line)
+            for line in (run_dir / "per-task-agent.jsonl").read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        errored = [row for row in task_rows if row.get("error")]
+        if not_ok or errored:
+            console.print(
+                f"[red]--strict: {len(not_ok)} surface(s) not ok,"
+                f" {len(errored)} errored task(s)[/red]"
+            )
             raise typer.Exit(code=1)
 
 
@@ -418,8 +542,6 @@ def run_diagnose_command(
     across providers) from "truly missed" (a real retrieval failure), so QA
     accuracy can be read honestly against the retrieval ceiling.
     """
-    import json
-
     from rich.table import Table
 
     out = run_diagnose_stage(run_dir=run_dir, source=source, recall_field=recall_field)

--- a/benchmarks/src/basic_memory_benchmarks/concurrent_write.py
+++ b/benchmarks/src/basic_memory_benchmarks/concurrent_write.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import json
 import math
-import os
 import random
 import re
 import sqlite3
@@ -45,8 +44,9 @@ from rich.console import Console
 
 from basic_memory_benchmarks.bm_runtime import (
     WarmMcpClient,
+    isolated_bm_env,
     resolve_bm_command_prefix,
-    status_json_is_ready,
+    settle_index,
 )
 from basic_memory_benchmarks.models import RuntimeInfo
 from basic_memory_benchmarks.utils import git_sha, run_command, runtime_info, utc_now_iso
@@ -56,7 +56,6 @@ console = Console()
 OpType = Literal["create_hub", "create", "edit_hub", "edit_own"]
 
 MARKER_PATTERN = re.compile(r"bmk-[a-z0-9-]+")
-FALLBACK_SETTLE_SECONDS = 10.0
 
 # --- Configuration and artifact models ---
 
@@ -837,65 +836,12 @@ def write_concurrent_artifacts(
 # --- Orchestration ---
 
 
-def _isolated_env(home: Path) -> dict[str, str]:
-    """Benchmark-owned env: fresh config dir AND fresh default-project home.
-
-    BASIC_MEMORY_HOME points inside the sandbox so the auto-created default
-    project indexes an empty directory instead of the operator's personal
-    notes (which would add noise to settle timing and DB contents).
-    """
-    env = dict(os.environ)
-    env.pop("BASIC_MEMORY_CLOUD_MODE", None)
-    env["BASIC_MEMORY_CONFIG_DIR"] = str(home / "config")
-    env["BASIC_MEMORY_HOME"] = str(home / "default-home")
-    return env
-
-
 def _bm_version(prefix: list[str], env: dict[str, str]) -> str | None:
     try:
         result = run_command(prefix + ["--version"], env=env)
     except Exception:
         return None
     return result.stdout.strip() or None
-
-
-def _settle_index(
-    *,
-    prefix: list[str],
-    env: dict[str, str],
-    project_name: str,
-    timeout_seconds: float,
-) -> tuple[float, Literal["status-json", "fixed-delay"]]:
-    """Wait until the index reports no pending work; returns (seconds, mode)."""
-    start = time.monotonic()
-    probe = run_command(prefix + ["status", "--json", "--local"], check=False, env=env)
-    merged = ((probe.stdout or "") + "\n" + (probe.stderr or "")).lower()
-    if "no such option: --json" in merged:
-        # Old BM without --json: no readiness signal exists; give the watcher a
-        # fixed grace period and record the mode so the artifact is explicit.
-        time.sleep(FALLBACK_SETTLE_SECONDS)
-        return time.monotonic() - start, "fixed-delay"
-
-    deadline = start + timeout_seconds
-    delay = 0.25
-    while True:
-        completed = run_command(
-            prefix + ["status", "--project", project_name, "--json", "--local"], env=env
-        )
-        payload = json.loads(completed.stdout.strip() or "{}")
-        if isinstance(payload, dict):
-            readiness = status_json_is_ready(payload)
-            if readiness is None:
-                time.sleep(FALLBACK_SETTLE_SECONDS)
-                return time.monotonic() - start, "fixed-delay"
-            if readiness:
-                return time.monotonic() - start, "status-json"
-        if time.monotonic() >= deadline:
-            raise TimeoutError(
-                f"Index did not settle within {timeout_seconds}s for project '{project_name}'"
-            )
-        time.sleep(delay)
-        delay = min(delay * 2, 2.0)
 
 
 def run_concurrent_write(config: ConcurrentWriteConfig) -> Path:
@@ -911,7 +857,7 @@ def run_concurrent_write(config: ConcurrentWriteConfig) -> Path:
     project_dir = home / "project"
     project_dir.mkdir(parents=True)
     (home / "default-home").mkdir()
-    env = _isolated_env(home)
+    env = isolated_bm_env(home)
 
     console.print(f"[bold]concurrent-write[/bold] run_id={config.run_id} home={home}")
     run_command(prefix + ["project", "add", config.project_name, str(project_dir)], env=env)
@@ -1002,7 +948,7 @@ def run_concurrent_write(config: ConcurrentWriteConfig) -> Path:
             client.stop()
 
     console.print("Waiting for index to settle...")
-    settle_seconds, settle_mode = _settle_index(
+    settle_seconds, settle_mode = settle_index(
         prefix=prefix,
         env=env,
         project_name=config.project_name,

--- a/benchmarks/src/basic_memory_benchmarks/fairness.py
+++ b/benchmarks/src/basic_memory_benchmarks/fairness.py
@@ -3,8 +3,16 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from typing import Protocol
 
 from basic_memory_benchmarks.models import PerQueryRetrievalResult
+
+
+class HasTaskId(Protocol):
+    """Any per-task result row (agent-task eval) carrying its task id."""
+
+    @property
+    def task_id(self) -> str: ...
 
 
 def validate_fairness(
@@ -29,6 +37,36 @@ def validate_fairness(
             extra = sorted(current_ids - baseline_ids)
             warnings.append(
                 f"Provider '{provider}' query mismatch: missing={missing[:5]} extra={extra[:5]}"
+            )
+
+    return warnings
+
+
+def validate_surface_fairness(
+    results_by_surface: Mapping[str, Sequence[HasTaskId]],
+) -> list[str]:
+    """Validate that all tool surfaces attempted the same task set.
+
+    A skipped surface produces no rows and must be excluded by the caller (its
+    status is already explicit); with fewer than two surfaces there is nothing
+    to compare. Returns warnings; empty means no mismatch detected.
+    """
+    warnings: list[str] = []
+    surface_names = sorted(results_by_surface.keys())
+    if len(surface_names) < 2:
+        return warnings
+
+    baseline_surface = surface_names[0]
+    baseline_ids = {row.task_id for row in results_by_surface[baseline_surface]}
+
+    for surface in surface_names[1:]:
+        current_ids = {row.task_id for row in results_by_surface[surface]}
+        if baseline_ids != current_ids:
+            missing = sorted(baseline_ids - current_ids)
+            extra = sorted(current_ids - baseline_ids)
+            warnings.append(
+                f"Surface '{surface}' task mismatch vs '{baseline_surface}':"
+                f" missing={missing[:5]} extra={extra[:5]}"
             )
 
     return warnings

--- a/benchmarks/src/basic_memory_benchmarks/llm/__init__.py
+++ b/benchmarks/src/basic_memory_benchmarks/llm/__init__.py
@@ -1,4 +1,4 @@
-"""LLM runner abstractions for answer generation and judging."""
+"""LLM runner abstractions for answer generation, judging, and tool-use agents."""
 
 from basic_memory_benchmarks.llm.runners import (
     ClaudeCLIRunner,
@@ -8,12 +8,38 @@ from basic_memory_benchmarks.llm.runners import (
     OpenAICompatRunner,
     create_runner,
 )
+from basic_memory_benchmarks.llm.tool_agent import (
+    AgentTurn,
+    AssistantTurn,
+    OpenAICompatToolAgent,
+    ScriptedToolAgent,
+    ToolAgentModel,
+    ToolCall,
+    ToolDef,
+    ToolReturn,
+    TranscriptItem,
+    UserMessage,
+    create_tool_agent_model,
+    substitute_placeholders,
+)
 
 __all__ = [
+    "AgentTurn",
+    "AssistantTurn",
     "ClaudeCLIRunner",
     "LLMResult",
     "LLMRunner",
     "LLMRunnerError",
     "OpenAICompatRunner",
+    "OpenAICompatToolAgent",
+    "ScriptedToolAgent",
+    "ToolAgentModel",
+    "ToolCall",
+    "ToolDef",
+    "ToolReturn",
+    "TranscriptItem",
+    "UserMessage",
     "create_runner",
+    "create_tool_agent_model",
+    "substitute_placeholders",
 ]

--- a/benchmarks/src/basic_memory_benchmarks/llm/tool_agent.py
+++ b/benchmarks/src/basic_memory_benchmarks/llm/tool_agent.py
@@ -1,0 +1,366 @@
+"""Tool-use model seam for the agent-task eval (basic-memory#1401).
+
+The single-prompt ``LLMRunner`` seam in ``runners.py`` cannot pause at a tool
+call, so the agent under test speaks a richer contract: the model receives a
+neutral transcript plus tool definitions and returns either tool calls or a
+final answer. Two transports:
+
+- ``openai-compat``: any ``/chat/completions`` endpoint that implements the
+  ``tools`` parameter (Ollama, vLLM, LM Studio, OpenAI — and Anthropic models
+  behind a LiteLLM proxy).
+- ``scripted``: a canned JSON script for offline tests and the LLM-free smoke.
+
+``claude:<model>`` is deliberately unsupported here: ``claude -p`` runs its own
+agent loop with ``--max-turns 1`` semantics and never hands a ``tool_use``
+block back to the harness.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from basic_memory_benchmarks.llm.runners import LLMRunnerError
+
+# --- Neutral transcript and tool types (transport-agnostic, loop-owned) ---
+
+
+@dataclass(frozen=True)
+class ToolDef:
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    call_id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ToolReturn:
+    call_id: str
+    name: str
+    text: str
+    is_error: bool
+
+
+@dataclass(frozen=True)
+class UserMessage:
+    text: str
+
+
+@dataclass(frozen=True)
+class AssistantTurn:
+    text: str
+    tool_calls: tuple[ToolCall, ...]
+
+
+type TranscriptItem = UserMessage | AssistantTurn | ToolReturn
+
+
+@dataclass(frozen=True)
+class AgentTurn:
+    """One model response: text and/or tool calls, plus usage accounting."""
+
+    text: str
+    tool_calls: tuple[ToolCall, ...]
+    model: str
+    input_tokens: int
+    output_tokens: int
+    latency_ms: float
+
+
+class ToolAgentModel(ABC):
+    """The model side of the agent loop: transcript in, one turn out."""
+
+    spec: str
+
+    @abstractmethod
+    def propose(self, transcript: Sequence[TranscriptItem], tools: Sequence[ToolDef]) -> AgentTurn:
+        """Return the model's next turn given the transcript so far."""
+
+    def describe(self) -> dict[str, str]:
+        return {"spec": self.spec}
+
+
+# --- OpenAI-compatible transport ---
+
+
+def _transcript_to_messages(transcript: Sequence[TranscriptItem]) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = []
+    for item in transcript:
+        match item:
+            case UserMessage(text=text):
+                messages.append({"role": "user", "content": text})
+            case AssistantTurn(text=text, tool_calls=tool_calls):
+                message: dict[str, Any] = {"role": "assistant", "content": text or None}
+                if tool_calls:
+                    message["tool_calls"] = [
+                        {
+                            "id": call.call_id,
+                            "type": "function",
+                            "function": {
+                                "name": call.name,
+                                "arguments": json.dumps(call.arguments),
+                            },
+                        }
+                        for call in tool_calls
+                    ]
+                messages.append(message)
+            case ToolReturn(call_id=call_id, text=text):
+                messages.append({"role": "tool", "tool_call_id": call_id, "content": text})
+    return messages
+
+
+def _tools_to_functions(tools: Sequence[ToolDef]) -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.input_schema,
+            },
+        }
+        for tool in tools
+    ]
+
+
+class OpenAICompatToolAgent(ToolAgentModel):
+    """Tool-use agent over an OpenAI-compatible chat-completions endpoint."""
+
+    def __init__(
+        self,
+        model: str,
+        base_url: str,
+        *,
+        api_key: str | None = None,
+        timeout_seconds: float = 300.0,
+        max_retries: int = 2,
+    ) -> None:
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+        self.spec = f"openai-compat:{model}@{self.base_url}"
+        self._api_key = api_key
+        self._timeout_seconds = timeout_seconds
+        self._max_retries = max_retries
+
+    def _post(self, body: dict[str, Any]) -> dict[str, Any]:
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        last_error: Exception | None = None
+        for _ in range(self._max_retries + 1):
+            try:
+                response = httpx.post(
+                    f"{self.base_url}/chat/completions",
+                    json=body,
+                    headers=headers,
+                    timeout=self._timeout_seconds,
+                )
+                response.raise_for_status()
+                payload = response.json()
+                if not isinstance(payload, dict):
+                    raise KeyError("response body is not a JSON object")
+                return payload
+            except (httpx.HTTPError, KeyError, json.JSONDecodeError) as exc:
+                last_error = exc
+        raise LLMRunnerError(
+            f"openai-compat call to {self.base_url} failed after "
+            f"{self._max_retries + 1} attempts: {last_error}"
+        )
+
+    def propose(self, transcript: Sequence[TranscriptItem], tools: Sequence[ToolDef]) -> AgentTurn:
+        body = {
+            "model": self.model,
+            "messages": _transcript_to_messages(transcript),
+            "tools": _tools_to_functions(tools),
+            "tool_choice": "auto",
+            "temperature": 0,
+        }
+        started = time.perf_counter()
+        payload = self._post(body)
+        latency_ms = (time.perf_counter() - started) * 1000.0
+
+        try:
+            message = payload["choices"][0]["message"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise LLMRunnerError(f"openai-compat response has no message: {exc}") from exc
+
+        tool_calls: list[ToolCall] = []
+        for index, raw_call in enumerate(message.get("tool_calls") or []):
+            function = raw_call.get("function") or {}
+            raw_arguments = function.get("arguments") or "{}"
+            try:
+                arguments = json.loads(raw_arguments)
+            except json.JSONDecodeError as exc:
+                # Malformed arguments are an explicit task error, never a
+                # silent skip: the loop propagates this to the driver.
+                raise LLMRunnerError(
+                    f"model returned malformed tool arguments for "
+                    f"'{function.get('name')}': {raw_arguments[:200]}"
+                ) from exc
+            if not isinstance(arguments, dict):
+                raise LLMRunnerError(
+                    f"model returned non-object tool arguments for "
+                    f"'{function.get('name')}': {raw_arguments[:200]}"
+                )
+            tool_calls.append(
+                ToolCall(
+                    call_id=str(raw_call.get("id") or f"call-{index}"),
+                    name=str(function.get("name") or ""),
+                    arguments=arguments,
+                )
+            )
+
+        # Token accounting is the headline metric AND the tokens budget input:
+        # an endpoint that omits usage would silently report 0-token turns and
+        # never trip max_total_tokens, so a missing block is an explicit error.
+        usage = payload.get("usage")
+        if not isinstance(usage, dict):
+            raise LLMRunnerError(
+                f"openai-compat response from {self.base_url} has no 'usage' block; "
+                "token accounting would be silently wrong"
+            )
+        try:
+            input_tokens = int(usage["prompt_tokens"])
+            output_tokens = int(usage["completion_tokens"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise LLMRunnerError(
+                f"openai-compat usage block from {self.base_url} has missing or "
+                f"malformed token counts: {usage!r}"
+            ) from exc
+        return AgentTurn(
+            text=str(message.get("content") or "").strip(),
+            tool_calls=tuple(tool_calls),
+            model=self.model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            latency_ms=latency_ms,
+        )
+
+
+# --- Scripted transport (offline tests and the LLM-free smoke) ---
+
+SCRIPTED_FAKE_INPUT_TOKENS = 10
+SCRIPTED_FAKE_OUTPUT_TOKENS = 5
+
+
+def substitute_placeholders(value: Any, substitutions: Mapping[str, str]) -> Any:
+    """Replace ``{name}`` placeholders in string values, recursively.
+
+    Scripted tool calls cannot know per-run values like the project name, so
+    the driver substitutes them just before dispatch.
+    """
+    if isinstance(value, str):
+        for name, replacement in substitutions.items():
+            value = value.replace("{" + name + "}", replacement)
+        return value
+    if isinstance(value, dict):
+        return {key: substitute_placeholders(item, substitutions) for key, item in value.items()}
+    if isinstance(value, list):
+        return [substitute_placeholders(item, substitutions) for item in value]
+    return value
+
+
+@dataclass(frozen=True)
+class ScriptedToolAgent(ToolAgentModel):
+    """Replays canned turns keyed by substring match on the first user message.
+
+    Script shape: ``{"tasks": {"<substring>": [turn, ...]}}`` where each turn
+    is ``{"tool_calls": [{"name": ..., "arguments": {...}}]}`` or
+    ``{"text": "..."}``. The agent is stateless: the number of AssistantTurns
+    already in the transcript selects the next scripted turn, so one instance
+    serves any number of tasks. Test/smoke-only — the script may "know" the
+    answer; it proves harness plumbing, not model quality.
+    """
+
+    script: dict[str, Any]
+    spec: str = field(default="scripted:<inline>")
+
+    @classmethod
+    def from_path(cls, path: Path) -> ScriptedToolAgent:
+        script = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(script, dict) or not isinstance(script.get("tasks"), dict):
+            raise ValueError(f"scripted model file must contain a 'tasks' object: {path}")
+        return cls(script=script, spec=f"scripted:{path}")
+
+    def _turns_for(self, first_user_text: str) -> tuple[str, list[dict[str, Any]]]:
+        tasks = self.script.get("tasks")
+        if not isinstance(tasks, dict):
+            raise LLMRunnerError(f"scripted model has no 'tasks' object ({self.spec})")
+        for needle, turns in tasks.items():
+            if needle in first_user_text:
+                return needle, list(turns)
+        raise LLMRunnerError(
+            f"scripted model has no entry matching prompt: {first_user_text[:120]}"
+        )
+
+    def propose(self, transcript: Sequence[TranscriptItem], tools: Sequence[ToolDef]) -> AgentTurn:
+        first_user = next((item for item in transcript if isinstance(item, UserMessage)), None)
+        if first_user is None:
+            raise LLMRunnerError("scripted model called with no user message in transcript")
+        needle, turns = self._turns_for(first_user.text)
+        emitted = sum(1 for item in transcript if isinstance(item, AssistantTurn))
+        if emitted >= len(turns):
+            raise LLMRunnerError(
+                f"scripted model exhausted after {len(turns)} turns for key '{needle}'"
+            )
+        turn_spec = turns[emitted]
+        tool_calls = tuple(
+            ToolCall(
+                call_id=f"scripted-{emitted}-{index}",
+                name=str(raw["name"]),
+                arguments=dict(raw.get("arguments") or {}),
+            )
+            for index, raw in enumerate(turn_spec.get("tool_calls") or [])
+        )
+        return AgentTurn(
+            text=str(turn_spec.get("text") or ""),
+            tool_calls=tool_calls,
+            model="scripted",
+            input_tokens=SCRIPTED_FAKE_INPUT_TOKENS,
+            output_tokens=SCRIPTED_FAKE_OUTPUT_TOKENS,
+            latency_ms=0.0,
+        )
+
+
+# --- Spec parsing ---
+
+
+def create_tool_agent_model(spec: str, *, api_key: str | None = None) -> ToolAgentModel:
+    """Build a tool-use agent from a spec string.
+
+    Formats: ``openai-compat:<model>@<base_url>`` or ``scripted:<path.json>``.
+    """
+    transport, _, remainder = spec.partition(":")
+    if transport == "claude":
+        raise ValueError(
+            "claude -p is single-shot and cannot pause at tool_use; use openai-compat "
+            "(e.g. an Anthropic model behind a LiteLLM proxy) or scripted:<path.json>"
+        )
+    if transport == "openai-compat" and remainder:
+        model, separator, base_url = remainder.partition("@")
+        if not separator or not model or not base_url:
+            raise ValueError(
+                f"openai-compat spec must be 'openai-compat:<model>@<base_url>', got: {spec}"
+            )
+        resolved_api_key = api_key if api_key is not None else os.getenv("OPENAI_API_KEY")
+        return OpenAICompatToolAgent(model=model, base_url=base_url, api_key=resolved_api_key)
+    if transport == "scripted" and remainder:
+        return ScriptedToolAgent.from_path(Path(remainder))
+    raise ValueError(
+        f"Unknown tool-agent spec '{spec}'. Expected 'openai-compat:<model>@<base_url>' "
+        f"or 'scripted:<path.json>'."
+    )

--- a/benchmarks/tests/agent_tasks/test_driver.py
+++ b/benchmarks/tests/agent_tasks/test_driver.py
@@ -1,0 +1,467 @@
+"""Driver tests: orchestration, artifacts, skip/strict, dead sessions, fairness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from mcp.types import CallToolResult, TextContent
+
+import basic_memory_benchmarks.agent_tasks.driver as driver
+from basic_memory_benchmarks.agent_tasks.driver import (
+    SessionTerminatedError,
+    SurfaceRuntime,
+    build_surface_summary,
+    run_agent_tasks,
+    tool_outcome_from_result,
+)
+from basic_memory_benchmarks.agent_tasks.loop import ToolOutcome
+from basic_memory_benchmarks.agent_tasks.models import AgentTaskResult, AgentTasksConfig
+from basic_memory_benchmarks.agent_tasks.surfaces import (
+    RICH_SURFACE,
+    SurfaceUnavailableError,
+)
+from basic_memory_benchmarks.fairness import validate_surface_fairness
+from basic_memory_benchmarks.llm.runners import LLMRunnerError
+from basic_memory_benchmarks.llm.tool_agent import ScriptedToolAgent, ToolDef
+
+CORPUS_DIR = Path(__file__).parents[2] / "benchmarks" / "datasets" / "agent-tasks" / "corpus"
+
+ORPHAN_ANSWER = (
+    "Orphans found.\n```json\n"
+    '{"permalinks": ["notes/redis-cache-tuning", "notes/postgres-vacuum-notes",'
+    ' "notes/coffee-brewing-log"]}\n```'
+)
+
+
+class FakeSession:
+    """AgentSession stub over canned tool names/results (no BM subprocess)."""
+
+    def __init__(
+        self,
+        tool_names: tuple[str, ...],
+        *,
+        die_on_call: bool = False,
+    ) -> None:
+        self.tool_names = tool_names
+        self.die_on_call = die_on_call
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.started = False
+        self.stopped = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def tools(self) -> list[ToolDef]:
+        return [
+            ToolDef(name=name, description="", input_schema={"type": "object"})
+            for name in self.tool_names
+        ]
+
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> ToolOutcome:
+        self.calls.append((name, arguments))
+        if self.die_on_call:
+            raise SessionTerminatedError("stdio session lost")
+        return ToolOutcome(text="[]", is_error=False)
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+def _stub_bm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(driver, "resolve_clean_checkout_sha", lambda checkout: "deadbeef")
+    monkeypatch.setattr(
+        driver, "run_command", lambda *args, **kwargs: SimpleNamespace(stdout="", stderr="")
+    )
+    monkeypatch.setattr(
+        driver,
+        "settle_index",
+        lambda *, prefix, env, project_name, timeout_seconds: (0.0, "status-json"),
+    )
+
+
+def _config(tmp_path: Path, **overrides: Any) -> AgentTasksConfig:
+    defaults: dict[str, Any] = {
+        "run_id": "test-run",
+        "surfaces": ["rich"],
+        "task_ids": ["curate-orphans"],
+        "model_spec": "scripted:inline",
+        "corpus_dir": str(CORPUS_DIR),
+        "output_root": str(tmp_path / "runs"),
+        "bm_local_path": str(tmp_path / "bm-checkout"),
+    }
+    defaults.update(overrides)
+    (tmp_path / "bm-checkout").mkdir(exist_ok=True)
+    return AgentTasksConfig.model_validate(defaults)
+
+
+def _orphan_agent(final_text: str = ORPHAN_ANSWER) -> ScriptedToolAgent:
+    return ScriptedToolAgent(
+        script={
+            "tasks": {
+                "orphan notes": [
+                    {
+                        "tool_calls": [
+                            {
+                                "name": "search_notes",
+                                "arguments": {"query": "x", "project": "{project}"},
+                            }
+                        ]
+                    },
+                    {"text": final_text},
+                ]
+            }
+        }
+    )
+
+
+def _run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    config: AgentTasksConfig,
+    agent: ScriptedToolAgent,
+    sessions: dict[str, FakeSession],
+) -> Path:
+    _stub_bm(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    def session_factory(runtime: SurfaceRuntime) -> FakeSession:
+        return sessions[runtime.surface.name]
+
+    return run_agent_tasks(
+        config,
+        model_factory=lambda spec: agent,
+        session_factory=session_factory,
+    )
+
+
+def test_happy_path_writes_all_artifacts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    session = FakeSession(RICH_SURFACE.tool_allowlist)
+    run_dir = _run(
+        tmp_path,
+        monkeypatch,
+        config=_config(tmp_path),
+        agent=_orphan_agent(),
+        sessions={"rich": session},
+    )
+
+    for artifact in (
+        "manifest.json",
+        "surface-status.json",
+        "per-turn.jsonl",
+        "per-task-agent.jsonl",
+        "agent-tasks-summary.json",
+        "summary.md",
+    ):
+        assert (run_dir / artifact).exists(), artifact
+
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert manifest["bm_resolved_sha"] == "deadbeef"
+    assert manifest["corpus_file_count"] > 20
+    assert manifest["surfaces"][0]["name"] == "rich"
+    assert manifest["surfaces"][0]["tool_allowlist"] == list(RICH_SURFACE.tool_allowlist)
+    assert manifest["surfaces"][0]["observed_tools"] == sorted(RICH_SURFACE.tool_allowlist)
+    assert manifest["budget"]["max_turns"] == 20
+
+    summary = json.loads((run_dir / "agent-tasks-summary.json").read_text())
+    surface_summary = summary["surfaces"][0]
+    assert surface_summary["tasks_passed"] == 1
+    assert surface_summary["tokens_per_completed_task"] is not None
+    assert summary["fairness_warnings"] == []
+
+    task_rows = [
+        json.loads(line) for line in (run_dir / "per-task-agent.jsonl").read_text().splitlines()
+    ]
+    assert task_rows[0]["passed"] is True
+    assert task_rows[0]["stopped_reason"] == "final"
+    assert "turn_records" not in task_rows[0]
+
+    turn_rows = [json.loads(line) for line in (run_dir / "per-turn.jsonl").read_text().splitlines()]
+    assert {row["kind"] for row in turn_rows} == {"model", "tool"}
+
+    # The scripted {project} placeholder was substituted before dispatch.
+    assert session.calls[0][1]["project"] == "at-test-run-curate-orphans"
+    assert session.stopped is True
+
+
+def test_headline_is_none_not_zero_when_nothing_completes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    wrong = 'nope\n```json\n{"permalinks": ["notes/wrong"]}\n```'
+    run_dir = _run(
+        tmp_path,
+        monkeypatch,
+        config=_config(tmp_path),
+        agent=_orphan_agent(final_text=wrong),
+        sessions={"rich": FakeSession(RICH_SURFACE.tool_allowlist)},
+    )
+    summary = json.loads((run_dir / "agent-tasks-summary.json").read_text())
+    surface_summary = summary["surfaces"][0]
+    assert surface_summary["tasks_passed"] == 0
+    assert surface_summary["tokens_per_completed_task"] is None
+    assert "n/a — 0 tasks completed" in (run_dir / "summary.md").read_text()
+
+
+def test_posix_without_tools_is_skipped_with_reason(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A rich-only BM: the posix session starts (shared write verbs exist) but
+    # exposes no cat/grep/... — recorded as an explicit skip, never dropped.
+    config = _config(tmp_path, surfaces=["rich", "posix"])
+    sessions = {
+        "rich": FakeSession(RICH_SURFACE.tool_allowlist),
+        "posix": FakeSession(("write_note", "edit_note", "move_note", "delete_note")),
+    }
+    run_dir = _run(tmp_path, monkeypatch, config=config, agent=_orphan_agent(), sessions=sessions)
+
+    statuses = {
+        row["provider"]: row for row in json.loads((run_dir / "surface-status.json").read_text())
+    }
+    assert statuses["rich"]["state"] == "ok"
+    assert statuses["posix"]["state"] == "skipped"
+    assert "cat" in statuses["posix"]["reason"]
+    assert "enable_posix_tools" in statuses["posix"]["reason"]
+    assert sessions["posix"].stopped is True
+
+    summary = json.loads((run_dir / "agent-tasks-summary.json").read_text())
+    assert [row["surface"] for row in summary["surfaces"]] == ["rich"]
+
+    # The human-facing report must say the A/B is incomplete, not just the
+    # status artifact and console output.
+    report = (run_dir / "summary.md").read_text()
+    assert "Surfaces not run" in report
+    assert "posix (skipped)" in report
+    assert "enable_posix_tools" in report
+
+
+def test_strict_surfaces_raises_instead_of_skipping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(tmp_path, surfaces=["posix"], allow_surface_skip=False)
+    sessions = {"posix": FakeSession(("write_note", "edit_note"))}
+    with pytest.raises(SurfaceUnavailableError, match="posix"):
+        _run(tmp_path, monkeypatch, config=config, agent=_orphan_agent(), sessions=sessions)
+
+
+def test_dead_session_marks_remaining_tasks_errored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(tmp_path, task_ids=["curate-orphans", "man-chain"])
+    session = FakeSession(RICH_SURFACE.tool_allowlist, die_on_call=True)
+    run_dir = _run(
+        tmp_path, monkeypatch, config=config, agent=_orphan_agent(), sessions={"rich": session}
+    )
+
+    task_rows = [
+        json.loads(line) for line in (run_dir / "per-task-agent.jsonl").read_text().splitlines()
+    ]
+    assert len(task_rows) == 2  # never silently dropped
+    assert all("mcp session terminated" in row["error"] for row in task_rows)
+
+    # The first task died mid-loop AFTER a real model call: its spent tokens
+    # and per-turn records must survive on the errored row. The second task
+    # never started (poisoned session), so it carries none.
+    first, second = task_rows
+    assert first["stopped_reason"] == "error"
+    assert first["turns"] == 1
+    assert first["tool_calls"] == 1
+    assert first["total_input_tokens"] == 10
+    assert first["total_output_tokens"] == 5
+    assert second["stopped_reason"] is None
+    assert second["total_input_tokens"] == 0
+
+    turn_rows = [json.loads(line) for line in (run_dir / "per-turn.jsonl").read_text().splitlines()]
+    assert [row["kind"] for row in turn_rows] == ["model", "tool"]
+    assert turn_rows[1]["is_error"] is True
+
+    summary = json.loads((run_dir / "agent-tasks-summary.json").read_text())
+    assert summary["surfaces"][0]["tasks_errored"] == 2
+    assert summary["surfaces"][0]["tasks_passed"] == 0
+    # The headline denominator still sees the spent tokens.
+    assert summary["surfaces"][0]["total_input_tokens"] == 10
+
+
+def test_mid_run_model_error_keeps_partial_accounting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The script exhausts after one tool-call turn, so the SECOND propose
+    # raises LLMRunnerError mid-loop: the errored row must keep the cost of
+    # the model call that already happened.
+    one_turn_agent = ScriptedToolAgent(
+        script={
+            "tasks": {
+                "orphan notes": [
+                    {"tool_calls": [{"name": "search_notes", "arguments": {"query": "x"}}]}
+                ]
+            }
+        }
+    )
+    run_dir = _run(
+        tmp_path,
+        monkeypatch,
+        config=_config(tmp_path),
+        agent=one_turn_agent,
+        sessions={"rich": FakeSession(RICH_SURFACE.tool_allowlist)},
+    )
+
+    (row,) = [
+        json.loads(line) for line in (run_dir / "per-task-agent.jsonl").read_text().splitlines()
+    ]
+    assert "exhausted" in row["error"]
+    assert row["stopped_reason"] == "error"
+    assert row["turns"] == 1
+    assert row["total_input_tokens"] == 10
+    assert row["total_output_tokens"] == 5
+
+
+def test_unknown_dispatch_bug_aborts_the_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class BuggySession(FakeSession):
+        def call_tool(self, name: str, arguments: dict[str, Any]) -> ToolOutcome:
+            raise ValueError("harness bug")
+
+    with pytest.raises(driver.AgentLoopError, match="harness bug"):
+        _run(
+            tmp_path,
+            monkeypatch,
+            config=_config(tmp_path),
+            agent=_orphan_agent(),
+            sessions={"rich": BuggySession(RICH_SURFACE.tool_allowlist)},
+        )
+
+
+def test_judge_failure_keeps_loop_accounting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def failing_grade(spec: Any, ctx: Any) -> Any:
+        raise LLMRunnerError("judge down")
+
+    monkeypatch.setattr(driver, "grade_task", failing_grade)
+    run_dir = _run(
+        tmp_path,
+        monkeypatch,
+        config=_config(tmp_path),
+        agent=_orphan_agent(),
+        sessions={"rich": FakeSession(RICH_SURFACE.tool_allowlist)},
+    )
+
+    (row,) = [
+        json.loads(line) for line in (run_dir / "per-task-agent.jsonl").read_text().splitlines()
+    ]
+    assert row["error"] == "grading failed: judge down"
+    # The loop completed before grading failed: its full accounting survives.
+    assert row["stopped_reason"] == "final"
+    assert row["turns"] == 2
+    assert row["total_input_tokens"] == 20
+    assert row["total_output_tokens"] == 10
+
+
+def test_reused_run_id_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _config(tmp_path)
+    _run(
+        tmp_path,
+        monkeypatch,
+        config=config,
+        agent=_orphan_agent(),
+        sessions={"rich": FakeSession(RICH_SURFACE.tool_allowlist)},
+    )
+    with pytest.raises(RuntimeError, match="Home already exists"):
+        _run(
+            tmp_path,
+            monkeypatch,
+            config=config,
+            agent=_orphan_agent(),
+            sessions={"rich": FakeSession(RICH_SURFACE.tool_allowlist)},
+        )
+
+
+def _task_row(surface: str, task_id: str) -> AgentTaskResult:
+    return AgentTaskResult(surface=surface, task_id=task_id, skill="memory-continue", passed=True)
+
+
+def test_validate_surface_fairness_flags_task_set_mismatch() -> None:
+    results = {
+        "rich": [_task_row("rich", "a"), _task_row("rich", "b")],
+        "posix": [_task_row("posix", "a")],
+    }
+    warnings = validate_surface_fairness(results)
+    assert len(warnings) == 1
+    # sorted() makes 'posix' the baseline, so rich's extra task 'b' is flagged.
+    assert "task mismatch" in warnings[0]
+    assert "'b'" in warnings[0]
+
+    aligned = {
+        "rich": [_task_row("rich", "a")],
+        "posix": [_task_row("posix", "a")],
+    }
+    assert validate_surface_fairness(aligned) == []
+    assert validate_surface_fairness({"rich": [_task_row("rich", "a")]}) == []
+
+
+def test_build_surface_summary_excludes_errored_from_means() -> None:
+    ok = AgentTaskResult(
+        surface="rich",
+        task_id="a",
+        skill="memory-continue",
+        passed=True,
+        stopped_reason="final",
+        turns=3,
+        tool_calls=2,
+        total_input_tokens=100,
+        total_output_tokens=50,
+        wall_seconds=1.0,
+    )
+    errored = AgentTaskResult(
+        surface="rich",
+        task_id="b",
+        skill="memory-curate",
+        passed=False,
+        total_input_tokens=40,
+        total_output_tokens=10,
+        error="mcp session terminated",
+    )
+    summary = build_surface_summary("rich", "scripted:x", [ok, errored])
+
+    assert summary.tasks_total == 2
+    assert summary.tasks_errored == 1
+    assert summary.tasks_passed == 1
+    assert summary.pass_rate == 1.0  # over graded tasks only
+    # Headline counts ALL attempted tokens (errored calls still cost tokens).
+    assert summary.tokens_per_completed_task == 200.0
+    assert summary.mean_tool_calls == 2.0  # errored rows excluded from means
+    assert summary.per_skill["memory-curate"].tokens_per_completed is None
+
+
+class TestToolOutcomeFromResult:
+    def test_plain_text_success_is_not_an_error(self) -> None:
+        result = CallToolResult(
+            content=[TextContent(type="text", text="# markdown body")], isError=False
+        )
+        outcome = tool_outcome_from_result(result)
+        assert outcome == ToolOutcome(text="# markdown body", is_error=False)
+
+    def test_mcp_error_flag(self) -> None:
+        result = CallToolResult(content=[TextContent(type="text", text="boom")], isError=True)
+        assert tool_outcome_from_result(result).is_error is True
+
+    def test_json_error_payload(self) -> None:
+        result = CallToolResult(
+            content=[TextContent(type="text", text='{"error": "not found"}')],
+            isError=False,
+        )
+        outcome = tool_outcome_from_result(result)
+        assert outcome.is_error is True
+        assert "not found" in outcome.text
+
+    def test_structured_content_fallback(self) -> None:
+        result = CallToolResult(
+            content=[], structuredContent={"result": {"title": "x"}}, isError=False
+        )
+        outcome = tool_outcome_from_result(result)
+        assert outcome.is_error is False
+        assert "title" in outcome.text

--- a/benchmarks/tests/agent_tasks/test_grading.py
+++ b/benchmarks/tests/agent_tasks/test_grading.py
@@ -1,0 +1,407 @@
+"""Tests for every grader kind against a tmp_path mini-project."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from basic_memory_benchmarks.agent_tasks.grading import (
+    GradingContext,
+    JudgeUsage,
+    evaluate_grader,
+    extract_final_json,
+    grade_task,
+    normalize_answer_item,
+)
+from basic_memory_benchmarks.agent_tasks.models import TurnRecord
+from basic_memory_benchmarks.agent_tasks.spec import (
+    AgentTaskSpec,
+    AnswerContains,
+    AnswerMatches,
+    AnswerSetEquals,
+    FileLineDiff,
+    FrontmatterEquals,
+    FrontmatterListLen,
+    FrontmatterMatches,
+    JudgeRubric,
+    MarkerAbsent,
+    MarkerPresent,
+    NewNoteUnder,
+    NoteCountDelta,
+    NotesUntouched,
+    ObservationLines,
+    RelationResolves,
+    ToolCalled,
+)
+from test_qa_scoring import FakeRunner
+
+NOTE_TEXT = """---
+title: Sample Note
+type: task
+status: active
+steps:
+  - one
+  - two
+current_step: 2
+review:
+  status: pending
+---
+
+# Sample Note
+
+- [status] step one done BMEVAL-test-1111
+"""
+
+
+def _project(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    project_dir = tmp_path / "project"
+    (project_dir / "tasks").mkdir(parents=True, exist_ok=True)
+    (project_dir / "tasks" / "sample.md").write_text(NOTE_TEXT, encoding="utf-8")
+    baseline = {"tasks/sample.md": NOTE_TEXT}
+    return project_dir, baseline
+
+
+def _ctx(
+    tmp_path: Path,
+    final_answer: str | None = None,
+    turn_records: tuple[TurnRecord, ...] = (),
+    judge: FakeRunner | None = None,
+) -> GradingContext:
+    project_dir, baseline = _project(tmp_path)
+    return GradingContext(
+        final_answer=final_answer,
+        project_dir=project_dir,
+        baseline=baseline,
+        db_path=tmp_path / "memory.db",
+        project_name="proj",
+        turn_records=turn_records,
+        judge=judge,
+    )
+
+
+class TestAnswerExtraction:
+    def test_last_fenced_block_wins(self) -> None:
+        answer = (
+            'first\n```json\n{"permalinks": ["a"]}\n```\n'
+            'revised\n```json\n{"permalinks": ["b"]}\n```\n'
+        )
+        assert extract_final_json(answer) == {"permalinks": ["b"]}
+
+    def test_missing_block_returns_none(self) -> None:
+        assert extract_final_json("no json here") is None
+        assert extract_final_json(None) is None
+
+    def test_unparseable_block_returns_none(self) -> None:
+        assert extract_final_json("```json\n{oops\n```") is None
+
+    def test_normalization(self) -> None:
+        assert normalize_answer_item(" /Notes/Redis-Cache-Tuning.md ") == (
+            "notes/redis-cache-tuning"
+        )
+
+
+class TestAnswerGraders:
+    def test_answer_set_equals_pass_and_fail(self, tmp_path: Path) -> None:
+        gold = frozenset({"notes/a", "notes/b"})
+        grader = AnswerSetEquals(key="permalinks", gold=gold)
+        good = _ctx(tmp_path, '```json\n{"permalinks": ["/notes/b.md", "Notes/A"]}\n```')
+        assert evaluate_grader(grader, good).passed is True
+
+        bad = _ctx(tmp_path, '```json\n{"permalinks": ["notes/a"]}\n```')
+        result = evaluate_grader(grader, bad)
+        assert result.passed is False
+        assert "missing" in result.detail
+
+    def test_answer_set_without_json_fails_with_detail(self, tmp_path: Path) -> None:
+        grader = AnswerSetEquals(key="permalinks", gold=frozenset({"a"}))
+        result = evaluate_grader(grader, _ctx(tmp_path, "no fenced block"))
+        assert result.passed is False
+        assert "no parseable fenced JSON block" in result.detail
+
+    def test_markers_and_contains(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path, "found BMEVAL-x-1 in the note")
+        assert evaluate_grader(MarkerPresent(marker="BMEVAL-x-1"), ctx).passed is True
+        assert evaluate_grader(MarkerAbsent(marker="BMEVAL-x-1"), ctx).passed is False
+        assert evaluate_grader(MarkerAbsent(marker="BMEVAL-y-2"), ctx).passed is True
+        assert evaluate_grader(AnswerContains(needle="Found"), ctx).passed is True
+
+    def test_no_final_answer_fails_present_passes_absent(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path, None)
+        assert evaluate_grader(MarkerPresent(marker="BMEVAL-x-1"), ctx).passed is False
+        assert evaluate_grader(MarkerAbsent(marker="BMEVAL-x-1"), ctx).passed is True
+
+    def test_answer_matches_accepts_both_tool_spellings(self, tmp_path: Path) -> None:
+        # The man-chain regression: the man page is edit-note(3) but the MCP
+        # tool is edit_note — both spellings are substantively correct.
+        grader = AnswerMatches(pattern=r"edit[-_]note")
+        assert evaluate_grader(grader, _ctx(tmp_path, "the page is edit-note(3)")).passed is True
+        assert evaluate_grader(grader, _ctx(tmp_path, "use the edit_note tool")).passed is True
+        result = evaluate_grader(grader, _ctx(tmp_path, "use write_note instead"))
+        assert result.passed is False
+        assert "missing" in result.detail
+
+    def test_answer_matches_is_case_insensitive_like_contains(self, tmp_path: Path) -> None:
+        grader = AnswerMatches(pattern=r"edit[-_]note")
+        assert evaluate_grader(grader, _ctx(tmp_path, "call Edit_Note")).passed is True
+        assert evaluate_grader(grader, _ctx(tmp_path, None)).passed is False
+
+
+class TestFileGraders:
+    def test_note_count_delta(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        assert evaluate_grader(NoteCountDelta(delta=0), ctx).passed is True
+        (ctx.project_dir / "tasks" / "new.md").write_text("---\ntitle: N\n---\n")
+        assert evaluate_grader(NoteCountDelta(delta=1), ctx).passed is True
+        assert evaluate_grader(NoteCountDelta(delta=0), ctx).passed is False
+
+    def test_notes_untouched_and_except_globs(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        assert evaluate_grader(NotesUntouched(), ctx).passed is True
+        (ctx.project_dir / "tasks" / "sample.md").write_text("changed", encoding="utf-8")
+        assert evaluate_grader(NotesUntouched(), ctx).passed is False
+        excused = NotesUntouched(except_globs=("tasks/sample.md",))
+        assert evaluate_grader(excused, ctx).passed is True
+
+    def test_frontmatter_equals_with_coercion_and_dot_notation(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        path = "tasks/sample.md"
+        assert evaluate_grader(
+            FrontmatterEquals(path=path, key="status", value="active"), ctx
+        ).passed
+        assert evaluate_grader(
+            FrontmatterEquals(path=path, key="current_step", value=2), ctx
+        ).passed
+        # str-comparison fallback: "2" matches the YAML int 2.
+        assert evaluate_grader(
+            FrontmatterEquals(path=path, key="current_step", value="2"), ctx
+        ).passed
+        assert evaluate_grader(
+            FrontmatterEquals(path=path, key="review.status", value="pending"), ctx
+        ).passed
+        assert not evaluate_grader(
+            FrontmatterEquals(path=path, key="review.status", value="done"), ctx
+        ).passed
+        assert not evaluate_grader(
+            FrontmatterEquals(path=path, key="missing", value="x"), ctx
+        ).passed
+
+    def test_frontmatter_matches_and_list_len(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        path = "tasks/sample.md"
+        assert evaluate_grader(
+            FrontmatterMatches(path=path, key="status", pattern=r"^act"), ctx
+        ).passed
+        assert evaluate_grader(FrontmatterListLen(path=path, key="steps", length=2), ctx).passed
+        assert not evaluate_grader(FrontmatterListLen(path=path, key="steps", length=3), ctx).passed
+        assert not evaluate_grader(
+            FrontmatterListLen(path=path, key="status", length=1), ctx
+        ).passed
+
+    def test_new_selector_targets_added_file(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        (ctx.project_dir / "tasks" / "added.md").write_text(
+            "---\ntitle: Added\ntype: task\n---\n\n- [status] fresh\n", encoding="utf-8"
+        )
+        assert evaluate_grader(FrontmatterEquals(path="new", key="type", value="task"), ctx).passed
+        assert evaluate_grader(
+            ObservationLines(path="new", pattern=r"^- \[[a-z-]+\] ", min_count=1), ctx
+        ).passed
+
+    def test_new_selector_with_no_new_file_fails(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        result = evaluate_grader(FrontmatterEquals(path="new", key="type", value="task"), ctx)
+        assert result.passed is False
+        assert "matched 0 files" in result.detail
+
+    def test_new_note_under_requires_the_prompted_directory(self, tmp_path: Path) -> None:
+        grader = NewNoteUnder(prefix="tasks/")
+        ctx = _ctx(tmp_path)
+        # No new note at all fails with detail — never a vacuous pass.
+        no_new = evaluate_grader(grader, ctx)
+        assert no_new.passed is False
+        assert "no new notes" in no_new.detail
+
+        (ctx.project_dir / "tasks" / "added.md").write_text(
+            "---\ntitle: A\n---\n", encoding="utf-8"
+        )
+        assert evaluate_grader(grader, ctx).passed is True
+
+    def test_new_note_outside_prefix_fails_with_the_path(self, tmp_path: Path) -> None:
+        grader = NewNoteUnder(prefix="tasks/")
+        ctx = _ctx(tmp_path)
+        (ctx.project_dir / "misplaced.md").write_text("---\ntitle: M\n---\n", encoding="utf-8")
+        result = evaluate_grader(grader, ctx)
+        assert result.passed is False
+        assert "misplaced.md" in result.detail
+
+    def test_new_note_under_uses_directory_semantics_not_string_prefix(
+        self, tmp_path: Path
+    ) -> None:
+        # "tasks-archive" starts with "tasks" as a string but is a different
+        # directory; a bare-string prefix check would wrongly accept it.
+        grader = NewNoteUnder(prefix="tasks")
+        ctx = _ctx(tmp_path)
+        (ctx.project_dir / "tasks-archive").mkdir()
+        (ctx.project_dir / "tasks-archive" / "x.md").write_text(
+            "---\ntitle: X\n---\n", encoding="utf-8"
+        )
+        assert evaluate_grader(grader, ctx).passed is False
+
+    def test_observation_lines_counts(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        grader = ObservationLines(path="tasks/sample.md", pattern=r"^- \[[a-z-]+\] ", min_count=2)
+        assert evaluate_grader(grader, ctx).passed is False
+
+    def test_file_line_diff_exactly_one_change(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        changed = NOTE_TEXT.replace("status: active", "status: done")
+        (ctx.project_dir / "tasks" / "sample.md").write_text(changed, encoding="utf-8")
+        grader = FileLineDiff(
+            path="tasks/sample.md",
+            removed_pattern=r"status: active",
+            added_pattern=r"status: done",
+        )
+        assert evaluate_grader(grader, ctx).passed is True
+
+        two_changes = changed.replace("title: Sample Note", "title: Renamed")
+        (ctx.project_dir / "tasks" / "sample.md").write_text(two_changes, encoding="utf-8")
+        assert evaluate_grader(grader, ctx).passed is False
+
+
+DB_SCHEMA = """
+CREATE TABLE project (id INTEGER PRIMARY KEY, name TEXT);
+CREATE TABLE entity (id INTEGER PRIMARY KEY, project_id INTEGER, permalink TEXT);
+CREATE TABLE relation (
+    id INTEGER PRIMARY KEY, from_id INTEGER, to_id INTEGER, to_name TEXT, relation_type TEXT
+);
+"""
+
+
+def _make_db(path: Path, rows: dict[str, list[tuple]]) -> None:
+    connection = sqlite3.connect(path)
+    connection.executescript(DB_SCHEMA)
+    for table, table_rows in rows.items():
+        if table_rows:
+            placeholders = ",".join("?" for _ in table_rows[0])
+            connection.executemany(f"INSERT INTO {table} VALUES ({placeholders})", table_rows)
+    connection.commit()
+    connection.close()
+
+
+class TestRelationResolves:
+    def test_resolved_relation_passes(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _make_db(
+            ctx.db_path,
+            {
+                "project": [(1, "proj")],
+                "entity": [(10, 1, "notes/source"), (11, 1, "notes/target")],
+                "relation": [(100, 10, 11, "Target", "relates_to")],
+            },
+        )
+        grader = RelationResolves(
+            source_permalink="notes/source", targets=frozenset({"notes/target"})
+        )
+        assert evaluate_grader(grader, ctx).passed is True
+
+    def test_relation_type_filter(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _make_db(
+            ctx.db_path,
+            {
+                "project": [(1, "proj")],
+                "entity": [(10, 1, "notes/source"), (11, 1, "notes/target")],
+                "relation": [(100, 10, 11, "Target", "relates_to")],
+            },
+        )
+        wrong_type = RelationResolves(
+            source_permalink="notes/source",
+            targets=frozenset({"notes/target"}),
+            relation_type="depends_on",
+        )
+        assert evaluate_grader(wrong_type, ctx).passed is False
+
+    def test_unresolved_forward_ref_fails(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _make_db(
+            ctx.db_path,
+            {
+                "project": [(1, "proj")],
+                "entity": [(10, 1, "notes/source")],
+                # to_id NULL: a forward reference that never resolved.
+                "relation": [(100, 10, None, "Target", "relates_to")],
+            },
+        )
+        grader = RelationResolves(
+            source_permalink="notes/source", targets=frozenset({"notes/target"})
+        )
+        assert evaluate_grader(grader, ctx).passed is False
+
+    def test_missing_db_fails_loudly(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        grader = RelationResolves(source_permalink="s", targets=frozenset({"t"}))
+        with pytest.raises(RuntimeError, match="Index database not found"):
+            evaluate_grader(grader, ctx)
+
+
+class TestToolCalledAndJudge:
+    def test_tool_called_diagnostic(self, tmp_path: Path) -> None:
+        records = (
+            TurnRecord(turn_index=0, kind="model"),
+            TurnRecord(turn_index=1, kind="tool", tool_name="search_notes"),
+        )
+        ctx = _ctx(tmp_path, turn_records=records)
+        grader = ToolCalled(name_pattern=r"search_notes|grep")
+        result = evaluate_grader(grader, ctx)
+        assert result.passed is True
+        assert result.required is False
+        assert evaluate_grader(ToolCalled(name_pattern=r"^cat$"), ctx).passed is False
+
+    def test_judge_rubric_verdicts_and_usage(self, tmp_path: Path) -> None:
+        judge = FakeRunner({"good answer": "CORRECT - covers the rubric"})
+        ctx = _ctx(tmp_path, "good answer", judge=judge)
+        usage = JudgeUsage()
+        result = evaluate_grader(JudgeRubric(rubric="must mention X"), ctx, usage)
+        assert result.passed is True
+        assert usage.calls == 1
+        assert usage.input_tokens == 10
+
+        judge_bad = FakeRunner({"bad answer": "INCORRECT - misses X"})
+        ctx_bad = _ctx(tmp_path / "b", "bad answer", judge=judge_bad)
+        assert evaluate_grader(JudgeRubric(rubric="must mention X"), ctx_bad).passed is False
+
+    def test_judge_without_runner_raises(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path, "answer")
+        with pytest.raises(RuntimeError, match="requires a judge"):
+            evaluate_grader(JudgeRubric(rubric="r"), ctx)
+
+
+class TestGradeTask:
+    def test_required_predicates_gate_the_pass(self, tmp_path: Path) -> None:
+        spec = AgentTaskSpec(
+            id="t",
+            skill="memory-continue",
+            source="test",
+            prompt="p",
+            graders=(
+                MarkerPresent(marker="BMEVAL-x-1"),
+                ToolCalled(name_pattern="never"),  # diagnostic, must not gate
+            ),
+        )
+        passed, predicates, usage = grade_task(spec, _ctx(tmp_path, "has BMEVAL-x-1"))
+        assert passed is True
+        assert [p.passed for p in predicates] == [True, False]
+        assert usage.calls == 0
+
+    def test_required_failure_fails_task(self, tmp_path: Path) -> None:
+        spec = AgentTaskSpec(
+            id="t",
+            skill="memory-continue",
+            source="test",
+            prompt="p",
+            graders=(MarkerPresent(marker="BMEVAL-x-1"),),
+        )
+        passed, _, _ = grade_task(spec, _ctx(tmp_path, "nothing"))
+        assert passed is False

--- a/benchmarks/tests/agent_tasks/test_loop.py
+++ b/benchmarks/tests/agent_tasks/test_loop.py
@@ -1,0 +1,303 @@
+"""Tests for the agent loop: budgets, dispatch, truncation, accounting."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+
+from basic_memory_benchmarks.agent_tasks.loop import (
+    TOOL_RESULT_MAX_CHARS,
+    AgentLoopError,
+    ToolOutcome,
+    run_agent_loop,
+)
+from basic_memory_benchmarks.agent_tasks.models import AgentBudget
+from basic_memory_benchmarks.llm.runners import LLMRunnerError
+from basic_memory_benchmarks.llm.tool_agent import (
+    AgentTurn,
+    AssistantTurn,
+    ScriptedToolAgent,
+    ToolAgentModel,
+    ToolCall,
+    ToolDef,
+    ToolReturn,
+    TranscriptItem,
+)
+
+SEARCH_TOOL = ToolDef(name="search_notes", description="", input_schema={"type": "object"})
+TOOLS = [SEARCH_TOOL]
+
+
+class RecordingDispatch:
+    def __init__(self, outcome: ToolOutcome | None = None) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.outcome = outcome or ToolOutcome(text="ok", is_error=False)
+
+    def __call__(self, name: str, arguments: dict[str, Any]) -> ToolOutcome:
+        self.calls.append((name, arguments))
+        return self.outcome
+
+
+def _scripted(turns: list[dict[str, Any]], needle: str = "Task") -> ScriptedToolAgent:
+    return ScriptedToolAgent(script={"tasks": {needle: turns}})
+
+
+def _run(model: ToolAgentModel, dispatch: RecordingDispatch, **budget: Any):
+    return run_agent_loop(
+        model=model,
+        dispatch=dispatch,
+        tools=TOOLS,
+        prompt="Task: do the thing",
+        budget=AgentBudget(**budget),
+    )
+
+
+def test_final_answer_path() -> None:
+    model = _scripted([{"text": "the answer"}])
+    dispatch = RecordingDispatch()
+    result = _run(model, dispatch)
+
+    assert result.final_answer == "the answer"
+    assert result.stopped_reason == "final"
+    assert result.turns == 1
+    assert result.tool_call_count == 0
+    assert dispatch.calls == []
+    assert len(result.turn_records) == 1
+    assert result.turn_records[0].kind == "model"
+    assert result.turn_records[0].finalized is True
+
+
+def test_multi_turn_feeds_tool_results_back() -> None:
+    class TranscriptSpy(ToolAgentModel):
+        spec = "spy:test"
+
+        def __init__(self) -> None:
+            self.seen: list[list[TranscriptItem]] = []
+
+        def propose(
+            self, transcript: Sequence[TranscriptItem], tools: Sequence[ToolDef]
+        ) -> AgentTurn:
+            self.seen.append(list(transcript))
+            if len(self.seen) == 1:
+                return AgentTurn(
+                    text="",
+                    tool_calls=(ToolCall(call_id="c1", name="search_notes", arguments={"q": "x"}),),
+                    model="spy",
+                    input_tokens=10,
+                    output_tokens=2,
+                    latency_ms=1.0,
+                )
+            return AgentTurn(
+                text="done",
+                tool_calls=(),
+                model="spy",
+                input_tokens=20,
+                output_tokens=4,
+                latency_ms=1.0,
+            )
+
+    model = TranscriptSpy()
+    dispatch = RecordingDispatch(ToolOutcome(text="search result text", is_error=False))
+    result = _run(model, dispatch)
+
+    assert result.final_answer == "done"
+    assert dispatch.calls == [("search_notes", {"q": "x"})]
+    # The second propose sees the assistant turn plus the tool result.
+    second_transcript = model.seen[1]
+    assert isinstance(second_transcript[1], AssistantTurn)
+    tool_return = second_transcript[2]
+    assert isinstance(tool_return, ToolReturn)
+    assert tool_return.text == "search result text"
+    assert result.total_input_tokens == 30
+    assert result.total_output_tokens == 6
+
+
+def test_turn_budget_stop() -> None:
+    model = _scripted([{"tool_calls": [{"name": "search_notes", "arguments": {}}]}] * 5)
+    dispatch = RecordingDispatch()
+    result = _run(model, dispatch, max_turns=2)
+
+    assert result.stopped_reason == "turns"
+    assert result.final_answer is None
+    assert result.turns == 2
+
+
+def test_token_budget_stop() -> None:
+    # Scripted turns cost 15 fake tokens each; a 25-token budget allows two
+    # model calls (gate checks BEFORE the call: 0 < 25, 15 < 25, 30 >= 25).
+    model = _scripted([{"tool_calls": [{"name": "search_notes", "arguments": {}}]}] * 5)
+    result = _run(model, RecordingDispatch(), max_total_tokens=25)
+
+    assert result.stopped_reason == "tokens"
+    assert result.turns == 2
+
+
+def test_wall_clock_budget_stop_uses_injected_clock() -> None:
+    ticks = iter([0.0, 0.0, 100.0, 100.0, 100.0])
+    model = _scripted([{"tool_calls": [{"name": "search_notes", "arguments": {}}]}] * 5)
+    result = run_agent_loop(
+        model=model,
+        dispatch=RecordingDispatch(),
+        tools=TOOLS,
+        prompt="Task: x",
+        budget=AgentBudget(max_task_seconds=50.0),
+        clock=lambda: next(ticks),
+    )
+
+    assert result.stopped_reason == "wall_clock"
+    assert result.turns == 1
+
+
+def test_off_allowlist_call_never_reaches_dispatch() -> None:
+    model = _scripted(
+        [
+            {"tool_calls": [{"name": "made_up_tool", "arguments": {}}]},
+            {"text": "recovered"},
+        ]
+    )
+    dispatch = RecordingDispatch()
+    result = _run(model, dispatch)
+
+    assert dispatch.calls == []
+    assert result.final_answer == "recovered"
+    tool_record = result.turn_records[1]
+    assert tool_record.kind == "tool"
+    assert tool_record.tool_name == "made_up_tool"
+    assert tool_record.is_error is True
+
+
+def test_tool_result_truncated_at_fixed_cap() -> None:
+    class TruncationSpy(ToolAgentModel):
+        spec = "spy:test"
+
+        def __init__(self) -> None:
+            self.fed_back: str | None = None
+
+        def propose(
+            self, transcript: Sequence[TranscriptItem], tools: Sequence[ToolDef]
+        ) -> AgentTurn:
+            for item in transcript:
+                if isinstance(item, ToolReturn):
+                    self.fed_back = item.text
+            if self.fed_back is None:
+                return AgentTurn(
+                    text="",
+                    tool_calls=(ToolCall(call_id="c", name="search_notes", arguments={}),),
+                    model="spy",
+                    input_tokens=1,
+                    output_tokens=1,
+                    latency_ms=0.0,
+                )
+            return AgentTurn(
+                text="done",
+                tool_calls=(),
+                model="spy",
+                input_tokens=1,
+                output_tokens=1,
+                latency_ms=0.0,
+            )
+
+    model = TruncationSpy()
+    huge = "x" * (TOOL_RESULT_MAX_CHARS + 500)
+    _run(model, RecordingDispatch(ToolOutcome(text=huge, is_error=False)))
+
+    assert model.fed_back is not None
+    assert model.fed_back.startswith("x" * 100)
+    assert "truncated" in model.fed_back
+    assert len(model.fed_back) < len(huge)
+
+
+def test_model_error_is_wrapped_with_partial_accounting() -> None:
+    model = _scripted([{"text": "unreachable"}], needle="never-matches")
+    with pytest.raises(AgentLoopError) as excinfo:
+        _run(model, RecordingDispatch())
+
+    assert isinstance(excinfo.value.cause, LLMRunnerError)
+    partial = excinfo.value.partial
+    assert partial.stopped_reason == "error"
+    assert partial.turns == 0
+    assert partial.total_input_tokens == 0
+
+
+def test_mid_loop_model_error_keeps_spent_tokens() -> None:
+    # One scripted turn, then the script exhausts: the second propose fails
+    # AFTER a real model call and tool dispatch — that cost must be preserved.
+    model = _scripted([{"tool_calls": [{"name": "search_notes", "arguments": {}}]}])
+    with pytest.raises(AgentLoopError) as excinfo:
+        _run(model, RecordingDispatch())
+
+    partial = excinfo.value.partial
+    assert partial.stopped_reason == "error"
+    assert partial.turns == 1
+    assert partial.tool_call_count == 1
+    assert partial.total_input_tokens == 10
+    assert partial.total_output_tokens == 5
+    assert [record.kind for record in partial.turn_records] == ["model", "tool"]
+
+
+def test_dispatch_error_is_wrapped_and_records_the_dying_call() -> None:
+    class ExplodingDispatch:
+        def __call__(self, name: str, arguments: dict[str, Any]) -> ToolOutcome:
+            raise RuntimeError("stdio session lost")
+
+    model = _scripted([{"tool_calls": [{"name": "search_notes", "arguments": {"q": "x"}}]}])
+    with pytest.raises(AgentLoopError) as excinfo:
+        run_agent_loop(
+            model=model,
+            dispatch=ExplodingDispatch(),
+            tools=TOOLS,
+            prompt="Task: x",
+            budget=AgentBudget(),
+        )
+
+    assert isinstance(excinfo.value.cause, RuntimeError)
+    partial = excinfo.value.partial
+    assert partial.total_input_tokens == 10  # the model turn already happened
+    assert partial.tool_call_count == 1
+    tool_record = partial.turn_records[-1]
+    assert tool_record.kind == "tool"
+    assert tool_record.tool_name == "search_notes"
+    assert tool_record.is_error is True
+
+
+def test_wall_clock_gate_between_tool_dispatches() -> None:
+    # One assistant turn with three tool calls; the injected clock breaches the
+    # budget after the first dispatch, so the remaining calls never dispatch.
+    ticks = iter([0.0, 0.0, 10.0, 100.0, 100.0])
+    model = _scripted([{"tool_calls": [{"name": "search_notes", "arguments": {}}] * 3}])
+    dispatch = RecordingDispatch()
+    result = run_agent_loop(
+        model=model,
+        dispatch=dispatch,
+        tools=TOOLS,
+        prompt="Task: x",
+        budget=AgentBudget(max_task_seconds=50.0),
+        clock=lambda: next(ticks),
+    )
+
+    assert result.stopped_reason == "wall_clock"
+    assert result.final_answer is None
+    assert len(dispatch.calls) == 1
+    assert result.tool_call_count == 1
+
+
+def test_per_turn_records_account_tokens_and_counts() -> None:
+    model = _scripted(
+        [
+            {"tool_calls": [{"name": "search_notes", "arguments": {"q": "a"}}]},
+            {"text": "done"},
+        ]
+    )
+    result = _run(model, RecordingDispatch())
+
+    kinds = [record.kind for record in result.turn_records]
+    assert kinds == ["model", "tool", "model"]
+    model_records = [record for record in result.turn_records if record.kind == "model"]
+    assert sum(record.input_tokens for record in model_records) == result.total_input_tokens
+    assert sum(record.output_tokens for record in model_records) == result.total_output_tokens
+    tool_record = result.turn_records[1]
+    assert tool_record.tool_name == "search_notes"
+    assert tool_record.result_chars == len("ok")
+    assert result.tool_call_count == 1

--- a/benchmarks/tests/agent_tasks/test_surfaces.py
+++ b/benchmarks/tests/agent_tasks/test_surfaces.py
@@ -1,0 +1,69 @@
+"""Tests for tool-surface definitions and the fail-fast availability check."""
+
+from __future__ import annotations
+
+import pytest
+
+from basic_memory_benchmarks.agent_tasks.surfaces import (
+    POSIX_SURFACE,
+    RICH_SURFACE,
+    SURFACES,
+    SurfaceUnavailableError,
+    surface_env,
+    verify_surface_tools,
+)
+
+POSIX_READ_TOOLS = ("cat", "grep", "ls", "find", "tail", "man")
+SHARED_WRITE_TOOLS = ("write_note", "edit_note", "move_note", "delete_note")
+
+
+def test_registry_names_both_surfaces() -> None:
+    assert set(SURFACES) == {"rich", "posix"}
+    assert SURFACES["rich"] is RICH_SURFACE
+    assert SURFACES["posix"] is POSIX_SURFACE
+
+
+def test_posix_allowlist_is_read_swap_plus_shared_write_verbs() -> None:
+    # Posix v1 (#1399) is read-side only: the six read tools replace the rich
+    # read verbs; the write verbs are shared with the rich surface.
+    assert POSIX_SURFACE.tool_allowlist == POSIX_READ_TOOLS + SHARED_WRITE_TOOLS
+    assert RICH_SURFACE.tool_allowlist[-4:] == SHARED_WRITE_TOOLS
+
+
+def test_rich_surface_needs_no_config_overrides() -> None:
+    assert RICH_SURFACE.config_overrides == {}
+
+
+def test_surface_env_maps_flag_to_basic_memory_env_var() -> None:
+    env = surface_env(POSIX_SURFACE, {"EXISTING": "1"})
+    assert env["BASIC_MEMORY_ENABLE_POSIX_TOOLS"] == "true"
+    assert env["EXISTING"] == "1"
+
+
+def test_surface_env_does_not_mutate_base_env() -> None:
+    base = {"EXISTING": "1"}
+    surface_env(POSIX_SURFACE, base)
+    assert base == {"EXISTING": "1"}
+
+
+def test_verify_passes_on_superset() -> None:
+    available = set(POSIX_SURFACE.tool_allowlist) | {"extra_tool"}
+    verify_surface_tools(POSIX_SURFACE, available)
+
+
+def test_verify_rich_surface_through_same_path() -> None:
+    verify_surface_tools(RICH_SURFACE, RICH_SURFACE.tool_allowlist)
+    with pytest.raises(SurfaceUnavailableError):
+        verify_surface_tools(RICH_SURFACE, ["write_note"])
+
+
+def test_verify_missing_posix_tools_raises_with_guidance() -> None:
+    # A rich-only BM (this branch) exposes the write verbs but no posix reads.
+    with pytest.raises(SurfaceUnavailableError) as excinfo:
+        verify_surface_tools(POSIX_SURFACE, SHARED_WRITE_TOOLS, bm_version="0.23.2")
+    message = str(excinfo.value)
+    assert "surface 'posix'" in message
+    assert "cat, grep, ls, find, tail, man" in message
+    assert "enable_posix_tools" in message
+    assert "0.23.2" in message
+    assert "--bm-local-path" in message

--- a/benchmarks/tests/agent_tasks/test_task_fixture.py
+++ b/benchmarks/tests/agent_tasks/test_task_fixture.py
@@ -1,0 +1,215 @@
+"""Fixture <-> spec integrity: gold values are recomputed from the checked-in corpus.
+
+Data-driven: if a corpus note or a task spec drifts, these tests name the exact
+mismatch instead of letting a live run fail mysteriously.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import frontmatter
+
+from basic_memory_benchmarks.agent_tasks.corpus import (
+    RECENT_AGE_DAYS,
+    TIMESTAMPS,
+    corpus_checksum,
+)
+from basic_memory_benchmarks.agent_tasks.spec import (
+    AnswerSetEquals,
+    MarkerAbsent,
+    MarkerPresent,
+    RelationResolves,
+)
+from basic_memory_benchmarks.agent_tasks.tasks import (
+    RECENT_TITLES,
+    TASKS,
+    TASKS_BY_ID,
+    select_tasks,
+)
+
+CORPUS_DIR = Path(__file__).parents[2] / "benchmarks" / "datasets" / "agent-tasks" / "corpus"
+WIKI_LINK_PATTERN = re.compile(r"\[\[([^\]]+)\]\]")
+REQUIRED_SKILLS = {
+    "memory-continue",
+    "memory-curate",
+    "memory-metadata-search",
+    "memory-tasks",
+    "manual",
+}
+
+
+def _corpus() -> dict[str, str]:
+    assert CORPUS_DIR.is_dir(), f"corpus fixture missing: {CORPUS_DIR}"
+    return {
+        str(path.relative_to(CORPUS_DIR)): path.read_text(encoding="utf-8")
+        for path in sorted(CORPUS_DIR.rglob("*.md"))
+    }
+
+
+def _metadata(text: str) -> dict:
+    return dict(frontmatter.loads(text).metadata)
+
+
+def _referenced_markers() -> set[str]:
+    markers: set[str] = set()
+    for task in TASKS:
+        for grader in task.graders:
+            if isinstance(grader, (MarkerPresent, MarkerAbsent)):
+                markers.add(grader.marker)
+    return markers
+
+
+def test_task_ids_unique_and_at_least_ten() -> None:
+    ids = [task.id for task in TASKS]
+    assert len(ids) == len(set(ids))
+    assert len(ids) >= 10
+
+
+def test_every_required_skill_area_is_covered() -> None:
+    assert REQUIRED_SKILLS <= {task.skill for task in TASKS}
+
+
+def test_select_tasks_rejects_unknown_ids() -> None:
+    assert [task.id for task in select_tasks([])] == sorted(TASKS_BY_ID)
+    try:
+        select_tasks(["nope"])
+    except ValueError as exc:
+        assert "nope" in str(exc)
+    else:  # pragma: no cover - guard
+        raise AssertionError("unknown id accepted")
+
+
+def test_every_referenced_marker_occurs_exactly_once_in_corpus() -> None:
+    corpus = _corpus()
+    all_text = "\n".join(corpus.values())
+    for marker in sorted(_referenced_markers()):
+        count = all_text.count(marker)
+        assert count == 1, f"marker {marker} occurs {count} times in the corpus"
+
+
+def test_task_prompts_never_leak_markers() -> None:
+    for task in TASKS:
+        assert "BMEVAL-" not in task.prompt or task.id == "man-chain", task.id
+    # man-chain names only the prefix, never a full marker.
+    assert re.search(r"BMEVAL-[a-z0-9-]+", TASKS_BY_ID["man-chain"].prompt) is None
+
+
+def test_gold_permalinks_map_to_corpus_files() -> None:
+    corpus = _corpus()
+    for task in TASKS:
+        for grader in task.graders:
+            if isinstance(grader, AnswerSetEquals) and grader.key == "permalinks":
+                for permalink in grader.gold:
+                    assert f"{permalink}.md" in corpus, f"{task.id}: {permalink}"
+            if isinstance(grader, RelationResolves):
+                assert f"{grader.source_permalink}.md" in corpus
+                for target in grader.targets:
+                    assert f"{target}.md" in corpus
+
+
+def test_orphan_gold_matches_link_scan() -> None:
+    corpus = _corpus()
+    title_to_relpath = {
+        str(_metadata(text).get("title")): relpath for relpath, text in corpus.items()
+    }
+    outbound: dict[str, set[str]] = {}
+    for relpath, text in corpus.items():
+        body = frontmatter.loads(text).content
+        outbound[relpath] = {
+            title_to_relpath[target.strip()]
+            for target in WIKI_LINK_PATTERN.findall(body)
+            if target.strip() in title_to_relpath
+        }
+    inbound: dict[str, set[str]] = {relpath: set() for relpath in corpus}
+    for source, targets in outbound.items():
+        for target in targets:
+            inbound[target].add(source)
+
+    computed_orphans = {
+        relpath.removesuffix(".md")
+        for relpath in corpus
+        if not outbound[relpath] and not inbound[relpath]
+    }
+    gold = next(
+        grader.gold
+        for grader in TASKS_BY_ID["curate-orphans"].graders
+        if isinstance(grader, AnswerSetEquals)
+    )
+    assert computed_orphans == set(gold)
+
+
+def _notes_metadata() -> dict[str, dict]:
+    return {relpath.removesuffix(".md"): _metadata(text) for relpath, text in _corpus().items()}
+
+
+def test_meta_status_priority_gold_recomputed() -> None:
+    notes = _notes_metadata()
+    computed = {
+        permalink
+        for permalink, meta in notes.items()
+        if meta.get("status") == "active" and meta.get("priority") in ("high", "critical")
+    }
+    gold = next(
+        grader.gold
+        for grader in TASKS_BY_ID["meta-status-priority"].graders
+        if isinstance(grader, AnswerSetEquals)
+    )
+    assert computed == set(gold)
+    # The trap: a note whose BODY mentions "priority: high" but whose
+    # frontmatter priority is low must stay excluded.
+    trap = _corpus()["notes/postgres-vacuum-notes.md"]
+    assert "priority: high" in frontmatter.loads(trap).content
+    assert notes["notes/postgres-vacuum-notes"]["priority"] == "low"
+
+
+def test_meta_confidence_gold_recomputed_with_boundary() -> None:
+    notes = _notes_metadata()
+    computed = {
+        permalink
+        for permalink, meta in notes.items()
+        if isinstance(meta.get("confidence"), (int, float)) and meta["confidence"] > 0.7
+    }
+    gold = next(
+        grader.gold
+        for grader in TASKS_BY_ID["meta-confidence-gt"].graders
+        if isinstance(grader, AnswerSetEquals)
+    )
+    assert computed == set(gold)
+    # The $gt-vs-$gte boundary note sits exactly at 0.7 and is excluded.
+    boundary = [meta for meta in notes.values() if meta.get("confidence") == 0.7]
+    assert boundary, "corpus lost its 0.7 confidence boundary note"
+
+
+def test_meta_nested_review_gold_recomputed() -> None:
+    notes = _notes_metadata()
+    computed = {
+        permalink
+        for permalink, meta in notes.items()
+        if meta.get("status") == "draft"
+        and isinstance(meta.get("review"), dict)
+        and meta["review"].get("status") == "pending"
+    }
+    gold = next(
+        grader.gold
+        for grader in TASKS_BY_ID["meta-nested-review"].graders
+        if isinstance(grader, AnswerSetEquals)
+    )
+    assert computed == set(gold)
+
+
+def test_timestamps_cover_exactly_the_recent_gold_files() -> None:
+    corpus = _corpus()
+    for relpath, age in TIMESTAMPS.items():
+        assert relpath in corpus, f"TIMESTAMPS references missing file {relpath}"
+        assert age == RECENT_AGE_DAYS
+    recent_titles = {str(_metadata(corpus[relpath]).get("title")) for relpath in TIMESTAMPS}
+    assert recent_titles == set(RECENT_TITLES)
+
+
+def test_corpus_checksum_is_stable_and_counts_files() -> None:
+    checksum_a, count_a = corpus_checksum(CORPUS_DIR)
+    checksum_b, count_b = corpus_checksum(CORPUS_DIR)
+    assert checksum_a == checksum_b
+    assert count_a == count_b == len(_corpus())

--- a/benchmarks/tests/llm/test_tool_agent.py
+++ b/benchmarks/tests/llm/test_tool_agent.py
@@ -1,0 +1,273 @@
+"""Tests for the tool-use model seam (spec parsing and both transports)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+import basic_memory_benchmarks.llm.tool_agent as tool_agent
+from basic_memory_benchmarks.llm.runners import LLMRunnerError
+from basic_memory_benchmarks.llm.tool_agent import (
+    AssistantTurn,
+    OpenAICompatToolAgent,
+    ScriptedToolAgent,
+    ToolCall,
+    ToolDef,
+    ToolReturn,
+    UserMessage,
+    create_tool_agent_model,
+    substitute_placeholders,
+)
+
+SEARCH_TOOL = ToolDef(
+    name="search_notes",
+    description="Search notes",
+    input_schema={"type": "object", "properties": {"query": {"type": "string"}}},
+)
+
+
+class TestCreateToolAgentModel:
+    def test_openai_compat_spec(self) -> None:
+        model = create_tool_agent_model("openai-compat:qwen3@http://localhost:11434/v1")
+        assert isinstance(model, OpenAICompatToolAgent)
+        assert model.model == "qwen3"
+        assert model.base_url == "http://localhost:11434/v1"
+
+    def test_scripted_spec(self, tmp_path: Path) -> None:
+        script_path = tmp_path / "script.json"
+        script_path.write_text(json.dumps({"tasks": {"hello": [{"text": "hi"}]}}))
+        model = create_tool_agent_model(f"scripted:{script_path}")
+        assert isinstance(model, ScriptedToolAgent)
+        assert model.spec == f"scripted:{script_path}"
+
+    def test_claude_rejected_with_explanation(self) -> None:
+        with pytest.raises(ValueError, match="single-shot.*tool_use|tool_use.*single-shot"):
+            create_tool_agent_model("claude:claude-haiku-4-5")
+
+    def test_junk_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            create_tool_agent_model("gemini:flash")
+        with pytest.raises(ValueError):
+            create_tool_agent_model("openai-compat:no-base-url")
+
+    def test_scripted_file_without_tasks_rejected(self, tmp_path: Path) -> None:
+        script_path = tmp_path / "bad.json"
+        script_path.write_text(json.dumps({"not_tasks": {}}))
+        with pytest.raises(ValueError, match="tasks"):
+            create_tool_agent_model(f"scripted:{script_path}")
+
+
+def _response(payload: dict[str, Any]) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        json=payload,
+        request=httpx.Request("POST", "http://localhost/v1/chat/completions"),
+    )
+
+
+class TestOpenAICompatToolAgent:
+    def _agent(self) -> OpenAICompatToolAgent:
+        return OpenAICompatToolAgent("qwen3", "http://localhost:11434/v1", max_retries=0)
+
+    def test_request_carries_tools_and_temperature(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_post(url: str, **kwargs: Any) -> httpx.Response:
+            captured["url"] = url
+            captured["body"] = kwargs["json"]
+            return _response(
+                {
+                    "choices": [{"message": {"content": "done", "tool_calls": []}}],
+                    "usage": {"prompt_tokens": 12, "completion_tokens": 3},
+                }
+            )
+
+        monkeypatch.setattr(tool_agent.httpx, "post", fake_post)
+        turn = self._agent().propose([UserMessage(text="find redis")], [SEARCH_TOOL])
+
+        assert captured["url"].endswith("/chat/completions")
+        body = captured["body"]
+        assert body["temperature"] == 0
+        assert body["tool_choice"] == "auto"
+        assert body["tools"] == [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search_notes",
+                    "description": "Search notes",
+                    "parameters": SEARCH_TOOL.input_schema,
+                },
+            }
+        ]
+        assert turn.text == "done"
+        assert turn.tool_calls == ()
+        assert turn.input_tokens == 12
+        assert turn.output_tokens == 3
+
+    def test_transcript_maps_assistant_and_tool_roles(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_post(url: str, **kwargs: Any) -> httpx.Response:
+            captured["body"] = kwargs["json"]
+            return _response(
+                {
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                }
+            )
+
+        monkeypatch.setattr(tool_agent.httpx, "post", fake_post)
+        transcript = [
+            UserMessage(text="find redis"),
+            AssistantTurn(
+                text="",
+                tool_calls=(
+                    ToolCall(call_id="c1", name="search_notes", arguments={"query": "redis"}),
+                ),
+            ),
+            ToolReturn(call_id="c1", name="search_notes", text="2 results", is_error=False),
+        ]
+        self._agent().propose(transcript, [SEARCH_TOOL])
+
+        messages = captured["body"]["messages"]
+        assert messages[0] == {"role": "user", "content": "find redis"}
+        assert messages[1]["role"] == "assistant"
+        assert messages[1]["tool_calls"][0]["function"]["name"] == "search_notes"
+        assert json.loads(messages[1]["tool_calls"][0]["function"]["arguments"]) == {
+            "query": "redis"
+        }
+        assert messages[2] == {"role": "tool", "tool_call_id": "c1", "content": "2 results"}
+
+    def test_parses_tool_calls_from_response(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        payload = {
+            "choices": [
+                {
+                    "message": {
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call-9",
+                                "function": {
+                                    "name": "search_notes",
+                                    "arguments": '{"query": "redis"}',
+                                },
+                            }
+                        ],
+                    }
+                }
+            ],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 7},
+        }
+        monkeypatch.setattr(tool_agent.httpx, "post", lambda url, **kw: _response(payload))
+        turn = self._agent().propose([UserMessage(text="go")], [SEARCH_TOOL])
+
+        assert turn.text == ""
+        assert turn.tool_calls == (
+            ToolCall(call_id="call-9", name="search_notes", arguments={"query": "redis"}),
+        )
+
+    def test_malformed_tool_arguments_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        payload = {
+            "choices": [
+                {
+                    "message": {
+                        "tool_calls": [
+                            {"id": "c", "function": {"name": "search_notes", "arguments": "{oops"}}
+                        ]
+                    }
+                }
+            ]
+        }
+        monkeypatch.setattr(tool_agent.httpx, "post", lambda url, **kw: _response(payload))
+        with pytest.raises(LLMRunnerError, match="malformed tool arguments"):
+            self._agent().propose([UserMessage(text="go")], [SEARCH_TOOL])
+
+    def test_missing_usage_block_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Silent 0-token turns would corrupt the headline metric and disarm the
+        # tokens budget, so an omitted usage block is an explicit error.
+        payload = {"choices": [{"message": {"content": "done"}}]}
+        monkeypatch.setattr(tool_agent.httpx, "post", lambda url, **kw: _response(payload))
+        with pytest.raises(LLMRunnerError, match="usage"):
+            self._agent().propose([UserMessage(text="go")], [SEARCH_TOOL])
+
+    def test_incomplete_usage_block_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        payload = {
+            "choices": [{"message": {"content": "done"}}],
+            "usage": {"prompt_tokens": 12},
+        }
+        monkeypatch.setattr(tool_agent.httpx, "post", lambda url, **kw: _response(payload))
+        with pytest.raises(LLMRunnerError, match="token counts"):
+            self._agent().propose([UserMessage(text="go")], [SEARCH_TOOL])
+
+    def test_retry_exhaustion_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls = {"count": 0}
+
+        def failing_post(url: str, **kwargs: Any) -> httpx.Response:
+            calls["count"] += 1
+            raise httpx.ConnectError("refused")
+
+        monkeypatch.setattr(tool_agent.httpx, "post", failing_post)
+        agent = OpenAICompatToolAgent("m", "http://localhost:1", max_retries=1)
+        with pytest.raises(LLMRunnerError, match="after 2 attempts"):
+            agent.propose([UserMessage(text="go")], [SEARCH_TOOL])
+        assert calls["count"] == 2
+
+
+class TestScriptedToolAgent:
+    def _agent(self) -> ScriptedToolAgent:
+        return ScriptedToolAgent(
+            script={
+                "tasks": {
+                    "orphan": [
+                        {
+                            "tool_calls": [
+                                {
+                                    "name": "search_notes",
+                                    "arguments": {"query": "x", "project": "{project}"},
+                                }
+                            ]
+                        },
+                        {"text": "final answer"},
+                    ]
+                }
+            }
+        )
+
+    def test_substring_keying_selects_turn_by_transcript_position(self) -> None:
+        agent = self._agent()
+        first = agent.propose([UserMessage(text="please find the orphan notes")], [])
+        assert first.tool_calls[0].name == "search_notes"
+
+        transcript = [
+            UserMessage(text="please find the orphan notes"),
+            AssistantTurn(text="", tool_calls=first.tool_calls),
+            ToolReturn(call_id="c", name="search_notes", text="results", is_error=False),
+        ]
+        second = agent.propose(transcript, [])
+        assert second.text == "final answer"
+        assert second.tool_calls == ()
+
+    def test_placeholder_substitution_is_recursive(self) -> None:
+        arguments = {"project": "{project}", "nested": {"p": "{project}"}, "n": 3}
+        resolved = substitute_placeholders(arguments, {"project": "at-run-task"})
+        assert resolved == {"project": "at-run-task", "nested": {"p": "at-run-task"}, "n": 3}
+
+    def test_unmatched_prompt_raises(self) -> None:
+        with pytest.raises(LLMRunnerError, match="no entry matching"):
+            self._agent().propose([UserMessage(text="something else")], [])
+
+    def test_exhausted_script_raises(self) -> None:
+        agent = self._agent()
+        transcript = [
+            UserMessage(text="orphan"),
+            AssistantTurn(text="", tool_calls=()),
+            AssistantTurn(text="", tool_calls=()),
+        ]
+        with pytest.raises(LLMRunnerError, match="exhausted"):
+            agent.propose(transcript, [])

--- a/benchmarks/tests/test_cli_surface.py
+++ b/benchmarks/tests/test_cli_surface.py
@@ -1,5 +1,10 @@
+from pathlib import Path
+
+import pytest
 from typer.testing import CliRunner
 
+from basic_memory_benchmarks import cli
+from basic_memory_benchmarks.agent_tasks.models import AgentTasksConfig
 from basic_memory_benchmarks.cli import app
 
 
@@ -41,3 +46,50 @@ def test_run_beam_score_command_wired() -> None:
     assert "--judge" in result.output
     assert "--source" in result.output
     assert "--max-workers" in result.output
+
+
+def test_run_agent_tasks_command_wired() -> None:
+    result = runner.invoke(app, ["run", "agent-tasks", "--help"])
+
+    assert result.exit_code == 0
+    assert "--surfaces" in result.output
+    assert "--model" in result.output
+    assert "--tasks" in result.output
+    assert "--bm-local-path" in result.output
+    assert "--max-turns" in result.output
+    assert "--strict-surfaces" in result.output
+
+
+def test_run_agent_tasks_dedupes_repeated_surfaces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `--surfaces rich,rich` used to pass the membership check and then crash
+    # mid-run creating the second identical surface home.
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(config: AgentTasksConfig) -> Path:
+        captured["surfaces"] = config.surfaces
+        return tmp_path / "run"
+
+    monkeypatch.setattr(cli, "run_agent_tasks", fake_run)
+    script = tmp_path / "script.json"
+    script.write_text('{"tasks": {}}', encoding="utf-8")
+    bm_checkout = tmp_path / "bm"
+    bm_checkout.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "agent-tasks",
+            "--surfaces",
+            "rich,rich",
+            "--model",
+            f"scripted:{script}",
+            "--bm-local-path",
+            str(bm_checkout),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["surfaces"] == ["rich"]

--- a/benchmarks/tests/test_concurrent_write.py
+++ b/benchmarks/tests/test_concurrent_write.py
@@ -224,14 +224,14 @@ def test_unknown_status_schema_uses_fixed_settle_delay(
 ) -> None:
     status = json.dumps({"total_files": 2, "observed_files": [{"path": "note.md"}]})
     monkeypatch.setattr(
-        concurrent_write,
+        bm_runtime,
         "run_command",
         lambda *_args, **_kwargs: SimpleNamespace(stdout=status, stderr=""),
     )
     delays: list[float] = []
-    monkeypatch.setattr(concurrent_write.time, "sleep", delays.append)
+    monkeypatch.setattr(bm_runtime.time, "sleep", delays.append)
 
-    _seconds, mode = concurrent_write._settle_index(
+    _seconds, mode = bm_runtime.settle_index(
         prefix=["bm"],
         env={},
         project_name="project",
@@ -239,7 +239,7 @@ def test_unknown_status_schema_uses_fixed_settle_delay(
     )
 
     assert mode == "fixed-delay"
-    assert delays == [concurrent_write.FALLBACK_SETTLE_SECONDS]
+    assert delays == [bm_runtime.FALLBACK_SETTLE_SECONDS]
 
 
 def test_resolve_clean_checkout_sha_rejects_dirty_target(


### PR DESCRIPTION
## Why

Third slice of the tracker (#1398), and the one that answers its central question: does the POSIX surface actually beat the rich tools on **tokens and accuracy**? This is an agent-in-the-loop eval where the **tool surface is the provider axis** — same model, same budgets, same tasks, same seeded corpus; only the tools differ. Headline metric: **tokens per successfully completed task** (the xAFS framing); reporting structurally cannot show accuracy alone.

Stacked on #1407 (`1400-beam-benchmark`). Closes #1401.

## What changed

- **`agent_tasks/loop.py`** — minimal tool-use loop: model proposes tool calls, the runner dispatches them against the ephemeral in-process BM MCP server, feeds results back until final answer or budget stop. Budgets (max turns, total tokens, wall clock) are enforced **between tool dispatches too**, so a single turn carrying many calls can't blow past the clock.
- **`llm/tool_agent.py`** — model seam: `openai-compat:<model>@<base_url>` for live runs, `scripted:<path.json>` for offline tests. Token accounting **fails fast on missing usage blocks** — a 0-token turn would silently corrupt the headline metric and disarm the token budget.
- **`agent_tasks/tasks.py` + fixture corpus** — twelve tasks derived from the shipped skills (memory-continue, memory-curate, memory-metadata-search, memory-tasks) plus SPEC-47's manual chain (search manual → read the `edit-note(3)` EXAMPLES section), graded against a hand-written seeded corpus with planted `BMEVAL-*` markers, orphans, and manpage-typed notes.
- **`agent_tasks/grading.py`/`spec.py`** — deterministic graders (marker presence/absence, frontmatter equality/regex, note-count delta, notes-untouched, new-note-under-directory, tool-called, answer regex) plus the package judge seam for open-ended outcomes. Predicates designed to be ungameable by trivial answers.
- **`agent_tasks/driver.py` + reporting** — per-surface artifacts (per-turn JSONL with tokens/tool/latency), summary.md that always shows tokens-per-completed-task beside accuracy and explicitly lists **skipped surfaces** (a rich-only run can't be misread as a completed A/B). Mid-task failures keep their partial token accounting — spent tokens are never discarded from the denominator.
- **Tool surface as data** — `--surfaces rich,posix`: `posix` maps to BM config overrides (`enable_posix_tools`) plus a tool allowlist and **fails fast** if the running BM lacks the flag. This branch deliberately does not merge the posix branch; the A/B becomes runnable when both stacks land on `main`.

## How it was built

Reviewed multi-agent workflow (map package/in-process-BM/skills → design → implement → offline tests → verify → adversarial review), then a follow-up pass applying all eight review findings — four should-fixes (budget bypass between dispatches, silent token-accounting hole, discarded partial accounting, skipped surfaces missing from the report) and four nits (imports-at-top, duplicate-surface rejection, unused params, two grading-strictness gaps).

## Verification

- ruff check / format — clean; pyright — 0 errors
- Full package suite — 342 passed, fully offline (scripted model; stubbed judge)

## Notes

- Ships the harness only; no paid runs. The live A/B (rich vs posix, real model) is the post-merge step once #1406/#1408 land, and its result decides whether the POSIX surface graduates from the flag.
- #1402 (xAFS adapter) stacks on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp
