### PR TITLE
feat(core): add xAFS dataset adapter to the benchmarks package

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -20,6 +20,7 @@ benchmarks/datasets/longmemeval/longmemeval_s.json
 benchmarks/datasets/longmemeval/longmemeval_s.provenance.json
 benchmarks/datasets/locomo-audit/
 benchmarks/datasets/beam/upstream/
+benchmarks/datasets/xafs/upstream/
 benchmarks/.mem0-qdrant/
 benchmarks/datasets/convomem/
 benchmarks/.bm-homes/

--- a/benchmarks/benchmarks/datasets/xafs/README.md
+++ b/benchmarks/benchmarks/datasets/xafs/README.md
@@ -1,0 +1,81 @@
+# xAFS Dataset
+
+xAFS ("Agentic File System") probes agentic retrieval over persona file trees:
+13 synthetic personas whose corpora scale from 5 to ~10K files, with questions
+answered by reading the files (single-hop, multi-hop, and format-spanning
+across non-markdown formats). Headline metric: tokens spent per correct
+answer, judged semantically.
+
+- Upstream: https://huggingface.co/datasets/supermemory/xAFS
+- License: **CC-BY-4.0** — attribution required.
+- **Vendor caveat:** xAFS is authored by supermemory, a memory-product vendor.
+  This package reports it as a SECONDARY dataset, never the headline, pending
+  a question-quality audit (see `bm-bench sample xafs` and
+  docs/benchmarks.md 6d).
+- The data is never vendored into this repo; fetch it locally (below).
+
+## Fetch
+
+The dataset is ~19K files / ~837MB in total, so fetch only the personas you
+need. The download is pinned to revision `21142b2c` for reproducibility.
+
+```bash
+# Two-persona subset (the cheap default the just targets use):
+XAFS_PERSONAS=dp_001,dp_002 bash benchmarks/datasets/xafs/download.sh
+# or via just:
+just bench-fetch-xafs
+
+# Everything (837MB):
+bash benchmarks/datasets/xafs/download.sh
+```
+
+This downloads into `benchmarks/datasets/xafs/upstream/` (gitignored) using
+the `hf` CLI (`pip install -U huggingface_hub`).
+
+## Layout
+
+Each persona directory `dp_001`..`dp_013` contains:
+
+- `data/` — the persona's file tree (mostly `.md`, including double-suffix
+  format files like `metrics.csv.md`, plus a handful of real non-markdown
+  `.eml` mails)
+- `question.json` — the persona's questions: `id`, `family`
+  (`single_hop` | `multi_hop` | `format_spanning`), `prompt`,
+  `gold_file_ids` (verbatim `data/...` relpaths), `gold_answer`
+
+Only `data/` subtrees are ever ingested; `question.json` (and any
+scenario/answer-key files) never reach a corpus.
+
+**Count note:** the upstream README advertises 110 questions (35/50/25 per
+family) but the shipped `question.json` files at the pinned revision sum to
+33/51/26. The loader trusts the JSON.
+
+## Convert and run
+
+```bash
+just bench-convert-xafs                     # dp_001,dp_002 -> benchmarks/generated/xafs
+BM_LOCAL_PATH=.. just bench-run-xafs-agent  # agent-task run over the manifest
+# or directly:
+uv run bm-bench convert xafs --personas dp_001,dp_002
+uv run bm-bench run agent-tasks \
+  --task-manifest benchmarks/generated/xafs/tasks.json \
+  --surfaces rich,posix \
+  --model openai-compat:<model>@<base_url> \
+  --judge claude:claude-sonnet-4-6 \
+  --bm-local-path <bm-checkout>
+```
+
+`conversion.json` in the output dir records the pinned revision, selected
+personas, per-persona aggregate sha256 over `(relpath, sha256)` pairs, the
+`question.json` checksums, and per-extension file counts.
+
+## Audit sampling
+
+```bash
+just bench-xafs-audit-sample    # 20 questions, seed 42, stratified by family
+```
+
+writes `benchmarks/generated/xafs-audit/` with the sampled prompts, gold
+answers, and verbatim copies of every gold source file for human review.
+Audit verdicts land in `benchmarks/datasets/xafs/corrections.json` (keyed
+`"<persona>/<qid>"`) and feed `bm-bench convert xafs --corrections ...`.

--- a/benchmarks/benchmarks/datasets/xafs/download.sh
+++ b/benchmarks/benchmarks/datasets/xafs/download.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# xAFS benchmark data (CC-BY-4.0) is never vendored into this repo.
+# Fetched from Hugging Face at a pinned revision so runs are reproducible.
+# Requires the `hf` CLI: pip install -U huggingface_hub  (or: uv tool install huggingface_hub)
+#
+# XAFS_PERSONAS: optional comma-separated persona subset, e.g. "dp_001,dp_002".
+# Unset/empty fetches every persona (~19K files / ~837MB) — subset unless you
+# really need the full dataset.
+
+dest="benchmarks/datasets/xafs/upstream"
+revision="21142b2c01113cb881c80d6c99bcf0f412ed17f2"
+
+include_args=()
+if [ -n "${XAFS_PERSONAS:-}" ]; then
+  IFS=',' read -ra personas <<<"$XAFS_PERSONAS"
+  for persona in "${personas[@]}"; do
+    include_args+=(--include "${persona// /}/*")
+  done
+fi
+
+# ${arr[@]+...} guards the empty-array expansion under `set -u` on bash 3.2 (macOS).
+hf download supermemory/xAFS \
+  --repo-type dataset \
+  --revision "$revision" \
+  --local-dir "$dest" \
+  ${include_args[@]+"${include_args[@]}"}
+
+echo "xAFS data available under $dest"
+echo "Fetch more personas with: XAFS_PERSONAS=dp_003,dp_004 bash benchmarks/datasets/xafs/download.sh"

--- a/benchmarks/benchmarks/datasets/xafs/source.json
+++ b/benchmarks/benchmarks/datasets/xafs/source.json
@@ -1,0 +1,6 @@
+{
+  "dataset_id": "xafs",
+  "source_url": "https://huggingface.co/datasets/supermemory/xAFS",
+  "citation": "xAFS (supermemory, 2026), revision 21142b2c01113cb881c80d6c99bcf0f412ed17f2",
+  "license_note": "CC-BY-4.0; vendor-authored (supermemory) — secondary dataset pending question-quality audit"
+}

--- a/benchmarks/docs/benchmarks.md
+++ b/benchmarks/docs/benchmarks.md
@@ -17,6 +17,8 @@ It covers:
 | `just` retrieval and QA workflows (`bench-full`, `bench-qa`) | Implemented |
 | Artifact generation and publish/compare commands | Implemented |
 | Manual BM revision comparison via worktrees + `--bm-local-path` | Implemented workflow, manual orchestration |
+| xAFS agent-path eval (`convert xafs`, `run agent-tasks --task-manifest`) | Implemented (secondary dataset; see 6d) |
+| xAFS retrieval diagnostic (`queries.json` for single/multi-hop) | Planned — blocked on the provider doc-id seam (see 6d) |
 | `bm-bench run revision-matrix` | Planned, not implemented yet |
 
 ## 1) Purpose and Scope
@@ -83,11 +85,18 @@ just bench-prepare-long
 - `bench-prepare-short`
 - `bench-prepare-long`
 - `bench-prepare-beam`
+- `bench-fetch-xafs`
+- `bench-convert-xafs`
+- `bench-prepare-xafs`
+- `bench-run-xafs-agent`
+- `bench-xafs-audit-sample`
 - `bench-run-short`
 - `bench-run-long`
 - `bench-run-full`
 - `bench-run-beam-100k`
 - `bench-beam-score`
+- `bench-agent-smoke`
+- `bench-agent-tasks`
 - `bench-validate`
 - `bench-publish`
 - `bench-compare`
@@ -100,13 +109,16 @@ Top-level commands:
 - `datasets fetch`
 - `convert locomo`
 - `convert beam`
+- `convert xafs`
 - `run retrieval`
 - `run concurrent-write`
+- `run agent-tasks`
 - `run full`
 - `run qa`
 - `run beam-score`
 - `run rejudge`
 - `run review`
+- `sample xafs`
 - `compare`
 - `validate-artifacts`
 - `publish`
@@ -424,13 +436,143 @@ quality.
 ### Artifacts
 
 `benchmarks/runs/<run-id>/`: `manifest.json` (BM SHA/version, model + judge
-specs, budget, corpus checksum + file count, full surface echoes),
+specs, budget, corpus checksum + file count, the `tasks.json` checksum for
+dataset-driven runs — a corrections re-run changes gold answers without
+touching the corpus — full surface echoes),
 `surface-status.json` (ok/skipped/error per surface, explicit reasons),
 `per-turn.jsonl` (per model turn and tool dispatch: tokens, tool name,
 latency, result size), `per-task-agent.jsonl`, `agent-tasks-summary.json`,
 `summary.md` (which repeats any skipped surface so the report cannot be
 misread as a completed A/B). `validate-artifacts` remains retrieval-only for now (as for
 concurrent-write); a kind-aware variant is a follow-up.
+
+## 6d) xAFS (supermemory, HF `supermemory/xAFS` @ 21142b2c)
+
+**Provenance caveat first: xAFS is authored by supermemory, a memory-product
+vendor. Numbers from it are reported as a SECONDARY dataset, never the
+headline, pending a ~20-question quality audit (tooling:
+`bm-bench sample xafs`; verdicts feed the corrections hook below).**
+
+xAFS ("Agentic File System") probes agentic retrieval over persona file
+trees: 13 synthetic personas whose corpora scale from 5 to ~10K files (~19K
+files / ~837MB total), questioned in three families — single-hop, multi-hop,
+and format-spanning (questions whose sources include non-markdown files, e.g.
+`.eml` mails). The headline is tokens spent per correct answer, judged
+semantically — exactly the agent-task harness's framing (6c), which is where
+xAFS runs.
+
+Count note: the upstream README advertises 110 questions (35/50/25 per
+family); the shipped `question.json` files at the pinned revision sum to
+33/51/26. The loader trusts the JSON and asserts nothing about totals.
+
+### Fetch (never vendored)
+
+```bash
+XAFS_PERSONAS=dp_001,dp_002 bash benchmarks/datasets/xafs/download.sh
+# just bench-fetch-xafs — same subset default; personas="" fetches all 837MB
+```
+
+The download is a pinned `hf download supermemory/xAFS --repo-type dataset
+--revision 21142b2c...` into `benchmarks/datasets/xafs/upstream/`
+(gitignored). Persona subsetting via `--include 'dp_NNN/*'` patterns is the
+normal mode — full ingestion is ~837MB, and the loader accepts partial
+snapshots (unknown *requested* personas fail fast listing what is on disk).
+
+### Workflow
+
+```bash
+just bench-fetch-xafs                       # pinned snapshot (subset default)
+just bench-convert-xafs                     # -> benchmarks/generated/xafs/{groups,tasks.json,conversion.json}
+BM_LOCAL_PATH=.. just bench-run-xafs-agent  # agent-task run over the manifest
+just bench-xafs-audit-sample                # seeded human-review sample
+```
+
+Conversion copies each persona's `data/` tree byte-for-byte (relpaths
+preserved, no frontmatter render — questions cite exact file content) into
+`groups/xafs-dpNNN/docs/`. BM's sync ingests `.md` files as notes and
+non-markdown files as file resources reachable via `read_content` (rich) or
+`cat`/`grep` (posix) — nothing is skipped, and `conversion.json` records
+per-extension counts plus a `skipped` list that must stay empty (a file the
+copy policy cannot place aborts the conversion). Gold answers and prompts
+exist only in `tasks.json`; an answer-key/scenario filename appearing inside
+`data/` aborts conversion (anti-leakage).
+
+### Execution split per question family
+
+| Family | Path | Rationale |
+| --- | --- | --- |
+| format_spanning (26) | Agent harness only | Verbatim file reading (`read_content` / `cat`+`grep`) is the point; the retrieval path only searches notes |
+| single_hop (33), multi_hop (51) | Agent harness (headline) | Tokens-per-correct-answer is literally the harness headline; a retrieval+QA diagnostic is deferred (below) |
+
+The retrieval diagnostic for single/multi-hop is deliberately NOT emitted in
+v1: the `bm-local` provider normalizes result doc ids to the basename sans
+`.md`, which is unique for rendered corpora but collides across xAFS's
+persona-shaped trees (repeated `notes.md`-style basenames), so recall against
+`gold_file_ids` would be silently wrong. It is planned behind widening the
+provider doc-id seam to full relpaths; at that point a converter
+`--emit-queries` flag plus a dataset-keyed breakout in `scoring/retrieval.py`
+(the BEAM precedent) keeps xAFS's `single_hop`/`multi_hop` labels out of the
+LoCoMo `official_headline` container despite the name collision.
+
+Manifest runs are grouped and read-only: each persona is ingested ONCE per
+(surface, group) as project `at-<run-id>-xafs-dpNNN` and every question in
+the group reuses that warm project (copying 837MB per question is untenable).
+To keep reuse safe AND fair, the shared write verbs (`write_note`,
+`edit_note`, `move_note`, `delete_note`) are dropped from BOTH surfaces
+symmetrically — rich becomes `search_notes, read_note, read_content,
+list_directory, recent_activity, build_context`; posix becomes `cat, grep,
+ls, find, tail, man` — matching upstream's read-only reference agent
+(grep/find/cat). The reduced allowlists are echoed into `manifest.json` via
+`SurfaceEcho`. State-free tasks (all xAFS tasks: judge-graded answers) skip
+the per-task baseline snapshot and post-loop settle. The per-group table in
+`summary.md` (tokens/correct per persona) is the corpus-scaling curve —
+xAFS's central claim — read alongside per-family (skill) accuracy.
+
+### Scoring definition
+
+- Headline: `(total agent tokens over ALL attempted tasks) / (judge-CORRECT
+  tasks)` per surface — the 6c headline, unchanged. Accuracy, tool calls,
+  turns, and wall time always appear in the same table.
+- The judge is the package judge seam (`JudgeRubric` →
+  `AGENT_JUDGE_PROMPT_TEMPLATE`, one CORRECT/INCORRECT line); judge tokens
+  are accounted separately and never enter the headline.
+- Errored tasks are excluded from means and never zero-scored (6c rules
+  inherited unchanged).
+
+### Runner provenance (divergences from supermemory's published setup)
+
+1. Judge model is operator-chosen (`--judge`; the just target defaults to
+   `claude:claude-sonnet-4-6`), not Gemini 3.1 Pro Preview — the dataset card
+   itself allows an equivalently-capable judge; `judge_spec` is pinned in
+   `manifest.json`.
+2. Upstream ships no judge prompt; ours is the fixed package template with a
+   rubric built deterministically from the upstream prompt + gold answer,
+   mirroring the card's semantic-equivalence criteria (paraphrase/format
+   tolerant; exact values, named entities, and multi-part coverage required).
+3. We judge the agent's full final message (including its fenced-JSON close),
+   not an extracted answer string.
+4. The harness adds the fixed `TASK_PROMPT_TEMPLATE` preamble and fenced-JSON
+   finalization (upstream is bring-your-own-runner).
+5. Correct-answer denominator = judge-CORRECT tasks; token numerator = agent
+   loop in+out over ALL attempted tasks; judge tokens excluded (upstream
+   unspecified); errored tasks excluded from means, never zero-scored.
+6. Family counts follow the shipped JSON (33/51/26), not the README
+   (35/50/25).
+7. Secondary-dataset caveat: vendor-authored; reported as secondary, never
+   the headline, pending the question-quality audit.
+
+### Audit sampling and corrections
+
+`bm-bench sample xafs --n 20 --seed 42` writes a seeded, family-stratified
+sample to `benchmarks/generated/xafs-audit/`: `audit-sample.json`,
+human-readable `sample.md`, and verbatim copies of every gold source file
+under `sources/<persona>-<qid>/`. The post-merge audit's verdicts land in
+`benchmarks/datasets/xafs/corrections.json` — records keyed
+`"<persona>/<qid>"` carrying the upstream `prompt` (cross-checked; drift
+fails the conversion loudly) plus either a corrected `gold_answer` or
+`"excluded": true` with a `reason`. `convert xafs --corrections` applies
+them; exclusions are dropped from `tasks.json` and counted in
+`conversion.json`.
 
 ## 7) Commit-to-Commit Comparison (Current Manual Method)
 

--- a/benchmarks/justfile
+++ b/benchmarks/justfile
@@ -15,6 +15,8 @@ longmemeval_dev_output_dir := "benchmarks/generated/longmemeval-s-dev"
 beam_root := "benchmarks/datasets/beam/upstream/chats"
 beam_100k_output_dir := "benchmarks/generated/beam-100k"
 beam_500k_output_dir := "benchmarks/generated/beam-500k"
+xafs_root := "benchmarks/datasets/xafs/upstream"
+xafs_output_dir := "benchmarks/generated/xafs"
 
 # --- Repo maintenance ---
 
@@ -105,6 +107,38 @@ bench-fetch-locomo-audit:
 
 bench-convert-locomo-corrected: bench-fetch-locomo bench-fetch-locomo-audit
     uv run bm-bench convert locomo --dataset-path {{locomo_dataset_path}} --output-dir benchmarks/generated/locomo-corrected --audit-corrections benchmarks/datasets/locomo-audit/corrections.json
+
+# xAFS data is never vendored: pinned hf download, persona-subset by default
+# (the full dataset is ~837MB). personas="" fetches everything.
+bench-fetch-xafs personas="dp_001,dp_002":
+    XAFS_PERSONAS="{{personas}}" bash benchmarks/datasets/xafs/download.sh
+
+# Cheap two-persona smoke by default; personas="all" converts every downloaded persona
+bench-convert-xafs personas="dp_001,dp_002":
+    uv run bm-bench convert xafs --dataset-root {{xafs_root}} --output-dir {{xafs_output_dir}} --personas "{{personas}}"
+
+bench-prepare-xafs: bench-fetch-xafs bench-convert-xafs
+
+# xAFS agent-task run: grouped per-persona corpora, read-only surfaces,
+# tokens-per-correct-answer headline judged semantically (docs/benchmarks.md 6d)
+bench-run-xafs-agent surfaces="rich,posix" model="openai-compat:qwen3@http://localhost:11434/v1" judge="claude:claude-sonnet-4-6":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ -z "{{bm_local_path}}" ]]; then
+        echo "BM_LOCAL_PATH must point to the Basic Memory git checkout under test" >&2
+        exit 2
+    fi
+    uv run bm-bench run agent-tasks \
+      --task-manifest {{xafs_output_dir}}/tasks.json \
+      --corpus-dir {{xafs_output_dir}}/groups \
+      --surfaces "{{surfaces}}" \
+      --model "{{model}}" \
+      --judge "{{judge}}" \
+      --bm-local-path "{{bm_local_path}}"
+
+# Seeded question sample (+ gold answers + gold source files) for human audit
+bench-xafs-audit-sample n="20" seed="42":
+    uv run bm-bench sample xafs --dataset-root {{xafs_root}} --n {{n}} --seed {{seed}} --output benchmarks/generated/xafs-audit
 
 # Grouped retrieval over the LongMemEval-S dev slice (bm-local only)
 bench-run-longmemeval-dev:

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/__init__.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/__init__.py
@@ -14,6 +14,7 @@ from basic_memory_benchmarks.agent_tasks.loop import (
     ToolOutcome,
     run_agent_loop,
 )
+from basic_memory_benchmarks.agent_tasks.manifest import load_task_manifest
 from basic_memory_benchmarks.agent_tasks.models import (
     AgentBudget,
     AgentTaskResult,
@@ -21,11 +22,16 @@ from basic_memory_benchmarks.agent_tasks.models import (
     AgentTasksManifest,
     SurfaceSummary,
 )
-from basic_memory_benchmarks.agent_tasks.spec import AgentTaskSpec, Grader
+from basic_memory_benchmarks.agent_tasks.spec import (
+    AgentTaskSpec,
+    Grader,
+    spec_needs_project_state,
+)
 from basic_memory_benchmarks.agent_tasks.surfaces import (
     SURFACES,
     SurfaceUnavailableError,
     ToolSurface,
+    read_only_view,
     surface_env,
     verify_surface_tools,
 )
@@ -52,9 +58,12 @@ __all__ = [
     "ToolDispatch",
     "ToolOutcome",
     "ToolSurface",
+    "load_task_manifest",
+    "read_only_view",
     "run_agent_loop",
     "run_agent_tasks",
     "select_tasks",
+    "spec_needs_project_state",
     "surface_env",
     "verify_surface_tools",
 ]

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/corpus.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/corpus.py
@@ -33,9 +33,15 @@ TIMESTAMPS: MappingProxyType[str, int] = MappingProxyType(
 
 
 def corpus_files(corpus_dir: Path) -> list[str]:
-    """Sorted relpaths of every markdown note in the corpus."""
+    """Sorted relpaths of every file in the corpus.
+
+    Every extension, not just ``.md``: dataset corpora (xAFS) carry
+    non-markdown resources (``.eml`` mails) that the checksum, copy, and
+    timestamp passes must all see. The shipped agent-tasks corpus is md-only,
+    so its behavior is unchanged.
+    """
     return sorted(
-        str(path.relative_to(corpus_dir)) for path in corpus_dir.rglob("*.md") if path.is_file()
+        str(path.relative_to(corpus_dir)) for path in corpus_dir.rglob("*") if path.is_file()
     )
 
 
@@ -68,8 +74,14 @@ def apply_timestamps(project_dir: Path, *, now: float | None = None) -> None:
 
 
 def snapshot_baseline(project_dir: Path) -> dict[str, str]:
-    """relpath -> file text for every markdown note (taken after seed settle)."""
+    """relpath -> file text for the markdown notes only (taken after seed settle).
+
+    Deliberately narrower than ``corpus_files``: state-tracking graders reason
+    about markdown notes only (``grading._markdown_relpaths``), and a corpus
+    with a binary resource would crash ``read_text`` here.
+    """
     return {
         relpath: (project_dir / relpath).read_text(encoding="utf-8")
         for relpath in corpus_files(project_dir)
+        if relpath.endswith(".md")
     }

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/driver.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/driver.py
@@ -32,6 +32,7 @@ from basic_memory_benchmarks.agent_tasks.loop import (
     ToolOutcome,
     run_agent_loop,
 )
+from basic_memory_benchmarks.agent_tasks.manifest import load_task_manifest
 from basic_memory_benchmarks.agent_tasks.models import (
     AgentTaskResult,
     AgentTasksConfig,
@@ -40,11 +41,12 @@ from basic_memory_benchmarks.agent_tasks.models import (
     SurfaceEcho,
     SurfaceSummary,
 )
-from basic_memory_benchmarks.agent_tasks.spec import AgentTaskSpec
+from basic_memory_benchmarks.agent_tasks.spec import AgentTaskSpec, spec_needs_project_state
 from basic_memory_benchmarks.agent_tasks.surfaces import (
     SURFACES,
     SurfaceUnavailableError,
     ToolSurface,
+    read_only_view,
     surface_env,
     verify_surface_tools,
 )
@@ -68,7 +70,13 @@ from basic_memory_benchmarks.llm.tool_agent import (
     substitute_placeholders,
 )
 from basic_memory_benchmarks.models import ProviderStatus, RuntimeInfo
-from basic_memory_benchmarks.utils import git_sha, run_command, runtime_info, utc_now_iso
+from basic_memory_benchmarks.utils import (
+    git_sha,
+    run_command,
+    runtime_info,
+    sha256_file,
+    utc_now_iso,
+)
 
 console = Console()
 
@@ -198,12 +206,18 @@ def _errored_result(
     # under-report spent cost.
     if partial is None:
         return AgentTaskResult(
-            surface=surface, task_id=task.id, skill=task.skill, passed=False, error=error
+            surface=surface,
+            task_id=task.id,
+            skill=task.skill,
+            group=task.group,
+            passed=False,
+            error=error,
         )
     return AgentTaskResult(
         surface=surface,
         task_id=task.id,
         skill=task.skill,
+        group=task.group,
         passed=False,
         error=error,
         stopped_reason=partial.stopped_reason,
@@ -214,6 +228,60 @@ def _errored_result(
         wall_seconds=round(partial.wall_seconds, 2),
         turn_records=partial.turn_records,
     )
+
+
+@dataclass(frozen=True)
+class TaskProject:
+    """The BM project a task runs against: per-task fresh, or shared per group."""
+
+    name: str
+    directory: Path
+
+
+def _prepare_task_project(
+    *,
+    task: AgentTaskSpec,
+    run_id: str,
+    corpus_dir: Path,
+    surface_home: Path,
+    prefix: list[str],
+    env: dict[str, str],
+    settle_timeout_seconds: float,
+    prepared_groups: dict[str, TaskProject],
+) -> TaskProject:
+    """Copy, register, and settle the project this task runs against.
+
+    Ungrouped (shipped) tasks get a fresh corpus copy each — the fairness
+    contract's identical starting state for write-graded tasks. Grouped tasks
+    (dataset manifests) ingest ONCE per (surface, group) and every task in the
+    group reuses the warm project: copying a multi-hundred-MB persona per
+    question is untenable, and grouped runs are read-only so reuse cannot leak
+    state between tasks.
+    """
+    if task.group is None:
+        project = TaskProject(
+            name=f"at-{run_id}-{task.id}", directory=surface_home / "projects" / task.id
+        )
+        source_dir = corpus_dir
+    else:
+        cached = prepared_groups.get(task.group)
+        if cached is not None:
+            return cached
+        project = TaskProject(
+            name=f"at-{run_id}-{task.group}", directory=surface_home / "projects" / task.group
+        )
+        source_dir = corpus_dir / task.group / "docs"
+    copy_corpus(source_dir, project.directory)
+    run_command(prefix + ["project", "add", project.name, str(project.directory)], env=env)
+    settle_index(
+        prefix=prefix,
+        env=env,
+        project_name=project.name,
+        timeout_seconds=settle_timeout_seconds,
+    )
+    if task.group is not None:
+        prepared_groups[task.group] = project
+    return project
 
 
 def _run_one_task(
@@ -228,24 +296,21 @@ def _run_one_task(
     prefix: list[str],
     env: dict[str, str],
     surface_home: Path,
+    project: TaskProject,
 ) -> AgentTaskResult:
-    project_name = f"at-{config.run_id}-{task.id}"
-    project_dir = surface_home / "projects" / task.id
-    copy_corpus(Path(config.corpus_dir), project_dir)
-    run_command(prefix + ["project", "add", project_name, str(project_dir)], env=env)
-    settle_index(
-        prefix=prefix,
-        env=env,
-        project_name=project_name,
-        timeout_seconds=config.settle_timeout_seconds,
-    )
-    baseline = snapshot_baseline(project_dir)
-    prompt = TASK_PROMPT_TEMPLATE.format(project=project_name, task_prompt=task.prompt)
+    # Trigger: every grader reads only the final answer / tool trace.
+    # Why: the baseline snapshot loads the whole corpus into memory (a large
+    # xAFS persona is hundreds of MB) and the post-loop settle waits on an
+    # index no grader will read.
+    # Outcome: skip both; project-state graders keep the full flow.
+    needs_state = spec_needs_project_state(task)
+    baseline = snapshot_baseline(project.directory) if needs_state else {}
+    prompt = TASK_PROMPT_TEMPLATE.format(project=project.name, task_prompt=task.prompt)
 
     def dispatch(name: str, arguments: dict[str, Any]) -> ToolOutcome:
         # {project} placeholders come from the scripted transport, which cannot
         # know per-run project names; a no-op for real model output.
-        resolved = substitute_placeholders(arguments, {"project": project_name})
+        resolved = substitute_placeholders(arguments, {"project": project.name})
         return session.call_tool(name, resolved)
 
     loop_result = run_agent_loop(
@@ -255,18 +320,19 @@ def _run_one_task(
         prompt=prompt,
         budget=config.budget,
     )
-    settle_index(
-        prefix=prefix,
-        env=env,
-        project_name=project_name,
-        timeout_seconds=config.settle_timeout_seconds,
-    )
+    if needs_state:
+        settle_index(
+            prefix=prefix,
+            env=env,
+            project_name=project.name,
+            timeout_seconds=config.settle_timeout_seconds,
+        )
     ctx = GradingContext(
         final_answer=loop_result.final_answer,
-        project_dir=project_dir,
+        project_dir=project.directory,
         baseline=baseline,
         db_path=surface_home / "config" / "memory.db",
-        project_name=project_name,
+        project_name=project.name,
         turn_records=loop_result.turn_records,
         judge=judge,
     )
@@ -280,6 +346,7 @@ def _run_one_task(
         surface=surface.name,
         task_id=task.id,
         skill=task.skill,
+        group=task.group,
         passed=passed,
         stopped_reason=loop_result.stopped_reason,
         turns=loop_result.turns,
@@ -310,18 +377,25 @@ def build_surface_summary(
         if row.stopped_reason is not None and row.stopped_reason != "final"
     )
 
-    per_skill: dict[str, SkillBreakdown] = {}
-    for skill in sorted({row.skill for row in results}):
-        skill_rows = [row for row in results if row.skill == skill]
-        skill_passed = [row for row in skill_rows if row.error is None and row.passed]
-        skill_tokens = sum(row.total_input_tokens + row.total_output_tokens for row in skill_rows)
-        per_skill[skill] = SkillBreakdown(
-            total=len(skill_rows),
-            passed=len(skill_passed),
-            tokens_per_completed=round(skill_tokens / len(skill_passed), 1)
-            if skill_passed
-            else None,
+    def breakdown(rows: list[AgentTaskResult]) -> SkillBreakdown:
+        completed = [row for row in rows if row.error is None and row.passed]
+        tokens = sum(row.total_input_tokens + row.total_output_tokens for row in rows)
+        return SkillBreakdown(
+            total=len(rows),
+            passed=len(completed),
+            tokens_per_completed=round(tokens / len(completed), 1) if completed else None,
         )
+
+    per_skill = {
+        skill: breakdown([row for row in results if row.skill == skill])
+        for skill in sorted({row.skill for row in results})
+    }
+    # tokens/correct per group (persona) IS the corpus-scaling curve for
+    # dataset-driven runs; empty for shipped tasks (group is None everywhere).
+    per_group = {
+        group: breakdown([row for row in results if row.group == group])
+        for group in sorted({row.group for row in results if row.group is not None})
+    }
 
     return SurfaceSummary(
         surface=surface,
@@ -343,6 +417,7 @@ def build_surface_summary(
         mean_turns=round(mean(row.turns for row in graded), 2) if graded else 0.0,
         mean_wall_seconds=round(mean(row.wall_seconds for row in graded), 2) if graded else 0.0,
         per_skill=per_skill,
+        per_group=per_group,
         judge_input_tokens=sum(row.judge_input_tokens for row in results),
         judge_output_tokens=sum(row.judge_output_tokens for row in results),
         judge_calls=sum(row.judge_calls for row in results),
@@ -414,6 +489,21 @@ def build_agent_summary_markdown(
                 f" {_format_tokens_per_completed(breakdown.tokens_per_completed)} |"
             )
 
+    # Per-group = per-persona: tokens/correct against corpus size is the
+    # scaling read dataset-driven runs (xAFS) exist to produce.
+    if any(summary.per_group for summary in summaries):
+        lines += ["", "## Per group (persona)", ""]
+        lines += [
+            "| Surface | Group | Passed/total | Tokens/completed |",
+            "| --- | --- | --- | --- |",
+        ]
+        for summary in summaries:
+            for group, breakdown in summary.per_group.items():
+                lines.append(
+                    f"| {summary.surface} | {group} | {breakdown.passed}/{breakdown.total} |"
+                    f" {_format_tokens_per_completed(breakdown.tokens_per_completed)} |"
+                )
+
     stops = [(s.surface, s.budget_stops) for s in summaries if s.budget_stops]
     if stops:
         lines += ["", "## Budget stops", ""]
@@ -473,7 +563,38 @@ def run_agent_tasks(
     if not corpus_dir.is_dir():
         raise ValueError(f"Corpus dir not found: {corpus_dir}")
     checksum, corpus_file_count = corpus_checksum(corpus_dir)
-    tasks = select_tasks(config.task_ids)
+
+    # Task source: the shipped Python task set, or a converted dataset manifest
+    # (e.g. `convert xafs`) whose grouped, judge-graded rows run through the
+    # exact same loop, budgets, and reporting.
+    if config.task_manifest:
+        task_manifest_path = Path(config.task_manifest)
+        # corpus_checksum pins the haystack; this pins the questions. A
+        # corrections re-run changes gold answers/rubrics without touching the
+        # corpus, and that A/B must be visible in manifest.json.
+        task_manifest_sha256 = sha256_file(task_manifest_path)
+        tasks = load_task_manifest(task_manifest_path, task_ids=config.task_ids)
+    else:
+        task_manifest_sha256 = None
+        tasks = select_tasks(config.task_ids)
+
+    # Grouped tasks expect corpus_dir to be a converter groups/ dir (one
+    # subtree per group); ungrouped tasks expect a flat corpus. Mixing the two
+    # in one run would make corpus_dir mean both at once.
+    grouped_ids = sorted({task.group for task in tasks if task.group is not None})
+    ungrouped_ids = [task.id for task in tasks if task.group is None]
+    if grouped_ids and ungrouped_ids:
+        raise ValueError(
+            f"Task set mixes grouped and ungrouped tasks (grouped={grouped_ids[:3]},"
+            f" ungrouped={ungrouped_ids[:3]}); a run must be one or the other"
+        )
+    for group in grouped_ids:
+        group_docs = corpus_dir / group / "docs"
+        if not group_docs.is_dir():
+            raise ValueError(
+                f"Grouped corpus missing {group_docs}; --corpus-dir must point at the"
+                " converter's groups/ directory"
+            )
 
     # Model and judge parse before any on-disk state is created, so a bad spec
     # fails fast without leaving an empty benchmark home behind.
@@ -498,6 +619,13 @@ def run_agent_tasks(
 
     for surface_name in config.surfaces:
         surface = SURFACES[surface_name]
+        if config.task_manifest:
+            # Trigger: manifest-driven (grouped) run.
+            # Why: tasks in a group share one warm project, and a write_note
+            # from an earlier question would pollute later questions' haystack.
+            # Outcome: the shared write verbs are dropped from BOTH surfaces
+            # symmetrically (fairness preserved; echoed via SurfaceEcho).
+            surface = read_only_view(surface)
         surface_home = home / surface.name
         (surface_home / "default-home").mkdir(parents=True)
         env = surface_env(surface, isolated_bm_env(surface_home))
@@ -541,6 +669,7 @@ def run_agent_tasks(
             # Deterministic order: schemas reach the model in allowlist order.
             tool_defs = [by_name[name] for name in surface.tool_allowlist]
 
+            prepared_groups: dict[str, TaskProject] = {}
             session_error: str | None = None
             for task in tasks:
                 if session_error is not None:
@@ -552,6 +681,16 @@ def run_agent_tasks(
                     continue
                 console.print(f"  [{surface.name}] task [cyan]{task.id}[/cyan]...")
                 try:
+                    project = _prepare_task_project(
+                        task=task,
+                        run_id=config.run_id,
+                        corpus_dir=corpus_dir,
+                        surface_home=surface_home,
+                        prefix=prefix,
+                        env=env,
+                        settle_timeout_seconds=config.settle_timeout_seconds,
+                        prepared_groups=prepared_groups,
+                    )
                     result = _run_one_task(
                         surface=surface,
                         task=task,
@@ -563,6 +702,7 @@ def run_agent_tasks(
                         prefix=prefix,
                         env=env,
                         surface_home=surface_home,
+                        project=project,
                     )
                 except AgentLoopError as exc:
                     # The loop wraps every mid-task failure with the partial
@@ -615,6 +755,7 @@ def run_agent_tasks(
         budget=config.budget,
         corpus_checksum=checksum,
         corpus_file_count=corpus_file_count,
+        task_manifest_sha256=task_manifest_sha256,
         task_ids=[task.id for task in tasks],
         surfaces=echoes,
         runtime=RuntimeInfo(

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/manifest.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/manifest.py
@@ -1,0 +1,105 @@
+"""Dataset-driven agent-task source: a ``tasks.json`` manifest -> AgentTaskSpec.
+
+The shipped tasks in ``tasks.py`` are hand-written Python data; converted
+datasets (``convert xafs``) emit a JSON manifest instead. This module parses
+that manifest into the same ``AgentTaskSpec`` shape the driver consumes, so
+budgets, fairness, artifacts, and reporting are identical for shipped and
+dataset-driven tasks — the seam beside ``tasks.select_tasks``.
+
+v1 manifest grader kinds are ``judge_rubric`` and ``tool_called`` only:
+manifest tasks run against shared read-only group projects, where
+project-state graders would cross-contaminate. An unknown kind fails fast
+rather than silently skipping a grader.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+from basic_memory_benchmarks.agent_tasks.spec import (
+    AgentTaskSpec,
+    Grader,
+    JudgeRubric,
+    ToolCalled,
+)
+
+_REQUIRED_TASK_KEYS = ("id", "skill", "group", "source", "prompt", "graders")
+
+
+def _manifest_string(raw: dict, key: str, *, label: str, path: Path) -> str:
+    value = raw[key]
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Task manifest {label} has an empty or non-string {key!r}: {path}")
+    return value
+
+
+def _parse_grader(raw: object, *, label: str, path: Path) -> Grader:
+    if not isinstance(raw, dict):
+        raise ValueError(f"Task manifest {label} grader is not an object: {path}")
+    kind = raw.get("kind")
+    if kind == "judge_rubric":
+        rubric = raw.get("rubric")
+        if not isinstance(rubric, str) or not rubric.strip():
+            raise ValueError(f"Task manifest {label} judge_rubric has no rubric text: {path}")
+        return JudgeRubric(rubric=rubric)
+    if kind == "tool_called":
+        pattern = raw.get("name_pattern")
+        if not isinstance(pattern, str) or not pattern:
+            raise ValueError(f"Task manifest {label} tool_called has no name_pattern: {path}")
+        return ToolCalled(name_pattern=pattern)
+    raise ValueError(
+        f"Task manifest {label} has unknown grader kind {kind!r}: {path}. "
+        "v1 manifest kinds: judge_rubric, tool_called"
+    )
+
+
+def _parse_task(raw: object, *, position: int, path: Path) -> AgentTaskSpec:
+    label = f"task at index {position}"
+    if not isinstance(raw, dict):
+        raise ValueError(f"Task manifest {label} is not an object: {path}")
+    missing = [key for key in _REQUIRED_TASK_KEYS if key not in raw]
+    if missing:
+        raise ValueError(f"Task manifest {label} is missing keys {missing}: {path}")
+    graders_raw = raw["graders"]
+    if not isinstance(graders_raw, list) or not graders_raw:
+        raise ValueError(f"Task manifest {label} has an empty or non-list 'graders': {path}")
+    return AgentTaskSpec(
+        id=_manifest_string(raw, "id", label=label, path=path),
+        skill=_manifest_string(raw, "skill", label=label, path=path),
+        source=_manifest_string(raw, "source", label=label, path=path),
+        prompt=_manifest_string(raw, "prompt", label=label, path=path),
+        graders=tuple(_parse_grader(grader, label=label, path=path) for grader in graders_raw),
+        group=_manifest_string(raw, "group", label=label, path=path),
+    )
+
+
+def load_task_manifest(path: Path, task_ids: Sequence[str] | None = None) -> list[AgentTaskSpec]:
+    """Load a converted-dataset task manifest, optionally filtered by id.
+
+    Unknown filter ids are rejected loudly (mirroring ``select_tasks``); the
+    returned tasks are ordered ``(group, id)`` so the driver ingests each group
+    corpus once and runs its tasks contiguously.
+    """
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list) or not payload:
+        raise ValueError(f"Task manifest must be a non-empty JSON array: {path}")
+
+    specs: list[AgentTaskSpec] = []
+    seen_ids: set[str] = set()
+    for position, raw in enumerate(payload):
+        spec = _parse_task(raw, position=position, path=path)
+        if spec.id in seen_ids:
+            raise ValueError(f"Task manifest has duplicate task id {spec.id!r}: {path}")
+        seen_ids.add(spec.id)
+        specs.append(spec)
+
+    if task_ids:
+        unknown = [task_id for task_id in task_ids if task_id not in seen_ids]
+        if unknown:
+            raise ValueError(f"Unknown task ids: {unknown}. Known: {sorted(seen_ids)}")
+        unique_ids = set(dict.fromkeys(task_ids))
+        specs = [spec for spec in specs if spec.id in unique_ids]
+
+    return sorted(specs, key=lambda spec: (spec.group or "", spec.id))

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/models.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/models.py
@@ -25,6 +25,9 @@ class AgentTasksConfig(BaseModel):
     run_id: str
     surfaces: list[str] = Field(default_factory=lambda: ["rich"])
     task_ids: list[str] = Field(default_factory=list)  # empty = all shipped tasks
+    # Converted-dataset tasks.json (e.g. convert xafs); None runs the shipped
+    # task set. Manifest runs are grouped and read-only (see driver).
+    task_manifest: str | None = None
     model_spec: str
     judge_spec: str | None = None
     corpus_dir: str = "benchmarks/datasets/agent-tasks/corpus"
@@ -65,6 +68,8 @@ class AgentTaskResult(BaseModel):
     surface: str
     task_id: str
     skill: str
+    # Corpus group (persona) for dataset-driven tasks; None for shipped tasks.
+    group: str | None = None
     passed: bool
     stopped_reason: StopReason | None = None
     turns: int = 0
@@ -109,6 +114,9 @@ class SurfaceSummary(BaseModel):
     mean_turns: float
     mean_wall_seconds: float
     per_skill: dict[str, SkillBreakdown] = Field(default_factory=dict)
+    # Per-group (persona) breakdown for dataset-driven runs — tokens/correct
+    # per persona is the corpus-scaling curve; empty for shipped-task runs.
+    per_group: dict[str, SkillBreakdown] = Field(default_factory=dict)
     judge_input_tokens: int = 0
     judge_output_tokens: int = 0
     judge_calls: int = 0
@@ -136,6 +144,11 @@ class AgentTasksManifest(BaseModel):
     budget: AgentBudget
     corpus_checksum: str
     corpus_file_count: int
+    # Pins the tasks.json a dataset-driven run executed. corpus_checksum alone
+    # cannot distinguish two runs differing only in --corrections (changed gold
+    # answers/rubrics, excluded questions) — exactly the pre/post-audit A/B.
+    # None for shipped-task runs.
+    task_manifest_sha256: str | None = None
     task_ids: list[str]
     surfaces: list[SurfaceEcho]
     runtime: RuntimeInfo

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/spec.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/spec.py
@@ -170,10 +170,39 @@ type Grader = (
 @dataclass(frozen=True)
 class AgentTaskSpec:
     id: str
-    # "memory-continue" | "memory-curate" | "memory-metadata-search" |
-    # "memory-tasks" | "manual"
+    # Shipped tasks: "memory-continue" | "memory-curate" |
+    # "memory-metadata-search" | "memory-tasks" | "manual".
+    # Dataset manifests reuse the field for the question family (e.g. xAFS
+    # "single_hop"), so the per-skill report is the per-family breakdown.
     skill: str
     # Attribution, e.g. "skills/memory-continue/SKILL.md" or "SPEC-47 manual chain".
     source: str
     prompt: str
     graders: tuple[Grader, ...]
+    # Corpus group / persona key for dataset-driven tasks (converter
+    # ``groups/<group>`` layout, one shared project per (surface, group)).
+    # None for the shipped per-task-fresh-corpus tasks.
+    group: str | None = None
+
+
+# Grader kinds that read only the final answer and tool trace — never the
+# settled project directory, baseline snapshot, or SQLite index.
+_STATE_FREE_GRADERS = (
+    AnswerSetEquals,
+    MarkerPresent,
+    MarkerAbsent,
+    AnswerContains,
+    AnswerMatches,
+    ToolCalled,
+    JudgeRubric,
+)
+
+
+def spec_needs_project_state(spec: AgentTaskSpec) -> bool:
+    """Whether grading this task reads project state (files, baseline, index).
+
+    A state-free task can skip the baseline snapshot and the post-loop settle
+    — load-bearing for grouped corpora, where one persona can be hundreds of
+    megabytes.
+    """
+    return any(not isinstance(grader, _STATE_FREE_GRADERS) for grader in spec.graders)

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/surfaces.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/surfaces.py
@@ -71,6 +71,27 @@ POSIX_SURFACE = ToolSurface(
 
 SURFACES: dict[str, ToolSurface] = {"rich": RICH_SURFACE, "posix": POSIX_SURFACE}
 
+# The write verbs both surfaces share (posix v1 is read-side only, see above).
+SHARED_WRITE_TOOLS = ("write_note", "edit_note", "move_note", "delete_note")
+
+
+def read_only_view(surface: ToolSurface) -> ToolSurface:
+    """The surface with the shared write verbs dropped — symmetrically.
+
+    Dataset-manifest runs reuse one warm project per (surface, group); a write
+    from an earlier question would pollute later questions' haystack. Dropping
+    the same four verbs from BOTH surfaces preserves the fairness contract and
+    matches xAFS's read-only reference agent (grep/find/cat).
+    """
+    return ToolSurface(
+        name=surface.name,
+        config_overrides=surface.config_overrides,
+        tool_allowlist=tuple(
+            name for name in surface.tool_allowlist if name not in SHARED_WRITE_TOOLS
+        ),
+        requires=surface.requires,
+    )
+
 
 def surface_env(surface: ToolSurface, base_env: dict[str, str]) -> dict[str, str]:
     """Apply the surface's config overrides on top of an isolated BM env."""

--- a/benchmarks/src/basic_memory_benchmarks/cli.py
+++ b/benchmarks/src/basic_memory_benchmarks/cli.py
@@ -11,6 +11,7 @@ import typer
 from rich.console import Console
 
 from basic_memory_benchmarks.agent_tasks.driver import run_agent_tasks
+from basic_memory_benchmarks.agent_tasks.manifest import load_task_manifest
 from basic_memory_benchmarks.agent_tasks.models import AgentBudget, AgentTasksConfig
 from basic_memory_benchmarks.agent_tasks.spec import JudgeRubric
 from basic_memory_benchmarks.agent_tasks.surfaces import SURFACES
@@ -23,6 +24,10 @@ from basic_memory_benchmarks.converters.beam_to_corpus import convert_beam_to_co
 from basic_memory_benchmarks.converters.convomem_to_corpus import convert_convomem_to_corpus
 from basic_memory_benchmarks.converters.locomo_to_corpus import convert_locomo_to_corpus
 from basic_memory_benchmarks.converters.longmemeval_to_corpus import convert_longmemeval_to_corpus
+from basic_memory_benchmarks.converters.xafs_to_corpus import (
+    convert_xafs_to_corpus,
+    sample_xafs_audit,
+)
 from basic_memory_benchmarks.datasets.convomem import fetch_convomem_batches
 from basic_memory_benchmarks.datasets.locomo import LOCOMO_URL, fetch_locomo_dataset
 from basic_memory_benchmarks.datasets.locomo_audit import fetch_locomo_audit_corrections
@@ -52,10 +57,12 @@ console = Console()
 datasets_app = typer.Typer(help="Dataset management commands")
 convert_app = typer.Typer(help="Dataset conversion commands")
 run_app = typer.Typer(help="Benchmark execution commands")
+sample_app = typer.Typer(help="Audit sampling commands (human question-quality review)")
 
 app.add_typer(datasets_app, name="datasets")
 app.add_typer(convert_app, name="convert")
 app.add_typer(run_app, name="run")
+app.add_typer(sample_app, name="sample")
 
 
 @datasets_app.command("fetch")
@@ -245,6 +252,87 @@ def convert_convomem(
     console.print(f"Sampling manifest: [cyan]{output_dir / 'sampling.json'}[/cyan]")
 
 
+def _parse_personas(personas: str) -> list[str] | None:
+    """Comma-separated persona ids; empty (or 'all') selects every one on disk."""
+    if personas.strip().lower() in ("", "all"):
+        return None
+    return [item.strip() for item in personas.split(",") if item.strip()]
+
+
+@convert_app.command("xafs")
+def convert_xafs(
+    dataset_root: Path = typer.Option(
+        Path("benchmarks/datasets/xafs/upstream"),
+        "--dataset-root",
+        help="Local xAFS snapshot (see benchmarks/datasets/xafs/download.sh; never vendored)",
+    ),
+    output_dir: Path = typer.Option(Path("benchmarks/generated/xafs"), "--output-dir"),
+    personas: str = typer.Option(
+        "",
+        "--personas",
+        help="Comma-separated persona ids (dp_001,...); empty/'all' converts every "
+        "downloaded persona (full ingestion is ~837MB)",
+    ),
+    corrections: Path | None = typer.Option(
+        None,
+        "--corrections",
+        help="Audit corrections JSON keyed '<persona>/<qid>'; overrides gold answers "
+        "or excludes questions (prompt cross-check fails loudly on drift)",
+    ),
+) -> None:
+    """Convert xAFS personas into grouped corpora + an agent-task manifest.
+
+    The dataset is never vendored; fetch it first with
+    `benchmarks/datasets/xafs/download.sh`. Run the result with
+    `run agent-tasks --task-manifest <output>/tasks.json`.
+    """
+    try:
+        groups_dir, tasks_path, file_count, task_count = convert_xafs_to_corpus(
+            dataset_root=dataset_root,
+            output_dir=output_dir,
+            personas=_parse_personas(personas),
+            corrections_path=corrections,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    console.print(f"Groups: [cyan]{groups_dir}[/cyan] ({file_count} files)")
+    console.print(f"Tasks: [cyan]{tasks_path}[/cyan] ({task_count})")
+    console.print(f"Conversion manifest: [cyan]{output_dir / 'conversion.json'}[/cyan]")
+
+
+@sample_app.command("xafs")
+def sample_xafs(
+    dataset_root: Path = typer.Option(
+        Path("benchmarks/datasets/xafs/upstream"),
+        "--dataset-root",
+        help="Local xAFS snapshot (see benchmarks/datasets/xafs/download.sh)",
+    ),
+    personas: str = typer.Option(
+        "", "--personas", help="Comma-separated persona ids; empty/'all' samples across all"
+    ),
+    n: int = typer.Option(20, "--n", help="Sample size (stratified across the three families)"),
+    seed: int = typer.Option(42, "--seed"),
+    output: Path = typer.Option(Path("benchmarks/generated/xafs-audit"), "--output"),
+) -> None:
+    """Extract a seeded question sample (with gold answers + source files) for human review.
+
+    Ships the tooling for the xAFS question-quality audit; verdicts land in
+    benchmarks/datasets/xafs/corrections.json and feed `convert xafs --corrections`.
+    """
+    try:
+        sample_path, sampled = sample_xafs_audit(
+            dataset_root=dataset_root,
+            output_dir=output,
+            personas=_parse_personas(personas),
+            sample_size=n,
+            seed=seed,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    console.print(f"Audit sample: [cyan]{sample_path}[/cyan] ({sampled} questions)")
+    console.print(f"Readable form + gold files: [cyan]{output / 'sample.md'}[/cyan]")
+
+
 @run_app.command("retrieval")
 def run_retrieval_command(
     providers: str = typer.Option("bm-local,mem0-local", "--providers"),
@@ -386,6 +474,14 @@ def run_agent_tasks_command(
     tasks: str = typer.Option(
         "", "--tasks", help="Comma-separated task ids; empty runs all shipped tasks"
     ),
+    task_manifest: Path | None = typer.Option(
+        None,
+        "--task-manifest",
+        help="Converted dataset tasks.json (e.g. `convert xafs`); replaces the shipped "
+        "task set with grouped, judge-graded questions run on read-only surfaces. "
+        "When set and --corpus-dir is left at its default, the corpus dir becomes "
+        "<manifest dir>/groups",
+    ),
     corpus_dir: Path = typer.Option(Path("benchmarks/datasets/agent-tasks/corpus"), "--corpus-dir"),
     output_root: Path = typer.Option(Path("benchmarks/runs"), "--output-root"),
     run_id: str | None = typer.Option(None, "--run-id"),
@@ -426,9 +522,17 @@ def run_agent_tasks_command(
         raise typer.BadParameter(f"Unknown surfaces: {unknown_surfaces}. Known: {sorted(SURFACES)}")
 
     task_ids = [item.strip() for item in tasks.split(",") if item.strip()]
+    # Manifest runs almost always want the converter's sibling groups/ dir; the
+    # shipped-corpus default would checksum the wrong corpus and then fail on
+    # missing group subtrees, so derive it unless --corpus-dir was set.
+    if task_manifest is not None and corpus_dir == Path("benchmarks/datasets/agent-tasks/corpus"):
+        corpus_dir = task_manifest.parent / "groups"
     try:
-        selected = select_tasks(task_ids)
-    except ValueError as exc:
+        if task_manifest is not None:
+            selected = load_task_manifest(task_manifest, task_ids=task_ids)
+        else:
+            selected = select_tasks(task_ids)
+    except (ValueError, FileNotFoundError) as exc:
         raise typer.BadParameter(str(exc)) from exc
 
     # Fail fast at parse time: a bad model spec (including claude:) and a
@@ -450,6 +554,7 @@ def run_agent_tasks_command(
         run_id=resolved_run_id,
         surfaces=surface_list,
         task_ids=task_ids,
+        task_manifest=str(task_manifest) if task_manifest is not None else None,
         model_spec=model,
         judge_spec=judge,
         corpus_dir=str(corpus_dir),

--- a/benchmarks/src/basic_memory_benchmarks/converters/xafs_to_corpus.py
+++ b/benchmarks/src/basic_memory_benchmarks/converters/xafs_to_corpus.py
@@ -1,0 +1,438 @@
+"""Convert xAFS personas into grouped corpora and an agent-task manifest.
+
+Each persona is an isolated haystack, so the converter writes one corpus per
+persona (``groups/<group_id>/docs``, the beam grouped convention) plus a single
+``tasks.json`` whose rows name their group. Questions run under the agent-task
+harness (``run agent-tasks --task-manifest``): the tool surface is the provider
+axis and tokens-per-correct-answer is the headline — exactly xAFS's framing.
+
+Files are copied byte-for-byte with their ``data/...`` relpaths preserved — no
+frontmatter render. xAFS files ship without YAML frontmatter and questions cite
+exact file content; BM's sync ingests ``.md`` files as notes and non-markdown
+files (the ``.eml`` mails) as file resources reachable via ``read_content``
+(rich surface) or ``cat``/``grep`` (posix surface), which is the required
+format-spanning handling. The copy policy is "copy everything": upstream is
+text-only, per-extension counts are recorded in ``conversion.json``, and the
+``skipped`` list there must stay empty — a file the policy cannot place raises
+instead of being silently dropped.
+
+Anti-leakage: only each persona's ``data/`` subtree is copied. Gold answers and
+prompts exist only in ``tasks.json``; a scenario/answer-key file name — or a
+symlink, which could smuggle any target — appearing inside ``data/`` aborts the
+conversion.
+
+Vendor caveat: xAFS is authored by supermemory, a memory-product vendor. It is
+reported as a SECONDARY dataset, never the headline, pending a question-quality
+audit (docs/benchmarks.md 6d). ``sample_xafs_audit`` ships the audit tooling.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import shutil
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass
+from math import floor
+from pathlib import Path
+
+from basic_memory_benchmarks.datasets.xafs import (
+    XAFS_FAMILIES,
+    XAFS_REVISION,
+    XAFS_SOURCE_URL,
+    XafsPersona,
+    XafsQuestion,
+    load_xafs,
+)
+from basic_memory_benchmarks.utils import sha256_file, utc_now_iso
+
+XAFS_CITATION = f"xAFS (supermemory, 2026), revision {XAFS_REVISION[:8]}"
+XAFS_LICENSE_NOTE = (
+    "CC-BY-4.0; vendor-authored (supermemory) — secondary dataset pending question-quality audit"
+)
+
+# Persona-root answer-key/scenario files must never reach an ingested corpus.
+# Only data/ subtrees are copied, so hitting one of these names inside data/
+# means the upstream layout changed under us — abort rather than risk leakage.
+_FORBIDDEN_BASENAMES = frozenset({"question.json", "SCENARIO.md", "facts.json", "manifest.json"})
+
+# The judge rubric mirrors the xAFS card's semantic-equivalence criteria; it is
+# built deterministically so re-conversion is byte-stable.
+_RUBRIC_TEMPLATE = """\
+Question: {prompt}
+Gold answer: {gold_answer}
+Mark CORRECT iff the agent's final answer is semantically equivalent to the gold
+answer: paraphrase-tolerant and format-tolerant, but exact values (numbers,
+amounts, dates, identifiers) and named entities must match, and every part of a
+multi-part gold answer must be covered."""
+
+
+def xafs_group_id(persona_id: str) -> str:
+    """Group/project key for a persona, e.g. ``dp_001`` -> ``xafs-dp001``."""
+    return f"xafs-{persona_id.replace('_', '')}"
+
+
+def build_judge_rubric(prompt: str, gold_answer: str) -> str:
+    return _RUBRIC_TEMPLATE.format(prompt=prompt, gold_answer=gold_answer)
+
+
+# --- Corrections hook (locomo-audit precedent) ---
+
+
+@dataclass(frozen=True)
+class XafsCorrection:
+    """One audited question: a corrected gold answer, or an exclusion."""
+
+    prompt: str  # cross-checked against the upstream prompt; drift fails loudly
+    gold_answer: str | None
+    excluded: bool
+    reason: str | None
+
+
+def load_xafs_corrections(path: Path) -> dict[str, XafsCorrection]:
+    """Load corrections keyed ``"<persona_id>/<question_id>"``."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"xAFS corrections file must be a JSON object: {path}")
+
+    corrections: dict[str, XafsCorrection] = {}
+    for key, raw in payload.items():
+        if not isinstance(raw, dict):
+            raise ValueError(f"xAFS correction {key!r} is not an object: {path}")
+        prompt = raw.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError(f"xAFS correction {key!r} needs the upstream 'prompt' text: {path}")
+        excluded = bool(raw.get("excluded", False))
+        gold_answer = raw.get("gold_answer")
+        reason = raw.get("reason")
+        if excluded:
+            if not isinstance(reason, str) or not reason.strip():
+                raise ValueError(f"xAFS correction {key!r} excludes without a 'reason': {path}")
+            if gold_answer is not None:
+                raise ValueError(
+                    f"xAFS correction {key!r} both excludes and overrides gold_answer: {path}"
+                )
+        elif not isinstance(gold_answer, str) or not gold_answer.strip():
+            raise ValueError(
+                f"xAFS correction {key!r} must override 'gold_answer' or set 'excluded': {path}"
+            )
+        corrections[key] = XafsCorrection(
+            prompt=prompt,
+            gold_answer=gold_answer if isinstance(gold_answer, str) else None,
+            excluded=excluded,
+            reason=reason if isinstance(reason, str) else None,
+        )
+    return corrections
+
+
+# --- Conversion ---
+
+
+def _reject_symlink(source: Path, *, persona_id: str, relpath: str) -> None:
+    """Refuse to copy a symlink out of a persona tree.
+
+    ``is_file()`` (both rglob's and the loader's) follows links, so a symlink
+    named like corpus data can smuggle any target — ``question.json`` gold
+    answers included — past the relpath-string checks.
+    """
+    if source.is_symlink():
+        raise ValueError(
+            f"xAFS {persona_id}: symlink would copy its target into the output: {relpath!r}"
+        )
+
+
+def _copy_persona_files(persona: XafsPersona, group_dir: Path) -> Counter[str]:
+    """Byte-for-byte copy of the persona's data/ tree; per-extension counts."""
+    docs_dir = group_dir / "docs"
+    # Trigger: re-conversion into an existing output_dir (a revision bump
+    # re-fetched in place — ``hf download`` never prunes removed files).
+    # Why: overwrite-only copying would keep files gone upstream in the
+    # ingested haystack while conversion.json counts only the new file set —
+    # invisible contamination, since nothing ties the run's corpus checksum
+    # back to this manifest.
+    # Outcome: docs/ always mirrors exactly this conversion's inputs.
+    if docs_dir.exists():
+        shutil.rmtree(docs_dir)
+    counts: Counter[str] = Counter()
+    for relpath in persona.data_files:
+        parts = Path(relpath).parts
+        # Defense in depth: data_files come from rglob so they cannot escape,
+        # but a symlinked or renamed upstream layout must not corrupt a corpus.
+        if Path(relpath).is_absolute() or ".." in parts:
+            raise ValueError(f"xAFS {persona.persona_id} file escapes the persona: {relpath!r}")
+        if parts[-1] in _FORBIDDEN_BASENAMES:
+            raise ValueError(
+                f"xAFS {persona.persona_id}: answer-key/scenario file would land in the "
+                f"ingested corpus: {relpath!r}"
+            )
+        # A symlink passes the relpath checks under its own name (e.g.
+        # data/x.md -> ../question.json) yet copyfile would materialize its
+        # target — gold answers included — into the ingested haystack.
+        _reject_symlink(persona.root / relpath, persona_id=persona.persona_id, relpath=relpath)
+        destination = docs_dir / relpath
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(persona.root / relpath, destination)
+        counts[Path(relpath).suffix or "(none)"] += 1
+    return counts
+
+
+def _persona_data_sha256(persona: XafsPersona) -> str:
+    """Aggregate fingerprint over sorted (relpath, sha256(file)) pairs.
+
+    Streams per-file digests instead of file bytes so a multi-hundred-MB
+    persona never sits in memory.
+    """
+    digest = hashlib.sha256()
+    for relpath in persona.data_files:
+        digest.update(relpath.encode("utf-8"))
+        digest.update(b"\x00")
+        digest.update(sha256_file(persona.root / relpath).encode("ascii"))
+        digest.update(b"\x00")
+    return digest.hexdigest()
+
+
+def _task_row(question: XafsQuestion, group_id: str, gold_answer: str) -> dict:
+    return {
+        "id": f"{group_id}-{question.id}",
+        "skill": question.family,
+        "group": group_id,
+        "source": (f"supermemory/xAFS {question.persona_id} {question.id} @{XAFS_REVISION[:8]}"),
+        "prompt": question.prompt,
+        "graders": [
+            {"kind": "judge_rubric", "rubric": build_judge_rubric(question.prompt, gold_answer)}
+        ],
+        "metadata": {
+            "gold_file_ids": list(question.gold_file_ids),
+            "gold_answer": gold_answer,
+        },
+    }
+
+
+def convert_xafs_to_corpus(
+    *,
+    dataset_root: Path,
+    output_dir: Path,
+    personas: Sequence[str] | None = None,
+    corrections_path: Path | None = None,
+) -> tuple[Path, Path, int, int]:
+    """Convert selected personas into per-persona corpora + a task manifest.
+
+    ``dataset_root`` is the local xAFS snapshot (see
+    ``benchmarks/datasets/xafs/download.sh``). Returns
+    ``(groups_dir, tasks_path, file_count, task_count)``. Runs pass the written
+    ``conversion.json`` provenance forward by pointing ``--corpus-dir`` at
+    ``groups/`` (the run manifest checksums the grouped corpus itself).
+    """
+    loaded = load_xafs(dataset_root, personas)
+    corrections = load_xafs_corrections(corrections_path) if corrections_path is not None else {}
+
+    groups_dir = output_dir / "groups"
+    groups_dir.mkdir(parents=True, exist_ok=True)
+
+    tasks: list[dict] = []
+    persona_manifests: list[dict] = []
+    excluded: list[dict] = []
+    corrections_applied = 0
+    file_count = 0
+    seen_correction_keys: set[str] = set()
+
+    for persona in loaded:
+        group_id = xafs_group_id(persona.persona_id)
+        extension_counts = _copy_persona_files(persona, groups_dir / group_id)
+        file_count += len(persona.data_files)
+
+        for question in persona.questions:
+            key = f"{question.persona_id}/{question.id}"
+            correction = corrections.get(key)
+            gold_answer = question.gold_answer
+            if correction is not None:
+                seen_correction_keys.add(key)
+                # Trigger: the stored prompt differs from the upstream prompt.
+                # Why: a silently drifted correction would override the wrong
+                # question (the locomo-audit cross-check precedent).
+                # Outcome: conversion aborts naming the question.
+                if correction.prompt != question.prompt:
+                    raise ValueError(
+                        f"xAFS correction {key!r} prompt does not match the upstream "
+                        "question; the dataset or corrections file drifted"
+                    )
+                if correction.excluded:
+                    excluded.append({"question": key, "reason": correction.reason})
+                    continue
+                assert correction.gold_answer is not None  # enforced by the loader
+                gold_answer = correction.gold_answer
+                corrections_applied += 1
+            tasks.append(_task_row(question, group_id, gold_answer))
+
+        persona_manifests.append(
+            {
+                "persona_id": persona.persona_id,
+                "group_id": group_id,
+                "question_file_sha256": sha256_file(persona.root / "question.json"),
+                "data_files_sha256": _persona_data_sha256(persona),
+                "file_count": len(persona.data_files),
+                "files_by_extension": dict(sorted(extension_counts.items())),
+                "question_count": len(persona.questions),
+            }
+        )
+
+    # A correction for a selected persona that matched no loaded question is
+    # drift (corrections for unselected personas are expected under subsetting).
+    selected_persona_ids = {persona.persona_id for persona in loaded}
+    stale = sorted(
+        key
+        for key in corrections
+        if key not in seen_correction_keys and key.split("/", 1)[0] in selected_persona_ids
+    )
+    if stale:
+        raise ValueError(f"xAFS corrections reference unknown questions: {stale}")
+
+    tasks_path = output_dir / "tasks.json"
+    tasks_path.write_text(json.dumps(tasks, indent=2), encoding="utf-8")
+
+    conversion_manifest = {
+        "dataset_id": "xafs",
+        "source_url": XAFS_SOURCE_URL,
+        "revision": XAFS_REVISION,
+        "citation": XAFS_CITATION,
+        "license_note": XAFS_LICENSE_NOTE,
+        "dataset_root": str(dataset_root),
+        "converter": {
+            "personas": list(personas) if personas is not None else None,
+            "corrections_path": str(corrections_path) if corrections_path is not None else None,
+        },
+        "corrections": {"applied": corrections_applied, "excluded": excluded},
+        # Copy policy is "copy everything"; this list existing (and staying
+        # empty) is the explicit never-silently-dropped contract.
+        "skipped": [],
+        "file_count": file_count,
+        "task_count": len(tasks),
+        "personas": persona_manifests,
+        "created_at_utc": utc_now_iso(),
+    }
+    (output_dir / "conversion.json").write_text(
+        json.dumps(conversion_manifest, indent=2), encoding="utf-8"
+    )
+
+    return groups_dir, tasks_path, file_count, len(tasks)
+
+
+# --- Audit sampling (the post-merge ~20-question quality audit's tooling) ---
+
+
+def _stratified_allocation(counts: dict[str, int], sample_size: int) -> dict[str, int]:
+    """Proportional per-family allocation via largest remainder; deterministic."""
+    total = sum(counts.values())
+    if sample_size >= total:
+        return dict(counts)
+    shares = {family: sample_size * count / total for family, count in counts.items()}
+    allocation = {family: floor(share) for family, share in shares.items()}
+    remainder = sample_size - sum(allocation.values())
+    # Ties broken by canonical family order so the same seed reproduces exactly.
+    by_fraction = sorted(
+        counts,
+        key=lambda family: (-(shares[family] - allocation[family]), XAFS_FAMILIES.index(family)),
+    )
+    for family in by_fraction:
+        if remainder == 0:
+            break
+        if allocation[family] < counts[family]:
+            allocation[family] += 1
+            remainder -= 1
+    return allocation
+
+
+def sample_xafs_audit(
+    *,
+    dataset_root: Path,
+    output_dir: Path,
+    personas: Sequence[str] | None = None,
+    sample_size: int = 20,
+    seed: int = 42,
+) -> tuple[Path, int]:
+    """Extract a seeded, family-stratified question sample for human review.
+
+    Writes ``audit-sample.json`` (persona, id, family, prompt, gold answer,
+    gold files), verbatim copies of every gold file under
+    ``sources/<persona>-<qid>/``, and a human-readable ``sample.md``. Returns
+    ``(sample_path, sampled_count)``.
+    """
+    loaded = load_xafs(dataset_root, personas)
+    by_family: dict[str, list[tuple[XafsPersona, XafsQuestion]]] = {
+        family: [] for family in XAFS_FAMILIES
+    }
+    for persona in loaded:
+        for question in persona.questions:
+            by_family[question.family].append((persona, question))
+
+    counts = {family: len(rows) for family, rows in by_family.items() if rows}
+    allocation = _stratified_allocation(counts, sample_size)
+    rng = random.Random(seed)
+    selected: list[tuple[XafsPersona, XafsQuestion]] = []
+    for family in XAFS_FAMILIES:
+        rows = by_family[family]
+        if rows:
+            selected.extend(rng.sample(rows, allocation[family]))
+    selected.sort(key=lambda pair: (pair[0].persona_id, pair[1].id))
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    sources_dir = output_dir / "sources"
+    # Trigger: re-sampling into an existing output_dir with a different
+    # --n/--seed (the _copy_persona_files re-conversion precedent).
+    # Why: overwrite-only copying would leave sources/<persona>-<qid>/ dirs
+    # the new audit-sample.json no longer references — a reviewer would audit
+    # gold files for questions that are not in the sample.
+    # Outcome: sources/ always mirrors exactly this sample's questions.
+    if sources_dir.exists():
+        shutil.rmtree(sources_dir)
+    records: list[dict] = []
+    markdown_lines = [
+        "# xAFS audit sample",
+        "",
+        f"Seed {seed}, {len(selected)} of {sum(counts.values())} questions, "
+        f"stratified across families ({', '.join(f'{f}: {allocation.get(f, 0)}' for f in XAFS_FAMILIES if f in counts)}).",
+        "",
+        "For each question: is the prompt answerable from the gold files, and is the "
+        "gold answer correct and complete? Record verdicts in "
+        "benchmarks/datasets/xafs/corrections.json.",
+    ]
+    for persona, question in selected:
+        records.append(
+            {
+                "persona_id": persona.persona_id,
+                "id": question.id,
+                "family": question.family,
+                "prompt": question.prompt,
+                "gold_answer": question.gold_answer,
+                "gold_file_ids": list(question.gold_file_ids),
+            }
+        )
+        source_dir = sources_dir / f"{persona.persona_id}-{question.id}"
+        for relpath in question.gold_file_ids:
+            # Same hole as the persona copy: a gold-file symlink would land
+            # its target in the audit output rather than the named file.
+            _reject_symlink(persona.root / relpath, persona_id=persona.persona_id, relpath=relpath)
+            destination = source_dir / relpath
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(persona.root / relpath, destination)
+        markdown_lines += [
+            "",
+            f"## {persona.persona_id}/{question.id} ({question.family})",
+            "",
+            f"**Prompt:** {question.prompt}",
+            "",
+            f"**Gold answer:** {question.gold_answer}",
+            "",
+            "**Gold files:**",
+            *[
+                f"- `{relpath}` (copied to `sources/{persona.persona_id}-{question.id}/{relpath}`)"
+                for relpath in question.gold_file_ids
+            ],
+        ]
+
+    sample_path = output_dir / "audit-sample.json"
+    sample_path.write_text(json.dumps(records, indent=2), encoding="utf-8")
+    (output_dir / "sample.md").write_text("\n".join(markdown_lines) + "\n", encoding="utf-8")
+    return sample_path, len(selected)

--- a/benchmarks/src/basic_memory_benchmarks/datasets/xafs.py
+++ b/benchmarks/src/basic_memory_benchmarks/datasets/xafs.py
@@ -1,0 +1,197 @@
+"""xAFS dataset loading.
+
+xAFS (supermemory's "Agentic File System" benchmark,
+https://huggingface.co/datasets/supermemory/xAFS, CC-BY-4.0) ships 13 synthetic
+personas (``dp_001``..``dp_013``), each a file tree under ``data/`` plus a
+``question.json`` of single-hop / multi-hop / format-spanning questions with
+gold answers and gold source files. Corpus size scales from 5 to ~10K files per
+persona (~19K files / ~837MB total), which is why persona subsetting is a
+first-class loading option.
+
+The dataset is never vendored into this repo — see
+``benchmarks/datasets/xafs/download.sh`` for the pinned ``hf download`` fetch.
+This module only loads a local snapshot; there is no fetch code here.
+
+Count note: the upstream README advertises 110 questions (35/50/25 per family)
+but the shipped ``question.json`` files at the pinned revision sum to 33/51/26.
+The loader trusts the JSON and asserts nothing about totals.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+XAFS_SOURCE_URL = "https://huggingface.co/datasets/supermemory/xAFS"
+# Pinned dataset revision. Bump deliberately (and re-verify counts/layout).
+XAFS_REVISION = "21142b2c01113cb881c80d6c99bcf0f412ed17f2"
+
+# Exact upstream family keys; the harness maps family -> task "skill" so the
+# existing per-skill reporting is the per-question-type breakdown.
+XAFS_FAMILIES = ("single_hop", "multi_hop", "format_spanning")
+
+_PERSONA_DIR_PATTERN = re.compile(r"^dp_\d{3}$")
+_REQUIRED_QUESTION_KEYS = ("id", "family", "prompt", "gold_file_ids", "gold_answer")
+
+
+@dataclass(frozen=True)
+class XafsQuestion:
+    id: str  # upstream "id" ("q01"...); unique only within a persona
+    persona_id: str  # "dp_001".."dp_013" (the persona dir name, added by the loader)
+    family: str  # one of XAFS_FAMILIES
+    prompt: str
+    gold_file_ids: tuple[str, ...]  # verbatim upstream "data/..." relpaths
+    gold_answer: str
+    extras: Mapping[str, Any]  # unknown upstream keys, preserved verbatim
+
+
+@dataclass(frozen=True)
+class XafsPersona:
+    persona_id: str
+    root: Path  # the local persona directory
+    # Sorted relpaths from the persona root, every extension, all prefixed
+    # "data/" — the same path vocabulary gold_file_ids uses, so gold references
+    # and corpus files never need a mapping layer.
+    data_files: tuple[str, ...]
+    questions: tuple[XafsQuestion, ...]  # upstream array order preserved
+
+
+def _parse_gold_file_ids(raw: object, *, persona_dir: Path, question_label: str) -> tuple[str, ...]:
+    if not isinstance(raw, list) or not raw:
+        raise ValueError(f"xAFS {question_label} has an empty or non-list gold_file_ids")
+    gold: list[str] = []
+    for item in raw:
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"xAFS {question_label} gold_file_ids must be non-empty strings")
+        relpath = item.strip()
+        # Gold references must stay inside the persona's data/ subtree: an
+        # absolute or escaping path would let ground truth point outside the
+        # corpus the converter copies (and outside the anti-leakage boundary).
+        if Path(relpath).is_absolute() or ".." in Path(relpath).parts:
+            raise ValueError(f"xAFS {question_label} gold file id escapes the persona: {relpath!r}")
+        if not relpath.startswith("data/"):
+            raise ValueError(
+                f"xAFS {question_label} gold file id is not data/-prefixed: {relpath!r}"
+            )
+        # Existence guards truncated downloads: every gold reference at the
+        # pinned revision resolves, so a miss means a broken local snapshot.
+        if not (persona_dir / relpath).is_file():
+            raise ValueError(
+                f"xAFS {question_label} gold file missing on disk: {persona_dir / relpath}"
+                " (partial download? re-run benchmarks/datasets/xafs/download.sh)"
+            )
+        gold.append(relpath)
+    return tuple(gold)
+
+
+def _required_string(raw: dict[str, Any], key: str, *, question_label: str) -> str:
+    value = raw[key]
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"xAFS {question_label} has an empty or non-string {key!r}")
+    return value
+
+
+def _parse_question(
+    raw: object, *, persona_id: str, persona_dir: Path, position: int
+) -> XafsQuestion:
+    label = f"question at index {position} in {persona_dir / 'question.json'}"
+    if not isinstance(raw, dict):
+        raise ValueError(f"xAFS {label} is not an object: {raw!r}")
+    missing = [key for key in _REQUIRED_QUESTION_KEYS if key not in raw]
+    if missing:
+        raise ValueError(f"xAFS {label} is missing keys {missing}")
+    question_id = _required_string(raw, "id", question_label=label)
+    family = _required_string(raw, "family", question_label=label)
+    if family not in XAFS_FAMILIES:
+        raise ValueError(
+            f"xAFS {label} has unknown family {family!r}; expected one of {XAFS_FAMILIES}"
+        )
+    return XafsQuestion(
+        id=question_id,
+        persona_id=persona_id,
+        family=family,
+        prompt=_required_string(raw, "prompt", question_label=label),
+        gold_file_ids=_parse_gold_file_ids(
+            raw["gold_file_ids"], persona_dir=persona_dir, question_label=label
+        ),
+        gold_answer=_required_string(raw, "gold_answer", question_label=label),
+        extras={key: value for key, value in raw.items() if key not in _REQUIRED_QUESTION_KEYS},
+    )
+
+
+def load_xafs_persona(persona_dir: Path) -> XafsPersona:
+    """Load one persona directory (``data/`` tree + ``question.json``)."""
+    persona_id = persona_dir.name
+    question_path = persona_dir / "question.json"
+    if not question_path.is_file():
+        raise FileNotFoundError(f"xAFS persona has no question.json: {persona_dir}")
+    data_dir = persona_dir / "data"
+    if not data_dir.is_dir():
+        raise FileNotFoundError(f"xAFS persona has no data/ directory: {persona_dir}")
+    data_files = tuple(
+        sorted(str(path.relative_to(persona_dir)) for path in data_dir.rglob("*") if path.is_file())
+    )
+    if not data_files:
+        raise ValueError(f"xAFS persona data/ directory is empty: {data_dir}")
+
+    payload = json.loads(question_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list) or not payload:
+        raise ValueError(f"xAFS question.json must be a non-empty JSON array: {question_path}")
+
+    questions: list[XafsQuestion] = []
+    seen_ids: set[str] = set()
+    for position, raw in enumerate(payload):
+        question = _parse_question(
+            raw, persona_id=persona_id, persona_dir=persona_dir, position=position
+        )
+        # (persona_id, id) is the upstream identity; a duplicate id inside one
+        # persona would silently collapse tasks and corrections.
+        if question.id in seen_ids:
+            raise ValueError(f"xAFS duplicate question id {question.id!r} in {question_path}")
+        seen_ids.add(question.id)
+        questions.append(question)
+
+    return XafsPersona(
+        persona_id=persona_id,
+        root=persona_dir,
+        data_files=data_files,
+        questions=tuple(questions),
+    )
+
+
+def load_xafs(root: Path, personas: Sequence[str] | None = None) -> list[XafsPersona]:
+    """Load personas from a local xAFS snapshot.
+
+    ``personas`` is an explicit subset of persona ids (full ingestion is
+    ~837MB, so subsetting is normal); ``None`` loads every ``dp_NNN`` directory
+    present — which supports partial ``--include`` downloads. Unknown requested
+    ids fail fast listing what is actually on disk.
+    """
+    if not root.is_dir():
+        raise FileNotFoundError(
+            f"xAFS dataset root not found: {root} (fetch with benchmarks/datasets/xafs/download.sh)"
+        )
+    available = sorted(
+        entry.name
+        for entry in root.iterdir()
+        if entry.is_dir() and _PERSONA_DIR_PATTERN.fullmatch(entry.name)
+    )
+    if not available:
+        raise ValueError(f"No xAFS persona directories (dp_NNN) under {root}")
+
+    if personas is None:
+        selected = available
+    else:
+        requested = list(dict.fromkeys(personas))
+        unknown = [persona for persona in requested if persona not in available]
+        if unknown:
+            raise ValueError(
+                f"Unknown xAFS personas {unknown}; available under {root}: {available}"
+            )
+        selected = sorted(requested)
+
+    return [load_xafs_persona(root / persona_id) for persona_id in selected]

--- a/benchmarks/tests/agent_tasks/test_corpus.py
+++ b/benchmarks/tests/agent_tasks/test_corpus.py
@@ -1,0 +1,66 @@
+"""Corpus helper tests: every-extension listing (xAFS .eml resources included)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from basic_memory_benchmarks.agent_tasks.corpus import (
+    DEFAULT_AGE_DAYS,
+    SECONDS_PER_DAY,
+    copy_corpus,
+    corpus_checksum,
+    corpus_files,
+    snapshot_baseline,
+)
+
+
+def _write_mixed_corpus(tmp_path: Path) -> Path:
+    corpus = tmp_path / "corpus"
+    (corpus / "notes").mkdir(parents=True)
+    (corpus / "notes" / "a.md").write_text("# alpha\n", encoding="utf-8")
+    (corpus / "mail").mkdir()
+    (corpus / "mail" / "b.eml").write_text("Subject: hello\n\nbody\n", encoding="utf-8")
+    return corpus
+
+
+def test_corpus_files_lists_every_extension(tmp_path: Path) -> None:
+    # Dataset corpora (xAFS) carry non-markdown resources; the checksum, copy,
+    # and timestamp passes must all see them, not just *.md.
+    corpus = _write_mixed_corpus(tmp_path)
+
+    assert corpus_files(corpus) == ["mail/b.eml", "notes/a.md"]
+
+
+def test_corpus_checksum_pins_non_markdown_bytes(tmp_path: Path) -> None:
+    corpus = _write_mixed_corpus(tmp_path)
+    checksum_before, count = corpus_checksum(corpus)
+
+    (corpus / "mail" / "b.eml").write_text("Subject: changed\n\nbody\n", encoding="utf-8")
+    checksum_after, count_after = corpus_checksum(corpus)
+
+    assert count == count_after == 2
+    assert checksum_before != checksum_after
+
+
+def test_copy_corpus_copies_and_ages_non_markdown(tmp_path: Path) -> None:
+    corpus = _write_mixed_corpus(tmp_path)
+    project_dir = tmp_path / "project"
+    now = 2_000_000_000.0
+
+    copy_corpus(corpus, project_dir, now=now)
+
+    copied_eml = project_dir / "mail" / "b.eml"
+    assert copied_eml.read_bytes() == (corpus / "mail" / "b.eml").read_bytes()
+    expected_mtime = now - DEFAULT_AGE_DAYS * SECONDS_PER_DAY
+    assert copied_eml.stat().st_mtime == expected_mtime
+    assert (project_dir / "notes" / "a.md").stat().st_mtime == expected_mtime
+
+
+def test_snapshot_baseline_is_markdown_only(tmp_path: Path) -> None:
+    # State-tracking graders reason about markdown notes only, and a corpus
+    # binary must not crash the snapshot's read_text.
+    corpus = _write_mixed_corpus(tmp_path)
+    (corpus / "assets").mkdir()
+    (corpus / "assets" / "blob.bin").write_bytes(b"\xff\xfe\x00not-utf8")
+
+    assert snapshot_baseline(corpus) == {"notes/a.md": "# alpha\n"}

--- a/benchmarks/tests/agent_tasks/test_driver.py
+++ b/benchmarks/tests/agent_tasks/test_driver.py
@@ -20,13 +20,25 @@ from basic_memory_benchmarks.agent_tasks.driver import (
 )
 from basic_memory_benchmarks.agent_tasks.loop import ToolOutcome
 from basic_memory_benchmarks.agent_tasks.models import AgentTaskResult, AgentTasksConfig
+from basic_memory_benchmarks.agent_tasks.spec import AgentTaskSpec, JudgeRubric
 from basic_memory_benchmarks.agent_tasks.surfaces import (
     RICH_SURFACE,
     SurfaceUnavailableError,
+    read_only_view,
 )
+from basic_memory_benchmarks.converters.xafs_to_corpus import convert_xafs_to_corpus
 from basic_memory_benchmarks.fairness import validate_surface_fairness
-from basic_memory_benchmarks.llm.runners import LLMRunnerError
+from basic_memory_benchmarks.llm.runners import LLMResult, LLMRunner, LLMRunnerError
 from basic_memory_benchmarks.llm.tool_agent import ScriptedToolAgent, ToolDef
+from basic_memory_benchmarks.utils import sha256_file
+from xafs_fixture import (
+    DP1_CROSS_FORMAT_ANSWER,
+    DP1_DUE_DATE,
+    DP1_INVOICE_AMOUNT,
+    DP1_REFERRER,
+    DP2_TRAINING_SUMMARY,
+    write_xafs_root,
+)
 
 CORPUS_DIR = Path(__file__).parents[2] / "benchmarks" / "datasets" / "agent-tasks" / "corpus"
 
@@ -162,6 +174,7 @@ def test_happy_path_writes_all_artifacts(tmp_path: Path, monkeypatch: pytest.Mon
     manifest = json.loads((run_dir / "manifest.json").read_text())
     assert manifest["bm_resolved_sha"] == "deadbeef"
     assert manifest["corpus_file_count"] > 20
+    assert manifest["task_manifest_sha256"] is None  # shipped-task run
     assert manifest["surfaces"][0]["name"] == "rich"
     assert manifest["surfaces"][0]["tool_allowlist"] == list(RICH_SURFACE.tool_allowlist)
     assert manifest["surfaces"][0]["observed_tools"] == sorted(RICH_SURFACE.tool_allowlist)
@@ -435,6 +448,267 @@ def test_build_surface_summary_excludes_errored_from_means() -> None:
     assert summary.tokens_per_completed_task == 200.0
     assert summary.mean_tool_calls == 2.0  # errored rows excluded from means
     assert summary.per_skill["memory-curate"].tokens_per_completed is None
+
+
+# --- Dataset-manifest (grouped) runs: the xAFS execution path ---
+
+
+MANIFEST_TASK_IDS = [
+    "xafs-dp001-q01",
+    "xafs-dp001-q02",
+    "xafs-dp001-q03",
+    "xafs-dp001-q04",
+    "xafs-dp002-q01",
+    "xafs-dp002-q02",
+]
+
+
+class _StubJudgeRunner(LLMRunner):
+    """Judge stub: CORRECT unless the judged final answer contains 'WRONG'."""
+
+    def __init__(self) -> None:
+        self.spec = "stub:judge"
+        self.prompts: list[str] = []
+
+    def complete(self, prompt: str) -> LLMResult:
+        self.prompts.append(prompt)
+        # Everything after the template's "Final answer:" is the agent's text;
+        # judging on it (not the rubric half) keeps the verdict answer-driven.
+        answer = prompt.split("Final answer:", 1)[1]
+        verdict = "INCORRECT - decoy answer" if "WRONG" in answer else "CORRECT - matches gold"
+        return LLMResult(
+            text=verdict, model="stub", input_tokens=7, output_tokens=3, latency_ms=0.0
+        )
+
+
+def _stub_bm_recording(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[list[list[str]], list[str]]:
+    """Like _stub_bm, but records every bm command and settle for assertions."""
+    commands: list[list[str]] = []
+    settles: list[str] = []
+    monkeypatch.setattr(driver, "resolve_clean_checkout_sha", lambda checkout: "deadbeef")
+
+    def record_command(command: list[str], **kwargs: Any) -> SimpleNamespace:
+        commands.append(list(command))
+        return SimpleNamespace(stdout="", stderr="")
+
+    monkeypatch.setattr(driver, "run_command", record_command)
+
+    def record_settle(
+        *, prefix: list[str], env: dict[str, str], project_name: str, timeout_seconds: float
+    ) -> tuple[float, str]:
+        settles.append(project_name)
+        return (0.0, "status-json")
+
+    monkeypatch.setattr(driver, "settle_index", record_settle)
+    return commands, settles
+
+
+def _forbid_baseline(project_dir: Path) -> dict[str, str]:
+    raise AssertionError("snapshot_baseline must not run for state-free manifest tasks")
+
+
+def _xafs_agent() -> ScriptedToolAgent:
+    """One scripted answer per fixture question, keyed by prompt substring.
+
+    format_spanning questions read the raw file resource (read_content);
+    single/multi-hop search notes. dp_002 q01 answers with a WRONG decoy the
+    stub judge marks INCORRECT, so pass/fail is judge-driven.
+    """
+
+    def turns(tool: str, arguments: dict[str, Any], answer: str) -> list[dict[str, Any]]:
+        return [
+            {"tool_calls": [{"name": tool, "arguments": {**arguments, "project": "{project}"}}]},
+            {"text": f"{answer}\n```json\n{{}}\n```"},
+        ]
+
+    return ScriptedToolAgent(
+        script={
+            "tasks": {
+                "amount of the Acme onboarding invoice": turns(
+                    "search_notes", {"query": "invoice"}, f"The invoice was {DP1_INVOICE_AMOUNT}."
+                ),
+                "referred the client": turns(
+                    "search_notes", {"query": "referral"}, f"{DP1_REFERRER} referred Acme."
+                ),
+                "when is payment due": turns(
+                    "read_content",
+                    {"path": "data/mail/2026-04-01_invoice.eml"},
+                    f"Payment is due {DP1_DUE_DATE}.",
+                ),
+                "revenue first exceed": turns(
+                    "read_content",
+                    {"path": "data/notes/metrics.csv.md"},
+                    f"In {DP1_CROSS_FORMAT_ANSWER}.",
+                ),
+                "goal pace": turns("search_notes", {"query": "pace"}, "WRONG: 9:30 per mile."),
+                "longest run": turns("search_notes", {"query": "race"}, f"{DP2_TRAINING_SUMMARY}."),
+            }
+        }
+    )
+
+
+def _manifest_config(tmp_path: Path) -> AgentTasksConfig:
+    root = write_xafs_root(tmp_path)
+    groups_dir, tasks_path, _, _ = convert_xafs_to_corpus(
+        dataset_root=root, output_dir=tmp_path / "generated"
+    )
+    return _config(
+        tmp_path,
+        run_id="xafs-run",
+        task_ids=[],
+        task_manifest=str(tasks_path),
+        corpus_dir=str(groups_dir),
+        judge_spec="stub:judge",
+    )
+
+
+def test_grouped_manifest_run_shares_projects_and_reports_groups(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _manifest_config(tmp_path)
+    commands, settles = _stub_bm_recording(monkeypatch)
+    monkeypatch.setattr(driver, "snapshot_baseline", _forbid_baseline)
+    monkeypatch.chdir(tmp_path)
+    session = FakeSession(RICH_SURFACE.tool_allowlist)
+    judge = _StubJudgeRunner()
+
+    run_dir = run_agent_tasks(
+        config,
+        model_factory=lambda spec: _xafs_agent(),
+        session_factory=lambda runtime: session,
+        judge_factory=lambda spec: judge,
+    )
+
+    # Ingest once per (surface, group): one `project add` and one settle per
+    # persona; NO post-loop settles (every manifest task is state-free), and
+    # snapshot_baseline (monkeypatched to raise) was never touched.
+    adds = [cmd for cmd in commands if "project" in cmd and "add" in cmd]
+    added_projects = sorted(cmd[cmd.index("add") + 1] for cmd in adds)
+    assert added_projects == ["at-xafs-run-xafs-dp001", "at-xafs-run-xafs-dp002"]
+    assert sorted(settles) == added_projects
+    assert len(settles) == 2
+
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert manifest["task_ids"] == MANIFEST_TASK_IDS  # (group, id) order
+    # tasks.json is pinned alongside the corpus: a corrections re-run changes
+    # gold answers/rubrics without touching the corpus checksum.
+    assert config.task_manifest is not None
+    assert manifest["task_manifest_sha256"] == sha256_file(Path(config.task_manifest))
+    # The read-only surface view is what actually ran, echoed for the
+    # fairness audit trail: no write verbs on a shared warm project.
+    echo = manifest["surfaces"][0]
+    assert echo["tool_allowlist"] == list(read_only_view(RICH_SURFACE).tool_allowlist)
+    assert "write_note" not in echo["tool_allowlist"]
+
+    rows = [
+        json.loads(line) for line in (run_dir / "per-task-agent.jsonl").read_text().splitlines()
+    ]
+    assert [row["task_id"] for row in rows] == MANIFEST_TASK_IDS
+    assert [row["group"] for row in rows] == ["xafs-dp001"] * 4 + ["xafs-dp002"] * 2
+    # skill = family: the per-skill report is the per-question-type breakdown.
+    assert {row["skill"] for row in rows} == {"single_hop", "multi_hop", "format_spanning"}
+
+    # Judge-driven pass/fail: the WRONG decoy fails as a graded task (never an
+    # error row); everything else passes.
+    (failed,) = [row for row in rows if not row["passed"]]
+    assert failed["task_id"] == "xafs-dp002-q01"
+    assert failed["error"] is None
+    assert failed["predicates"][0]["kind"] == "JudgeRubric"
+    assert failed["predicates"][0]["passed"] is False
+
+    summary = json.loads((run_dir / "agent-tasks-summary.json").read_text())
+    surface = summary["surfaces"][0]
+    assert surface["tasks_passed"] == 5
+    assert surface["tasks_errored"] == 0
+    # Headline excludes judge tokens: 6 tasks x 2 scripted model turns at
+    # 10 in / 5 out each; the judge's 7/3 per call lands only in judge_*.
+    assert surface["total_input_tokens"] == 120
+    assert surface["total_output_tokens"] == 60
+    assert surface["tokens_per_completed_task"] == 36.0
+    assert surface["judge_calls"] == 6
+    assert surface["judge_input_tokens"] == 42
+    assert surface["judge_output_tokens"] == 18
+    assert surface["per_skill"]["single_hop"] == {
+        "total": 2,
+        "passed": 1,
+        "tokens_per_completed": 60.0,
+    }
+    # tokens/correct per group (persona) is the corpus-scaling curve.
+    assert surface["per_group"]["xafs-dp001"] == {
+        "total": 4,
+        "passed": 4,
+        "tokens_per_completed": 30.0,
+    }
+    assert surface["per_group"]["xafs-dp002"] == {
+        "total": 2,
+        "passed": 1,
+        "tokens_per_completed": 60.0,
+    }
+
+    report = (run_dir / "summary.md").read_text()
+    assert "## Per group (persona)" in report
+    assert "| rich | xafs-dp001 | 4/4 | 30.0 |" in report
+    assert "| rich | xafs-dp002 | 1/2 | 60.0 |" in report
+    assert "## Judge usage (never part of the headline)" in report
+    assert "- rich: 60 tokens over 6 calls" in report
+
+    # The scripted {project} placeholder resolved to the shared group project.
+    assert session.calls[0][1]["project"] == "at-xafs-run-xafs-dp001"
+    assert len(judge.prompts) == 6
+
+
+def test_mixed_grouped_and_ungrouped_task_set_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_bm(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    mixed = [
+        AgentTaskSpec(
+            id="a",
+            skill="s",
+            source="src",
+            prompt="p",
+            graders=(JudgeRubric(rubric="r"),),
+            group="g1",
+        ),
+        AgentTaskSpec(
+            id="b", skill="s", source="src", prompt="p", graders=(JudgeRubric(rubric="r"),)
+        ),
+    ]
+    monkeypatch.setattr(driver, "load_task_manifest", lambda path, task_ids=None: mixed)
+    # The manifest file must exist: the driver fingerprints it before loading.
+    (tmp_path / "tasks.json").write_text("[]", encoding="utf-8")
+    config = _config(tmp_path, task_ids=[], task_manifest="tasks.json")
+
+    with pytest.raises(ValueError, match="mixes grouped and ungrouped"):
+        run_agent_tasks(
+            config,
+            model_factory=lambda spec: _orphan_agent(),
+            session_factory=lambda runtime: FakeSession(RICH_SURFACE.tool_allowlist),
+        )
+
+
+def test_grouped_run_requires_the_converter_groups_layout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_bm(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    root = write_xafs_root(tmp_path)
+    _, tasks_path, _, _ = convert_xafs_to_corpus(
+        dataset_root=root, output_dir=tmp_path / "generated"
+    )
+    # corpus_dir left at the shipped flat corpus: the run must refuse rather
+    # than checksum one corpus and ingest another.
+    config = _config(tmp_path, task_ids=[], task_manifest=str(tasks_path))
+
+    with pytest.raises(ValueError, match="must point at the converter's groups/"):
+        run_agent_tasks(
+            config,
+            model_factory=lambda spec: _xafs_agent(),
+            session_factory=lambda runtime: FakeSession(RICH_SURFACE.tool_allowlist),
+        )
 
 
 class TestToolOutcomeFromResult:

--- a/benchmarks/tests/agent_tasks/test_manifest_source.py
+++ b/benchmarks/tests/agent_tasks/test_manifest_source.py
@@ -1,0 +1,246 @@
+"""Task-manifest source tests: parse, fail-fast schema, id filter, state predicate."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from basic_memory_benchmarks.agent_tasks.manifest import load_task_manifest
+from basic_memory_benchmarks.agent_tasks.spec import (
+    AgentTaskSpec,
+    AnswerContains,
+    AnswerMatches,
+    AnswerSetEquals,
+    Grader,
+    JudgeRubric,
+    MarkerAbsent,
+    MarkerPresent,
+    NoteCountDelta,
+    NotesUntouched,
+    RelationResolves,
+    ToolCalled,
+    spec_needs_project_state,
+)
+
+
+def _row(task_id: str = "xafs-dp001-q01", group: str = "xafs-dp001", **overrides: Any) -> dict:
+    row: dict[str, Any] = {
+        "id": task_id,
+        "skill": "single_hop",
+        "group": group,
+        "source": "supermemory/xAFS dp_001 q01 @21142b2c",
+        "prompt": "What was the amount of the invoice?",
+        "graders": [{"kind": "judge_rubric", "rubric": "Question: ...\nGold answer: ..."}],
+    }
+    row.update(overrides)
+    return row
+
+
+def _write_manifest(tmp_path: Path, rows: object) -> Path:
+    path = tmp_path / "tasks.json"
+    path.write_text(json.dumps(rows), encoding="utf-8")
+    return path
+
+
+def test_manifest_rows_parse_into_specs(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path, [_row()])
+
+    (spec,) = load_task_manifest(path)
+
+    assert spec == AgentTaskSpec(
+        id="xafs-dp001-q01",
+        skill="single_hop",
+        source="supermemory/xAFS dp_001 q01 @21142b2c",
+        prompt="What was the amount of the invoice?",
+        graders=(JudgeRubric(rubric="Question: ...\nGold answer: ..."),),
+        group="xafs-dp001",
+    )
+    assert spec.graders[0].required is True
+
+
+def test_tool_called_grader_parses_as_diagnostic(tmp_path: Path) -> None:
+    row = _row(graders=[{"kind": "tool_called", "name_pattern": "search_.*"}])
+    path = _write_manifest(tmp_path, [row])
+
+    (spec,) = load_task_manifest(path)
+
+    assert spec.graders == (ToolCalled(name_pattern="search_.*"),)
+    assert spec.graders[0].required is False  # diagnostics never gate a pass
+
+
+def test_tasks_are_ordered_group_then_id(tmp_path: Path) -> None:
+    # Shuffled input: the loader orders (group, id) so the driver ingests each
+    # group corpus once and runs its tasks contiguously.
+    rows = [
+        _row("xafs-dp002-q01", group="xafs-dp002"),
+        _row("xafs-dp001-q02"),
+        _row("xafs-dp001-q01"),
+    ]
+    path = _write_manifest(tmp_path, rows)
+
+    specs = load_task_manifest(path)
+
+    assert [spec.id for spec in specs] == [
+        "xafs-dp001-q01",
+        "xafs-dp001-q02",
+        "xafs-dp002-q01",
+    ]
+
+
+def test_id_filter_selects_subset_and_dedupes(tmp_path: Path) -> None:
+    rows = [_row("a-q1", group="a"), _row("a-q2", group="a"), _row("b-q1", group="b")]
+    path = _write_manifest(tmp_path, rows)
+
+    specs = load_task_manifest(path, task_ids=["b-q1", "a-q1", "b-q1"])
+
+    assert [spec.id for spec in specs] == ["a-q1", "b-q1"]
+
+
+def test_unknown_filter_id_rejected_listing_known(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path, [_row()])
+
+    with pytest.raises(ValueError, match=r"Unknown task ids: \['nope'\]") as excinfo:
+        load_task_manifest(path, task_ids=["nope"])
+    assert "xafs-dp001-q01" in str(excinfo.value)
+
+
+def test_missing_manifest_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_task_manifest(tmp_path / "missing.json")
+
+
+@pytest.mark.parametrize("payload", [{}, [], "rows"])
+def test_manifest_must_be_nonempty_array(tmp_path: Path, payload: object) -> None:
+    path = _write_manifest(tmp_path, payload)
+
+    with pytest.raises(ValueError, match="non-empty JSON array"):
+        load_task_manifest(path)
+
+
+def test_non_object_task_row_fails(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path, ["not a task"])
+
+    with pytest.raises(ValueError, match="task at index 0 is not an object"):
+        load_task_manifest(path)
+
+
+@pytest.mark.parametrize("missing", ["id", "skill", "group", "source", "prompt", "graders"])
+def test_missing_task_key_is_named(tmp_path: Path, missing: str) -> None:
+    row = _row()
+    del row[missing]
+    path = _write_manifest(tmp_path, [row])
+
+    with pytest.raises(ValueError, match=f"missing keys \\['{missing}'\\]"):
+        load_task_manifest(path)
+
+
+def test_empty_string_field_fails(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path, [_row(prompt="   ")])
+
+    with pytest.raises(ValueError, match="empty or non-string 'prompt'"):
+        load_task_manifest(path)
+
+
+@pytest.mark.parametrize("graders", [[], "judge"])
+def test_empty_or_non_list_graders_fails(tmp_path: Path, graders: object) -> None:
+    path = _write_manifest(tmp_path, [_row(graders=graders)])
+
+    with pytest.raises(ValueError, match="empty or non-list 'graders'"):
+        load_task_manifest(path)
+
+
+def test_non_object_grader_fails(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path, [_row(graders=["judge_rubric"])])
+
+    with pytest.raises(ValueError, match="grader is not an object"):
+        load_task_manifest(path)
+
+
+def test_unknown_grader_kind_fails_listing_v1_kinds(tmp_path: Path) -> None:
+    # v1 manifest kinds are the state-free pair only: manifest tasks share
+    # read-only group projects where project-state graders would
+    # cross-contaminate. Unknown kinds fail fast, never silently skip.
+    row = _row(graders=[{"kind": "note_count_delta", "delta": 1}])
+    path = _write_manifest(tmp_path, [row])
+
+    with pytest.raises(ValueError, match="unknown grader kind 'note_count_delta'") as excinfo:
+        load_task_manifest(path)
+    assert "judge_rubric, tool_called" in str(excinfo.value)
+
+
+def test_judge_rubric_without_rubric_text_fails(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path, [_row(graders=[{"kind": "judge_rubric", "rubric": ""}])])
+
+    with pytest.raises(ValueError, match="judge_rubric has no rubric text"):
+        load_task_manifest(path)
+
+
+def test_tool_called_without_pattern_fails(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path, [_row(graders=[{"kind": "tool_called"}])])
+
+    with pytest.raises(ValueError, match="tool_called has no name_pattern"):
+        load_task_manifest(path)
+
+
+def test_duplicate_task_id_fails(tmp_path: Path) -> None:
+    path = _write_manifest(tmp_path, [_row(), _row()])
+
+    with pytest.raises(ValueError, match="duplicate task id 'xafs-dp001-q01'"):
+        load_task_manifest(path)
+
+
+# --- Grader kind -> project-state predicate mapping ---
+
+
+def _spec_with(*graders: Grader) -> AgentTaskSpec:
+    return AgentTaskSpec(id="t", skill="s", source="src", prompt="p", graders=tuple(graders))
+
+
+@pytest.mark.parametrize(
+    "grader",
+    [
+        AnswerSetEquals(key="k", gold=frozenset({"x"})),
+        MarkerPresent(marker="M"),
+        MarkerAbsent(marker="M"),
+        AnswerContains(needle="x"),
+        AnswerMatches(pattern="x"),
+        ToolCalled(name_pattern="x"),
+        JudgeRubric(rubric="r"),
+    ],
+)
+def test_answer_and_trace_graders_are_state_free(grader: Grader) -> None:
+    assert spec_needs_project_state(_spec_with(grader)) is False
+
+
+@pytest.mark.parametrize(
+    "grader",
+    [
+        NoteCountDelta(delta=1),
+        NotesUntouched(),
+        RelationResolves(source_permalink="p", targets=frozenset({"t"})),
+    ],
+)
+def test_project_state_graders_keep_the_full_flow(grader: Grader) -> None:
+    assert spec_needs_project_state(_spec_with(grader)) is True
+
+
+def test_one_stateful_grader_makes_the_spec_stateful() -> None:
+    spec = _spec_with(JudgeRubric(rubric="r"), NoteCountDelta(delta=0))
+    assert spec_needs_project_state(spec) is True
+
+
+def test_manifest_loaded_specs_are_state_free(tmp_path: Path) -> None:
+    # The v1 manifest kinds are exactly the state-free set, so every
+    # manifest-loaded task skips baseline snapshot and post-loop settle.
+    rows = [
+        _row("a-q1", group="a"),
+        _row("a-q2", group="a", graders=[{"kind": "tool_called", "name_pattern": "read_.*"}]),
+    ]
+    path = _write_manifest(tmp_path, rows)
+
+    specs = load_task_manifest(path)
+
+    assert all(spec_needs_project_state(spec) is False for spec in specs)

--- a/benchmarks/tests/agent_tasks/test_surfaces.py
+++ b/benchmarks/tests/agent_tasks/test_surfaces.py
@@ -9,6 +9,7 @@ from basic_memory_benchmarks.agent_tasks.surfaces import (
     RICH_SURFACE,
     SURFACES,
     SurfaceUnavailableError,
+    read_only_view,
     surface_env,
     verify_surface_tools,
 )
@@ -32,6 +33,26 @@ def test_posix_allowlist_is_read_swap_plus_shared_write_verbs() -> None:
 
 def test_rich_surface_needs_no_config_overrides() -> None:
     assert RICH_SURFACE.config_overrides == {}
+
+
+def test_read_only_view_drops_shared_write_verbs_symmetrically() -> None:
+    # Dataset-manifest runs share one warm project per (surface, group), so
+    # the same four write verbs disappear from BOTH surfaces (fairness).
+    rich_view = read_only_view(RICH_SURFACE)
+    posix_view = read_only_view(POSIX_SURFACE)
+
+    assert rich_view.tool_allowlist == RICH_SURFACE.tool_allowlist[:6]
+    assert posix_view.tool_allowlist == POSIX_READ_TOOLS
+    for view in (rich_view, posix_view):
+        assert not set(SHARED_WRITE_TOOLS) & set(view.tool_allowlist)
+
+
+def test_read_only_view_preserves_identity_and_overrides() -> None:
+    posix_view = read_only_view(POSIX_SURFACE)
+
+    assert posix_view.name == "posix"
+    assert posix_view.config_overrides == POSIX_SURFACE.config_overrides
+    assert posix_view.requires == POSIX_SURFACE.requires
 
 
 def test_surface_env_maps_flag_to_basic_memory_env_var() -> None:

--- a/benchmarks/tests/converters/test_xafs_converter.py
+++ b/benchmarks/tests/converters/test_xafs_converter.py
@@ -1,0 +1,428 @@
+"""xAFS converter tests: verbatim copy, anti-leakage, manifest, corrections, sampling."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from basic_memory_benchmarks.converters.xafs_to_corpus import (
+    _copy_persona_files,
+    _stratified_allocation,
+    build_judge_rubric,
+    convert_xafs_to_corpus,
+    load_xafs_corrections,
+    sample_xafs_audit,
+    xafs_group_id,
+)
+from basic_memory_benchmarks.datasets.xafs import XAFS_REVISION, XafsPersona
+from basic_memory_benchmarks.utils import sha256_file
+from xafs_fixture import (
+    DP1_FILES,
+    DP1_Q1_PROMPT,
+    DP1_Q3_PROMPT,
+    question,
+    write_persona,
+    write_xafs_root,
+)
+
+EXPECTED_TASK_IDS = [
+    "xafs-dp001-q01",
+    "xafs-dp001-q02",
+    "xafs-dp001-q03",
+    "xafs-dp001-q04",
+    "xafs-dp002-q01",
+    "xafs-dp002-q02",
+]
+
+
+def _convert(tmp_path: Path, **kwargs: Any) -> tuple[Path, Path, int, int]:
+    root = write_xafs_root(tmp_path)
+    return convert_xafs_to_corpus(dataset_root=root, output_dir=tmp_path / "generated", **kwargs)
+
+
+def _tasks(output_dir: Path) -> list[dict[str, Any]]:
+    return json.loads((output_dir / "tasks.json").read_text(encoding="utf-8"))
+
+
+def _conversion(output_dir: Path) -> dict[str, Any]:
+    return json.loads((output_dir / "conversion.json").read_text(encoding="utf-8"))
+
+
+def test_group_id_strips_the_underscore() -> None:
+    assert xafs_group_id("dp_001") == "xafs-dp001"
+
+
+def test_verbatim_copy_including_non_markdown(tmp_path: Path) -> None:
+    root = write_xafs_root(tmp_path)
+    groups_dir, tasks_path, file_count, task_count = _convert(tmp_path)
+
+    assert groups_dir == tmp_path / "generated" / "groups"
+    assert tasks_path == tmp_path / "generated" / "tasks.json"
+    assert file_count == 6
+    assert task_count == 6
+    # Byte-for-byte, data/ relpaths preserved (one path vocabulary with
+    # gold_file_ids), no frontmatter render — the .eml included.
+    for relpath in DP1_FILES:
+        source = (root / "dp_001" / relpath).read_bytes()
+        copied = (groups_dir / "xafs-dp001" / "docs" / relpath).read_bytes()
+        assert copied == source, relpath
+    assert (groups_dir / "xafs-dp001" / "docs" / "data/mail/2026-04-01_invoice.eml").is_file()
+
+
+def test_answer_key_never_lands_in_docs(tmp_path: Path) -> None:
+    groups_dir, _, _, _ = _convert(tmp_path)
+
+    leaked = [path for path in groups_dir.rglob("question.json")]
+    assert leaked == []
+    # Only data/ subtrees are copied: nothing outside docs/data exists.
+    for group_dir in groups_dir.iterdir():
+        docs = group_dir / "docs"
+        assert sorted(entry.name for entry in docs.iterdir()) == ["data"]
+
+
+@pytest.mark.parametrize("forbidden", ["question.json", "SCENARIO.md", "facts.json"])
+def test_forbidden_basename_inside_data_aborts(tmp_path: Path, forbidden: str) -> None:
+    # An answer-key/scenario file inside data/ means the upstream layout
+    # changed under us; conversion must abort, not ingest it.
+    root = tmp_path / "root"
+    write_persona(
+        root,
+        "dp_001",
+        {"data/notes/a.md": "alpha\n", f"data/misc/{forbidden}": "leak\n"},
+        [question("q01", "single_hop", "Alpha?", ["data/notes/a.md"], "alpha")],
+    )
+
+    with pytest.raises(ValueError, match="answer-key/scenario file"):
+        convert_xafs_to_corpus(dataset_root=root, output_dir=tmp_path / "out")
+
+
+def test_escaping_relpath_defense_in_depth(tmp_path: Path) -> None:
+    # data_files come from rglob so this is unreachable via load_xafs; the
+    # copy still refuses a crafted/symlinked layout rather than escaping.
+    persona = XafsPersona(
+        persona_id="dp_666",
+        root=tmp_path,
+        data_files=("data/../evil.md",),
+        questions=(),
+    )
+    with pytest.raises(ValueError, match="escapes the persona"):
+        _copy_persona_files(persona, tmp_path / "group")
+
+
+def _symlink_or_skip(link: Path, target: str) -> None:
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symbolic links not supported on this filesystem")
+
+
+def test_symlinked_data_file_aborts_conversion(tmp_path: Path) -> None:
+    # A symlink named like corpus data passes the relpath-string checks under
+    # its own name; copying it would materialize the answer key into the
+    # ingested haystack, so conversion must refuse it.
+    root = tmp_path / "root"
+    write_persona(
+        root,
+        "dp_001",
+        {"data/notes/a.md": "alpha\n"},
+        [question("q01", "single_hop", "Alpha?", ["data/notes/a.md"], "alpha")],
+    )
+    _symlink_or_skip(root / "dp_001" / "data" / "leak.md", "../question.json")
+
+    with pytest.raises(ValueError, match="symlink"):
+        convert_xafs_to_corpus(dataset_root=root, output_dir=tmp_path / "out")
+
+
+def test_conversion_manifest_counts_and_empty_skipped(tmp_path: Path) -> None:
+    root = write_xafs_root(tmp_path)
+    _convert(tmp_path)
+
+    manifest = _conversion(tmp_path / "generated")
+    assert manifest["dataset_id"] == "xafs"
+    assert manifest["revision"] == XAFS_REVISION
+    assert "secondary dataset" in manifest["license_note"]
+    assert manifest["file_count"] == 6
+    assert manifest["task_count"] == 6
+    # The never-silently-dropped contract: the list exists and is empty.
+    assert manifest["skipped"] == []
+    assert manifest["corrections"] == {"applied": 0, "excluded": []}
+
+    dp1, dp2 = manifest["personas"]
+    assert dp1["persona_id"] == "dp_001"
+    assert dp1["group_id"] == "xafs-dp001"
+    assert dp1["file_count"] == 4
+    assert dp1["files_by_extension"] == {".eml": 1, ".md": 3}
+    assert dp1["question_count"] == 4
+    assert dp1["question_file_sha256"] == sha256_file(root / "dp_001" / "question.json")
+    assert dp2["files_by_extension"] == {".md": 2}
+
+
+def test_tasks_manifest_rows_route_families_to_judge_graded_tasks(tmp_path: Path) -> None:
+    _convert(tmp_path)
+
+    tasks = _tasks(tmp_path / "generated")
+    assert [row["id"] for row in tasks] == EXPECTED_TASK_IDS
+    # skill = family: the per-skill report becomes the per-question-type
+    # breakdown; every question routes to the agent harness as judge-graded.
+    assert [row["skill"] for row in tasks] == [
+        "single_hop",
+        "multi_hop",
+        "format_spanning",
+        "format_spanning",
+        "single_hop",
+        "multi_hop",
+    ]
+    first = tasks[0]
+    assert first["group"] == "xafs-dp001"
+    assert first["source"] == f"supermemory/xAFS dp_001 q01 @{XAFS_REVISION[:8]}"
+    assert first["prompt"] == DP1_Q1_PROMPT
+    (grader,) = first["graders"]
+    assert grader["kind"] == "judge_rubric"
+    assert grader["rubric"] == build_judge_rubric(DP1_Q1_PROMPT, "$2,034")
+    assert f"Question: {DP1_Q1_PROMPT}" in grader["rubric"]
+    assert "Gold answer: $2,034" in grader["rubric"]
+    assert first["metadata"] == {
+        "gold_file_ids": ["data/client/kickoff-transcript.md"],
+        "gold_answer": "$2,034",
+    }
+
+
+def test_no_retrieval_queries_artifact_is_emitted(tmp_path: Path) -> None:
+    # The retrieval diagnostic is deferred (provider doc-id collision); an
+    # artifact no stage can consume correctly must not exist.
+    _convert(tmp_path)
+
+    assert not (tmp_path / "generated" / "queries.json").exists()
+
+
+def test_persona_subsetting(tmp_path: Path) -> None:
+    groups_dir, _, file_count, task_count = _convert(tmp_path, personas=["dp_001"])
+
+    assert file_count == 4
+    assert task_count == 4
+    assert sorted(entry.name for entry in groups_dir.iterdir()) == ["xafs-dp001"]
+    manifest = _conversion(tmp_path / "generated")
+    assert manifest["converter"]["personas"] == ["dp_001"]
+    assert [row["group"] for row in _tasks(tmp_path / "generated")] == ["xafs-dp001"] * 4
+
+
+def test_checksums_deterministic_across_runs(tmp_path: Path) -> None:
+    root = write_xafs_root(tmp_path)
+    convert_xafs_to_corpus(dataset_root=root, output_dir=tmp_path / "run-a")
+    convert_xafs_to_corpus(dataset_root=root, output_dir=tmp_path / "run-b")
+
+    manifest_a = json.loads((tmp_path / "run-a" / "conversion.json").read_text())
+    manifest_b = json.loads((tmp_path / "run-b" / "conversion.json").read_text())
+    assert manifest_a["personas"] == manifest_b["personas"]
+    assert manifest_a["personas"][0]["data_files_sha256"]
+
+
+def test_reconversion_prunes_files_gone_upstream(tmp_path: Path) -> None:
+    # A revision bump re-fetched in place: `hf download` never prunes removed
+    # files, and neither would overwrite-only copying — the stale file would
+    # sit in the ingested haystack while conversion.json counts the new set.
+    root = write_xafs_root(tmp_path)
+    stale_upstream = root / "dp_001" / "data" / "notes" / "scratch.md"
+    stale_upstream.write_text("draft that the next revision removes\n", encoding="utf-8")
+    output_dir = tmp_path / "generated"
+    convert_xafs_to_corpus(dataset_root=root, output_dir=output_dir)
+    stale_copy = output_dir / "groups" / "xafs-dp001" / "docs" / "data" / "notes" / "scratch.md"
+    assert stale_copy.is_file()
+
+    stale_upstream.unlink()
+    _, _, file_count, _ = convert_xafs_to_corpus(dataset_root=root, output_dir=output_dir)
+
+    assert not stale_copy.exists()
+    assert file_count == 6  # docs/ mirrors exactly this conversion's inputs
+
+
+# --- Corrections hook (locomo-audit precedent) ---
+
+
+def _write_corrections(tmp_path: Path, payload: object) -> Path:
+    path = tmp_path / "corrections.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_correction_overrides_gold_answer_everywhere(tmp_path: Path) -> None:
+    corrections = _write_corrections(
+        tmp_path, {"dp_001/q01": {"prompt": DP1_Q1_PROMPT, "gold_answer": "$9,999"}}
+    )
+    _convert(tmp_path, corrections_path=corrections)
+
+    tasks = _tasks(tmp_path / "generated")
+    first = tasks[0]
+    assert first["metadata"]["gold_answer"] == "$9,999"
+    assert "Gold answer: $9,999" in first["graders"][0]["rubric"]
+    manifest = _conversion(tmp_path / "generated")
+    assert manifest["corrections"] == {"applied": 1, "excluded": []}
+    assert manifest["converter"]["corrections_path"] == str(corrections)
+
+
+def test_correction_prompt_drift_fails_loudly(tmp_path: Path) -> None:
+    corrections = _write_corrections(
+        tmp_path, {"dp_001/q01": {"prompt": "A different question?", "gold_answer": "$9,999"}}
+    )
+    with pytest.raises(ValueError, match="drifted"):
+        _convert(tmp_path, corrections_path=corrections)
+
+
+def test_correction_exclusion_drops_the_task_and_counts_it(tmp_path: Path) -> None:
+    corrections = _write_corrections(
+        tmp_path,
+        {"dp_001/q03": {"prompt": DP1_Q3_PROMPT, "excluded": True, "reason": "ambiguous gold"}},
+    )
+    _, _, _, task_count = _convert(tmp_path, corrections_path=corrections)
+
+    assert task_count == 5
+    task_ids = [row["id"] for row in _tasks(tmp_path / "generated")]
+    assert "xafs-dp001-q03" not in task_ids
+    manifest = _conversion(tmp_path / "generated")
+    assert manifest["corrections"]["excluded"] == [
+        {"question": "dp_001/q03", "reason": "ambiguous gold"}
+    ]
+
+
+def test_stale_correction_for_selected_persona_fails(tmp_path: Path) -> None:
+    corrections = _write_corrections(
+        tmp_path, {"dp_001/q99": {"prompt": "Gone?", "gold_answer": "x"}}
+    )
+    with pytest.raises(ValueError, match=r"unknown questions: \['dp_001/q99'\]"):
+        _convert(tmp_path, corrections_path=corrections)
+
+
+def test_correction_for_unselected_persona_is_ignored_under_subsetting(tmp_path: Path) -> None:
+    corrections = _write_corrections(
+        tmp_path, {"dp_002/q01": {"prompt": "whatever", "gold_answer": "x"}}
+    )
+    _, _, _, task_count = _convert(tmp_path, personas=["dp_001"], corrections_path=corrections)
+
+    assert task_count == 4
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        (["not", "an", "object"], "must be a JSON object"),
+        ({"dp_001/q01": "not an object"}, "is not an object"),
+        ({"dp_001/q01": {"gold_answer": "x"}}, "needs the upstream 'prompt'"),
+        ({"dp_001/q01": {"prompt": "p", "excluded": True}}, "excludes without a 'reason'"),
+        (
+            {"dp_001/q01": {"prompt": "p", "excluded": True, "reason": "r", "gold_answer": "x"}},
+            "both excludes and overrides",
+        ),
+        ({"dp_001/q01": {"prompt": "p"}}, "must override 'gold_answer' or set 'excluded'"),
+    ],
+)
+def test_malformed_corrections_fail(tmp_path: Path, payload: object, match: str) -> None:
+    corrections = _write_corrections(tmp_path, payload)
+
+    with pytest.raises(ValueError, match=match):
+        load_xafs_corrections(corrections)
+
+
+# --- Audit sampling ---
+
+
+def test_stratified_allocation_uses_largest_remainder() -> None:
+    # The real shipped counts: 20 * (33, 51, 26) / 110 -> floors (6, 9, 4)
+    # with one remainder seat going to format_spanning (largest fraction).
+    counts = {"single_hop": 33, "multi_hop": 51, "format_spanning": 26}
+    assert _stratified_allocation(counts, 20) == {
+        "single_hop": 6,
+        "multi_hop": 9,
+        "format_spanning": 5,
+    }
+    # Sample >= population: everything is selected.
+    assert _stratified_allocation(counts, 200) == counts
+
+
+def test_audit_sample_covers_all_when_n_exceeds_total(tmp_path: Path) -> None:
+    root = write_xafs_root(tmp_path)
+    sample_path, sampled = sample_xafs_audit(
+        dataset_root=root, output_dir=tmp_path / "audit", sample_size=20, seed=42
+    )
+
+    assert sampled == 6
+    records = json.loads(sample_path.read_text(encoding="utf-8"))
+    assert [(row["persona_id"], row["id"]) for row in records] == [
+        ("dp_001", "q01"),
+        ("dp_001", "q02"),
+        ("dp_001", "q03"),
+        ("dp_001", "q04"),
+        ("dp_002", "q01"),
+        ("dp_002", "q02"),
+    ]
+    q03 = records[2]
+    assert q03["family"] == "format_spanning"
+    assert q03["gold_file_ids"] == ["data/mail/2026-04-01_invoice.eml"]
+
+    # Verbatim gold-file copies for the human reviewer, .eml included.
+    copied = tmp_path / "audit" / "sources" / "dp_001-q03" / "data/mail/2026-04-01_invoice.eml"
+    assert (
+        copied.read_bytes() == (root / "dp_001" / "data/mail/2026-04-01_invoice.eml").read_bytes()
+    )
+
+    sample_md = (tmp_path / "audit" / "sample.md").read_text(encoding="utf-8")
+    assert "## dp_001/q03 (format_spanning)" in sample_md
+    assert DP1_Q3_PROMPT in sample_md
+    assert "corrections.json" in sample_md
+
+
+def test_audit_sample_is_stratified_and_seed_deterministic(tmp_path: Path) -> None:
+    root = write_xafs_root(tmp_path)
+    sample_path_a, sampled = sample_xafs_audit(
+        dataset_root=root, output_dir=tmp_path / "audit-a", sample_size=3, seed=7
+    )
+    sample_path_b, _ = sample_xafs_audit(
+        dataset_root=root, output_dir=tmp_path / "audit-b", sample_size=3, seed=7
+    )
+
+    assert sampled == 3
+    records = json.loads(sample_path_a.read_text(encoding="utf-8"))
+    # 2/2/2 questions per family and n=3 -> exactly one per family.
+    assert sorted(row["family"] for row in records) == [
+        "format_spanning",
+        "multi_hop",
+        "single_hop",
+    ]
+    assert sample_path_a.read_text() == sample_path_b.read_text()
+
+
+def test_resampling_prunes_stale_sources(tmp_path: Path) -> None:
+    # Re-sampling into the same output_dir with a different --n/--seed must
+    # not leave sources/ dirs the new audit-sample.json no longer references.
+    root = write_xafs_root(tmp_path)
+    audit_dir = tmp_path / "audit"
+    sample_xafs_audit(dataset_root=root, output_dir=audit_dir, sample_size=20, seed=42)
+    assert len(list((audit_dir / "sources").iterdir())) == 6
+
+    sample_path, sampled = sample_xafs_audit(
+        dataset_root=root, output_dir=audit_dir, sample_size=3, seed=7
+    )
+
+    assert sampled == 3
+    records = json.loads(sample_path.read_text(encoding="utf-8"))
+    expected_dirs = sorted(f"{row['persona_id']}-{row['id']}" for row in records)
+    assert sorted(entry.name for entry in (audit_dir / "sources").iterdir()) == expected_dirs
+
+
+def test_symlinked_gold_file_aborts_audit_sampling(tmp_path: Path) -> None:
+    # Same hole as the persona copy: the loader's is_file() existence check
+    # follows links, so a gold-file symlink would land its target in the
+    # audit output. The sampler must refuse it.
+    root = tmp_path / "root"
+    write_persona(
+        root,
+        "dp_001",
+        {"data/notes/a.md": "alpha\n"},
+        [question("q01", "single_hop", "Alpha?", ["data/leak.md"], "alpha")],
+    )
+    _symlink_or_skip(root / "dp_001" / "data" / "leak.md", "../question.json")
+
+    with pytest.raises(ValueError, match="symlink"):
+        sample_xafs_audit(dataset_root=root, output_dir=tmp_path / "audit")

--- a/benchmarks/tests/test_cli_surface.py
+++ b/benchmarks/tests/test_cli_surface.py
@@ -1,4 +1,6 @@
+import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 from typer.testing import CliRunner
@@ -6,6 +8,7 @@ from typer.testing import CliRunner
 from basic_memory_benchmarks import cli
 from basic_memory_benchmarks.agent_tasks.models import AgentTasksConfig
 from basic_memory_benchmarks.cli import app
+from xafs_fixture import write_xafs_root
 
 
 runner = CliRunner()
@@ -55,9 +58,232 @@ def test_run_agent_tasks_command_wired() -> None:
     assert "--surfaces" in result.output
     assert "--model" in result.output
     assert "--tasks" in result.output
+    assert "--task-manifest" in result.output
     assert "--bm-local-path" in result.output
     assert "--max-turns" in result.output
     assert "--strict-surfaces" in result.output
+
+
+def test_convert_xafs_command_wired() -> None:
+    result = runner.invoke(app, ["convert", "xafs", "--help"])
+
+    assert result.exit_code == 0
+    assert "--dataset-root" in result.output
+    assert "--output-dir" in result.output
+    assert "--personas" in result.output
+    assert "--corrections" in result.output
+
+
+def test_sample_xafs_command_wired() -> None:
+    result = runner.invoke(app, ["sample", "xafs", "--help"])
+
+    assert result.exit_code == 0
+    assert "--dataset-root" in result.output
+    assert "--personas" in result.output
+    assert "--n" in result.output
+    assert "--seed" in result.output
+    assert "--output" in result.output
+
+
+def test_convert_and_sample_xafs_end_to_end(tmp_path: Path) -> None:
+    root = write_xafs_root(tmp_path)
+    output_dir = tmp_path / "generated"
+
+    convert = runner.invoke(
+        app,
+        [
+            "convert",
+            "xafs",
+            "--dataset-root",
+            str(root),
+            "--output-dir",
+            str(output_dir),
+            "--personas",
+            "dp_001",
+        ],
+    )
+
+    assert convert.exit_code == 0, convert.output
+    assert (output_dir / "tasks.json").exists()
+    assert (output_dir / "conversion.json").exists()
+    assert (output_dir / "groups" / "xafs-dp001" / "docs").is_dir()
+
+    audit_dir = tmp_path / "audit"
+    sample = runner.invoke(
+        app,
+        [
+            "sample",
+            "xafs",
+            "--dataset-root",
+            str(root),
+            "--n",
+            "3",
+            "--output",
+            str(audit_dir),
+        ],
+    )
+
+    assert sample.exit_code == 0, sample.output
+    assert (audit_dir / "audit-sample.json").exists()
+    assert (audit_dir / "sample.md").exists()
+
+
+def test_convert_xafs_missing_root_is_a_parameter_error(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["convert", "xafs", "--dataset-root", str(tmp_path / "missing")])
+
+    assert result.exit_code != 0
+    assert "download.sh" in result.output
+
+
+def _manifest_row() -> dict[str, Any]:
+    return {
+        "id": "xafs-dp001-q01",
+        "skill": "single_hop",
+        "group": "xafs-dp001",
+        "source": "supermemory/xAFS dp_001 q01 @21142b2c",
+        "prompt": "What was the amount?",
+        "graders": [{"kind": "judge_rubric", "rubric": "Gold answer: $2,034"}],
+    }
+
+
+def _agent_tasks_setup(tmp_path: Path) -> tuple[Path, Path, Path]:
+    manifest = tmp_path / "gen" / "tasks.json"
+    manifest.parent.mkdir()
+    manifest.write_text(json.dumps([_manifest_row()]), encoding="utf-8")
+    script = tmp_path / "script.json"
+    script.write_text('{"tasks": {}}', encoding="utf-8")
+    bm_checkout = tmp_path / "bm"
+    bm_checkout.mkdir()
+    return manifest, script, bm_checkout
+
+
+def test_task_manifest_derives_groups_corpus_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, AgentTasksConfig] = {}
+
+    def fake_run(config: AgentTasksConfig) -> Path:
+        captured["config"] = config
+        return tmp_path / "run"
+
+    monkeypatch.setattr(cli, "run_agent_tasks", fake_run)
+    manifest, script, bm_checkout = _agent_tasks_setup(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "agent-tasks",
+            "--task-manifest",
+            str(manifest),
+            "--model",
+            f"scripted:{script}",
+            "--judge",
+            "claude:claude-sonnet-4-6",
+            "--bm-local-path",
+            str(bm_checkout),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    config = captured["config"]
+    assert config.task_manifest == str(manifest)
+    # The default shipped-corpus dir would checksum the wrong corpus and then
+    # fail on missing group subtrees; a manifest run derives the sibling
+    # groups/ dir instead.
+    assert config.corpus_dir == str(manifest.parent / "groups")
+    assert config.judge_spec == "claude:claude-sonnet-4-6"
+
+
+def test_task_manifest_respects_explicit_corpus_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, AgentTasksConfig] = {}
+
+    def fake_run(config: AgentTasksConfig) -> Path:
+        captured["config"] = config
+        return tmp_path / "run"
+
+    monkeypatch.setattr(cli, "run_agent_tasks", fake_run)
+    manifest, script, bm_checkout = _agent_tasks_setup(tmp_path)
+    custom_corpus = tmp_path / "custom-groups"
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "agent-tasks",
+            "--task-manifest",
+            str(manifest),
+            "--corpus-dir",
+            str(custom_corpus),
+            "--model",
+            f"scripted:{script}",
+            "--judge",
+            "claude:claude-sonnet-4-6",
+            "--bm-local-path",
+            str(bm_checkout),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["config"].corpus_dir == str(custom_corpus)
+
+
+def test_task_manifest_judge_graded_tasks_require_judge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_run(config: AgentTasksConfig) -> Path:
+        raise AssertionError("run_agent_tasks must not start without a judge")
+
+    monkeypatch.setattr(cli, "run_agent_tasks", fail_run)
+    manifest, script, bm_checkout = _agent_tasks_setup(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "agent-tasks",
+            "--task-manifest",
+            str(manifest),
+            "--model",
+            f"scripted:{script}",
+            "--bm-local-path",
+            str(bm_checkout),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "judge_rubric" in result.output
+    assert "--judge" in result.output
+
+
+def test_task_manifest_unknown_task_id_is_a_parameter_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cli, "run_agent_tasks", lambda config: tmp_path / "run")
+    manifest, script, bm_checkout = _agent_tasks_setup(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "agent-tasks",
+            "--task-manifest",
+            str(manifest),
+            "--tasks",
+            "nope",
+            "--model",
+            f"scripted:{script}",
+            "--judge",
+            "claude:claude-sonnet-4-6",
+            "--bm-local-path",
+            str(bm_checkout),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Unknown task ids" in result.output
 
 
 def test_run_agent_tasks_dedupes_repeated_surfaces(

--- a/benchmarks/tests/test_xafs_dataset.py
+++ b/benchmarks/tests/test_xafs_dataset.py
@@ -1,0 +1,272 @@
+"""xAFS loader tests: discovery, subsetting, verbatim fields, fail-fast parsing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from basic_memory_benchmarks.datasets.xafs import (
+    XAFS_FAMILIES,
+    load_xafs,
+    load_xafs_persona,
+)
+from xafs_fixture import (
+    DP1_FILES,
+    DP1_INVOICE_AMOUNT,
+    DP1_Q1_PROMPT,
+    dp1_questions,
+    question,
+    write_persona,
+    write_xafs_root,
+)
+
+
+def test_family_constant_matches_upstream_keys() -> None:
+    assert XAFS_FAMILIES == ("single_hop", "multi_hop", "format_spanning")
+
+
+# --- Discovery and persona selection ---
+
+
+def test_load_discovers_every_persona_dir(tmp_path: Path) -> None:
+    root = write_xafs_root(tmp_path)
+    # Non-persona entries must be ignored, not rejected.
+    (root / "README.md").write_text("upstream readme", encoding="utf-8")
+    (root / "misc").mkdir()
+
+    personas = load_xafs(root)
+
+    assert [persona.persona_id for persona in personas] == ["dp_001", "dp_002"]
+    assert personas[0].root == root / "dp_001"
+
+
+def test_persona_subset_selection_dedupes_and_sorts(tmp_path: Path) -> None:
+    root = write_xafs_root(tmp_path)
+
+    personas = load_xafs(root, ["dp_002", "dp_002", "dp_001"])
+
+    assert [persona.persona_id for persona in personas] == ["dp_001", "dp_002"]
+    only_two = load_xafs(root, ["dp_002"])
+    assert [persona.persona_id for persona in only_two] == ["dp_002"]
+
+
+def test_unknown_persona_rejected_listing_available(tmp_path: Path) -> None:
+    root = write_xafs_root(tmp_path)
+
+    with pytest.raises(ValueError, match=r"Unknown xAFS personas \['dp_009'\]") as excinfo:
+        load_xafs(root, ["dp_001", "dp_009"])
+    assert "dp_001" in str(excinfo.value)
+    assert "dp_002" in str(excinfo.value)
+
+
+def test_missing_root_names_the_fetch_script(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="download.sh"):
+        load_xafs(tmp_path / "nope")
+
+
+def test_root_without_persona_dirs_is_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "empty-root"
+    (root / "not-a-persona").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="No xAFS persona directories"):
+        load_xafs(root)
+
+
+# --- Verbatim fields, ordering, extras ---
+
+
+def test_data_files_cover_every_extension_sorted(tmp_path: Path) -> None:
+    root = write_xafs_root(tmp_path)
+
+    (persona,) = load_xafs(root, ["dp_001"])
+
+    assert persona.data_files == tuple(sorted(DP1_FILES))
+    assert "data/mail/2026-04-01_invoice.eml" in persona.data_files
+    assert all(relpath.startswith("data/") for relpath in persona.data_files)
+
+
+def test_question_fields_round_trip_verbatim(tmp_path: Path) -> None:
+    root = write_xafs_root(tmp_path)
+
+    (persona,) = load_xafs(root, ["dp_001"])
+
+    assert [q.id for q in persona.questions] == ["q01", "q02", "q03", "q04"]
+    first = persona.questions[0]
+    assert first.persona_id == "dp_001"
+    assert first.family == "single_hop"
+    assert first.prompt == DP1_Q1_PROMPT
+    assert first.gold_file_ids == ("data/client/kickoff-transcript.md",)
+    assert first.gold_answer == DP1_INVOICE_AMOUNT
+    # Unknown upstream keys survive verbatim; known keys never leak into extras.
+    assert dict(first.extras) == {"difficulty": "easy"}
+    assert dict(persona.questions[1].extras) == {}
+
+
+def test_question_order_is_upstream_array_order_not_sorted(tmp_path: Path) -> None:
+    files = {"data/a.md": "alpha\n", "data/b.md": "beta\n"}
+    questions = [
+        question("q02", "single_hop", "Second first?", ["data/b.md"], "beta"),
+        question("q01", "multi_hop", "First second?", ["data/a.md", "data/b.md"], "alpha"),
+    ]
+    persona_dir = write_persona(tmp_path, "dp_007", files, questions)
+
+    persona = load_xafs_persona(persona_dir)
+
+    assert [q.id for q in persona.questions] == ["q02", "q01"]
+
+
+# --- Fail-fast parsing (stated assumptions -> loud errors, never guesses) ---
+
+
+def _dp1_dir(tmp_path: Path) -> Path:
+    return write_xafs_root(tmp_path) / "dp_001"
+
+
+def _rewrite_questions(persona_dir: Path, payload: object) -> None:
+    (persona_dir / "question.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_missing_question_json_fails(tmp_path: Path) -> None:
+    persona_dir = _dp1_dir(tmp_path)
+    (persona_dir / "question.json").unlink()
+
+    with pytest.raises(FileNotFoundError, match="no question.json"):
+        load_xafs_persona(persona_dir)
+
+
+def test_missing_data_dir_fails(tmp_path: Path) -> None:
+    persona_dir = tmp_path / "dp_003"
+    persona_dir.mkdir()
+    _rewrite_questions(persona_dir, dp1_questions())
+
+    with pytest.raises(FileNotFoundError, match="no data/ directory"):
+        load_xafs_persona(persona_dir)
+
+
+def test_empty_data_dir_fails(tmp_path: Path) -> None:
+    persona_dir = tmp_path / "dp_003"
+    (persona_dir / "data").mkdir(parents=True)
+    _rewrite_questions(persona_dir, dp1_questions())
+
+    with pytest.raises(ValueError, match="data/ directory is empty"):
+        load_xafs_persona(persona_dir)
+
+
+@pytest.mark.parametrize("payload", [{"questions": []}, [], "not a list"])
+def test_question_json_must_be_nonempty_array(tmp_path: Path, payload: object) -> None:
+    persona_dir = _dp1_dir(tmp_path)
+    _rewrite_questions(persona_dir, payload)
+
+    with pytest.raises(ValueError, match="non-empty JSON array"):
+        load_xafs_persona(persona_dir)
+
+
+def test_non_object_question_record_fails(tmp_path: Path) -> None:
+    persona_dir = _dp1_dir(tmp_path)
+    _rewrite_questions(persona_dir, ["not an object"])
+
+    with pytest.raises(ValueError, match="is not an object"):
+        load_xafs_persona(persona_dir)
+
+
+def test_missing_required_key_is_named(tmp_path: Path) -> None:
+    broken = dp1_questions()
+    del broken[1]["family"]
+    persona_dir = _dp1_dir(tmp_path)
+    _rewrite_questions(persona_dir, broken)
+
+    with pytest.raises(ValueError, match=r"missing keys \['family'\]"):
+        load_xafs_persona(persona_dir)
+
+
+@pytest.mark.parametrize("key", ["id", "prompt", "gold_answer"])
+@pytest.mark.parametrize("bad_value", ["", "   ", 3])
+def test_empty_or_non_string_required_field_fails(
+    tmp_path: Path, key: str, bad_value: object
+) -> None:
+    broken = dp1_questions()
+    broken[0][key] = bad_value
+    persona_dir = _dp1_dir(tmp_path)
+    _rewrite_questions(persona_dir, broken)
+
+    with pytest.raises(ValueError, match=f"empty or non-string {key!r}"):
+        load_xafs_persona(persona_dir)
+
+
+def test_unknown_family_fails_listing_the_three(tmp_path: Path) -> None:
+    broken = dp1_questions()
+    broken[0]["family"] = "temporal"
+    persona_dir = _dp1_dir(tmp_path)
+    _rewrite_questions(persona_dir, broken)
+
+    with pytest.raises(ValueError, match="unknown family 'temporal'") as excinfo:
+        load_xafs_persona(persona_dir)
+    assert "single_hop" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("bad_gold", [[], "data/client/kickoff-transcript.md"])
+def test_empty_or_non_list_gold_file_ids_fails(tmp_path: Path, bad_gold: object) -> None:
+    broken = dp1_questions()
+    broken[0]["gold_file_ids"] = bad_gold
+    persona_dir = _dp1_dir(tmp_path)
+    _rewrite_questions(persona_dir, broken)
+
+    with pytest.raises(ValueError, match="empty or non-list gold_file_ids"):
+        load_xafs_persona(persona_dir)
+
+
+@pytest.mark.parametrize("bad_item", [3, "", "   "])
+def test_non_string_gold_item_fails(tmp_path: Path, bad_item: object) -> None:
+    broken = dp1_questions()
+    broken[0]["gold_file_ids"] = [bad_item]
+    persona_dir = _dp1_dir(tmp_path)
+    _rewrite_questions(persona_dir, broken)
+
+    with pytest.raises(ValueError, match="must be non-empty strings"):
+        load_xafs_persona(persona_dir)
+
+
+@pytest.mark.parametrize("escaping", ["/etc/passwd", "data/../question.json"])
+def test_escaping_gold_path_fails(tmp_path: Path, escaping: str) -> None:
+    broken = dp1_questions()
+    broken[0]["gold_file_ids"] = [escaping]
+    persona_dir = _dp1_dir(tmp_path)
+    _rewrite_questions(persona_dir, broken)
+
+    with pytest.raises(ValueError, match="escapes the persona"):
+        load_xafs_persona(persona_dir)
+
+
+def test_gold_path_outside_data_fails(tmp_path: Path) -> None:
+    broken = dp1_questions()
+    broken[0]["gold_file_ids"] = ["question.json"]
+    persona_dir = _dp1_dir(tmp_path)
+    _rewrite_questions(persona_dir, broken)
+
+    with pytest.raises(ValueError, match="not data/-prefixed"):
+        load_xafs_persona(persona_dir)
+
+
+def test_dangling_gold_reference_names_the_fetch_script(tmp_path: Path) -> None:
+    # A gold file missing on disk means a truncated download, not a soft skip.
+    broken = dp1_questions()
+    broken[0]["gold_file_ids"] = ["data/client/deleted.md"]
+    persona_dir = _dp1_dir(tmp_path)
+    _rewrite_questions(persona_dir, broken)
+
+    with pytest.raises(ValueError, match="gold file missing on disk") as excinfo:
+        load_xafs_persona(persona_dir)
+    assert "download.sh" in str(excinfo.value)
+
+
+def test_duplicate_question_id_fails(tmp_path: Path) -> None:
+    duplicated: list[dict[str, Any]] = dp1_questions()
+    duplicated[1]["id"] = "q01"
+    persona_dir = _dp1_dir(tmp_path)
+    _rewrite_questions(persona_dir, duplicated)
+
+    with pytest.raises(ValueError, match="duplicate question id 'q01'"):
+        load_xafs_persona(persona_dir)

--- a/benchmarks/tests/xafs_fixture.py
+++ b/benchmarks/tests/xafs_fixture.py
@@ -1,0 +1,177 @@
+"""Hand-written miniature xAFS-layout fixture builders.
+
+Mirrors the upstream supermemory/xAFS on-disk layout
+(``<root>/dp_NNN/data/...`` + ``<root>/dp_NNN/question.json``) at toy scale:
+two personas covering all three question families, one non-markdown file (the
+``.eml`` mail) and one double-suffix table (``.csv.md``). Everything is built
+programmatically into tmp_path — no upstream data is vendored and no network
+is touched (the beam_fixture pattern).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+# Gold values shared by loader, converter, and driver tests.
+DP1_INVOICE_AMOUNT = "$2,034"
+DP1_REFERRER = "Dana Whitfield"
+DP1_DUE_DATE = "2026-05-01"
+DP1_CROSS_FORMAT_ANSWER = "June 2026"
+DP2_GOAL_PACE = "8:45 per mile"
+DP2_TRAINING_SUMMARY = "Portland half marathon; longest run 9 miles"
+
+# Distinctive prompt phrasings: driver tests key a ScriptedToolAgent by
+# substring match on these, so no prompt may contain another prompt's key.
+DP1_Q1_PROMPT = "What was the amount of the Acme onboarding invoice?"
+DP1_Q2_PROMPT = "Who referred the client that was billed for onboarding?"
+DP1_Q3_PROMPT = "According to the invoice email, when is payment due?"
+DP1_Q4_PROMPT = "In which month did monthly revenue first exceed the invoiced amount?"
+DP2_Q1_PROMPT = "What goal pace is set for the half marathon?"
+DP2_Q2_PROMPT = "Which race is being trained for, and how long was the longest run so far?"
+
+DP1_FILES: Mapping[str, str] = {
+    "data/client/kickoff-transcript.md": (
+        "# Acme kickoff transcript\n"
+        "\n"
+        f"Kickoff call with Acme Corp. The onboarding invoice was {DP1_INVOICE_AMOUNT},\n"
+        "covering setup and the first training block.\n"
+    ),
+    "data/memory/overview.md": (
+        "# Client overview\n"
+        "\n"
+        f"Acme Corp came to us through a referral from {DP1_REFERRER} in March 2026.\n"
+    ),
+    # The non-markdown file: BM ingests .eml as a file resource, not a note.
+    "data/mail/2026-04-01_invoice.eml": (
+        "From: billing@acme.example\n"
+        "To: ops@basicmachines.example\n"
+        "Subject: Invoice INV-2034\n"
+        "Date: Wed, 01 Apr 2026 09:00:00 +0000\n"
+        "\n"
+        f"Invoice INV-2034 for {DP1_INVOICE_AMOUNT} is attached.\n"
+        f"Payment is due {DP1_DUE_DATE}.\n"
+    ),
+    # Double-suffix format file: ordinary markdown to the loader/converter.
+    "data/notes/metrics.csv.md": (
+        "# Monthly revenue\n"
+        "\n"
+        "| month | revenue |\n"
+        "| --- | --- |\n"
+        "| April 2026 | $1,500 |\n"
+        "| May 2026 | $1,900 |\n"
+        "| June 2026 | $2,600 |\n"
+    ),
+}
+
+DP2_FILES: Mapping[str, str] = {
+    "data/journal/2026-03-10.md": (
+        "# 2026-03-10\n"
+        "\n"
+        "Started training for the Portland half marathon. Longest run so far: 9 miles.\n"
+    ),
+    "data/journal/2026-03-24.md": (
+        f"# 2026-03-24\n\nRace day is 2026-06-14. Goal pace is {DP2_GOAL_PACE}.\n"
+    ),
+}
+
+
+def question(
+    qid: str,
+    family: str,
+    prompt: str,
+    gold_file_ids: Sequence[str],
+    gold_answer: str,
+    **extras: Any,
+) -> dict[str, Any]:
+    """One upstream-shaped question record; ``extras`` become unknown keys."""
+    record: dict[str, Any] = {
+        "id": qid,
+        "family": family,
+        "prompt": prompt,
+        "gold_file_ids": list(gold_file_ids),
+        "gold_answer": gold_answer,
+    }
+    record.update(extras)
+    return record
+
+
+def dp1_questions() -> list[dict[str, Any]]:
+    """Four questions across the three families; q01 carries an unknown key."""
+    return [
+        question(
+            "q01",
+            "single_hop",
+            DP1_Q1_PROMPT,
+            ["data/client/kickoff-transcript.md"],
+            DP1_INVOICE_AMOUNT,
+            difficulty="easy",  # unknown upstream key -> loader extras
+        ),
+        question(
+            "q02",
+            "multi_hop",
+            DP1_Q2_PROMPT,
+            ["data/memory/overview.md", "data/client/kickoff-transcript.md"],
+            DP1_REFERRER,
+        ),
+        question(
+            "q03",
+            "format_spanning",
+            DP1_Q3_PROMPT,
+            ["data/mail/2026-04-01_invoice.eml"],
+            DP1_DUE_DATE,
+        ),
+        question(
+            "q04",
+            "format_spanning",
+            DP1_Q4_PROMPT,
+            ["data/notes/metrics.csv.md", "data/mail/2026-04-01_invoice.eml"],
+            DP1_CROSS_FORMAT_ANSWER,
+        ),
+    ]
+
+
+def dp2_questions() -> list[dict[str, Any]]:
+    return [
+        question(
+            "q01",
+            "single_hop",
+            DP2_Q1_PROMPT,
+            ["data/journal/2026-03-24.md"],
+            DP2_GOAL_PACE,
+        ),
+        question(
+            "q02",
+            "multi_hop",
+            DP2_Q2_PROMPT,
+            ["data/journal/2026-03-10.md", "data/journal/2026-03-24.md"],
+            DP2_TRAINING_SUMMARY,
+        ),
+    ]
+
+
+def write_persona(
+    root: Path,
+    persona_id: str,
+    files: Mapping[str, str],
+    questions: Sequence[Mapping[str, Any]],
+) -> Path:
+    """Write one persona dir in the upstream layout; returns the persona dir."""
+    persona_dir = root / persona_id
+    persona_dir.mkdir(parents=True, exist_ok=True)
+    for relpath, content in files.items():
+        path = persona_dir / relpath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    (persona_dir / "question.json").write_text(json.dumps(list(questions)), encoding="utf-8")
+    return persona_dir
+
+
+def write_xafs_root(tmp_path: Path) -> Path:
+    """The two-persona miniature snapshot; returns the dataset root."""
+    root = tmp_path / "xafs-upstream"
+    write_persona(root, "dp_001", DP1_FILES, dp1_questions())
+    write_persona(root, "dp_002", DP2_FILES, dp2_questions())
+    return root


### PR DESCRIPTION
## Why

Fourth slice of the tracker (#1398): supermemory's [xAFS](https://huggingface.co/datasets/supermemory/xAFS) (CC-BY-4.0) is a surface-agnostic agent-filesystem retrieval eval whose headline metric — **tokens per correct answer** — is exactly the question our rich-vs-POSIX A/B asks, with distractor-density scaling our skills-based tasks don't cover. Vendor-made, so it ships with guardrails: reported as a **secondary dataset, never the headline**, pending the ~20-question quality audit (tooling included, audit itself is post-merge).

Stacked on #1409 (`1401-agent-task-eval`). Closes #1402.

## What changed

- **`datasets/xafs.py`** — frozen-dataclass loader for the upstream layout (personas, question.json, data trees), local-snapshot-only with the fetch command documented, **fail-fast on schema drift** (upstream is vendor-controlled), persona-subset selection (full corpus is 837MB).
- **`converters/xafs_to_corpus.py`** — persona → benchmark corpus with anti-leakage guarantees: probe/gold files never enter the ingested tree, **symlinks rejected in both copy paths** (a `data/x.md → ../question.json` link would have materialized gold answers into the haystack), stale files **pruned on reconversion** (hf download never prunes, so a revision bump into the same dir silently contaminated the corpus otherwise), non-markdown files ingested or explicitly skip-counted — never silently dropped.
- **Agent-task integration** — xAFS questions run as a manifest-driven task source under the #1401 harness (same fairness contract, same tokens-per-correct-answer reporting); a corrections workflow lets audited gold answers/rubrics be amended, and the run manifest now **fingerprints tasks.json** so pre/post-audit runs are distinguishable artifacts.
- **`sample_xafs_audit`** — audit tooling: N seeded random questions with expected answers and source files extracted for human review; re-sampling clears stale source dirs so an auditor can't review outside the sample.
- **Docs** — judging setup and every divergence from supermemory's published methodology documented; the secondary-dataset caveat is in the provenance section.

## How it was built

Reviewed multi-agent workflow (package/upstream mapping → design → implement → offline tests → verify → adversarial review) plus a follow-up pass. Review catches applied: the reconversion stale-file window and the missing tasks.json fingerprint (both should-fix), then the symlink escape, audit-sampler stale sources, and an md-only baseline constraint (nits — the symlink one turned out worse than flagged, since the gold-file existence check also followed links).

## Verification

- ruff check / format — clean; pyright — 0 errors
- Full package suite — **462 passed**, fully offline (miniature hand-written fixture: 2 mini personas incl. a non-UTF-8 file, questions across all three types)

## Notes

- No dataset bytes vendored; no paid runs in this PR. The audited live run lands after merge, and its numbers carry the secondary-dataset caveat until the question-quality audit passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp
