### PR TITLE
feat(integrations): expose note metadata fields in OpenClaw

### DIFF
--- a/integrations/openclaw/CLAUDE.md
+++ b/integrations/openclaw/CLAUDE.md
@@ -198,7 +198,12 @@ read_note(identifier="decisions/auth-strategy", project="backend")
 ### `write_note`
 **Purpose**: Create new notes in the knowledge graph
 **When to use**: When users share important information, make decisions, or want to save insights for later
-**Best practices**: Use clear titles, organize in appropriate folders, structure with headings
+**Best practices**: Use clear titles, organize in appropriate folders, structure the Markdown body with headings, and pass frontmatter through the dedicated parameters instead of embedding YAML in `content`
+
+**Frontmatter parameters**:
+- `tags`: A string array or comma-separated string
+- `note_type`: The note type stored as `type`; defaults to `note`
+- `metadata`: Additional frontmatter fields, including nested objects
 
 **Examples**:
 ```
@@ -231,6 +236,12 @@ We chose JWT tokens with refresh token rotation.
 write_note(
   title="Client Meeting - February 8, 2024",
   folder="meetings",
+  tags=["client", "planning"],
+  note_type="Meeting",
+  metadata={
+    "status": "complete",
+    "attendees": ["John", "Sarah"],
+  },
   content="""
 # Client Meeting - February 8, 2024
 
@@ -256,6 +267,7 @@ write_note(
 **Purpose**: Modify existing notes incrementally
 **When to use**: To add updates, fix information, or organize existing content
 **Operations**: append, prepend, find_replace, replace_section
+**Frontmatter updates**: Pass `metadata` to merge custom frontmatter fields in the same call. Provided keys replace existing values, unrelated fields remain unchanged, and nested objects are supported.
 
 **Examples**:
 ```
@@ -276,6 +288,7 @@ edit_note(
   identifier="weekly-review",
   operation="replace_section",
   section="## This Week",
+  metadata={"status": "review", "progress": {"completed": 4, "total": 6}},
   content="""## This Week
 - Completed API authentication
 - Client meeting went well

--- a/integrations/openclaw/MEMORY_TASK_FLOW.md
+++ b/integrations/openclaw/MEMORY_TASK_FLOW.md
@@ -104,14 +104,10 @@ This fallback behavior keeps tasks discoverable even if the graph index is stale
 write_note(
   title="migrate-auth-routes",
   folder="tasks",
-  content="""---
-title: migrate-auth-routes
-type: Task
-status: active
-current_step: 1
----
-
-## Context
+  note_type="Task",
+  tags=["auth", "migration"],
+  metadata={"status": "active", "current_step": 1},
+  content="""## Context
 Starting auth route migration.
 
 ## Plan
@@ -122,12 +118,35 @@ Starting auth route migration.
 
 ### Advance a task
 
-- Update plan checkboxes with `edit_note` + `replace_section`
-- Bump step with `edit_note` + `find_replace` (for `current_step`)
+Update the plan and its frontmatter state together:
+
+```
+edit_note(
+  identifier="tasks/migrate-auth-routes",
+  operation="replace_section",
+  section="## Plan",
+  metadata={"current_step": 2},
+  content="""## Plan
+- [x] Implement middleware
+- [ ] Add tests"""
+)
+```
 
 ### Complete a task
 
-Use `edit_note` (`find_replace`) to change `status: active` to `status: done`.
+Record the outcome while setting the structured status field:
+
+```
+edit_note(
+  identifier="tasks/migrate-auth-routes",
+  operation="append",
+  metadata={"status": "done"},
+  content="""
+
+## Outcome
+Migration completed and verified."""
+)
+```
 
 ## Operational Tips
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -161,8 +161,8 @@ All tools accept an optional `project` parameter for cross-project operations.
 | `memory_get` | Read a specific note by title or path |
 | `search_notes` | Search the knowledge graph directly |
 | `read_note` | Read a note by title, permalink, or `memory://` URL |
-| `write_note` | Create or update a note |
-| `edit_note` | Append, prepend, find/replace, or replace a section |
+| `write_note` | Create or overwrite a note with optional tags, note type, and custom frontmatter metadata |
+| `edit_note` | Append, prepend, replace content, and merge custom frontmatter metadata |
 | `delete_note` | Delete a note |
 | `move_note` | Move a note to a different folder |
 | `build_context` | Navigate the knowledge graph — follow relations and connections |
@@ -171,6 +171,22 @@ All tools accept an optional `project` parameter for cross-project operations.
 | `schema_validate` | Validate notes against Picoschema definitions |
 | `schema_infer` | Analyze notes and suggest a schema |
 | `schema_diff` | Detect drift between schema and actual usage |
+
+Use the dedicated frontmatter parameters when creating structured notes:
+
+```
+write_note(
+  title="auth-middleware-rollout",
+  folder="tasks",
+  note_type="Task",
+  tags=["auth", "rollout"],
+  metadata={"status": "active", "current_step": 2},
+  content="""## Context
+Rolling JWT middleware to all API routes."""
+)
+```
+
+`edit_note` accepts `metadata` alongside any edit operation, so content and frontmatter state can be updated in one call. Metadata keys supplied by the caller are merged into existing frontmatter; unrelated fields remain unchanged.
 
 ## Slash commands
 

--- a/integrations/openclaw/bm-client.test.ts
+++ b/integrations/openclaw/bm-client.test.ts
@@ -140,6 +140,51 @@ describe("BmClient MCP behavior", () => {
     })
   })
 
+  it("writeNote passes metadata, tags, and note_type when provided", async () => {
+    const callTool = jest.fn().mockResolvedValue(
+      mcpResult({
+        title: "Task Note",
+        permalink: "tasks/task-note",
+        file_path: "tasks/task-note.md",
+        action: "created",
+      }),
+    )
+    setConnected(client, callTool)
+
+    await client.writeNote(
+      "Task Note",
+      "hello",
+      "tasks",
+      undefined,
+      undefined,
+      {
+        metadata: {
+          status: "active",
+          scheduling: { due: "2026-09-02" },
+        },
+        tags: "work,priority",
+        noteType: "Task",
+      },
+    )
+
+    expect(callTool).toHaveBeenCalledWith({
+      name: "write_note",
+      arguments: {
+        title: "Task Note",
+        content: "hello",
+        directory: "tasks",
+        output_format: "json",
+        project: DEFAULT_PROJECT,
+        metadata: {
+          status: "active",
+          scheduling: { due: "2026-09-02" },
+        },
+        tags: "work,priority",
+        note_type: "Task",
+      },
+    })
+  })
+
   it("writeNote throws NoteAlreadyExistsError on conflict response", async () => {
     const callTool = jest.fn().mockResolvedValue(
       mcpResult({
@@ -189,6 +234,34 @@ describe("BmClient MCP behavior", () => {
       },
     })
     expect(result.checksum).toBe("abc")
+  })
+
+  it("editNote passes metadata to edit_note", async () => {
+    const callTool = jest.fn().mockResolvedValue(
+      mcpResult({
+        title: "t",
+        permalink: "p",
+        file_path: "notes/t.md",
+        operation: "append",
+      }),
+    )
+    setConnected(client, callTool)
+
+    await client.editNote("t", "append", "new", {
+      metadata: { status: "complete", review: { approved: true } },
+    })
+
+    expect(callTool).toHaveBeenCalledWith({
+      name: "edit_note",
+      arguments: {
+        identifier: "t",
+        operation: "append",
+        content: "new",
+        metadata: { status: "complete", review: { approved: true } },
+        output_format: "json",
+        project: DEFAULT_PROJECT,
+      },
+    })
   })
 
   it("search calls search_notes with paging params", async () => {

--- a/integrations/openclaw/bm-client.ts
+++ b/integrations/openclaw/bm-client.ts
@@ -61,10 +61,17 @@ interface ReadNoteOptions {
   includeFrontmatter?: boolean
 }
 
+interface WriteNoteOptions {
+  metadata?: Record<string, unknown>
+  tags?: string[] | string
+  noteType?: string
+}
+
 interface EditNoteOptions {
   find_text?: string
   section?: string
   expected_replacements?: number
+  metadata?: Record<string, unknown>
 }
 
 export interface ContextResult {
@@ -605,6 +612,7 @@ export class BmClient {
     folder: string,
     project?: string,
     overwrite?: boolean,
+    options: WriteNoteOptions = {},
   ): Promise<NoteResult> {
     const args: Record<string, unknown> = {
       title,
@@ -614,6 +622,9 @@ export class BmClient {
       project: this.routedProject(project),
     }
     if (overwrite !== undefined) args.overwrite = overwrite
+    if (options.metadata !== undefined) args.metadata = options.metadata
+    if (options.tags !== undefined) args.tags = options.tags
+    if (options.noteType !== undefined) args.note_type = options.noteType
 
     const payload = await this.callTool("write_note", args)
 
@@ -707,6 +718,7 @@ export class BmClient {
     if (options.section) args.section = options.section
     if (options.expected_replacements != null)
       args.expected_replacements = options.expected_replacements
+    if (options.metadata !== undefined) args.metadata = options.metadata
 
     const payload = await this.callTool("edit_note", args)
 

--- a/integrations/openclaw/tools/edit-note.test.ts
+++ b/integrations/openclaw/tools/edit-note.test.ts
@@ -36,6 +36,10 @@ describe("edit tool", () => {
                 type: "number",
               }),
               project: expect.objectContaining({ type: "string" }),
+              metadata: expect.objectContaining({
+                type: "object",
+                additionalProperties: true,
+              }),
             }),
           }),
           execute: expect.any(Function),
@@ -89,6 +93,7 @@ describe("edit tool", () => {
           find_text: undefined,
           section: undefined,
           expected_replacements: undefined,
+          metadata: undefined,
         },
         undefined,
       )
@@ -126,6 +131,7 @@ describe("edit tool", () => {
           find_text: "old text",
           section: undefined,
           expected_replacements: 3,
+          metadata: undefined,
         },
         undefined,
       )
@@ -154,6 +160,7 @@ describe("edit tool", () => {
           find_text: undefined,
           section: "## This Week",
           expected_replacements: undefined,
+          metadata: undefined,
         },
         undefined,
       )
@@ -182,8 +189,44 @@ describe("edit tool", () => {
           find_text: undefined,
           section: undefined,
           expected_replacements: undefined,
+          metadata: undefined,
         },
         "other-project",
+      )
+    })
+
+    it("passes metadata through independently of the edit operation", async () => {
+      ;(mockClient.editNote as jest.MockedFunction<any>).mockResolvedValue({
+        title: "Test Note",
+        permalink: "test-note",
+        file_path: "notes/test-note.md",
+        operation: "append",
+      })
+
+      await executeFunction("tool-call-id", {
+        identifier: "test-note",
+        operation: "append",
+        content: "new content",
+        metadata: {
+          status: "complete",
+          review: { approved: true },
+        },
+      })
+
+      expect(mockClient.editNote).toHaveBeenCalledWith(
+        "test-note",
+        "append",
+        "new content",
+        {
+          find_text: undefined,
+          section: undefined,
+          expected_replacements: undefined,
+          metadata: {
+            status: "complete",
+            review: { approved: true },
+          },
+        },
+        undefined,
       )
     })
 

--- a/integrations/openclaw/tools/edit-note.ts
+++ b/integrations/openclaw/tools/edit-note.ts
@@ -59,6 +59,16 @@ export function registerEditTool(
             description: "Target project name (defaults to current project)",
           }),
         ),
+        metadata: Type.Optional(
+          Type.Object(
+            {},
+            {
+              additionalProperties: true,
+              description:
+                "Frontmatter fields to merge independently of the edit operation. Nested objects are supported.",
+            },
+          ),
+        ),
       }),
       async execute(
         _toolCallId: string,
@@ -70,6 +80,7 @@ export function registerEditTool(
           section?: string
           expected_replacements?: number
           project?: string
+          metadata?: Record<string, unknown>
         },
       ) {
         log.debug(`edit_note: id="${params.identifier}" op=${params.operation}`)
@@ -83,6 +94,7 @@ export function registerEditTool(
               find_text: params.find_text,
               section: params.section,
               expected_replacements: params.expected_replacements,
+              metadata: params.metadata,
             },
             params.project,
           )

--- a/integrations/openclaw/tools/write-note.test.ts
+++ b/integrations/openclaw/tools/write-note.test.ts
@@ -50,6 +50,14 @@ describe("write tool", () => {
               overwrite: expect.objectContaining({
                 type: "boolean",
               }),
+              metadata: expect.objectContaining({
+                type: "object",
+                additionalProperties: true,
+              }),
+              tags: expect.any(Object),
+              note_type: expect.objectContaining({
+                type: "string",
+              }),
             }),
           }),
           execute: expect.any(Function),
@@ -105,6 +113,7 @@ describe("write tool", () => {
         "notes",
         undefined,
         undefined,
+        undefined,
       )
 
       expect(result).toEqual({
@@ -146,6 +155,7 @@ describe("write tool", () => {
         "",
         undefined,
         undefined,
+        undefined,
       )
     })
 
@@ -171,6 +181,7 @@ describe("write tool", () => {
         "Nested Note",
         "Nested folder note",
         "projects/subfolder",
+        undefined,
         undefined,
         undefined,
       )
@@ -217,6 +228,7 @@ const code = "example";
         "notes",
         undefined,
         undefined,
+        undefined,
       )
     })
 
@@ -243,6 +255,7 @@ const code = "example";
         specialTitle,
         "Content",
         "notes",
+        undefined,
         undefined,
         undefined,
       )
@@ -275,6 +288,7 @@ const code = "example";
         "notes",
         undefined,
         undefined,
+        undefined,
       )
     })
 
@@ -301,6 +315,7 @@ const code = "example";
         "Long Note",
         longContent,
         "notes",
+        undefined,
         undefined,
         undefined,
       )
@@ -330,6 +345,7 @@ const code = "example";
         "notes",
         undefined,
         undefined,
+        undefined,
       )
     })
 
@@ -353,6 +369,7 @@ const code = "example";
         "content",
         "notes",
         "other-project",
+        undefined,
         undefined,
       )
     })
@@ -379,9 +396,47 @@ const code = "example";
         "notes",
         undefined,
         true,
+        undefined,
       )
 
       expect(result.content[0].text).toContain("Note saved: Note")
+    })
+
+    it("passes metadata, tags, and note_type to client.writeNote", async () => {
+      ;(mockClient.writeNote as jest.MockedFunction<any>).mockResolvedValue({
+        title: "Task Note",
+        permalink: "tasks/task-note",
+        content: "content",
+        file_path: "tasks/task-note.md",
+      })
+
+      await executeFunction("tool-call-id", {
+        title: "Task Note",
+        content: "content",
+        folder: "tasks",
+        metadata: {
+          status: "active",
+          scheduling: { due: "2026-09-02" },
+        },
+        tags: ["work", "priority"],
+        note_type: "Task",
+      })
+
+      expect(mockClient.writeNote).toHaveBeenCalledWith(
+        "Task Note",
+        "content",
+        "tasks",
+        undefined,
+        undefined,
+        {
+          metadata: {
+            status: "active",
+            scheduling: { due: "2026-09-02" },
+          },
+          tags: ["work", "priority"],
+          noteType: "Task",
+        },
+      )
     })
 
     it("should return helpful hint when note already exists", async () => {
@@ -462,6 +517,7 @@ Normal line
         "notes",
         undefined,
         undefined,
+        undefined,
       )
     })
 
@@ -488,6 +544,7 @@ Normal line
         multilineTitle,
         "Content",
         "notes",
+        undefined,
         undefined,
         undefined,
       )

--- a/integrations/openclaw/tools/write-note.ts
+++ b/integrations/openclaw/tools/write-note.ts
@@ -37,6 +37,27 @@ export function registerWriteTool(
               "Set to true to replace an existing note. Defaults to false.",
           }),
         ),
+        metadata: Type.Optional(
+          Type.Object(
+            {},
+            {
+              additionalProperties: true,
+              description:
+                "Extra frontmatter fields to merge into the note. Nested objects are supported.",
+            },
+          ),
+        ),
+        tags: Type.Optional(
+          Type.Union([Type.Array(Type.String()), Type.String()], {
+            description:
+              "Tags for the note, as an array or comma-separated string.",
+          }),
+        ),
+        note_type: Type.Optional(
+          Type.String({
+            description: 'Note type stored in frontmatter. Defaults to "note".',
+          }),
+        ),
       }),
       async execute(
         _toolCallId: string,
@@ -46,9 +67,23 @@ export function registerWriteTool(
           folder: string
           project?: string
           overwrite?: boolean
+          metadata?: Record<string, unknown>
+          tags?: string[] | string
+          note_type?: string
         },
       ) {
         log.debug(`write_note: title=${params.title} folder=${params.folder}`)
+
+        const options =
+          params.metadata !== undefined ||
+          params.tags !== undefined ||
+          params.note_type !== undefined
+            ? {
+                metadata: params.metadata,
+                tags: params.tags,
+                noteType: params.note_type,
+              }
+            : undefined
 
         try {
           const note = await client.writeNote(
@@ -57,6 +92,7 @@ export function registerWriteTool(
             params.folder,
             params.project,
             params.overwrite,
+            options,
           )
 
           const msg = `Note saved: ${note.title} (${note.permalink})`


### PR DESCRIPTION
## Why

The OpenClaw plugin exposes `write_note` and `edit_note` through its own TypeBox tool schemas and forwards calls to the Basic Memory MCP server.

Those wrappers currently omit several frontmatter parameters already supported by the corresponding MCP tools:

- `write_note`: `metadata`, `tags`, and `note_type`
- `edit_note`: `metadata`

As a result, OpenClaw agents cannot use the normal structured-note interface for tasks, schema-backed notes, status fields, priorities, nested metadata, or tags. They must instead embed YAML frontmatter inside `content` or modify frontmatter as text, which bypasses the cleaner MCP parameter contract and makes agent instructions inconsistent across hosts.

## What changed

### `write_note`

Added these optional OpenClaw tool parameters:

- `metadata`: arbitrary custom frontmatter fields, including nested objects
- `tags`: either an array of strings or a comma-separated string
- `note_type`: the note type stored in frontmatter, defaulting to the MCP behavior of `note`

The values are forwarded unchanged to the MCP `write_note` call as:

- `metadata`
- `tags`
- `note_type`

The existing `project` and `overwrite` behavior remains unchanged. The new fields are grouped in a typed `WriteNoteOptions` object inside `BmClient` rather than extending its positional argument list with several unrelated parameters.

### `edit_note`

Added an optional `metadata` object to the OpenClaw tool schema.

It is forwarded to the MCP `edit_note` call alongside the selected content operation. This allows callers to update note content and merge custom frontmatter fields in one tool call.

The existing append, prepend, find/replace, and section-replacement behavior remains unchanged.

### Tool schemas

Both metadata parameters use open TypeBox object schemas with arbitrary additional properties, matching the MCP tools' support for custom and nested frontmatter values.

Optional parameters are omitted from MCP payloads when they are not supplied, preserving the existing call shape for current users.

## Documentation

Updated the OpenClaw documentation and agent instructions to match the expanded tool contract:

- `integrations/openclaw/CLAUDE.md`
  - documents `metadata`, `tags`, and `note_type`
  - adds structured note examples
  - explains metadata merging during edits
- `integrations/openclaw/MEMORY_TASK_FLOW.md`
  - replaces embedded YAML examples with dedicated `note_type`, `tags`, and `metadata` parameters
  - demonstrates updating task content and structured state together
- `integrations/openclaw/README.md`
  - expands the tool reference
  - adds a structured task example

## Examples

Create a structured task:
```text
write_note(
  title="auth-middleware-rollout",
  folder="tasks",
  note_type="Task",
  tags=["auth", "rollout"],
  metadata={
    "status": "active",
"current_step": 2,
    "scheduling": {"due": "2026-09-15"}
  },
  content="""## Context
Rolling JWT middleware to all API routes."""
)
```

Update content and frontmatter in one call:
```text
edit_note(
  identifier="tasks/auth-middleware-rollout",
  operation="replace_section",
  section="## Plan",
  metadata={
    "status": "review",
"current_step": 3
  },
  content="""## Plan
[x] Deploy to staging
[ ] Review error rates
[ ] Roll out to production"""
)
```

## Tests

Added regression coverage at both OpenClaw integration layers:

- tool schema tests verify that the new parameters are exposed
- tool handler tests verify nested metadata, tags, and note type are passed to `BmClient`
- `BmClient` tests verify the exact MCP argument names and payloads
- existing tests verify omitted optional fields preserve prior behavior

## Verification

- TypeScript typecheck passed
- Biome lint passed
- TypeScript build passed
- OpenClaw test suite: 232 passed
- npm package dry-run passed
- `git diff --check` passed
