### PR TITLE
feat(cli): add local wiki projection commands

### DIFF
--- a/src/basic_memory/cli/app.py
+++ b/src/basic_memory/cli/app.py
@@ -140,6 +140,7 @@ def app_callback(
         "prune",
         "update",
         "watch",
+        "wiki",
         "workspace",
         # POSIX read verbs (#1404): API-hitting commands that initialize via
         # deps.py, same as status/tool.

--- a/src/basic_memory/cli/commands/__init__.py
+++ b/src/basic_memory/cli/commands/__init__.py
@@ -14,6 +14,7 @@ from . import (
     format,
     schema,
     update,
+    wiki,
     workspace,
 )
 
@@ -37,6 +38,7 @@ __all__ = [
     "format",
     "schema",
     "update",
+    "wiki",
     "workspace",
     "man",
 ]

--- a/src/basic_memory/cli/commands/wiki.py
+++ b/src/basic_memory/cli/commands/wiki.py
@@ -1,0 +1,370 @@
+"""Build and inspect deterministic Wiki navigation for local projects."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+import typer
+from rich.console import Console
+
+from basic_memory.cli.app import app
+from basic_memory.cli.commands.command_utils import run_with_cleanup
+from basic_memory.config import BasicMemoryConfig, ConfigManager, ProjectMode
+
+if TYPE_CHECKING:
+    from basic_memory.index.local_wiki_projection import LocalWikiInspection
+
+console = Console()
+wiki_app = typer.Typer(help="Build and inspect deterministic Wiki navigation")
+app.add_typer(wiki_app, name="wiki")
+
+type WikiCommandName = Literal["status", "validate", "rebuild"]
+type WikiReportState = Literal[
+    "current",
+    "uninitialized",
+    "outdated",
+    "partial",
+    "conflicted",
+]
+
+
+class WikiProjectReport(BaseModel):
+    """Machine-readable result for one local project."""
+
+    project: str
+    path: str
+    state: WikiReportState
+    created: int = Field(ge=0)
+    updated: int = Field(ge=0)
+    unchanged: int = Field(ge=0)
+    writes: list[str] = Field(default_factory=list)
+    conflicts: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    pending_materialization: list[int] = Field(default_factory=list)
+
+
+class WikiCommandReport(BaseModel):
+    """Stable JSON boundary shared by Wiki CLI commands and aliases."""
+
+    command: WikiCommandName
+    dry_run: bool = False
+    success: bool
+    projects: list[WikiProjectReport]
+
+
+@wiki_app.command("status")
+def wiki_status(
+    project: str | None = typer.Option(
+        None,
+        "--project",
+        "-p",
+        help="Project to inspect (defaults to the default project)",
+    ),
+    all_projects: bool = typer.Option(False, "--all", help="Inspect every local project"),
+    json_output: bool = typer.Option(False, "--json", help="Output machine-readable JSON"),
+) -> None:
+    """Show whether generated Wiki navigation is current."""
+    _run_wiki_command(
+        command="status",
+        project=project,
+        all_projects=all_projects,
+        dry_run=False,
+        json_output=json_output,
+    )
+
+
+@wiki_app.command("validate")
+def wiki_validate(
+    project: str | None = typer.Option(
+        None,
+        "--project",
+        "-p",
+        help="Project to validate (defaults to the default project)",
+    ),
+    all_projects: bool = typer.Option(False, "--all", help="Validate every local project"),
+    json_output: bool = typer.Option(False, "--json", help="Output machine-readable JSON"),
+) -> None:
+    """Validate generated Wiki documents; exit nonzero when repair is needed."""
+    _run_wiki_command(
+        command="validate",
+        project=project,
+        all_projects=all_projects,
+        dry_run=False,
+        json_output=json_output,
+    )
+
+
+@wiki_app.command("rebuild")
+def wiki_rebuild(
+    project: str | None = typer.Option(
+        None,
+        "--project",
+        "-p",
+        help="Project to rebuild (defaults to the default project)",
+    ),
+    all_projects: bool = typer.Option(False, "--all", help="Rebuild every local project"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview generated writes"),
+    json_output: bool = typer.Option(False, "--json", help="Output machine-readable JSON"),
+) -> None:
+    """Idempotently build every generated index.md and log.md."""
+    _run_rebuild_alias(
+        project=project,
+        all_projects=all_projects,
+        dry_run=dry_run,
+        json_output=json_output,
+    )
+
+
+@wiki_app.command("init")
+def wiki_init(
+    project: str | None = typer.Option(
+        None,
+        "--project",
+        "-p",
+        help="Project to rebuild (defaults to the default project)",
+    ),
+    all_projects: bool = typer.Option(False, "--all", help="Rebuild every local project"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview generated writes"),
+    json_output: bool = typer.Option(False, "--json", help="Output machine-readable JSON"),
+) -> None:
+    """Alias for `bm wiki rebuild`."""
+    _run_rebuild_alias(
+        project=project,
+        all_projects=all_projects,
+        dry_run=dry_run,
+        json_output=json_output,
+    )
+
+
+@wiki_app.command("update")
+def wiki_update(
+    project: str | None = typer.Option(
+        None,
+        "--project",
+        "-p",
+        help="Project to rebuild (defaults to the default project)",
+    ),
+    all_projects: bool = typer.Option(False, "--all", help="Rebuild every local project"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview generated writes"),
+    json_output: bool = typer.Option(False, "--json", help="Output machine-readable JSON"),
+) -> None:
+    """Alias for `bm wiki rebuild`."""
+    _run_rebuild_alias(
+        project=project,
+        all_projects=all_projects,
+        dry_run=dry_run,
+        json_output=json_output,
+    )
+
+
+def _run_rebuild_alias(
+    *,
+    project: str | None,
+    all_projects: bool,
+    dry_run: bool,
+    json_output: bool,
+) -> None:
+    _run_wiki_command(
+        command="rebuild",
+        project=project,
+        all_projects=all_projects,
+        dry_run=dry_run,
+        json_output=json_output,
+    )
+
+
+def _run_wiki_command(
+    *,
+    command: WikiCommandName,
+    project: str | None,
+    all_projects: bool,
+    dry_run: bool,
+    json_output: bool,
+) -> None:
+    if project is not None and all_projects:
+        console.print("[red]Use either --project or --all, not both.[/red]")
+        raise typer.Exit(1)
+
+    from basic_memory.index.local_wiki_projection import LocalWikiWriteConflict
+
+    try:
+        report = run_with_cleanup(
+            _execute_wiki_command(
+                ConfigManager().config,
+                command=command,
+                project_name=project,
+                all_projects=all_projects,
+                dry_run=dry_run,
+            )
+        )
+    except (LocalWikiWriteConflict, OSError, ValueError) as error:
+        console.print(f"[red]Wiki {command} failed: {error}[/red]")
+        raise typer.Exit(1) from error
+
+    if json_output:
+        typer.echo(report.model_dump_json())
+    else:
+        _render_report(report)
+    if not report.success:
+        raise typer.Exit(1)
+
+
+async def _execute_wiki_command(
+    app_config: BasicMemoryConfig,
+    *,
+    command: WikiCommandName,
+    project_name: str | None,
+    all_projects: bool,
+    dry_run: bool,
+) -> WikiCommandReport:
+    # Heavy runtime imports remain behind the command boundary so `bm --help`
+    # keeps the CLI's lightweight startup contract.
+    from basic_memory import db
+    from basic_memory.index.local_project import (
+        LocalProjectIndexRuntimeFactory,
+        run_local_project_index_for_project,
+    )
+    from basic_memory.index.local_wiki_projection import (
+        LocalWikiState,
+        apply_local_wiki_projection,
+        inspect_local_wiki_projection,
+    )
+    from basic_memory.repository import ProjectRepository
+    from basic_memory.services.initialization import (
+        reconcile_projects_with_config,
+        recover_project_materializations,
+    )
+
+    selected_names = _selected_local_project_names(
+        app_config,
+        project_name=project_name,
+        all_projects=all_projects,
+    )
+    await reconcile_projects_with_config(app_config)
+    _, session_maker = await db.get_or_create_db(
+        db_path=app_config.database_path,
+        db_type=db.DatabaseType.FILESYSTEM,
+    )
+    async with db.scoped_session(session_maker) as session:
+        active_projects = await ProjectRepository().get_active_projects(session)
+    projects_by_name = {project.name: project for project in active_projects}
+    missing_names = [name for name in selected_names if name not in projects_by_name]
+    if missing_names:
+        raise ValueError(f"Local project not found: {', '.join(missing_names)}")
+
+    reports: list[WikiProjectReport] = []
+    for name in selected_names:
+        project = projects_by_name[name]
+        if command == "rebuild" and not dry_run:
+            await recover_project_materializations(project, session_maker)
+        inspection = await inspect_local_wiki_projection(
+            project,
+            session_maker=session_maker,
+        )
+        state = inspection.state
+        if (
+            command == "rebuild"
+            and not dry_run
+            and state
+            not in {
+                LocalWikiState.partial,
+                LocalWikiState.conflicted,
+            }
+        ):
+            await apply_local_wiki_projection(inspection)
+            # The files are canonical locally; indexing makes the generated
+            # navigation immediately available through API, MCP, and search.
+            await run_local_project_index_for_project(
+                project,
+                runtime_factory=LocalProjectIndexRuntimeFactory(),
+                force_full=False,
+            )
+            state = LocalWikiState.current
+        reports.append(_project_report(inspection, state=state.value))
+
+    success = _command_succeeded(command, reports=reports, dry_run=dry_run)
+    return WikiCommandReport(
+        command=command,
+        dry_run=dry_run,
+        success=success,
+        projects=reports,
+    )
+
+
+def _selected_local_project_names(
+    app_config: BasicMemoryConfig,
+    *,
+    project_name: str | None,
+    all_projects: bool,
+) -> list[str]:
+    if all_projects:
+        names = sorted(
+            name for name, entry in app_config.projects.items() if entry.mode == ProjectMode.LOCAL
+        )
+        if not names:
+            raise ValueError("No local projects are configured")
+        return names
+
+    selected = project_name or app_config.default_project
+    if selected is None:
+        raise ValueError("No project given and no default project is set; pass --project")
+    entry = app_config.projects.get(selected)
+    if entry is None:
+        raise ValueError(f"Project '{selected}' is not configured")
+    if entry.mode == ProjectMode.CLOUD:
+        raise ValueError(
+            f"Project '{selected}' is a cloud project; Core Wiki commands operate locally"
+        )
+    return [selected]
+
+
+def _project_report(
+    inspection: LocalWikiInspection,
+    *,
+    state: WikiReportState,
+) -> WikiProjectReport:
+    plan = inspection.plan
+    return WikiProjectReport(
+        project=inspection.project_name,
+        path=str(inspection.project_root),
+        state=state,
+        created=plan.result.created,
+        updated=plan.result.updated,
+        unchanged=plan.result.unchanged,
+        writes=[write.path for write in plan.writes],
+        conflicts=[f"{conflict.path}: {conflict.reason}" for conflict in plan.result.conflicts],
+        warnings=list(plan.result.warnings),
+        pending_materialization=list(plan.result.pending_materialization),
+    )
+
+
+def _command_succeeded(
+    command: WikiCommandName,
+    *,
+    reports: list[WikiProjectReport],
+    dry_run: bool,
+) -> bool:
+    if command == "status":
+        return True
+    if command == "validate":
+        return all(report.state == "current" for report in reports)
+    if dry_run:
+        return all(report.state not in {"partial", "conflicted"} for report in reports)
+    return all(report.state == "current" for report in reports)
+
+
+def _render_report(report: WikiCommandReport) -> None:
+    for project in report.projects:
+        color = "green" if project.state == "current" else "yellow"
+        if project.state == "conflicted":
+            color = "red"
+        counts = (
+            f"create {project.created}, update {project.updated}, unchanged {project.unchanged}"
+        )
+        prefix = "would rebuild" if report.dry_run else project.state
+        console.print(f"[{color}]{project.project}: {prefix}[/{color}] ({counts})")
+        for conflict in project.conflicts:
+            console.print(f"  [red]- {conflict}[/red]")
+        for warning in project.warnings:
+            console.print(f"  [yellow]- {warning}[/yellow]")

--- a/src/basic_memory/cli/commands/wiki.py
+++ b/src/basic_memory/cli/commands/wiki.py
@@ -272,7 +272,10 @@ async def _execute_wiki_command(
                 LocalWikiState.conflicted,
             }
         ):
-            await apply_local_wiki_projection(inspection)
+            await apply_local_wiki_projection(
+                inspection,
+                session_maker=session_maker,
+            )
             # The files are canonical locally; indexing makes the generated
             # navigation immediately available through API, MCP, and search.
             await run_local_project_index_for_project(
@@ -299,9 +302,20 @@ def _selected_local_project_names(
     all_projects: bool,
 ) -> list[str]:
     if all_projects:
-        names = sorted(
-            name for name, entry in app_config.projects.items() if entry.mode == ProjectMode.LOCAL
+        local_entries = {
+            name: entry
+            for name, entry in app_config.projects.items()
+            if entry.mode == ProjectMode.LOCAL
+        }
+        unsafe_names = sorted(
+            name
+            for name, entry in app_config.projects.items()
+            if entry.mode == ProjectMode.LOCAL
+            and not app_config.is_locally_syncable(name, entry.path)
         )
+        if unsafe_names:
+            raise ValueError("Local project paths must be absolute: " + ", ".join(unsafe_names))
+        names = sorted(local_entries)
         if not names:
             raise ValueError("No local projects are configured")
         return names
@@ -316,6 +330,8 @@ def _selected_local_project_names(
         raise ValueError(
             f"Project '{selected}' is a cloud project; Core Wiki commands operate locally"
         )
+    if not app_config.is_locally_syncable(selected, entry.path):
+        raise ValueError(f"Local project '{selected}' must have an absolute path")
     return [selected]
 
 

--- a/src/basic_memory/cli/commands/wiki.py
+++ b/src/basic_memory/cli/commands/wiki.py
@@ -15,6 +15,7 @@ from basic_memory.config import BasicMemoryConfig, ConfigManager, ProjectMode
 
 if TYPE_CHECKING:
     from basic_memory.index.local_wiki_projection import LocalWikiInspection
+    from basic_memory.indexing.project_index_coordinator import ProjectIndexCoordinatorResult
 
 console = Console()
 wiki_app = typer.Typer(help="Build and inspect deterministic Wiki navigation")
@@ -284,11 +285,12 @@ async def _execute_wiki_command(
             )
             # The files are canonical locally; indexing makes the generated
             # navigation immediately available through API, MCP, and search.
-            await run_local_project_index_for_project(
+            index_result = await run_local_project_index_for_project(
                 project,
                 runtime_factory=LocalProjectIndexRuntimeFactory(),
                 force_full=False,
             )
+            _require_successful_index(index_result)
             state = LocalWikiState.current
         reports.append(_project_report(inspection, state=state.value))
 
@@ -299,6 +301,13 @@ async def _execute_wiki_command(
         success=success,
         projects=reports,
     )
+
+
+def _require_successful_index(result: ProjectIndexCoordinatorResult) -> None:
+    """Reject rebuilds whose project index recorded any per-file failure."""
+    failed_files = sum(batch.failed_files for batch in result.batch_results)
+    if failed_files:
+        raise ValueError(f"Wiki rebuild indexing failed for {failed_files} project files")
 
 
 def _selected_local_project_names(

--- a/src/basic_memory/cli/commands/wiki.py
+++ b/src/basic_memory/cli/commands/wiki.py
@@ -268,6 +268,7 @@ async def _execute_wiki_command(
         inspection = await inspect_local_wiki_projection(
             project,
             session_maker=session_maker,
+            include_project_permalinks=app_config.permalinks_include_project,
         )
         state = inspection.state
         if (

--- a/src/basic_memory/cli/commands/wiki.py
+++ b/src/basic_memory/cli/commands/wiki.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
@@ -256,6 +257,11 @@ async def _execute_wiki_command(
     reports: list[WikiProjectReport] = []
     for name in selected_names:
         project = projects_by_name[name]
+        _require_matching_project_root(
+            project_name=name,
+            configured_path=app_config.projects[name].path,
+            persisted_path=project.path,
+        )
         if command == "rebuild" and not dry_run:
             await recover_project_materializations(project, session_maker)
         inspection = await inspect_local_wiki_projection(
@@ -333,6 +339,24 @@ def _selected_local_project_names(
     if not app_config.is_locally_syncable(selected, entry.path):
         raise ValueError(f"Local project '{selected}' must have an absolute path")
     return [selected]
+
+
+def _require_matching_project_root(
+    *,
+    project_name: str,
+    configured_path: str,
+    persisted_path: str,
+) -> None:
+    configured_root = Path(configured_path).expanduser()
+    persisted_root = Path(persisted_path).expanduser()
+    if (
+        not configured_root.is_absolute()
+        or not persisted_root.is_absolute()
+        or configured_root.resolve() != persisted_root.resolve()
+    ):
+        raise ValueError(
+            f"Local project '{project_name}' path differs between config and the project database"
+        )
 
 
 def _project_report(

--- a/src/basic_memory/cli/main.py
+++ b/src/basic_memory/cli/main.py
@@ -35,6 +35,7 @@ if not _version_only_invocation(sys.argv[1:]):
         status,
         tool,
         update,
+        wiki,
         workspace,
     )
 

--- a/src/basic_memory/file_utils.py
+++ b/src/basic_memory/file_utils.py
@@ -117,7 +117,7 @@ async def write_file_atomic(path: FilePath, content: str) -> None:
     temp_path: Path | None = None
 
     try:
-        temp_path = _create_atomic_temp_path(path_obj)
+        temp_path, target_mode = _create_atomic_temp_path(path_obj)
         # Trigger: callers hand us normalized Python text, but the final bytes are allowed
         #          to use the host platform's native newline convention during the write.
         # Why: preserving CRLF on Windows keeps local files aligned with editors like
@@ -128,6 +128,8 @@ async def write_file_atomic(path: FilePath, content: str) -> None:
         async with aiofiles.open(temp_path, mode="w", encoding="utf-8") as f:
             await f.write(content)
 
+        if target_mode is not None:
+            temp_path.chmod(target_mode)
         # Atomic rename (this is fast, doesn't need async)
         temp_path.replace(path_obj)
         logger.debug("Wrote file atomically", path=str(path_obj), content_length=len(content))
@@ -144,10 +146,12 @@ async def write_file_atomic_bytes(path: FilePath, content: bytes) -> None:
     temp_path: Path | None = None
 
     try:
-        temp_path = _create_atomic_temp_path(path_obj)
+        temp_path, target_mode = _create_atomic_temp_path(path_obj)
         async with aiofiles.open(temp_path, mode="wb") as f:
             await f.write(content)
 
+        if target_mode is not None:
+            temp_path.chmod(target_mode)
         temp_path.replace(path_obj)
         logger.debug("Wrote file atomically", path=str(path_obj), content_length=len(content))
     except Exception as e:  # pragma: no cover
@@ -157,7 +161,7 @@ async def write_file_atomic_bytes(path: FilePath, content: bytes) -> None:
         raise FileWriteError(f"Failed to write file {path}: {e}")
 
 
-def _create_atomic_temp_path(target: Path) -> Path:
+def _create_atomic_temp_path(target: Path) -> tuple[Path, int | None]:
     """Reserve a collision-free staging file beside an atomic-write target."""
     for _attempt in range(10):
         staging_path = target.parent / f".{target.name}.{secrets.token_hex(8)}.tmp"
@@ -171,12 +175,13 @@ def _create_atomic_temp_path(target: Path) -> Path:
             continue
         os.close(descriptor)
         try:
-            if target.exists():
-                staging_path.chmod(stat.S_IMODE(target.stat().st_mode))
+            target_mode = stat.S_IMODE(target.stat().st_mode)
+        except FileNotFoundError:
+            target_mode = None
         except Exception:
             staging_path.unlink(missing_ok=True)
             raise
-        return staging_path
+        return staging_path, target_mode
     raise FileWriteError(f"Failed to reserve atomic staging file for {target}")
 
 

--- a/src/basic_memory/file_utils.py
+++ b/src/basic_memory/file_utils.py
@@ -2,12 +2,14 @@
 
 import asyncio
 import hashlib
+import os
 import shlex
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 import re
-import tempfile
+import secrets
+import stat
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import aiofiles
@@ -157,13 +159,25 @@ async def write_file_atomic_bytes(path: FilePath, content: bytes) -> None:
 
 def _create_atomic_temp_path(target: Path) -> Path:
     """Reserve a collision-free staging file beside an atomic-write target."""
-    with tempfile.NamedTemporaryFile(
-        dir=target.parent,
-        prefix=f".{target.name}.",
-        suffix=".tmp",
-        delete=False,
-    ) as staging_file:
-        return Path(staging_file.name)
+    for _attempt in range(10):
+        staging_path = target.parent / f".{target.name}.{secrets.token_hex(8)}.tmp"
+        try:
+            descriptor = os.open(
+                staging_path,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o666,
+            )
+        except FileExistsError:  # pragma: no cover - random collision defense
+            continue
+        os.close(descriptor)
+        try:
+            if target.exists():
+                staging_path.chmod(stat.S_IMODE(target.stat().st_mode))
+        except Exception:
+            staging_path.unlink(missing_ok=True)
+            raise
+        return staging_path
+    raise FileWriteError(f"Failed to reserve atomic staging file for {target}")
 
 
 async def format_markdown_builtin(path: Path) -> Optional[str]:

--- a/src/basic_memory/file_utils.py
+++ b/src/basic_memory/file_utils.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 import re
+import tempfile
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import aiofiles
@@ -111,9 +112,10 @@ async def write_file_atomic(path: FilePath, content: str) -> None:
     """
     # Convert string to Path if needed
     path_obj = Path(path) if isinstance(path, str) else path
-    temp_path = path_obj.with_suffix(".tmp")
+    temp_path: Path | None = None
 
     try:
+        temp_path = _create_atomic_temp_path(path_obj)
         # Trigger: callers hand us normalized Python text, but the final bytes are allowed
         #          to use the host platform's native newline convention during the write.
         # Why: preserving CRLF on Windows keeps local files aligned with editors like
@@ -128,7 +130,8 @@ async def write_file_atomic(path: FilePath, content: str) -> None:
         temp_path.replace(path_obj)
         logger.debug("Wrote file atomically", path=str(path_obj), content_length=len(content))
     except Exception as e:  # pragma: no cover
-        temp_path.unlink(missing_ok=True)
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
         logger.error("Failed to write file", path=str(path_obj), error=str(e))
         raise FileWriteError(f"Failed to write file {path}: {e}")
 
@@ -136,18 +139,31 @@ async def write_file_atomic(path: FilePath, content: str) -> None:
 async def write_file_atomic_bytes(path: FilePath, content: bytes) -> None:
     """Write bytes atomically without text newline translation."""
     path_obj = Path(path) if isinstance(path, str) else path
-    temp_path = path_obj.with_suffix(".tmp")
+    temp_path: Path | None = None
 
     try:
+        temp_path = _create_atomic_temp_path(path_obj)
         async with aiofiles.open(temp_path, mode="wb") as f:
             await f.write(content)
 
         temp_path.replace(path_obj)
         logger.debug("Wrote file atomically", path=str(path_obj), content_length=len(content))
     except Exception as e:  # pragma: no cover
-        temp_path.unlink(missing_ok=True)
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
         logger.error("Failed to write file", path=str(path_obj), error=str(e))
         raise FileWriteError(f"Failed to write file {path}: {e}")
+
+
+def _create_atomic_temp_path(target: Path) -> Path:
+    """Reserve a collision-free staging file beside an atomic-write target."""
+    with tempfile.NamedTemporaryFile(
+        dir=target.parent,
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as staging_file:
+        return Path(staging_file.name)
 
 
 async def format_markdown_builtin(path: Path) -> Optional[str]:

--- a/src/basic_memory/index/local_wiki_projection.py
+++ b/src/basic_memory/index/local_wiki_projection.py
@@ -1,0 +1,258 @@
+"""Local filesystem adapter for the deterministic Wiki Projector."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from hashlib import sha256
+from pathlib import Path, PurePosixPath
+from typing import Mapping
+
+import frontmatter
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+import yaml
+
+from basic_memory import db
+from basic_memory.file_utils import write_file_atomic_bytes
+from basic_memory.index.local_project import scan_local_project_index_files
+from basic_memory.indexing.wiki_projector import (
+    RESERVED_WIKI_FILENAMES,
+    WIKI_PROFILE,
+    WIKI_PROJECTOR_NAME,
+    WIKI_PROJECTOR_VERSION,
+    WikiChangeOperation,
+    WikiProjectionPlan,
+    WikiProjectionReason,
+    WikiProjectionRequest,
+    WikiProjectionSnapshot,
+    WikiReservedDocument,
+    WikiSourceChange,
+    WikiSourceNote,
+    plan_wiki_projection,
+)
+from basic_memory.markdown import EntityParser
+from basic_memory.models import AcceptedProjectNoteChange, Project
+from basic_memory.runtime.storage import runtime_file_path_is_markdown_note
+from basic_memory.utils import ensure_timezone_aware, generate_permalink
+
+
+class LocalWikiState(StrEnum):
+    """User-visible state of a local Wiki projection."""
+
+    current = "current"
+    uninitialized = "uninitialized"
+    outdated = "outdated"
+    partial = "partial"
+    conflicted = "conflicted"
+
+
+class LocalWikiWriteConflict(RuntimeError):
+    """A reserved document changed after the projection was planned."""
+
+
+@dataclass(frozen=True, slots=True)
+class LocalWikiInspection:
+    """One deterministic local projection plan and its user-visible state."""
+
+    project_name: str
+    project_root: Path
+    state: LocalWikiState
+    plan: WikiProjectionPlan
+
+
+@dataclass(frozen=True, slots=True)
+class AppliedLocalWikiProjection:
+    """Reserved documents written by one successful local projection."""
+
+    paths: tuple[str, ...]
+
+
+async def inspect_local_wiki_projection(
+    project: Project,
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> LocalWikiInspection:
+    """Plan a full local Wiki rebuild without modifying canonical files."""
+    project_root = Path(project.path).expanduser().resolve()
+    snapshot = await _load_local_wiki_snapshot(
+        project,
+        project_root=project_root,
+        session_maker=session_maker,
+    )
+    plan = plan_wiki_projection(
+        WikiProjectionRequest(
+            project_id=project.external_id,
+            through_partition_position=project.partition_position,
+            projector_version=WIKI_PROJECTOR_VERSION,
+            reason=WikiProjectionReason.manual_rebuild,
+        ),
+        snapshot,
+    )
+    root_initialized = any(
+        document.path.casefold() == "index.md" and document.projector_owned
+        for document in snapshot.reserved_documents
+    )
+    if plan.result.conflicts:
+        state = LocalWikiState.conflicted
+    elif plan.result.pending_materialization:
+        state = LocalWikiState.partial
+    elif not root_initialized:
+        state = LocalWikiState.uninitialized
+    elif plan.writes:
+        state = LocalWikiState.outdated
+    else:
+        state = LocalWikiState.current
+    return LocalWikiInspection(
+        project_name=project.name,
+        project_root=project_root,
+        state=state,
+        plan=plan,
+    )
+
+
+async def apply_local_wiki_projection(
+    inspection: LocalWikiInspection,
+) -> AppliedLocalWikiProjection:
+    """Apply an inspected plan with an all-path checksum preflight."""
+    plan = inspection.plan
+    if plan.result.conflicts:
+        raise LocalWikiWriteConflict("Wiki projection has reserved-document conflicts")
+    if plan.result.pending_materialization:
+        positions = ", ".join(str(position) for position in plan.result.pending_materialization)
+        raise LocalWikiWriteConflict(
+            f"Wiki projection is waiting for materialized changes: {positions}"
+        )
+
+    # Every reserved path is checked before the first write. A concurrent edit
+    # therefore fails the rebuild without publishing a knowingly mixed projection.
+    for write in plan.writes:
+        target = inspection.project_root / write.path
+        if write.expected_checksum is None:
+            if target.exists():
+                raise LocalWikiWriteConflict(
+                    f"Wiki reserved path appeared after planning: {write.path}"
+                )
+            continue
+        if not target.is_file():
+            raise LocalWikiWriteConflict(
+                f"Wiki reserved path disappeared after planning: {write.path}"
+            )
+        current_checksum = sha256(target.read_bytes()).hexdigest()
+        if current_checksum != write.expected_checksum:
+            raise LocalWikiWriteConflict(f"Wiki reserved path changed after planning: {write.path}")
+
+    for write in plan.writes:
+        target = inspection.project_root / write.path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        await write_file_atomic_bytes(target, write.content)
+    return AppliedLocalWikiProjection(paths=tuple(write.path for write in plan.writes))
+
+
+async def _load_local_wiki_snapshot(
+    project: Project,
+    *,
+    project_root: Path,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> WikiProjectionSnapshot:
+    if not project_root.is_dir():
+        raise ValueError(f"Local project directory does not exist: {project_root}")
+
+    parser = EntityParser(project_root)
+    source_notes: list[WikiSourceNote] = []
+    reserved_documents: list[WikiReservedDocument] = []
+    source_modified_at: list[datetime] = []
+    scan = scan_local_project_index_files(project_root)
+    for relative_path in scan.file_paths:
+        if not runtime_file_path_is_markdown_note(relative_path):
+            continue
+        path = project_root / relative_path
+        content = path.read_bytes()
+        if PurePosixPath(relative_path).name.casefold() in RESERVED_WIKI_FILENAMES:
+            reserved_documents.append(
+                WikiReservedDocument(
+                    path=relative_path,
+                    checksum=sha256(content).hexdigest(),
+                    content=content,
+                    projector_owned=_is_projector_owned(relative_path, content),
+                )
+            )
+            continue
+
+        markdown = await parser.parse_file(path)
+        permalink = markdown.frontmatter.permalink or generate_permalink(relative_path)
+        source_notes.append(
+            WikiSourceNote(
+                path=relative_path,
+                permalink=permalink,
+                title=markdown.frontmatter.title,
+                note_type=markdown.frontmatter.type,
+                checksum=sha256(content).hexdigest(),
+            )
+        )
+        if markdown.modified is not None:
+            source_modified_at.append(ensure_timezone_aware(markdown.modified))
+
+    async with db.scoped_session(session_maker) as session:
+        change_rows = (
+            await session.execute(
+                select(AcceptedProjectNoteChange)
+                .where(
+                    AcceptedProjectNoteChange.project_id == project.id,
+                    AcceptedProjectNoteChange.partition_position <= project.partition_position,
+                )
+                .order_by(AcceptedProjectNoteChange.partition_position)
+            )
+        ).scalars()
+        changes = tuple(
+            WikiSourceChange(
+                partition_position=change.partition_position,
+                operation=WikiChangeOperation(change.operation),
+                path=change.file_path,
+                permalink=change.permalink,
+                previous_path=change.previous_file_path,
+                title=change.title,
+                accepted_at=ensure_timezone_aware(change.accepted_at),
+                materialized=change.materialized_at is not None,
+                source=change.source,
+            )
+            for change in change_rows
+        )
+
+    accepted_at = [change.accepted_at for change in changes]
+    source_accepted_at = max(
+        (*source_modified_at, *accepted_at, ensure_timezone_aware(project.created_at))
+    )
+    return WikiProjectionSnapshot(
+        project_id=project.external_id,
+        project_name=project.name,
+        source_partition_position=project.partition_position,
+        # Local runs have no durable projection ledger. Full rebuilds compare
+        # complete rendered bytes, so zero is the honest replay starting point.
+        current_output_watermark=0,
+        source_accepted_at=source_accepted_at,
+        notes=tuple(source_notes),
+        changes=changes,
+        reserved_documents=tuple(reserved_documents),
+    )
+
+
+def _is_projector_owned(relative_path: str, content: bytes) -> bool:
+    # Non-canonical casing is unsafe to rewrite portably: Linux could create a
+    # second file while macOS/Windows replace the first one.
+    path = PurePosixPath(relative_path)
+    if path.name not in RESERVED_WIKI_FILENAMES:
+        return False
+    try:
+        metadata, _ = frontmatter.parse(content.decode("utf-8"))
+    except (UnicodeDecodeError, yaml.YAMLError):
+        return False
+    generated = metadata.get("generated")
+    basic_memory = metadata.get("bm")
+    return (
+        isinstance(generated, Mapping)
+        and generated.get("by") == WIKI_PROJECTOR_NAME
+        and isinstance(basic_memory, Mapping)
+        and basic_memory.get("profile") == WIKI_PROFILE
+    )

--- a/src/basic_memory/index/local_wiki_projection.py
+++ b/src/basic_memory/index/local_wiki_projection.py
@@ -53,12 +53,26 @@ class LocalWikiWriteConflict(RuntimeError):
 
 
 @dataclass(frozen=True, slots=True)
+class LocalWikiSourceState:
+    """Projection inputs revalidated before publishing generated files."""
+
+    project_external_id: str
+    project_name: str
+    partition_position: int
+    accepted_at: datetime
+    notes: tuple[WikiSourceNote, ...]
+    changes: tuple[WikiSourceChange, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class LocalWikiInspection:
     """One deterministic local projection plan and its user-visible state."""
 
+    project_database_id: int
     project_name: str
     project_root: Path
     state: LocalWikiState
+    source_state: LocalWikiSourceState
     plan: WikiProjectionPlan
 
 
@@ -75,7 +89,16 @@ async def inspect_local_wiki_projection(
     session_maker: async_sessionmaker[AsyncSession],
 ) -> LocalWikiInspection:
     """Plan a full local Wiki rebuild without modifying canonical files."""
-    project_root = Path(project.path).expanduser().resolve()
+    async with db.scoped_session(session_maker) as session:
+        persisted_project = await session.get(Project, project.id)
+    if persisted_project is None:
+        raise ValueError(f"Local project is not registered: {project.name}")
+
+    project = persisted_project
+    configured_root = Path(project.path).expanduser()
+    if not configured_root.is_absolute():
+        raise ValueError(f"Local Wiki project path must be absolute: {project.path}")
+    project_root = configured_root.resolve()
     snapshot = await _load_local_wiki_snapshot(
         project,
         project_root=project_root,
@@ -105,15 +128,19 @@ async def inspect_local_wiki_projection(
     else:
         state = LocalWikiState.current
     return LocalWikiInspection(
+        project_database_id=project.id,
         project_name=project.name,
         project_root=project_root,
         state=state,
+        source_state=_source_state(snapshot),
         plan=plan,
     )
 
 
 async def apply_local_wiki_projection(
     inspection: LocalWikiInspection,
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
 ) -> AppliedLocalWikiProjection:
     """Apply an inspected plan with an all-path checksum preflight."""
     plan = inspection.plan
@@ -124,6 +151,11 @@ async def apply_local_wiki_projection(
         raise LocalWikiWriteConflict(
             f"Wiki projection is waiting for materialized changes: {positions}"
         )
+
+    await _assert_projection_sources_unchanged(
+        inspection,
+        session_maker=session_maker,
+    )
 
     # Every reserved path is checked before the first write. A concurrent edit
     # therefore fails the rebuild without publishing a knowingly mixed projection.
@@ -148,6 +180,41 @@ async def apply_local_wiki_projection(
         target.parent.mkdir(parents=True, exist_ok=True)
         await write_file_atomic_bytes(target, write.content)
     return AppliedLocalWikiProjection(paths=tuple(write.path for write in plan.writes))
+
+
+async def _assert_projection_sources_unchanged(
+    inspection: LocalWikiInspection,
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db.scoped_session(session_maker) as session:
+        project = await session.get(Project, inspection.project_database_id)
+    if project is None:
+        raise LocalWikiWriteConflict("Wiki project disappeared after planning")
+
+    current_root = Path(project.path).expanduser()
+    if not current_root.is_absolute() or current_root.resolve() != inspection.project_root:
+        raise LocalWikiWriteConflict("Wiki project root changed after planning")
+
+    current_snapshot = await _load_local_wiki_snapshot(
+        project,
+        project_root=current_root.resolve(),
+        session_maker=session_maker,
+    )
+    if _source_state(current_snapshot) != inspection.source_state:
+        raise LocalWikiWriteConflict("Wiki source notes or journal changed after planning")
+
+
+def _source_state(snapshot: WikiProjectionSnapshot) -> LocalWikiSourceState:
+    """Return only the projection inputs that generated writes depend on."""
+    return LocalWikiSourceState(
+        project_external_id=snapshot.project_id,
+        project_name=snapshot.project_name,
+        partition_position=snapshot.source_partition_position,
+        accepted_at=snapshot.source_accepted_at,
+        notes=snapshot.notes,
+        changes=snapshot.changes,
+    )
 
 
 async def _load_local_wiki_snapshot(

--- a/src/basic_memory/index/local_wiki_projection.py
+++ b/src/basic_memory/index/local_wiki_projection.py
@@ -16,6 +16,7 @@ import yaml
 
 from basic_memory import db
 from basic_memory.file_utils import write_file_atomic_bytes
+from basic_memory.ignore_utils import load_gitignore_patterns, should_ignore_path
 from basic_memory.index.local_project import scan_local_project_index_files
 from basic_memory.indexing.wiki_projector import (
     RESERVED_WIKI_FILENAMES,
@@ -62,6 +63,7 @@ class LocalWikiSourceState:
     accepted_at: datetime
     notes: tuple[WikiSourceNote, ...]
     changes: tuple[WikiSourceChange, ...]
+    ignore_patterns: tuple[str, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -99,10 +101,12 @@ async def inspect_local_wiki_projection(
     if not configured_root.is_absolute():
         raise ValueError(f"Local Wiki project path must be absolute: {project.path}")
     project_root = configured_root.resolve()
+    ignore_patterns = load_gitignore_patterns(project_root)
     snapshot = await _load_local_wiki_snapshot(
         project,
         project_root=project_root,
         session_maker=session_maker,
+        ignore_patterns=ignore_patterns,
     )
     plan = plan_wiki_projection(
         WikiProjectionRequest(
@@ -113,6 +117,15 @@ async def inspect_local_wiki_projection(
         ),
         snapshot,
     )
+    ignored_destinations = tuple(
+        write.path
+        for write in plan.writes
+        if should_ignore_path(project_root / write.path, project_root, ignore_patterns)
+    )
+    if ignored_destinations:
+        raise ValueError(
+            "Wiki reserved paths are ignored by project rules: " + ", ".join(ignored_destinations)
+        )
     root_initialized = any(
         document.path.casefold() == "index.md" and document.projector_owned
         for document in snapshot.reserved_documents
@@ -132,7 +145,7 @@ async def inspect_local_wiki_projection(
         project_name=project.name,
         project_root=project_root,
         state=state,
-        source_state=_source_state(snapshot),
+        source_state=_source_state(snapshot, ignore_patterns=ignore_patterns),
         plan=plan,
     )
 
@@ -196,16 +209,25 @@ async def _assert_projection_sources_unchanged(
     if not current_root.is_absolute() or current_root.resolve() != inspection.project_root:
         raise LocalWikiWriteConflict("Wiki project root changed after planning")
 
+    current_ignore_patterns = load_gitignore_patterns(current_root)
     current_snapshot = await _load_local_wiki_snapshot(
         project,
         project_root=current_root.resolve(),
         session_maker=session_maker,
+        ignore_patterns=current_ignore_patterns,
     )
-    if _source_state(current_snapshot) != inspection.source_state:
+    if (
+        _source_state(current_snapshot, ignore_patterns=current_ignore_patterns)
+        != inspection.source_state
+    ):
         raise LocalWikiWriteConflict("Wiki source notes or journal changed after planning")
 
 
-def _source_state(snapshot: WikiProjectionSnapshot) -> LocalWikiSourceState:
+def _source_state(
+    snapshot: WikiProjectionSnapshot,
+    *,
+    ignore_patterns: set[str],
+) -> LocalWikiSourceState:
     """Return only the projection inputs that generated writes depend on."""
     return LocalWikiSourceState(
         project_external_id=snapshot.project_id,
@@ -214,6 +236,7 @@ def _source_state(snapshot: WikiProjectionSnapshot) -> LocalWikiSourceState:
         accepted_at=snapshot.source_accepted_at,
         notes=snapshot.notes,
         changes=snapshot.changes,
+        ignore_patterns=tuple(sorted(ignore_patterns)),
     )
 
 
@@ -222,6 +245,7 @@ async def _load_local_wiki_snapshot(
     *,
     project_root: Path,
     session_maker: async_sessionmaker[AsyncSession],
+    ignore_patterns: set[str],
 ) -> WikiProjectionSnapshot:
     if not project_root.is_dir():
         raise ValueError(f"Local project directory does not exist: {project_root}")
@@ -229,8 +253,10 @@ async def _load_local_wiki_snapshot(
     parser = EntityParser(project_root)
     source_notes: list[WikiSourceNote] = []
     reserved_documents: list[WikiReservedDocument] = []
-    source_modified_at: list[datetime] = []
-    scan = scan_local_project_index_files(project_root)
+    scan = scan_local_project_index_files(
+        project_root,
+        ignore_patterns=ignore_patterns,
+    )
     for relative_path in scan.file_paths:
         if not runtime_file_path_is_markdown_note(relative_path):
             continue
@@ -258,9 +284,6 @@ async def _load_local_wiki_snapshot(
                 checksum=sha256(content).hexdigest(),
             )
         )
-        if markdown.modified is not None:
-            source_modified_at.append(ensure_timezone_aware(markdown.modified))
-
     async with db.scoped_session(session_maker) as session:
         change_rows = (
             await session.execute(
@@ -288,9 +311,7 @@ async def _load_local_wiki_snapshot(
         )
 
     accepted_at = [change.accepted_at for change in changes]
-    source_accepted_at = max(
-        (*source_modified_at, *accepted_at, ensure_timezone_aware(project.created_at))
-    )
+    source_accepted_at = max((*accepted_at, ensure_timezone_aware(project.created_at)))
     return WikiProjectionSnapshot(
         project_id=project.external_id,
         project_name=project.name,

--- a/src/basic_memory/index/local_wiki_projection.py
+++ b/src/basic_memory/index/local_wiki_projection.py
@@ -175,6 +175,11 @@ async def apply_local_wiki_projection(
     # therefore fails the rebuild without publishing a knowingly mixed projection.
     for write in plan.writes:
         target = inspection.project_root / write.path
+        _require_safe_projection_destination(
+            project_root=inspection.project_root,
+            target=target,
+            relative_path=write.path,
+        )
         if write.expected_checksum is None:
             if target.exists():
                 raise LocalWikiWriteConflict(
@@ -194,6 +199,24 @@ async def apply_local_wiki_projection(
         target.parent.mkdir(parents=True, exist_ok=True)
         await write_file_atomic_bytes(target, write.content)
     return AppliedLocalWikiProjection(paths=tuple(write.path for write in plan.writes))
+
+
+def _require_safe_projection_destination(
+    *,
+    project_root: Path,
+    target: Path,
+    relative_path: str,
+) -> None:
+    """Keep every generated write inside the real project directory tree."""
+    current = project_root
+    for component in target.relative_to(project_root).parts:
+        current /= component
+        if current.is_symlink():
+            raise LocalWikiWriteConflict(f"Wiki reserved path crosses a symlink: {relative_path}")
+    if not target.resolve(strict=False).is_relative_to(project_root):
+        raise LocalWikiWriteConflict(
+            f"Wiki reserved path escapes the project root: {relative_path}"
+        )
 
 
 async def _assert_projection_sources_unchanged(

--- a/src/basic_memory/index/local_wiki_projection.py
+++ b/src/basic_memory/index/local_wiki_projection.py
@@ -36,7 +36,7 @@ from basic_memory.indexing.wiki_projector import (
 from basic_memory.markdown import EntityParser
 from basic_memory.models import AcceptedProjectNoteChange, Project
 from basic_memory.runtime.storage import runtime_file_path_is_markdown_note
-from basic_memory.utils import ensure_timezone_aware, generate_permalink
+from basic_memory.utils import build_canonical_permalink, ensure_timezone_aware
 
 
 class LocalWikiState(StrEnum):
@@ -59,6 +59,7 @@ class LocalWikiSourceState:
 
     project_external_id: str
     project_name: str
+    include_project_permalinks: bool
     partition_position: int
     accepted_at: datetime
     notes: tuple[WikiSourceNote, ...]
@@ -90,6 +91,7 @@ async def inspect_local_wiki_projection(
     project: Project,
     *,
     session_maker: async_sessionmaker[AsyncSession],
+    include_project_permalinks: bool = True,
 ) -> LocalWikiInspection:
     """Plan a full local Wiki rebuild without modifying canonical files."""
     async with db.scoped_session(session_maker) as session:
@@ -108,6 +110,7 @@ async def inspect_local_wiki_projection(
         project_root=project_root,
         session_maker=session_maker,
         ignore_patterns=ignore_patterns,
+        include_project_permalinks=include_project_permalinks,
     )
     plan = plan_wiki_projection(
         WikiProjectionRequest(
@@ -146,7 +149,11 @@ async def inspect_local_wiki_projection(
         project_name=project.name,
         project_root=project_root,
         state=state,
-        source_state=_source_state(snapshot, ignore_patterns=ignore_patterns),
+        source_state=_source_state(
+            snapshot,
+            ignore_patterns=ignore_patterns,
+            include_project_permalinks=include_project_permalinks,
+        ),
         plan=plan,
     )
 
@@ -239,9 +246,14 @@ async def _assert_projection_sources_unchanged(
         project_root=current_root.resolve(),
         session_maker=session_maker,
         ignore_patterns=current_ignore_patterns,
+        include_project_permalinks=inspection.source_state.include_project_permalinks,
     )
     if (
-        _source_state(current_snapshot, ignore_patterns=current_ignore_patterns)
+        _source_state(
+            current_snapshot,
+            ignore_patterns=current_ignore_patterns,
+            include_project_permalinks=inspection.source_state.include_project_permalinks,
+        )
         != inspection.source_state
     ):
         raise LocalWikiWriteConflict("Wiki projection inputs changed after planning")
@@ -251,11 +263,13 @@ def _source_state(
     snapshot: WikiProjectionSnapshot,
     *,
     ignore_patterns: set[str],
+    include_project_permalinks: bool,
 ) -> LocalWikiSourceState:
     """Return only the projection inputs that generated writes depend on."""
     return LocalWikiSourceState(
         project_external_id=snapshot.project_id,
         project_name=snapshot.project_name,
+        include_project_permalinks=include_project_permalinks,
         partition_position=snapshot.source_partition_position,
         accepted_at=snapshot.source_accepted_at,
         notes=snapshot.notes,
@@ -271,6 +285,7 @@ async def _load_local_wiki_snapshot(
     project_root: Path,
     session_maker: async_sessionmaker[AsyncSession],
     ignore_patterns: set[str],
+    include_project_permalinks: bool,
 ) -> WikiProjectionSnapshot:
     if not project_root.is_dir():
         raise ValueError(f"Local project directory does not exist: {project_root}")
@@ -304,7 +319,11 @@ async def _load_local_wiki_snapshot(
             continue
 
         markdown = await parser.parse_file(path)
-        permalink = markdown.frontmatter.permalink or generate_permalink(relative_path)
+        permalink = markdown.frontmatter.permalink or build_canonical_permalink(
+            project.permalink,
+            relative_path,
+            include_project=include_project_permalinks,
+        )
         source_notes.append(
             WikiSourceNote(
                 path=relative_path,

--- a/src/basic_memory/index/local_wiki_projection.py
+++ b/src/basic_memory/index/local_wiki_projection.py
@@ -63,6 +63,7 @@ class LocalWikiSourceState:
     accepted_at: datetime
     notes: tuple[WikiSourceNote, ...]
     changes: tuple[WikiSourceChange, ...]
+    reserved_documents: tuple[WikiReservedDocument, ...]
     ignore_patterns: tuple[str, ...]
 
 
@@ -220,7 +221,7 @@ async def _assert_projection_sources_unchanged(
         _source_state(current_snapshot, ignore_patterns=current_ignore_patterns)
         != inspection.source_state
     ):
-        raise LocalWikiWriteConflict("Wiki source notes or journal changed after planning")
+        raise LocalWikiWriteConflict("Wiki projection inputs changed after planning")
 
 
 def _source_state(
@@ -236,6 +237,7 @@ def _source_state(
         accepted_at=snapshot.source_accepted_at,
         notes=snapshot.notes,
         changes=snapshot.changes,
+        reserved_documents=snapshot.reserved_documents,
         ignore_patterns=tuple(sorted(ignore_patterns)),
     )
 
@@ -257,6 +259,11 @@ async def _load_local_wiki_snapshot(
         project_root,
         ignore_patterns=ignore_patterns,
     )
+    if scan.unreadable_directories:
+        raise OSError(
+            "Local Wiki scan is incomplete; unreadable directories: "
+            + ", ".join(scan.unreadable_directories)
+        )
     for relative_path in scan.file_paths:
         if not runtime_file_path_is_markdown_note(relative_path):
             continue

--- a/src/basic_memory/indexing/wiki_projector.py
+++ b/src/basic_memory/indexing/wiki_projector.py
@@ -11,6 +11,7 @@ from pathlib import PurePosixPath, PureWindowsPath
 import unicodedata
 
 from basic_memory.runtime.project_partition import RuntimeProjectNoteOperation
+from basic_memory.runtime.storage import RUNTIME_MARKDOWN_FILE_SUFFIXES
 
 OKF_VERSION = "0.2"
 WIKI_PROFILE = "wiki/1"
@@ -655,7 +656,10 @@ def _is_projector_change(change: WikiSourceChange) -> bool:
 
 def _normalize_note_path(path: str) -> str:
     normalized = _normalize_relative_path(path)
-    if not normalized or PurePosixPath(normalized).suffix.lower() != ".md":
+    if (
+        not normalized
+        or PurePosixPath(normalized).suffix.lower() not in RUNTIME_MARKDOWN_FILE_SUFFIXES
+    ):
         raise ValueError(f"Wiki note path must be project-relative Markdown: {path}")
     if "::" in normalized or any(character in normalized for character in "\r\n[]|`<>"):
         raise ValueError(f"Wiki note path contains unsupported Markdown delimiters: {path}")

--- a/src/basic_memory/indexing/wiki_projector.py
+++ b/src/basic_memory/indexing/wiki_projector.py
@@ -544,6 +544,7 @@ def _render_index(
     return _render_document(
         note_type="Index",
         title=title,
+        permalink=_reserved_path(scope, "index.md").removesuffix(".md"),
         source_watermark=source_watermark,
         generated_at=snapshot.source_accepted_at,
         body="\n".join(body),
@@ -590,6 +591,7 @@ def _render_log(
     return _render_document(
         note_type="Log",
         title=title,
+        permalink=_reserved_path(scope, "log.md").removesuffix(".md"),
         source_watermark=source_watermark,
         generated_at=snapshot.source_accepted_at,
         body="\n".join(body),
@@ -619,6 +621,7 @@ def _render_document(
     *,
     note_type: str,
     title: str,
+    permalink: str,
     source_watermark: int,
     generated_at: datetime,
     body: str,
@@ -628,6 +631,7 @@ def _render_document(
         "---",
         f"type: {note_type}",
         "bm_parse_semantics: false",
+        f"permalink: {json.dumps(permalink, ensure_ascii=False)}",
     ]
     if include_okf_version:
         frontmatter.append(f'okf_version: "{OKF_VERSION}"')

--- a/tests/cli/test_wiki_command.py
+++ b/tests/cli/test_wiki_command.py
@@ -3,11 +3,17 @@
 import json
 from types import SimpleNamespace
 
+import pytest
 from typer.testing import CliRunner
 
 from basic_memory.cli.app import app
-from basic_memory.cli.commands.wiki import WikiCommandReport, WikiProjectReport
+from basic_memory.cli.commands.wiki import (
+    WikiCommandReport,
+    WikiProjectReport,
+    _selected_local_project_names,
+)
 from basic_memory.cli.main import app as cli_app
+from basic_memory.config import BasicMemoryConfig, ProjectEntry
 import basic_memory.cli.commands.wiki as wiki_command
 
 runner = CliRunner()
@@ -121,6 +127,36 @@ def test_wiki_rejects_project_and_all_together(monkeypatch):
     assert result.exit_code == 1
     assert "either --project or --all" in result.stdout
     assert captured == []
+
+
+def test_wiki_rejects_relative_local_project_root():
+    app_config = BasicMemoryConfig(
+        projects={"unsafe": ProjectEntry(path="relative-root")},
+        default_project="unsafe",
+    )
+
+    with pytest.raises(ValueError, match="must have an absolute path"):
+        _selected_local_project_names(
+            app_config,
+            project_name="unsafe",
+            all_projects=False,
+        )
+
+
+def test_wiki_all_rejects_relative_local_project_root(tmp_path):
+    app_config = BasicMemoryConfig(
+        projects={
+            "safe": ProjectEntry(path=str(tmp_path / "safe")),
+            "unsafe": ProjectEntry(path="relative-root"),
+        }
+    )
+
+    with pytest.raises(ValueError, match="paths must be absolute: unsafe"):
+        _selected_local_project_names(
+            app_config,
+            project_name=None,
+            all_projects=True,
+        )
 
 
 def test_wiki_rebuild_builds_local_navigation(config_home, config_manager):

--- a/tests/cli/test_wiki_command.py
+++ b/tests/cli/test_wiki_command.py
@@ -10,6 +10,7 @@ from basic_memory.cli.app import app
 from basic_memory.cli.commands.wiki import (
     WikiCommandReport,
     WikiProjectReport,
+    _require_matching_project_root,
     _selected_local_project_names,
 )
 from basic_memory.cli.main import app as cli_app
@@ -156,6 +157,15 @@ def test_wiki_all_rejects_relative_local_project_root(tmp_path):
             app_config,
             project_name=None,
             all_projects=True,
+        )
+
+
+def test_wiki_rejects_persisted_root_that_differs_from_config(tmp_path):
+    with pytest.raises(ValueError, match="differs between config and the project database"):
+        _require_matching_project_root(
+            project_name="main",
+            configured_path=str(tmp_path / "configured"),
+            persisted_path=str(tmp_path / "stale-database-root"),
         )
 
 

--- a/tests/cli/test_wiki_command.py
+++ b/tests/cli/test_wiki_command.py
@@ -11,10 +11,13 @@ from basic_memory.cli.commands.wiki import (
     WikiCommandReport,
     WikiProjectReport,
     _require_matching_project_root,
+    _require_successful_index,
     _selected_local_project_names,
 )
 from basic_memory.cli.main import app as cli_app
 from basic_memory.config import BasicMemoryConfig, ProjectEntry
+from basic_memory.indexing.models import IndexFileBatchJobResult
+from basic_memory.indexing.project_index_coordinator import ProjectIndexCoordinatorResult
 import basic_memory.cli.commands.wiki as wiki_command
 
 runner = CliRunner()
@@ -167,6 +170,28 @@ def test_wiki_rejects_persisted_root_that_differs_from_config(tmp_path):
             configured_path=str(tmp_path / "configured"),
             persisted_path=str(tmp_path / "stale-database-root"),
         )
+
+
+def test_wiki_rebuild_rejects_recorded_index_failures():
+    result = ProjectIndexCoordinatorResult(
+        total_files=2,
+        enqueued_files=2,
+        enqueued_batches=1,
+        deleted_files=0,
+        batch_results=(
+            IndexFileBatchJobResult(
+                total_files=2,
+                processed_files=0,
+                missing_files=0,
+                failed_files=2,
+                file_results=(),
+                vector_targets=(),
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="indexing failed for 2 project files"):
+        _require_successful_index(result)
 
 
 def test_wiki_rebuild_builds_local_navigation(config_home, config_manager):

--- a/tests/cli/test_wiki_command.py
+++ b/tests/cli/test_wiki_command.py
@@ -172,7 +172,10 @@ def test_wiki_rejects_persisted_root_that_differs_from_config(tmp_path):
 def test_wiki_rebuild_builds_local_navigation(config_home, config_manager):
     note = config_home / "guides" / "start.md"
     note.parent.mkdir()
-    note.write_text("---\ntitle: Start Here\n---\n\n# Start\n", encoding="utf-8")
+    note.write_text(
+        "---\ntitle: Start Here\npermalink: guides/start\n---\n\n# Start\n",
+        encoding="utf-8",
+    )
 
     result = runner.invoke(
         cli_app,
@@ -187,3 +190,16 @@ def test_wiki_rebuild_builds_local_navigation(config_home, config_manager):
     assert (config_home / "index.md").is_file()
     assert (config_home / "guides" / "index.md").is_file()
     assert "[[guides/index|Guides]]" in (config_home / "index.md").read_text(encoding="utf-8")
+    initial_index = (config_home / "index.md").read_bytes()
+
+    status = runner.invoke(
+        cli_app,
+        ["wiki", "status", "--project", "test-project", "--json"],
+        env={"BASIC_MEMORY_NO_PROMOS": "1"},
+    )
+
+    assert status.exit_code == 0, status.stdout
+    status_report = json.loads(status.stdout)
+    assert status_report["projects"][0]["state"] == "current"
+    assert status_report["projects"][0]["writes"] == []
+    assert (config_home / "index.md").read_bytes() == initial_index

--- a/tests/cli/test_wiki_command.py
+++ b/tests/cli/test_wiki_command.py
@@ -1,0 +1,143 @@
+"""CLI contract for local Wiki projection commands."""
+
+import json
+from types import SimpleNamespace
+
+from typer.testing import CliRunner
+
+from basic_memory.cli.app import app
+from basic_memory.cli.commands.wiki import WikiCommandReport, WikiProjectReport
+from basic_memory.cli.main import app as cli_app
+import basic_memory.cli.commands.wiki as wiki_command
+
+runner = CliRunner()
+
+
+def _configure_cli(monkeypatch, captured: list[dict[str, object]]) -> None:
+    app_config = SimpleNamespace()
+    monkeypatch.setattr("basic_memory.cli.app.init_cli_logging", lambda: None)
+    monkeypatch.setattr("basic_memory.cli.app.maybe_show_init_line", lambda *_args: None)
+    monkeypatch.setattr("basic_memory.cli.app.maybe_show_cloud_promo", lambda *_args: None)
+    monkeypatch.setattr("basic_memory.cli.app.maybe_run_periodic_auto_update", lambda *_args: None)
+    monkeypatch.setattr(
+        "basic_memory.cli.app.CliContainer.create",
+        lambda: SimpleNamespace(config=app_config, mode=SimpleNamespace(is_cloud=False)),
+    )
+    monkeypatch.setattr("basic_memory.db.maybe_install_uvloop", lambda _config: None)
+    monkeypatch.setattr(
+        wiki_command,
+        "ConfigManager",
+        lambda: SimpleNamespace(config=app_config),
+    )
+
+    async def fake_execute(
+        config,
+        *,
+        command,
+        project_name,
+        all_projects,
+        dry_run,
+    ):
+        captured.append(
+            {
+                "config": config,
+                "command": command,
+                "project_name": project_name,
+                "all_projects": all_projects,
+                "dry_run": dry_run,
+            }
+        )
+        return WikiCommandReport(
+            command=command,
+            dry_run=dry_run,
+            success=True,
+            projects=[
+                WikiProjectReport(
+                    project=project_name or "main",
+                    path="/tmp/main",
+                    state="current",
+                    created=0,
+                    updated=0,
+                    unchanged=2,
+                )
+            ],
+        )
+
+    monkeypatch.setattr(wiki_command, "_execute_wiki_command", fake_execute)
+
+
+def test_wiki_rebuild_aliases_have_identical_semantics(monkeypatch):
+    captured: list[dict[str, object]] = []
+    _configure_cli(monkeypatch, captured)
+
+    for alias in ("rebuild", "init", "update"):
+        result = runner.invoke(
+            app,
+            ["wiki", alias, "--project", "research", "--dry-run", "--json"],
+        )
+        assert result.exit_code == 0, result.stdout
+        assert '"command":"rebuild"' in result.stdout
+
+    assert [entry["command"] for entry in captured] == ["rebuild", "rebuild", "rebuild"]
+    assert all(entry["project_name"] == "research" for entry in captured)
+    assert all(entry["dry_run"] is True for entry in captured)
+
+
+def test_wiki_validate_exits_nonzero_when_rebuild_is_needed(monkeypatch):
+    captured: list[dict[str, object]] = []
+    _configure_cli(monkeypatch, captured)
+
+    async def fake_validate(*_args, **_kwargs):
+        return WikiCommandReport(
+            command="validate",
+            success=False,
+            projects=[
+                WikiProjectReport(
+                    project="main",
+                    path="/tmp/main",
+                    state="outdated",
+                    created=0,
+                    updated=1,
+                    unchanged=1,
+                    writes=["index.md"],
+                )
+            ],
+        )
+
+    monkeypatch.setattr(wiki_command, "_execute_wiki_command", fake_validate)
+
+    result = runner.invoke(app, ["wiki", "validate", "--json"])
+
+    assert result.exit_code == 1
+    assert '"state":"outdated"' in result.stdout
+
+
+def test_wiki_rejects_project_and_all_together(monkeypatch):
+    captured: list[dict[str, object]] = []
+    _configure_cli(monkeypatch, captured)
+
+    result = runner.invoke(app, ["wiki", "status", "--project", "main", "--all"])
+
+    assert result.exit_code == 1
+    assert "either --project or --all" in result.stdout
+    assert captured == []
+
+
+def test_wiki_rebuild_builds_local_navigation(config_home, config_manager):
+    note = config_home / "guides" / "start.md"
+    note.parent.mkdir()
+    note.write_text("---\ntitle: Start Here\n---\n\n# Start\n", encoding="utf-8")
+
+    result = runner.invoke(
+        cli_app,
+        ["wiki", "rebuild", "--project", "test-project", "--json"],
+        env={"BASIC_MEMORY_NO_PROMOS": "1"},
+    )
+
+    assert result.exit_code == 0, result.stdout
+    report = json.loads(result.stdout)
+    assert report["success"] is True
+    assert report["projects"][0]["state"] == "current"
+    assert (config_home / "index.md").is_file()
+    assert (config_home / "guides" / "index.md").is_file()
+    assert "[[guides/index|Guides]]" in (config_home / "index.md").read_text(encoding="utf-8")

--- a/tests/fixtures/wiki_projector/basic_projection.json
+++ b/tests/fixtures/wiki_projector/basic_projection.json
@@ -3,9 +3,9 @@
   "project_id": "project-88",
   "through_partition_position": 3,
   "expected_sha256": {
-    "guides/index.md": "e0b43158cd8459fc441fb3d4f81100b0de8cf29b4ab324cc01a7b7c77e2c5b63",
-    "guides/log.md": "4f9a35fe972a1bcd7c38495e710b5bd9c712ec8e136033706f7436ecaee57031",
-    "index.md": "95771dff8c870604fdd4d4fce2d9a6dad8be1ea13f9ec56996f4b13218c378d2",
-    "log.md": "058f0f21ec2171d2e922c816ae97419cd2d942f3595db175d0b74a5b1cec9a97"
+    "guides/index.md": "f3ab73a5d89fe41fe8afddb15a4cff876ac7e37b18a3414f026f31bbd993c0c0",
+    "guides/log.md": "b035ec20f8f0f30d8cad072310b484f8eb2e2f8638cb840811a8d8b1f996a2d8",
+    "index.md": "feb74475e91fe6b037b24789d07365a94182e42a3c8ed7e6b1937130792ab87f",
+    "log.md": "7774b9f3cb6f9ee45dd765780ce7f0226ccb0f7dea48c9eaad8ee297fce1dd09"
   }
 }

--- a/tests/index/test_local_wiki_projection.py
+++ b/tests/index/test_local_wiki_projection.py
@@ -12,7 +12,7 @@ from basic_memory.index.local_wiki_projection import (
     apply_local_wiki_projection,
     inspect_local_wiki_projection,
 )
-from basic_memory.models import AcceptedProjectNoteChange
+from basic_memory.models import AcceptedProjectNoteChange, Project
 
 
 @pytest.mark.asyncio
@@ -34,7 +34,7 @@ async def test_local_wiki_rebuild_is_idempotent(config_home, session_maker, test
         "index.md",
         "log.md",
     ]
-    await apply_local_wiki_projection(first)
+    await apply_local_wiki_projection(first, session_maker=session_maker)
     initial_checksums = {
         path: sha256((config_home / path).read_bytes()).hexdigest()
         for path in ("guides/index.md", "guides/log.md", "index.md", "log.md")
@@ -75,13 +75,13 @@ async def test_local_wiki_reports_outdated_after_source_metadata_changes(
     note = config_home / "note.md"
     note.write_text("---\ntitle: First\n---\n\n# Note\n", encoding="utf-8")
     initial = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
-    await apply_local_wiki_projection(initial)
+    await apply_local_wiki_projection(initial, session_maker=session_maker)
     note.write_text("---\ntitle: Second\n---\n\n# Note\n", encoding="utf-8")
 
     inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
 
     assert inspection.state is LocalWikiState.outdated
-    assert [write.path for write in inspection.plan.writes] == ["index.md", "log.md"]
+    assert [write.path for write in inspection.plan.writes] == ["index.md"]
 
 
 @pytest.mark.asyncio
@@ -92,8 +92,10 @@ async def test_local_wiki_waits_for_pending_accepted_change(
 ):
     note = config_home / "note.md"
     note.write_text("# Note\n", encoding="utf-8")
-    test_project.partition_position = 1
     async with db.scoped_session(session_maker) as session:
+        project = await session.get(Project, test_project.id)
+        assert project is not None
+        project.partition_position = 1
         session.add(
             AcceptedProjectNoteChange(
                 project_id=test_project.id,
@@ -115,7 +117,7 @@ async def test_local_wiki_waits_for_pending_accepted_change(
     assert inspection.state is LocalWikiState.partial
     assert inspection.plan.result.pending_materialization == (1,)
     with pytest.raises(LocalWikiWriteConflict, match="materialized changes: 1"):
-        await apply_local_wiki_projection(inspection)
+        await apply_local_wiki_projection(inspection, session_maker=session_maker)
 
 
 @pytest.mark.asyncio
@@ -133,7 +135,7 @@ async def test_local_wiki_refuses_user_owned_reserved_document(
     assert inspection.plan.writes == ()
     assert [conflict.path for conflict in inspection.plan.result.conflicts] == ["index.md"]
     with pytest.raises(LocalWikiWriteConflict, match="reserved-document conflicts"):
-        await apply_local_wiki_projection(inspection)
+        await apply_local_wiki_projection(inspection, session_maker=session_maker)
     assert existing.read_text(encoding="utf-8") == "# My hand-written index\n"
 
 
@@ -149,7 +151,7 @@ async def test_local_wiki_checks_every_reserved_path_before_writing(
     (config_home / "log.md").write_text("concurrent edit\n", encoding="utf-8")
 
     with pytest.raises(LocalWikiWriteConflict, match="appeared after planning: log.md"):
-        await apply_local_wiki_projection(inspection)
+        await apply_local_wiki_projection(inspection, session_maker=session_maker)
 
     # The preflight sees the later log.md conflict before creating index.md.
     assert not (config_home / "index.md").exists()
@@ -171,7 +173,7 @@ async def test_local_wiki_refuses_changed_existing_reserved_document(
     note = config_home / "note.md"
     note.write_text("---\ntitle: First\n---\n\n# Note\n", encoding="utf-8")
     initial = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
-    await apply_local_wiki_projection(initial)
+    await apply_local_wiki_projection(initial, session_maker=session_maker)
     note.write_text("---\ntitle: Second\n---\n\n# Note\n", encoding="utf-8")
     update = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
     index_path = config_home / "index.md"
@@ -181,7 +183,59 @@ async def test_local_wiki_refuses_changed_existing_reserved_document(
         index_path.unlink()
 
     with pytest.raises(LocalWikiWriteConflict, match=f"{message} after planning"):
-        await apply_local_wiki_projection(update)
+        await apply_local_wiki_projection(update, session_maker=session_maker)
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_refuses_source_note_changed_after_planning(
+    config_home,
+    session_maker,
+    test_project,
+):
+    note = config_home / "note.md"
+    note.write_text("# First\n", encoding="utf-8")
+    inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+    note.write_text("# Second\n", encoding="utf-8")
+
+    with pytest.raises(LocalWikiWriteConflict, match="source notes or journal changed"):
+        await apply_local_wiki_projection(inspection, session_maker=session_maker)
+
+    assert not (config_home / "index.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_refuses_journal_advanced_after_planning(
+    config_home,
+    session_maker,
+    test_project,
+):
+    note = config_home / "note.md"
+    note.write_text("# Note\n", encoding="utf-8")
+    inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+    async with db.scoped_session(session_maker) as session:
+        project = await session.get(Project, test_project.id)
+        assert project is not None
+        project.partition_position = 1
+        session.add(
+            AcceptedProjectNoteChange(
+                project_id=test_project.id,
+                project_external_id=test_project.external_id,
+                partition_position=1,
+                entity_id=1,
+                note_external_id="note-1",
+                permalink="note",
+                title="Note",
+                operation="updated",
+                file_path="note.md",
+                accepted_at=datetime.now(UTC),
+                source="write_note",
+            )
+        )
+
+    with pytest.raises(LocalWikiWriteConflict, match="source notes or journal changed"):
+        await apply_local_wiki_projection(inspection, session_maker=session_maker)
+
+    assert not (config_home / "index.md").exists()
 
 
 @pytest.mark.asyncio
@@ -226,7 +280,10 @@ async def test_local_wiki_requires_existing_project_directory(
     session_maker,
     test_project,
 ):
-    test_project.path = str(config_home / "missing")
+    async with db.scoped_session(session_maker) as session:
+        project = await session.get(Project, test_project.id)
+        assert project is not None
+        project.path = str(config_home / "missing")
 
     with pytest.raises(ValueError, match="Local project directory does not exist"):
         await inspect_local_wiki_projection(test_project, session_maker=session_maker)

--- a/tests/index/test_local_wiki_projection.py
+++ b/tests/index/test_local_wiki_projection.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime
 from hashlib import sha256
+import sys
 
 import pytest
 
@@ -104,6 +105,47 @@ async def test_local_wiki_rejects_incomplete_filesystem_scan(
         await inspect_local_wiki_projection(test_project, session_maker=session_maker)
 
     assert not (config_home / "index.md").exists()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Symlink setup requires extra privileges")
+@pytest.mark.asyncio
+async def test_local_wiki_refuses_symlinked_projection_parent(
+    config_home,
+    session_maker,
+    test_project,
+    tmp_path,
+):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (config_home / "linked").symlink_to(outside, target_is_directory=True)
+    accepted_at = datetime.now(UTC)
+    async with db.scoped_session(session_maker) as session:
+        project = await session.get(Project, test_project.id)
+        assert project is not None
+        project.partition_position = 1
+        session.add(
+            AcceptedProjectNoteChange(
+                project_id=test_project.id,
+                project_external_id=test_project.external_id,
+                partition_position=1,
+                entity_id=1,
+                note_external_id="deleted-note",
+                permalink="linked/note",
+                title="Deleted note",
+                operation="deleted",
+                file_path="linked/note.md",
+                accepted_at=accepted_at,
+                materialized_at=accepted_at,
+                source="delete_note",
+            )
+        )
+
+    inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+
+    with pytest.raises(LocalWikiWriteConflict, match="crosses a symlink.*linked/index.md"):
+        await apply_local_wiki_projection(inspection, session_maker=session_maker)
+
+    assert list(outside.iterdir()) == []
 
 
 @pytest.mark.asyncio

--- a/tests/index/test_local_wiki_projection.py
+++ b/tests/index/test_local_wiki_projection.py
@@ -1,0 +1,232 @@
+"""Local filesystem execution for deterministic Wiki projections."""
+
+from datetime import UTC, datetime
+from hashlib import sha256
+
+import pytest
+
+from basic_memory import db
+from basic_memory.index.local_wiki_projection import (
+    LocalWikiState,
+    LocalWikiWriteConflict,
+    apply_local_wiki_projection,
+    inspect_local_wiki_projection,
+)
+from basic_memory.models import AcceptedProjectNoteChange
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_rebuild_is_idempotent(config_home, session_maker, test_project):
+    guide = config_home / "guides" / "getting-started.md"
+    guide.parent.mkdir()
+    guide.write_text(
+        "---\ntitle: Getting Started\npermalink: guides/getting-started\n---\n\n# Start\n",
+        encoding="utf-8",
+    )
+    (config_home / "attachment.txt").write_text("not a note\n", encoding="utf-8")
+
+    first = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+
+    assert first.state is LocalWikiState.uninitialized
+    assert [write.path for write in first.plan.writes] == [
+        "guides/index.md",
+        "guides/log.md",
+        "index.md",
+        "log.md",
+    ]
+    await apply_local_wiki_projection(first)
+    initial_checksums = {
+        path: sha256((config_home / path).read_bytes()).hexdigest()
+        for path in ("guides/index.md", "guides/log.md", "index.md", "log.md")
+    }
+
+    second = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+
+    assert second.state is LocalWikiState.current
+    assert second.plan.writes == ()
+    assert second.plan.result.unchanged == 4
+    assert {
+        path: sha256((config_home / path).read_bytes()).hexdigest() for path in initial_checksums
+    } == initial_checksums
+    assert "[[guides/index|Guides]]" in (config_home / "index.md").read_text()
+    assert (
+        "[[guides/getting-started|Getting Started]]"
+        in (config_home / "guides" / "index.md").read_text()
+    )
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_includes_long_markdown_suffix(config_home, session_maker, test_project):
+    note = config_home / "reference.markdown"
+    note.write_text("---\ntitle: Reference\n---\n\n# Reference\n", encoding="utf-8")
+
+    inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+
+    root_index = next(write for write in inspection.plan.writes if write.path == "index.md")
+    assert "[[reference|Reference]]" in root_index.content.decode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_reports_outdated_after_source_metadata_changes(
+    config_home,
+    session_maker,
+    test_project,
+):
+    note = config_home / "note.md"
+    note.write_text("---\ntitle: First\n---\n\n# Note\n", encoding="utf-8")
+    initial = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+    await apply_local_wiki_projection(initial)
+    note.write_text("---\ntitle: Second\n---\n\n# Note\n", encoding="utf-8")
+
+    inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+
+    assert inspection.state is LocalWikiState.outdated
+    assert [write.path for write in inspection.plan.writes] == ["index.md", "log.md"]
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_waits_for_pending_accepted_change(
+    config_home,
+    session_maker,
+    test_project,
+):
+    note = config_home / "note.md"
+    note.write_text("# Note\n", encoding="utf-8")
+    test_project.partition_position = 1
+    async with db.scoped_session(session_maker) as session:
+        session.add(
+            AcceptedProjectNoteChange(
+                project_id=test_project.id,
+                project_external_id=test_project.external_id,
+                partition_position=1,
+                entity_id=1,
+                note_external_id="note-1",
+                permalink="note",
+                title="Note",
+                operation="created",
+                file_path="note.md",
+                accepted_at=datetime.now(UTC),
+                source="write_note",
+            )
+        )
+
+    inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+
+    assert inspection.state is LocalWikiState.partial
+    assert inspection.plan.result.pending_materialization == (1,)
+    with pytest.raises(LocalWikiWriteConflict, match="materialized changes: 1"):
+        await apply_local_wiki_projection(inspection)
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_refuses_user_owned_reserved_document(
+    config_home,
+    session_maker,
+    test_project,
+):
+    existing = config_home / "index.md"
+    existing.write_text("# My hand-written index\n", encoding="utf-8")
+
+    inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+
+    assert inspection.state is LocalWikiState.conflicted
+    assert inspection.plan.writes == ()
+    assert [conflict.path for conflict in inspection.plan.result.conflicts] == ["index.md"]
+    with pytest.raises(LocalWikiWriteConflict, match="reserved-document conflicts"):
+        await apply_local_wiki_projection(inspection)
+    assert existing.read_text(encoding="utf-8") == "# My hand-written index\n"
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_checks_every_reserved_path_before_writing(
+    config_home,
+    session_maker,
+    test_project,
+):
+    note = config_home / "note.md"
+    note.write_text("# Note\n", encoding="utf-8")
+    inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+    (config_home / "log.md").write_text("concurrent edit\n", encoding="utf-8")
+
+    with pytest.raises(LocalWikiWriteConflict, match="appeared after planning: log.md"):
+        await apply_local_wiki_projection(inspection)
+
+    # The preflight sees the later log.md conflict before creating index.md.
+    assert not (config_home / "index.md").exists()
+    assert (config_home / "log.md").read_text(encoding="utf-8") == "concurrent edit\n"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("concurrent_change", "message"),
+    [("changed", "changed"), ("missing", "disappeared")],
+)
+async def test_local_wiki_refuses_changed_existing_reserved_document(
+    config_home,
+    session_maker,
+    test_project,
+    concurrent_change,
+    message,
+):
+    note = config_home / "note.md"
+    note.write_text("---\ntitle: First\n---\n\n# Note\n", encoding="utf-8")
+    initial = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+    await apply_local_wiki_projection(initial)
+    note.write_text("---\ntitle: Second\n---\n\n# Note\n", encoding="utf-8")
+    update = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+    index_path = config_home / "index.md"
+    if concurrent_change == "changed":
+        index_path.write_text("concurrent edit\n", encoding="utf-8")
+    else:
+        index_path.unlink()
+
+    with pytest.raises(LocalWikiWriteConflict, match=f"{message} after planning"):
+        await apply_local_wiki_projection(update)
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_rejects_noncanonical_reserved_filename(
+    config_home,
+    session_maker,
+    test_project,
+):
+    (config_home / "Index.md").write_text(
+        """---
+generated:
+  by: Basic Memory Wiki Projector
+bm:
+  profile: wiki/1
+---
+# Index
+""",
+        encoding="utf-8",
+    )
+
+    inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+
+    assert inspection.state is LocalWikiState.conflicted
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_treats_malformed_reserved_frontmatter_as_unowned(
+    config_home,
+    session_maker,
+    test_project,
+):
+    (config_home / "index.md").write_text("---\ngenerated: [\n---\n", encoding="utf-8")
+
+    inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+
+    assert inspection.state is LocalWikiState.conflicted
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_requires_existing_project_directory(
+    config_home,
+    session_maker,
+    test_project,
+):
+    test_project.path = str(config_home / "missing")
+
+    with pytest.raises(ValueError, match="Local project directory does not exist"):
+        await inspect_local_wiki_projection(test_project, session_maker=session_maker)

--- a/tests/index/test_local_wiki_projection.py
+++ b/tests/index/test_local_wiki_projection.py
@@ -66,7 +66,26 @@ async def test_local_wiki_includes_long_markdown_suffix(config_home, session_mak
     inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
 
     root_index = next(write for write in inspection.plan.writes if write.path == "index.md")
-    assert "[[reference|Reference]]" in root_index.content.decode("utf-8")
+    assert "[[test-project/reference|Reference]]" in root_index.content.decode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_uses_configured_canonical_fallback_permalink(
+    config_home,
+    session_maker,
+    test_project,
+):
+    note = config_home / "reference.md"
+    note.write_text("---\ntitle: Reference\n---\n\n# Reference\n", encoding="utf-8")
+
+    inspection = await inspect_local_wiki_projection(
+        test_project,
+        session_maker=session_maker,
+        include_project_permalinks=True,
+    )
+
+    root_index = next(write for write in inspection.plan.writes if write.path == "index.md")
+    assert f"[[{test_project.permalink}/reference|Reference]]" in root_index.content.decode("utf-8")
 
 
 @pytest.mark.asyncio

--- a/tests/index/test_local_wiki_projection.py
+++ b/tests/index/test_local_wiki_projection.py
@@ -67,6 +67,21 @@ async def test_local_wiki_includes_long_markdown_suffix(config_home, session_mak
 
 
 @pytest.mark.asyncio
+async def test_local_wiki_rejects_ignored_reserved_destination(
+    config_home,
+    session_maker,
+    test_project,
+):
+    (config_home / ".gitignore").write_text("index.md\n", encoding="utf-8")
+    (config_home / "note.md").write_text("# Note\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="reserved paths are ignored.*index.md"):
+        await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+
+    assert not (config_home / "index.md").exists()
+
+
+@pytest.mark.asyncio
 async def test_local_wiki_reports_outdated_after_source_metadata_changes(
     config_home,
     session_maker,
@@ -196,6 +211,22 @@ async def test_local_wiki_refuses_source_note_changed_after_planning(
     note.write_text("# First\n", encoding="utf-8")
     inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
     note.write_text("# Second\n", encoding="utf-8")
+
+    with pytest.raises(LocalWikiWriteConflict, match="source notes or journal changed"):
+        await apply_local_wiki_projection(inspection, session_maker=session_maker)
+
+    assert not (config_home / "index.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_refuses_ignore_rules_changed_after_planning(
+    config_home,
+    session_maker,
+    test_project,
+):
+    (config_home / "note.md").write_text("# Note\n", encoding="utf-8")
+    inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+    (config_home / ".gitignore").write_text("index.md\n", encoding="utf-8")
 
     with pytest.raises(LocalWikiWriteConflict, match="source notes or journal changed"):
         await apply_local_wiki_projection(inspection, session_maker=session_maker)

--- a/tests/index/test_local_wiki_projection.py
+++ b/tests/index/test_local_wiki_projection.py
@@ -12,6 +12,8 @@ from basic_memory.index.local_wiki_projection import (
     apply_local_wiki_projection,
     inspect_local_wiki_projection,
 )
+from basic_memory.index.local_project import LocalProjectIndexScan
+import basic_memory.index.local_wiki_projection as local_wiki_projection
 from basic_memory.models import AcceptedProjectNoteChange, Project
 
 
@@ -76,6 +78,29 @@ async def test_local_wiki_rejects_ignored_reserved_destination(
     (config_home / "note.md").write_text("# Note\n", encoding="utf-8")
 
     with pytest.raises(ValueError, match="reserved paths are ignored.*index.md"):
+        await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+
+    assert not (config_home / "index.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_rejects_incomplete_filesystem_scan(
+    config_home,
+    session_maker,
+    test_project,
+    monkeypatch,
+):
+    (config_home / "note.md").write_text("# Note\n", encoding="utf-8")
+    monkeypatch.setattr(
+        local_wiki_projection,
+        "scan_local_project_index_files",
+        lambda *_args, **_kwargs: LocalProjectIndexScan(
+            file_paths=("note.md",),
+            unreadable_directories=("private",),
+        ),
+    )
+
+    with pytest.raises(OSError, match="scan is incomplete.*private"):
         await inspect_local_wiki_projection(test_project, session_maker=session_maker)
 
     assert not (config_home / "index.md").exists()
@@ -165,7 +190,7 @@ async def test_local_wiki_checks_every_reserved_path_before_writing(
     inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
     (config_home / "log.md").write_text("concurrent edit\n", encoding="utf-8")
 
-    with pytest.raises(LocalWikiWriteConflict, match="appeared after planning: log.md"):
+    with pytest.raises(LocalWikiWriteConflict, match="projection inputs changed"):
         await apply_local_wiki_projection(inspection, session_maker=session_maker)
 
     # The preflight sees the later log.md conflict before creating index.md.
@@ -174,16 +199,12 @@ async def test_local_wiki_checks_every_reserved_path_before_writing(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("concurrent_change", "message"),
-    [("changed", "changed"), ("missing", "disappeared")],
-)
+@pytest.mark.parametrize("concurrent_change", ["changed", "missing"])
 async def test_local_wiki_refuses_changed_existing_reserved_document(
     config_home,
     session_maker,
     test_project,
     concurrent_change,
-    message,
 ):
     note = config_home / "note.md"
     note.write_text("---\ntitle: First\n---\n\n# Note\n", encoding="utf-8")
@@ -197,8 +218,31 @@ async def test_local_wiki_refuses_changed_existing_reserved_document(
     else:
         index_path.unlink()
 
-    with pytest.raises(LocalWikiWriteConflict, match=f"{message} after planning"):
+    with pytest.raises(LocalWikiWriteConflict, match="projection inputs changed"):
         await apply_local_wiki_projection(update, session_maker=session_maker)
+
+
+@pytest.mark.asyncio
+async def test_local_wiki_preflights_unchanged_reserved_documents(
+    config_home,
+    session_maker,
+    test_project,
+):
+    note = config_home / "note.md"
+    note.write_text("---\ntitle: First\n---\n\n# Note\n", encoding="utf-8")
+    initial = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+    await apply_local_wiki_projection(initial, session_maker=session_maker)
+    original_index = (config_home / "index.md").read_bytes()
+
+    note.write_text("---\ntitle: Second\n---\n\n# Note\n", encoding="utf-8")
+    update = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+    assert [write.path for write in update.plan.writes] == ["index.md"]
+    (config_home / "log.md").write_text("concurrent edit\n", encoding="utf-8")
+
+    with pytest.raises(LocalWikiWriteConflict, match="projection inputs changed"):
+        await apply_local_wiki_projection(update, session_maker=session_maker)
+
+    assert (config_home / "index.md").read_bytes() == original_index
 
 
 @pytest.mark.asyncio
@@ -212,7 +256,7 @@ async def test_local_wiki_refuses_source_note_changed_after_planning(
     inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
     note.write_text("# Second\n", encoding="utf-8")
 
-    with pytest.raises(LocalWikiWriteConflict, match="source notes or journal changed"):
+    with pytest.raises(LocalWikiWriteConflict, match="projection inputs changed"):
         await apply_local_wiki_projection(inspection, session_maker=session_maker)
 
     assert not (config_home / "index.md").exists()
@@ -228,7 +272,7 @@ async def test_local_wiki_refuses_ignore_rules_changed_after_planning(
     inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
     (config_home / ".gitignore").write_text("index.md\n", encoding="utf-8")
 
-    with pytest.raises(LocalWikiWriteConflict, match="source notes or journal changed"):
+    with pytest.raises(LocalWikiWriteConflict, match="projection inputs changed"):
         await apply_local_wiki_projection(inspection, session_maker=session_maker)
 
     assert not (config_home / "index.md").exists()
@@ -263,7 +307,7 @@ async def test_local_wiki_refuses_journal_advanced_after_planning(
             )
         )
 
-    with pytest.raises(LocalWikiWriteConflict, match="source notes or journal changed"):
+    with pytest.raises(LocalWikiWriteConflict, match="projection inputs changed"):
         await apply_local_wiki_projection(inspection, session_maker=session_maker)
 
     assert not (config_home / "index.md").exists()

--- a/tests/indexing/test_wiki_projector.py
+++ b/tests/indexing/test_wiki_projector.py
@@ -390,6 +390,8 @@ def test_projection_renders_root_and_affected_directory_indexes_and_logs() -> No
     assert "Updated [[guides/setup|Setup]]" in rendered["guides/log.md"]
     assert "bm_parse_semantics: false" in rendered["index.md"]
     assert "bm_parse_semantics: false" in rendered["log.md"]
+    assert 'permalink: "index"' in rendered["index.md"]
+    assert 'permalink: "guides/log"' in rendered["guides/log.md"]
     assert plan.result.source_watermark == 3
     assert plan.result.output_watermark == 3
     assert plan.result.created == 4

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -22,6 +22,7 @@ from basic_memory.file_utils import (
     sanitize_for_filename,
     sanitize_for_directory,
     write_file_atomic,
+    write_file_atomic_bytes,
 )
 
 # Skip marker for tests that use Unix-specific commands (cat, sh, sleep, /dev/null)
@@ -71,6 +72,24 @@ async def test_write_file_atomic(tmp_path: Path):
 
     # Temp file should be cleaned up
     assert not test_file.with_suffix(".tmp").exists()
+
+
+@pytest.mark.asyncio
+async def test_atomic_writes_preserve_legacy_staging_names(tmp_path: Path):
+    text_target = tmp_path / "note.md"
+    bytes_target = tmp_path / "index.md"
+    text_staging_name = tmp_path / "note.tmp"
+    bytes_staging_name = tmp_path / "index.tmp"
+    text_staging_name.write_text("user text\n", encoding="utf-8")
+    bytes_staging_name.write_bytes(b"user bytes\n")
+
+    await write_file_atomic(text_target, "new text\n")
+    await write_file_atomic_bytes(bytes_target, b"new bytes\n")
+
+    assert text_target.read_text(encoding="utf-8") == "new text\n"
+    assert bytes_target.read_bytes() == b"new bytes\n"
+    assert text_staging_name.read_text(encoding="utf-8") == "user text\n"
+    assert bytes_staging_name.read_bytes() == b"user bytes\n"
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -1,6 +1,7 @@
 """Tests for file utilities."""
 
 import random
+import stat
 import string
 import sys
 from pathlib import Path
@@ -90,6 +91,28 @@ async def test_atomic_writes_preserve_legacy_staging_names(tmp_path: Path):
     assert bytes_target.read_bytes() == b"new bytes\n"
     assert text_staging_name.read_text(encoding="utf-8") == "user text\n"
     assert bytes_staging_name.read_bytes() == b"user bytes\n"
+
+
+@skip_on_windows
+@pytest.mark.asyncio
+async def test_atomic_writes_preserve_existing_modes_and_umask_defaults(tmp_path: Path):
+    text_target = tmp_path / "note.md"
+    bytes_target = tmp_path / "index.md"
+    text_target.write_text("old text\n", encoding="utf-8")
+    bytes_target.write_bytes(b"old bytes\n")
+    text_target.chmod(0o664)
+    bytes_target.chmod(0o640)
+    reference = tmp_path / "reference.md"
+    reference.touch()
+    new_target = tmp_path / "new.md"
+
+    await write_file_atomic(text_target, "new text\n")
+    await write_file_atomic_bytes(bytes_target, b"new bytes\n")
+    await write_file_atomic_bytes(new_target, b"new file\n")
+
+    assert stat.S_IMODE(text_target.stat().st_mode) == 0o664
+    assert stat.S_IMODE(bytes_target.stat().st_mode) == 0o640
+    assert stat.S_IMODE(new_target.stat().st_mode) == stat.S_IMODE(reference.stat().st_mode)
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -100,18 +100,30 @@ async def test_atomic_writes_preserve_existing_modes_and_umask_defaults(tmp_path
     bytes_target = tmp_path / "index.md"
     text_target.write_text("old text\n", encoding="utf-8")
     bytes_target.write_bytes(b"old bytes\n")
+    readonly_text_target = tmp_path / "readonly-note.md"
+    readonly_bytes_target = tmp_path / "readonly-index.md"
+    readonly_text_target.write_text("old readonly text\n", encoding="utf-8")
+    readonly_bytes_target.write_bytes(b"old readonly bytes\n")
     text_target.chmod(0o664)
     bytes_target.chmod(0o640)
+    readonly_text_target.chmod(0o444)
+    readonly_bytes_target.chmod(0o444)
     reference = tmp_path / "reference.md"
     reference.touch()
     new_target = tmp_path / "new.md"
 
     await write_file_atomic(text_target, "new text\n")
     await write_file_atomic_bytes(bytes_target, b"new bytes\n")
+    await write_file_atomic(readonly_text_target, "new readonly text\n")
+    await write_file_atomic_bytes(readonly_bytes_target, b"new readonly bytes\n")
     await write_file_atomic_bytes(new_target, b"new file\n")
 
     assert stat.S_IMODE(text_target.stat().st_mode) == 0o664
     assert stat.S_IMODE(bytes_target.stat().st_mode) == 0o640
+    assert readonly_text_target.read_text(encoding="utf-8") == "new readonly text\n"
+    assert readonly_bytes_target.read_bytes() == b"new readonly bytes\n"
+    assert stat.S_IMODE(readonly_text_target.stat().st_mode) == 0o444
+    assert stat.S_IMODE(readonly_bytes_target.stat().st_mode) == 0o444
     assert stat.S_IMODE(new_target.stat().st_mode) == stat.S_IMODE(reference.stat().st_mode)
 
 


### PR DESCRIPTION
## Why

Basic Memory now has a shared deterministic Wiki projector, but local Core projects had no supported way to materialize its navigation pages. That left `index.md` and `log.md` generation unavailable from the CLI even though those pages are needed for normal Wiki traversal.

## What Changed

- Add `bm wiki status` and `bm wiki validate` for inspecting local Wiki projection state.
- Add idempotent `bm wiki rebuild`, with `init` and `update` as exact aliases.
- Support `--project`, `--all`, `--json`, and build previews through `--dry-run`.
- Generate root and nested `index.md`/`log.md` documents and index them immediately for API, MCP, and search access.
- Recognize both `.md` and `.markdown` notes in the shared projector.

## Implementation Details

- `local_wiki_projection.py` adapts the existing pure Wiki projection planner to local filesystem projects instead of introducing a second renderer.
- Generated-file ownership requires the canonical reserved filename plus the Wiki projector frontmatter markers. User-authored reserved documents and noncanonical casing are treated as conflicts.
- Rebuilds perform checksum preflight checks for every planned path before the first atomic write, preventing knowingly mixed projections after concurrent edits.
- Commands reuse Core's local-sync safety guard and reject empty or relative project roots before filesystem access.
- Commands require the configured project root to match the persisted database root before inspecting or rebuilding a projection.
- Apply reloads the canonical project row and revalidates the complete note and accepted-change input state before publishing a planned projection.
- Apply preflights every inspected reserved document, including pages whose planned output is unchanged, before writing any other page.
- Apply rejects generated destinations with symlinked path components so historical scopes cannot escape the project root.
- Incomplete filesystem scans abort projection planning instead of treating unreadable subtrees as empty.
- Local generated timestamps advance from accepted journal evidence rather than filesystem mtimes, avoiding project-wide timestamp-only rewrites after a direct edit.
- Source notes without an explicit permalink use the same project-prefix configuration as normal indexing, preventing a rebuild from becoming stale when indexing adds frontmatter.
- Generated pages carry stable path-derived permalinks before indexing, so index normalization cannot make a completed rebuild immediately outdated.
- Rebuilds inspect project-index batch results and fail when any file could not be indexed instead of reporting a false current state.
- Atomic file writes use collision-free same-directory staging files, preserve existing target permissions, honor the process umask for new files, and preserve user-owned legacy names such as `index.tmp`.
- Planned reserved paths are rejected when project ignore rules would prevent them from being indexed; ignore-rule changes are also revalidated before writes.
- Local runs compare the complete rendered output because Core does not maintain a durable projection ledger. A second rebuild is therefore a byte-for-byte no-op.
- CLI JSON output is defined by typed Pydantic report models. Cloud projects are rejected explicitly; scheduled Cloud materialization is a separate follow-up.

## Testing

### Automated

- `just fast-check`: passed
- `.venv/bin/pytest -q tests/utils/test_file_utils.py tests/index/test_local_wiki_projection.py tests/indexing/test_wiki_projector.py tests/cli/test_wiki_command.py tests/cli/test_cli_exit.py::test_bm_cli_import_does_not_load_heavy_stack tests/cli/test_cli_exit.py::test_bm_help_exits_cleanly`: 160 passed
- `git diff --check`: passed

### Manual

- `BASIC_MEMORY_CONFIG_DIR=/tmp/basic-memory-wiki-cli-smoke .venv/bin/bm wiki --help`: confirmed the complete command surface and alias descriptions.

## Risks / Follow-ups

- Rebuild intentionally refuses to overwrite user-owned `index.md` or `log.md` documents; users must resolve those ownership conflicts explicitly.
- Cloud scheduling is not included. Basic Memory Cloud will add equivalent PGQueuer jobs after the Core behavior is accepted.
