### PR TITLE
docs(skills): use the POSIX read verbs in literary analysis, drop canvas

### DIFF
--- a/skills/memory-literary-analysis/SKILL.md
+++ b/skills/memory-literary-analysis/SKILL.md
@@ -479,9 +479,11 @@ A field a note never set comes back as a blank cell (`null` under `--json`), so 
 blanks are the work queue. This turns "audit the graph" from a read of every note into one
 call per question.
 
-Note the capitalized `Chapter`/`Character` — they must match the `note_type` your Phase 0
-schemas authored, exactly. And `--page-size 200` is not decoration: without it these return
-the first 10 rows and the work queue looks ten items long.
+Note the lowercase `chapter`/`character` — `write_note` snake-cases `note_type` before the
+note is written, so that is the value on disk no matter how your Phase 0 schemas spelled it.
+Match it exactly; the capitalized spelling returns zero rows and exit 0. And `--page-size 200`
+is not decoration: without it these return the first 10 rows and the work queue looks ten
+items long.
 
 ### Character Arcs
 For each major character, write a full `[arc]` summary observation covering their trajectory across the work.

--- a/skills/memory-literary-analysis/SKILL.md
+++ b/skills/memory-literary-analysis/SKILL.md
@@ -34,8 +34,8 @@ the work in a long analysis — prefer the POSIX read verbs where they are avail
 
 | Need | Use | Instead of |
 |------|-----|-----------|
-| A section of a long note | `cat <note> --section EXAMPLES` | reading the whole note |
-| A line range of the source text | `cat <file> --lines 4200-4890` | loading the whole book |
+| A section of a long note | `cat <note> --section Observations` | reading the whole note |
+| A line range of the source text | `cat <source>.txt --lines 4200-4890` | loading the whole book |
 | Notes matching frontmatter | `find --meta status=active` | reading notes to check fields |
 | Fields across many notes | `find --meta ... --fields pov,setting` | one read per note |
 | Where something lives | `ls`, `tree`, `find --name '*.md'` | listing everything |
@@ -49,6 +49,23 @@ The two rules that matter across a 100+ chapter run:
 
 These compound. In measured runs, predicate queries replaced 28-call scans with a single
 call; across 138 chapters that difference is the run.
+
+Three sharp edges to know before you write a query. The first two fail *quietly* — a wrong
+answer, exit 0, no warning — so learn them here rather than from a graph you thought you had
+audited:
+
+- **`--meta` reads frontmatter, and matches case-sensitively.** `note_type` is an alias for
+  the frontmatter `type:` key, compared with SQL `=`. A note written with
+  `note_type="Chapter"` matches `--meta 'note_type=Chapter'` and **not**
+  `--meta 'note_type=chapter'` — the lowercase form returns zero rows and exit 0. Confusingly,
+  a result row *displays* the snake-cased index projection (`"note_type": "chapter"`,
+  `"literary_device"`); that is not the value to query with. Query with the casing your
+  schemas authored.
+- **`find` pages, and the default page is 10.** Any query whose answer is "all N chapters"
+  needs `--page-size 200` (the maximum) — see [Coverage Checks](#coverage-checks).
+- **`--name` cannot combine with `--meta`.** The metadata search matches slugified permalinks,
+  not filenames. Scope a `--meta` query with the positional path instead: `find /characters
+  --meta 'note_type=Character'`.
 
 If the POSIX verbs are unavailable, every step below still works with `search_notes`,
 `read_note`, and `list_directory` — it just costs more.
@@ -239,6 +256,7 @@ Schema for literary technique and device notes.
 
 ```
 <project>/
+  <work>.txt         # the source text, verbatim (see Phase 2)
   schema/            # 6 schema definitions
   chapters/          # one note per chapter/section + prologue/epilogue
   characters/
@@ -298,14 +316,41 @@ Stubs don't need to be complete — they give `[[wiki-link]]` targets and will b
 
 Obtain the full text and identify chapter/section boundaries. For public domain works, Project Gutenberg is a good source. For copyrighted works, work from a physical or licensed digital copy.
 
-**Build a chapter offset map once, before processing.** Scan the text for chapter headings
-and record the line range of each chapter, then read chapters by range rather than reloading
-the book:
+**Put the source text inside the project directory, as `.txt`, and index it once.** `bm cat`
+resolves a *note identifier*, not a filesystem path — it can only reach a file the project
+index has observed. A one-time index pass gives the raw text an entity row, after which the
+line-range slice works against it:
 
 ```bash
-grep -n '^CHAPTER ' moby-dick.txt        # or the work's heading pattern
-bm cat moby-dick.txt --lines 4200-4890   # one chapter, not the whole text
+cp ~/Downloads/moby-dick.txt ~/basic-memory/moby-dick/moby-dick.txt
+bm reindex --search -p moby-dick          # one pass; the .txt becomes readable
 ```
+
+Two constraints that make this the right shape, both worth respecting:
+
+- **Keep it `.txt`, do not convert it to `.md`.** Basic Memory injects frontmatter into
+  markdown notes, which shifts every line number by the height of that block — an offset map
+  built from the original file would then be silently wrong. A `.txt` is stored verbatim, so
+  its line numbers stay 1:1 with the file on disk.
+- **Keep it inside the project.** A source text elsewhere on disk is not an entity, and
+  `bm cat` answers `Error: Entity not found`. If you must leave it outside, drop the BM verbs
+  for the source and use plain shell (`sed -n '4200,4890p' <path>`) — the notes still get the
+  BM verbs, only the raw source falls back to the shell.
+
+**Then build a chapter offset map once, before processing.** Scan the text for chapter
+headings and record the line range of each chapter, then read chapters by range rather than
+reloading the book:
+
+```bash
+grep -n '^CHAPTER ' ~/basic-memory/moby-dick/moby-dick.txt   # heading -> line number
+bm cat moby-dick.txt --lines 4200-4890 --plain               # one chapter, not the whole text
+```
+
+`grep -n` here is the shell's grep on a filesystem path (this is the map-building step, and
+it needs the file). `bm cat` then takes the *note identifier* — `moby-dick.txt`, the file's
+path within the project — and returns exactly that slice plus a `lines 4200-4890 of N`
+footer. `bm head moby-dick.txt -n 40` is the cheap way to eyeball the heading format before
+writing the grep pattern.
 
 Store the map in the project (a note or a small JSON file) so later batches — and a resumed
 run after context compaction — do not have to rediscover it. On a long work this is the
@@ -330,8 +375,8 @@ Adjust batch size based on chapter length and density. Short, action-heavy chapt
 For each chapter:
 
 **1. Read the chapter carefully.** Read the chapter's line range from the offset map
-(`cat <source> --lines <start>-<end>`), not the whole file. Read the actual text — never
-work from memory or a summary; textual evidence is the entire point.
+(`bm cat <source>.txt --lines <start>-<end>`), not the whole file. Read the actual text —
+never work from memory or a summary; textual evidence is the entire point.
 
 **2. Create the chapter note:**
 
@@ -424,13 +469,18 @@ After all chapters are processed:
 Do not re-read every note to decide what is thin. Query for it:
 
 ```bash
-bm find --meta 'note_type=chapter' --fields chapter_number,pov,setting   # coverage at a glance
-bm find --meta 'note_type=character' --fields role,status                # who is still a stub
-bm find --meta 'chapter_number>100' --fields pov                         # late-book POV drift
+bm find --meta 'note_type=Chapter' --fields chapter_number,pov,setting --page-size 200
+bm find --meta 'note_type=Character' --fields role,status --page-size 200   # who is still a stub
+bm find --meta 'chapter_number>100' --fields pov --page-size 200           # late-book POV drift
 ```
 
-Rows with null fields are the work queue. This turns "audit the graph" from a read of every
-note into one call per question.
+A field a note never set comes back as a blank cell (`null` under `--json`), so rows with
+blanks are the work queue. This turns "audit the graph" from a read of every note into one
+call per question.
+
+Note the capitalized `Chapter`/`Character` — they must match the `note_type` your Phase 0
+schemas authored, exactly. And `--page-size 200` is not decoration: without it these return
+the first 10 rows and the work queue looks ten items long.
 
 ### Character Arcs
 For each major character, write a full `[arc]` summary observation covering their trajectory across the work.
@@ -506,13 +556,33 @@ Fix issues found — common fixes:
 Schema validation proves notes match their shape. These prove the graph is *complete*:
 
 ```bash
-bm find --meta 'note_type=chapter' --fields chapter_number      # every chapter present?
-bm find --meta 'note_type=chapter' --fields pov,setting         # any missing required context?
-bm find --name '*.md' --meta 'note_type=character'              # entity inventory vs. seed list
+bm find --meta 'note_type=Chapter' --fields chapter_number --page-size 200   # every chapter present?
+bm find --meta 'note_type=Chapter' --fields pov,setting --page-size 200      # missing context?
+bm find /characters --meta 'note_type=Character' --fields role --page-size 200  # inventory vs. seed list
 ```
 
-Compare the chapter count against the work's actual chapter count, and check for gaps in the
-sequence — a missing chapter in the middle of a batch is the most common processing failure
+**A coverage check that pages is not a coverage check.** `bm find` defaults to
+`--page-size 10`, so the un-sized form of the first query "proves" a 138-chapter work has 10
+chapters. 200 is the maximum page size; past that, iterate with `--page 2`, `--page 3`, … .
+Scope a `--meta` query with the positional path (`/characters`), never `--name` — the two
+options are mutually exclusive, because metadata search matches slugified permalinks rather
+than filenames.
+
+Read the count off the footer, not off the rows you can see. Every `find` result reports
+`page 1 • total 138`, and appends `• more available (--page)` when the page truncated the
+answer — that suffix appearing is the check *failing*, whatever the visible rows say.
+
+For the sequence gap — the failure that a count alone cannot catch — take the numbers from
+`--json`, which carries `total`, `total_is_exact`, and `has_more`:
+
+```bash
+bm find --meta 'note_type=Chapter' --fields chapter_number --page-size 200 --json \
+  | jq '{total, has_more, missing: ([.results[].fields.chapter_number | tonumber] | sort
+         | (([range(1; (max + 1))]) - .))}'
+```
+
+`has_more: false` with `missing: []` is the check passing. Compare `total` against the work's
+actual chapter count — a gap in the middle of a batch is the most common processing failure
 and the easiest to miss by eye.
 
 ### Relation Consistency
@@ -533,10 +603,12 @@ orphans behind has made the graph worse.
 With the graph complete, traverse it to find what the chapter-by-chapter pass could not see:
 
 ```bash
-bm tool build-context --url 'memory://characters/major/*' --depth 2   # the character web
-bm find --meta 'note_type=theme' --fields prevalence                  # thematic weight
+bm tool build-context 'memory://characters/major/*' --depth 2         # the character web
+bm find --meta 'note_type=Theme' --fields prevalence --page-size 200  # thematic weight
 bm grep "doubloon" --project <work>                                   # a symbol across the work
 ```
+
+`build-context` takes its URL as a positional argument — there is no `--url` option.
 
 Traversal is where second-order questions get answered — which characters share the most
 chapters, which themes converge in the final act, where a symbol's meaning shifts. Capture
@@ -579,8 +651,8 @@ This pipeline works for any literary text. Adjust schemas for genre:
 - **Seed before processing.** Create entity stubs first so wiki-links resolve immediately during chapter processing.
 - **Batch for sanity.** Processing ~10 chapters at a time balances depth with momentum. Track progress with a Task note.
 - **Read the source text.** Don't rely on memory or summaries. Read (or re-read) the actual text for each batch before creating notes. Textual evidence is everything.
-- **Read narrowly.** Build the chapter offset map once, then read chapters by line range and notes by section. On a long work, whole-file reads are the largest avoidable cost in the pipeline.
-- **Query, don't scan.** When you need to know which notes have a field, ask with `--meta` predicates and `--fields` projection. Reading notes to check frontmatter is the mistake this pipeline makes at scale.
+- **Read narrowly.** Keep the source text in the project as `.txt`, index it once, build the chapter offset map once, then read chapters by line range and notes by section. On a long work, whole-file reads are the largest avoidable cost in the pipeline.
+- **Query, don't scan.** When you need to know which notes have a field, ask with `--meta` predicates and `--fields` projection. Reading notes to check frontmatter is the mistake this pipeline makes at scale. Two ways these queries lie quietly: `--meta` is case-sensitive against the frontmatter `type:` your schemas authored, and `find` returns 10 rows unless you pass `--page-size`.
 - **Observations are your index.** The knowledge graph's value comes from categorized observations. Be generous with categories and specific with content.
 - **Relations are your web.** Every chapter should link to characters, themes, locations, and devices. Every entity should link back to chapters where it appears.
 - **Enrich iteratively.** Entity notes grow richer with each chapter. Don't try to write the perfect character note upfront — append as you go.

--- a/skills/memory-literary-analysis/SKILL.md
+++ b/skills/memory-literary-analysis/SKILL.md
@@ -579,20 +579,32 @@ For the sequence gap — the failure that a count alone cannot catch — take th
 `--json`, which carries `total`, `total_is_exact`, and `has_more`:
 
 ```bash
-bm find --meta 'note_type=chapter' --fields chapter_number --page-size 200 --json \
-  | jq --argjson expected 138 '
-      [.results[].fields.chapter_number | tonumber] as $n
-      | { total, has_more,
-          missing:      ([range(1; $expected + 1)] - $n),
-          duplicates:   ($n | group_by(.) | map(select(length > 1) | .[0])),
-          out_of_range: ($n | map(select(. < 1 or . > $expected)) | unique) }'
+expected=138; page=1; nums='[]'
+while :; do
+  resp=$(bm find --meta 'note_type=chapter' --fields chapter_number \
+           --page-size 200 --page $page --project <work> --json)
+  nums=$(jq -n --argjson acc "$nums" --argjson r "$resp" \
+           '$acc + [$r.results[].fields.chapter_number | tonumber]')
+  [ "$(jq -r '.has_more' <<<"$resp")" = "true" ] || break
+  page=$((page + 1))
+done
+jq -n --argjson n "$nums" --argjson expected "$expected" '
+  { total:        ($n | length),
+    missing:      ([range(1; $expected + 1)] - $n),
+    duplicates:   ($n | group_by(.) | map(select(length > 1) | .[0])),
+    out_of_range: ($n | map(select(. < 1 or . > $expected)) | unique) }'
 ```
+
+The loop is not ceremony. `--page-size` caps at 200, so a single call cannot inventory a work
+with more than 200 chapters — and rerunning it with `--page 2` *replaces* the numbers rather
+than accumulating them, which reports chapters 1-200 as missing on a corpus that is complete.
+Walk until `has_more` is false and check the union.
 
 Pass the work's **actual** chapter count as `$expected` — deriving the range from the highest
 number found lets an incomplete graph pass. With 138 rows numbered 1..137 plus one duplicate,
 a max-derived check reports `missing: []` while a chapter is genuinely absent: the duplicate
 keeps the count right and the missing tail moves the goalpost. The check passes on
-`has_more: false`, `missing: []`, `duplicates: []`, **and** `out_of_range: []` together.
+`missing: []`, `duplicates: []`, **and** `out_of_range: []` together, over the combined pages.
 
 `out_of_range` is not hypothetical: a prologue or epilogue typed as `chapter` lands at 0 or at
 `$expected + 1`, and without that key the report reads clean — every expected number present,

--- a/skills/memory-literary-analysis/SKILL.md
+++ b/skills/memory-literary-analysis/SKILL.md
@@ -637,6 +637,13 @@ even 100, so check whether the last page was full and walk `--page 2`, `--page 3
 not. A truncated symbol search fails the same silent way as an unpaginated `find`: a plausible
 answer, exit 0, and no sign that the tail is missing.
 
+And `grep` searches **your notes, not the source**. The `<work>.txt` is indexed as an entity,
+but its body is not in the searchable text, so an occurrence you never carried into a note is
+unreachable — verified: a word present only in the source returns `total: 0` while a word in
+both returns just the note. So this answers "where have I written about the doubloon", not
+"where does the doubloon appear in the book". For the latter, search the file itself and use
+the [chapter offset map](#source-text-preparation) to turn a hit into a chapter.
+
 Traversal is where second-order questions get answered — which characters share the most
 chapters, which themes converge in the final act, where a symbol's meaning shifts. Capture
 what you find as `analysis/` notes; those syntheses are the payoff of having built the graph.

--- a/skills/memory-literary-analysis/SKILL.md
+++ b/skills/memory-literary-analysis/SKILL.md
@@ -35,7 +35,7 @@ the work in a long analysis — prefer the POSIX read verbs where they are avail
 | Need | Use | Instead of |
 |------|-----|-----------|
 | A section of a long note | `cat <note> --section Observations` | reading the whole note |
-| A line range of the source text | `cat <source>.txt --lines 4200-4890` | loading the whole book |
+| A line range of the source text | `cat <source>.txt --lines 4200-4890` | pulling the whole book into context |
 | Notes matching frontmatter | `find --meta status=active` | reading notes to check fields |
 | Fields across many notes | `find --meta ... --fields pov,setting` | one read per note |
 | Where something lives | `ls`, `tree`, `find --name '*.md'` | listing everything |
@@ -44,8 +44,10 @@ The two rules that matter across a 100+ chapter run:
 
 - **Never read a note to check a field.** That is what `--meta` predicates and `--fields`
   projection are for — one call answers what a read-per-note loop would cost.
-- **Never read a whole file to reach one part of it.** Sections and line ranges exist so a
-  long chapter or a full source text costs what the relevant part costs.
+- **Never pull a whole file into context to reach one part of it.** Sections and line ranges
+  slice the *output*: the full note is still fetched, then cut down before it is returned. What
+  they save is context, not I/O — a long chapter or a full source text costs you the tokens of
+  the relevant part, not of the whole file.
 
 These compound. In measured runs, predicate queries replaced 28-call scans with a single
 call; across 138 chapters that difference is the run.
@@ -339,11 +341,11 @@ Two constraints that make this the right shape, both worth respecting:
 
 **Then build a chapter offset map once, before processing.** Scan the text for chapter
 headings and record the line range of each chapter, then read chapters by range rather than
-reloading the book:
+re-reading the whole book into context:
 
 ```bash
 grep -n '^CHAPTER ' ~/basic-memory/moby-dick/moby-dick.txt   # heading -> line number
-bm cat moby-dick.txt --lines 4200-4890 --plain               # one chapter, not the whole text
+bm cat moby-dick.txt --lines 4200-4890 --plain               # returns one chapter, not the whole text
 ```
 
 `grep -n` here is the shell's grep on a filesystem path (this is the map-building step, and
@@ -354,7 +356,7 @@ writing the grep pattern.
 
 Store the map in the project (a note or a small JSON file) so later batches — and a resumed
 run after context compaction — do not have to rediscover it. On a long work this is the
-single largest read saving in the pipeline.
+single largest context saving in the pipeline.
 
 ### Batching Strategy
 
@@ -659,7 +661,7 @@ This pipeline works for any literary text. Adjust schemas for genre:
 - **Seed before processing.** Create entity stubs first so wiki-links resolve immediately during chapter processing.
 - **Batch for sanity.** Processing ~10 chapters at a time balances depth with momentum. Track progress with a Task note.
 - **Read the source text.** Don't rely on memory or summaries. Read (or re-read) the actual text for each batch before creating notes. Textual evidence is everything.
-- **Read narrowly.** Keep the source text in the project as `.txt`, index it once, build the chapter offset map once, then read chapters by line range and notes by section. On a long work, whole-file reads are the largest avoidable cost in the pipeline.
+- **Read narrowly.** Keep the source text in the project as `.txt`, index it once, build the chapter offset map once, then read chapters by line range and notes by section. On a long work, whole files landing in context are the largest avoidable cost in the pipeline.
 - **Query, don't scan.** When you need to know which notes have a field, ask with `--meta` predicates and `--fields` projection. Reading notes to check frontmatter is the mistake this pipeline makes at scale. Two ways these queries lie quietly: `--meta` is case-sensitive against the frontmatter `type:` your schemas authored, and `find` returns 10 rows unless you pass `--page-size`.
 - **Observations are your index.** The knowledge graph's value comes from categorized observations. Be generous with categories and specific with content.
 - **Relations are your web.** Every chapter should link to characters, themes, locations, and devices. Every entity should link back to chapters where it appears.

--- a/skills/memory-literary-analysis/SKILL.md
+++ b/skills/memory-literary-analysis/SKILL.md
@@ -583,15 +583,21 @@ bm find --meta 'note_type=chapter' --fields chapter_number --page-size 200 --jso
   | jq --argjson expected 138 '
       [.results[].fields.chapter_number | tonumber] as $n
       | { total, has_more,
-          missing:    ([range(1; $expected + 1)] - $n),
-          duplicates: ($n | group_by(.) | map(select(length > 1) | .[0])) }'
+          missing:      ([range(1; $expected + 1)] - $n),
+          duplicates:   ($n | group_by(.) | map(select(length > 1) | .[0])),
+          out_of_range: ($n | map(select(. < 1 or . > $expected)) | unique) }'
 ```
 
 Pass the work's **actual** chapter count as `$expected` — deriving the range from the highest
 number found lets an incomplete graph pass. With 138 rows numbered 1..137 plus one duplicate,
 a max-derived check reports `missing: []` while a chapter is genuinely absent: the duplicate
 keeps the count right and the missing tail moves the goalpost. The check passes on
-`has_more: false`, `missing: []`, **and** `duplicates: []` together.
+`has_more: false`, `missing: []`, `duplicates: []`, **and** `out_of_range: []` together.
+
+`out_of_range` is not hypothetical: a prologue or epilogue typed as `chapter` lands at 0 or at
+`$expected + 1`, and without that key the report reads clean — every expected number present,
+none repeated — while the inventory holds a note the numbering does not account for. Type
+front and back matter as its own note type, or widen `$expected` deliberately.
 
 A gap in the middle of a batch is the most common processing failure and the easiest to miss
 by eye; a duplicated chapter number is the second, and it hides the first.
@@ -625,6 +631,11 @@ bm grep -F "doubloon" --page-size 100 --project <work>                # every me
 quietly truncates "where does this appear?" — a symbol in 40 chapters comes back as 10. For
 symbol tracing, pass `-F` for literal matching and raise `--page-size`; the meaning shifts you
 are hunting are usually in the later occurrences, which the default would have dropped.
+
+`--page-size` raises the ceiling, it does not remove it. A symbol in a long work can exceed
+even 100, so check whether the last page was full and walk `--page 2`, `--page 3` until it is
+not. A truncated symbol search fails the same silent way as an unpaginated `find`: a plausible
+answer, exit 0, and no sign that the tail is missing.
 
 Traversal is where second-order questions get answered — which characters share the most
 chapters, which themes converge in the final act, where a symbol's meaning shifts. Capture

--- a/skills/memory-literary-analysis/SKILL.md
+++ b/skills/memory-literary-analysis/SKILL.md
@@ -577,13 +577,21 @@ For the sequence gap — the failure that a count alone cannot catch — take th
 
 ```bash
 bm find --meta 'note_type=Chapter' --fields chapter_number --page-size 200 --json \
-  | jq '{total, has_more, missing: ([.results[].fields.chapter_number | tonumber] | sort
-         | (([range(1; (max + 1))]) - .))}'
+  | jq --argjson expected 138 '
+      [.results[].fields.chapter_number | tonumber] as $n
+      | { total, has_more,
+          missing:    ([range(1; $expected + 1)] - $n),
+          duplicates: ($n | group_by(.) | map(select(length > 1) | .[0])) }'
 ```
 
-`has_more: false` with `missing: []` is the check passing. Compare `total` against the work's
-actual chapter count — a gap in the middle of a batch is the most common processing failure
-and the easiest to miss by eye.
+Pass the work's **actual** chapter count as `$expected` — deriving the range from the highest
+number found lets an incomplete graph pass. With 138 rows numbered 1..137 plus one duplicate,
+a max-derived check reports `missing: []` while a chapter is genuinely absent: the duplicate
+keeps the count right and the missing tail moves the goalpost. The check passes on
+`has_more: false`, `missing: []`, **and** `duplicates: []` together.
+
+A gap in the middle of a batch is the most common processing failure and the easiest to miss
+by eye; a duplicated chapter number is the second, and it hides the first.
 
 ### Relation Consistency
 Spot-check bidirectional relations: if Chapter X `features [[Character]]`, does Character have observations referencing Chapter X? Fix gaps.

--- a/skills/memory-literary-analysis/SKILL.md
+++ b/skills/memory-literary-analysis/SKILL.md
@@ -56,18 +56,17 @@ Three sharp edges to know before you write a query. The first two fail *quietly*
 answer, exit 0, no warning — so learn them here rather than from a graph you thought you had
 audited:
 
-- **`--meta` reads frontmatter, and matches case-sensitively.** `note_type` is an alias for
-  the frontmatter `type:` key, compared with SQL `=`. A note written with
-  `note_type="Chapter"` matches `--meta 'note_type=Chapter'` and **not**
-  `--meta 'note_type=chapter'` — the lowercase form returns zero rows and exit 0. Confusingly,
-  a result row *displays* the snake-cased index projection (`"note_type": "chapter"`,
-  `"literary_device"`); that is not the value to query with. Query with the casing your
-  schemas authored.
+- **`--meta` matches case-sensitively, and the stored value is always snake_case.** `note_type`
+  is an alias for the frontmatter `type:` key, compared with SQL `=`. `write_note` normalizes
+  `note_type` through `to_snake_case` before writing, so a note authored as `note_type="Chapter"`
+  is stored as `type: chapter` — the casing you author with is *not* the casing on disk. Query
+  the snake_case form: `--meta 'note_type=chapter'`. The capitalized spelling returns zero rows
+  and exit 0. The value a result row displays is the value to query with.
 - **`find` pages, and the default page is 10.** Any query whose answer is "all N chapters"
   needs `--page-size 200` (the maximum) — see [Coverage Checks](#coverage-checks).
 - **`--name` cannot combine with `--meta`.** The metadata search matches slugified permalinks,
   not filenames. Scope a `--meta` query with the positional path instead: `find /characters
-  --meta 'note_type=Character'`.
+  --meta 'note_type=character'`.
 
 If the POSIX verbs are unavailable, every step below still works with `search_notes`,
 `read_note`, and `list_directory` — it just costs more.
@@ -471,8 +470,8 @@ After all chapters are processed:
 Do not re-read every note to decide what is thin. Query for it:
 
 ```bash
-bm find --meta 'note_type=Chapter' --fields chapter_number,pov,setting --page-size 200
-bm find --meta 'note_type=Character' --fields role,status --page-size 200   # who is still a stub
+bm find --meta 'note_type=chapter' --fields chapter_number,pov,setting --page-size 200
+bm find --meta 'note_type=character' --fields role,status --page-size 200   # who is still a stub
 bm find --meta 'chapter_number>100' --fields pov --page-size 200           # late-book POV drift
 ```
 
@@ -558,9 +557,9 @@ Fix issues found — common fixes:
 Schema validation proves notes match their shape. These prove the graph is *complete*:
 
 ```bash
-bm find --meta 'note_type=Chapter' --fields chapter_number --page-size 200   # every chapter present?
-bm find --meta 'note_type=Chapter' --fields pov,setting --page-size 200      # missing context?
-bm find /characters --meta 'note_type=Character' --fields role --page-size 200  # inventory vs. seed list
+bm find --meta 'note_type=chapter' --fields chapter_number --page-size 200   # every chapter present?
+bm find --meta 'note_type=chapter' --fields pov,setting --page-size 200      # missing context?
+bm find /characters --meta 'note_type=character' --fields role --page-size 200  # inventory vs. seed list
 ```
 
 **A coverage check that pages is not a coverage check.** `bm find` defaults to
@@ -578,7 +577,7 @@ For the sequence gap — the failure that a count alone cannot catch — take th
 `--json`, which carries `total`, `total_is_exact`, and `has_more`:
 
 ```bash
-bm find --meta 'note_type=Chapter' --fields chapter_number --page-size 200 --json \
+bm find --meta 'note_type=chapter' --fields chapter_number --page-size 200 --json \
   | jq --argjson expected 138 '
       [.results[].fields.chapter_number | tonumber] as $n
       | { total, has_more,
@@ -614,11 +613,16 @@ With the graph complete, traverse it to find what the chapter-by-chapter pass co
 
 ```bash
 bm tool build-context 'memory://characters/major/*' --depth 2         # the character web
-bm find --meta 'note_type=Theme' --fields prevalence --page-size 200  # thematic weight
-bm grep "doubloon" --project <work>                                   # a symbol across the work
+bm find --meta 'note_type=theme' --fields prevalence --page-size 200  # thematic weight
+bm grep -F "doubloon" --page-size 100 --project <work>                # every mention of a symbol
 ```
 
 `build-context` takes its URL as a positional argument — there is no `--url` option.
+
+`grep` defaults to semantic ranking and a page of 10, which answers "what is this about?" but
+quietly truncates "where does this appear?" — a symbol in 40 chapters comes back as 10. For
+symbol tracing, pass `-F` for literal matching and raise `--page-size`; the meaning shifts you
+are hunting are usually in the later occurrences, which the default would have dropped.
 
 Traversal is where second-order questions get answered — which characters share the most
 chapters, which themes converge in the final act, where a symbol's meaning shifts. Capture

--- a/skills/memory-literary-analysis/SKILL.md
+++ b/skills/memory-literary-analysis/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: memory-literary-analysis
-description: "Analyze a complete literary work into a structured Basic Memory knowledge graph. Covers schema design, entity seeding, chapter-by-chapter processing, cross-referencing, validation, and visualization."
+description: "Analyze a complete literary work into a structured Basic Memory knowledge graph. Covers schema design, entity seeding, chapter-by-chapter processing, cross-referencing, validation, and graph exploration."
 ---
 
 # Memory Literary Analysis
 
-Transform a complete literary work into a structured knowledge graph. Characters, themes, chapters, locations, symbols, and literary devices become interconnected notes — searchable, validatable, and visualizable.
+Transform a complete literary work into a structured knowledge graph. Characters, themes, chapters, locations, symbols, and literary devices become interconnected notes — searchable, validatable, and traversable.
 
 ## When to Use
 
@@ -23,8 +23,35 @@ Phase 1: Seed          → stub notes for known major entities
 Phase 2: Process       → chapter-by-chapter notes in batches
 Phase 3: Cross-ref     → enrich arcs, add parallels, write analysis
 Phase 4: Validate      → schema checks, drift detection, consistency
-Phase 5: Visualize     → Obsidian canvas files for character webs, timelines
+Phase 5: Explore       → traverse the graph, write synthesis notes
 ```
+
+## Tools
+
+Writing always goes through `write_note` and `edit_note`. For *reading* — which is most of
+the work in a long analysis — prefer the POSIX read verbs where they are available
+(`enable_posix_tools` for the MCP tools; the `bm` CLI verbs are always available):
+
+| Need | Use | Instead of |
+|------|-----|-----------|
+| A section of a long note | `cat <note> --section EXAMPLES` | reading the whole note |
+| A line range of the source text | `cat <file> --lines 4200-4890` | loading the whole book |
+| Notes matching frontmatter | `find --meta status=active` | reading notes to check fields |
+| Fields across many notes | `find --meta ... --fields pov,setting` | one read per note |
+| Where something lives | `ls`, `tree`, `find --name '*.md'` | listing everything |
+
+The two rules that matter across a 100+ chapter run:
+
+- **Never read a note to check a field.** That is what `--meta` predicates and `--fields`
+  projection are for — one call answers what a read-per-note loop would cost.
+- **Never read a whole file to reach one part of it.** Sections and line ranges exist so a
+  long chapter or a full source text costs what the relevant part costs.
+
+These compound. In measured runs, predicate queries replaced 28-call scans with a single
+call; across 138 chapters that difference is the run.
+
+If the POSIX verbs are unavailable, every step below still works with `search_notes`,
+`read_note`, and `list_directory` — it just costs more.
 
 ## Phase 0: Setup
 
@@ -271,6 +298,19 @@ Stubs don't need to be complete — they give `[[wiki-link]]` targets and will b
 
 Obtain the full text and identify chapter/section boundaries. For public domain works, Project Gutenberg is a good source. For copyrighted works, work from a physical or licensed digital copy.
 
+**Build a chapter offset map once, before processing.** Scan the text for chapter headings
+and record the line range of each chapter, then read chapters by range rather than reloading
+the book:
+
+```bash
+grep -n '^CHAPTER ' moby-dick.txt        # or the work's heading pattern
+bm cat moby-dick.txt --lines 4200-4890   # one chapter, not the whole text
+```
+
+Store the map in the project (a note or a small JSON file) so later batches — and a resumed
+run after context compaction — do not have to rediscover it. On a long work this is the
+single largest read saving in the pipeline.
+
 ### Batching Strategy
 
 Process ~10 chapters per batch to balance depth with progress. Group by narrative arc or thematic focus:
@@ -289,7 +329,9 @@ Adjust batch size based on chapter length and density. Short, action-heavy chapt
 
 For each chapter:
 
-**1. Read the chapter carefully.** If working from a source text file, read the relevant section.
+**1. Read the chapter carefully.** Read the chapter's line range from the offset map
+(`cat <source> --lines <start>-<end>`), not the whole file. Read the actual text — never
+work from memory or a summary; textual evidence is the entire point.
 
 **2. Create the chapter note:**
 
@@ -377,6 +419,19 @@ The prose adds the interpretive texture that structured observations alone canno
 
 After all chapters are processed:
 
+### Find What Needs Enriching
+
+Do not re-read every note to decide what is thin. Query for it:
+
+```bash
+bm find --meta 'note_type=chapter' --fields chapter_number,pov,setting   # coverage at a glance
+bm find --meta 'note_type=character' --fields role,status                # who is still a stub
+bm find --meta 'chapter_number>100' --fields pov                         # late-book POV drift
+```
+
+Rows with null fields are the work queue. This turns "audit the graph" from a read of every
+note into one call per question.
+
 ### Character Arcs
 For each major character, write a full `[arc]` summary observation covering their trajectory across the work.
 
@@ -446,26 +501,46 @@ Fix issues found — common fixes:
 - Enum values outside allowed set → correct metadata
 - Fields in notes but not schema → add as optional to schema if legitimate
 
+### Coverage Checks
+
+Schema validation proves notes match their shape. These prove the graph is *complete*:
+
+```bash
+bm find --meta 'note_type=chapter' --fields chapter_number      # every chapter present?
+bm find --meta 'note_type=chapter' --fields pov,setting         # any missing required context?
+bm find --name '*.md' --meta 'note_type=character'              # entity inventory vs. seed list
+```
+
+Compare the chapter count against the work's actual chapter count, and check for gaps in the
+sequence — a missing chapter in the middle of a batch is the most common processing failure
+and the easiest to miss by eye.
+
 ### Relation Consistency
 Spot-check bidirectional relations: if Chapter X `features [[Character]]`, does Character have observations referencing Chapter X? Fix gaps.
 
-## Phase 5: Visualization
+Orphans are the other half of this check — a note with no inbound or outbound relations is
+either genuinely isolated or was never linked back into the graph:
 
-Write [JSON Canvas](https://jsoncanvas.org/) files (`.canvas`) into the project directory for visual exploration in Obsidian. Query the graph first (`search_notes`, `build_context`), then lay out the results as canvas nodes and edges:
-
-```json
-{
-  "nodes": [
-    {"id": "ahab", "type": "file", "file": "characters/captain-ahab.md", "x": 0, "y": 0, "width": 400, "height": 300},
-    {"id": "ishmael", "type": "file", "file": "characters/ishmael.md", "x": 500, "y": 0, "width": 400, "height": 300}
-  ],
-  "edges": [
-    {"id": "e1", "fromNode": "ishmael", "toNode": "ahab", "label": "narrates"}
-  ]
-}
+```bash
+bm orphans          # entities with no relations in the graph
 ```
 
-Useful canvases: character relationship web (protagonist/antagonist/supporting), theme connections, chapter timeline with key events.
+Graph quality is relation *density*, not note count. A pass that adds notes while leaving
+orphans behind has made the graph worse.
+
+## Phase 5: Explore the Graph
+
+With the graph complete, traverse it to find what the chapter-by-chapter pass could not see:
+
+```bash
+bm tool build-context --url 'memory://characters/major/*' --depth 2   # the character web
+bm find --meta 'note_type=theme' --fields prevalence                  # thematic weight
+bm grep "doubloon" --project <work>                                   # a symbol across the work
+```
+
+Traversal is where second-order questions get answered — which characters share the most
+chapters, which themes converge in the final act, where a symbol's meaning shifts. Capture
+what you find as `analysis/` notes; those syntheses are the payoff of having built the graph.
 
 ## Adapting to Other Genres
 
@@ -504,6 +579,8 @@ This pipeline works for any literary text. Adjust schemas for genre:
 - **Seed before processing.** Create entity stubs first so wiki-links resolve immediately during chapter processing.
 - **Batch for sanity.** Processing ~10 chapters at a time balances depth with momentum. Track progress with a Task note.
 - **Read the source text.** Don't rely on memory or summaries. Read (or re-read) the actual text for each batch before creating notes. Textual evidence is everything.
+- **Read narrowly.** Build the chapter offset map once, then read chapters by line range and notes by section. On a long work, whole-file reads are the largest avoidable cost in the pipeline.
+- **Query, don't scan.** When you need to know which notes have a field, ask with `--meta` predicates and `--fields` projection. Reading notes to check frontmatter is the mistake this pipeline makes at scale.
 - **Observations are your index.** The knowledge graph's value comes from categorized observations. Be generous with categories and specific with content.
 - **Relations are your web.** Every chapter should link to characters, themes, locations, and devices. Every entity should link back to chapters where it appears.
 - **Enrich iteratively.** Entity notes grow richer with each chapter. Don't try to write the perfect character note upfront — append as you go.

--- a/skills/memory-literary-analysis/SKILL.md
+++ b/skills/memory-literary-analysis/SKILL.md
@@ -579,20 +579,23 @@ For the sequence gap — the failure that a count alone cannot catch — take th
 `--json`, which carries `total`, `total_is_exact`, and `has_more`:
 
 ```bash
-expected=138; page=1; nums='[]'
+expected=138; page=1; rows='[]'
 while :; do
   resp=$(bm find --meta 'note_type=chapter' --fields chapter_number \
            --page-size 200 --page $page --project <work> --json)
-  nums=$(jq -n --argjson acc "$nums" --argjson r "$resp" \
-           '$acc + [$r.results[].fields.chapter_number | tonumber]')
+  rows=$(jq -n --argjson acc "$rows" --argjson r "$resp" \
+           '$acc + [$r.results[] | {title, n: .fields.chapter_number}]')
   [ "$(jq -r '.has_more' <<<"$resp")" = "true" ] || break
   page=$((page + 1))
 done
-jq -n --argjson n "$nums" --argjson expected "$expected" '
-  { total:        ($n | length),
-    missing:      ([range(1; $expected + 1)] - $n),
-    duplicates:   ($n | group_by(.) | map(select(length > 1) | .[0])),
-    out_of_range: ($n | map(select(. < 1 or . > $expected)) | unique) }'
+jq -n --argjson rows "$rows" --argjson expected "$expected" '
+  ([$rows[] | select(.n != null and (.n | tostring | test("^[0-9]+$"))) | .n | tonumber]) as $n
+  | { total:        ($rows | length),
+      unnumbered:   [$rows[] | select(.n == null or (.n | tostring | test("^[0-9]+$") | not))
+                             | .title],
+      missing:      ([range(1; $expected + 1)] - $n),
+      duplicates:   ($n | group_by(.) | map(select(length > 1) | .[0])),
+      out_of_range: ($n | map(select(. < 1 or . > $expected)) | unique) }'
 ```
 
 The loop is not ceremony. `--page-size` caps at 200, so a single call cannot inventory a work
@@ -604,7 +607,13 @@ Pass the work's **actual** chapter count as `$expected` — deriving the range f
 number found lets an incomplete graph pass. With 138 rows numbered 1..137 plus one duplicate,
 a max-derived check reports `missing: []` while a chapter is genuinely absent: the duplicate
 keeps the count right and the missing tail moves the goalpost. The check passes on
-`missing: []`, `duplicates: []`, **and** `out_of_range: []` together, over the combined pages.
+`unnumbered: []`, `missing: []`, `duplicates: []`, **and** `out_of_range: []` together, over
+the combined pages.
+
+`unnumbered` is not decoration either. A `chapter` note that never got a `chapter_number` comes
+back as `null`, and feeding that straight to `tonumber` aborts the whole pipeline with `null
+cannot be parsed as a number` — so the check *crashes on exactly the malformed inventory it
+exists to find*. Partitioning first turns that into a named row.
 
 `out_of_range` is not hypothetical: a prologue or epilogue typed as `chapter` lands at 0 or at
 `$expected + 1`, and without that key the report reads clean — every expected number present,


### PR DESCRIPTION
## Why

The `memory-literary-analysis` pipeline predates the POSIX surface, so it is written entirely in `write_note`/`edit_note`/`search_notes`/`list_directory`. A 138-chapter run following it would never call `find --meta` or `cat --section` — which means the planned Moby Dick re-run would measure nothing about the tools we just built and shipped. Updating the skill is a prerequisite for that eval, not polish.

Also removes the canvas instructions: that tool was taken out.

## What changed

- **New Tools section** naming the read verbs and the two rules that compound across a long run: never read a note to check a field (that is what `--meta` predicates and `--fields` projection are for), and never read a whole file to reach one part of it. States the fallback plainly for anyone without the verbs.
- **Phase 2**: build a chapter offset map once (`grep -n` for headings), then read chapters by line range instead of reloading the source text per chapter — the largest single read saving on a long work, and it survives context compaction.
- **Phase 3**: find what needs enriching with `find --meta ... --fields` instead of re-reading every note to see which are thin. Null fields are the work queue.
- **Phase 4**: coverage checks (every chapter present, no sequence gaps, required context fields set) alongside the existing schema validation, plus `bm orphans` — framed around relation *density*, since a pass that adds notes while leaving orphans has made the graph worse.
- **Phase 5** was canvas generation; it is now graph exploration — traversal that answers second-order questions and produces `analysis/` synthesis notes.
- Two new guidelines: read narrowly, query don't scan.

## Verification

`just package-check-skills` — 15 skills validated. No canvas references remain anywhere in the packaged skills.

## Notes

Temporal-qualifier authoring guidance (SPEC-82) will be a follow-up to this once that lands — chapter `[event]` observations and character `[arc]` observations are where narrative time gets authored, and that is what makes the Moby Dick run the validation for temporal semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp