### PR TITLE
fix(core): bound generated wiki logs

### DIFF
--- a/src/basic_memory/indexing/wiki_projector.py
+++ b/src/basic_memory/indexing/wiki_projector.py
@@ -18,6 +18,7 @@ WIKI_PROFILE = "wiki/1"
 WIKI_PROJECTOR_VERSION = "wiki/1.0.0"
 WIKI_PROJECTOR_NAME = "Basic Memory Wiki Projector"
 WIKI_PROJECTOR_SOURCE = "wiki_projector"
+WIKI_LOG_ENTRY_LIMIT = 25
 RESERVED_WIKI_FILENAMES = frozenset({"index.md", "log.md"})
 WINDOWS_RESERVED_NAMES = frozenset(
     {"CON", "PRN", "AUX", "NUL"}
@@ -575,7 +576,7 @@ def _render_log(
             ),
             key=lambda change: change.partition_position,
             reverse=True,
-        )
+        )[:WIKI_LOG_ENTRY_LIMIT]
     )
     title = (
         f"{snapshot.project_name} log"

--- a/tests/indexing/test_wiki_projector.py
+++ b/tests/indexing/test_wiki_projector.py
@@ -19,6 +19,7 @@ from basic_memory.indexing.wiki_projector import (
     WikiReservedDocument,
     WikiSourceChange,
     WikiSourceNote,
+    WIKI_LOG_ENTRY_LIMIT,
     affected_wiki_scopes,
     plan_wiki_projection,
 )
@@ -754,6 +755,39 @@ def test_created_and_moved_changes_render_in_the_log() -> None:
 
     assert "Created [[created|Created]]" in log
     assert "Moved `old.md` to [[moved|Moved]]" in log
+
+
+def test_log_keeps_only_the_25_most_recent_changes() -> None:
+    changes = tuple(
+        WikiSourceChange(
+            partition_position=position,
+            operation=WikiChangeOperation.updated,
+            path="note.md",
+            permalink="note",
+            title=f"Revision {position}",
+            accepted_at=ACCEPTED_AT,
+            materialized=True,
+            source="web",
+        )
+        for position in range(1, WIKI_LOG_ENTRY_LIMIT + 2)
+    )
+    snapshot = WikiProjectionSnapshot(
+        project_id="project-88",
+        project_name="Project 88",
+        source_partition_position=len(changes),
+        current_output_watermark=0,
+        source_accepted_at=ACCEPTED_AT,
+        notes=(),
+        changes=changes,
+    )
+
+    plan = plan_wiki_projection(_request(position=len(changes), scopes=()), snapshot)
+    log = next(write.content.decode() for write in plan.writes if write.path == "log.md")
+
+    assert log.count("\n- ") == WIKI_LOG_ENTRY_LIMIT
+    assert f"Updated [[note|Revision {WIKI_LOG_ENTRY_LIMIT + 1}]]" in log
+    assert "Updated [[note|Revision 2]]" in log
+    assert "Updated [[note|Revision 1]]" not in log
 
 
 def test_log_preserves_ampersands_in_code_formatted_paths() -> None:


### PR DESCRIPTION
## Why

Generated Wiki `log.md` documents currently include every accepted materialized change relevant to their directory. Root and long-lived folder logs therefore grow without bound even though the accepted-change journal remains the canonical temporal record.

## What Changed

- Limit every generated directory `log.md` to its 25 most recent relevant changes.
- Preserve existing newest-first, per-scope filtering behavior.
- Add regression coverage proving the newest 25 entries are retained and older entries are omitted.

## Implementation Details

- `src/basic_memory/indexing/wiki_projector.py` applies one fixed `WIKI_LOG_ENTRY_LIMIT` after deterministic partition-position sorting.
- The limit is intentionally not configurable: generated Wiki documents are shared project artifacts and must remain deterministic across users and runtimes.
- The accepted-change journal remains complete; only its portable human-facing log projection is bounded.

## Testing

### Automated

- `uv run pytest -q tests/indexing/test_wiki_projector.py`: 80 passed.
- `uv run ty check src/basic_memory/indexing/wiki_projector.py tests/indexing/test_wiki_projector.py`: passed.
- `git diff --check`: passed.
- `just fast-check`: Ruff and formatting passed; the repository-wide typecheck was blocked by the fresh worktree not having the optional `pymilvus` dependency. Targeted typing of both changed files passed.

### Manual

- No manual UI verification required; this is a deterministic projector boundary change.

## Risks / Follow-ups

- Older log entries intentionally disappear from generated Markdown after the 26th relevant change. Complete history remains available from the accepted-change journal and its temporal views.
- No settings UI or project configuration is introduced.
