### PR TITLE
fix(core): link empty wiki folders from parent indexes

### DIFF
--- a/src/basic_memory/indexing/wiki_projector.py
+++ b/src/basic_memory/indexing/wiki_projector.py
@@ -387,21 +387,21 @@ def plan_wiki_projection(
             or PurePosixPath(document.path).name.casefold() != "index.md"
         ):
             continue
-        projected_scope = _parent_scope(document.path)
-        portable_scope = _portable_path_key(projected_scope)
-        if existing_note := note_by_path.get(portable_scope):
-            raise ValueError(
-                "Wiki projection scope collides with an existing source note path: "
-                f"{projected_scope}, {existing_note.path}"
-            )
-        if (
-            existing_scope := projected_scope_by_portable_path.get(portable_scope)
-        ) is not None and existing_scope != projected_scope:
-            raise ValueError(
-                "Wiki projected scopes must be unique when compared as portable paths: "
-                f"{existing_scope}, {projected_scope}"
-            )
-        projected_scope_by_portable_path[portable_scope] = projected_scope
+        for projected_scope in affected_wiki_scopes(document.path):
+            portable_scope = _portable_path_key(projected_scope)
+            if existing_note := note_by_path.get(portable_scope):
+                raise ValueError(
+                    "Wiki projection scope collides with an existing source note path: "
+                    f"{projected_scope}, {existing_note.path}"
+                )
+            if (
+                existing_scope := projected_scope_by_portable_path.get(portable_scope)
+            ) is not None and existing_scope != projected_scope:
+                raise ValueError(
+                    "Wiki projected scopes must be unique when compared as portable paths: "
+                    f"{existing_scope}, {projected_scope}"
+                )
+            projected_scope_by_portable_path[portable_scope] = projected_scope
     projected_scopes = tuple(sorted(projected_scope_by_portable_path.values()))
     rendered: dict[str, bytes] = {}
     for scope in scopes:

--- a/src/basic_memory/indexing/wiki_projector.py
+++ b/src/basic_memory/indexing/wiki_projector.py
@@ -389,6 +389,11 @@ def plan_wiki_projection(
             continue
         projected_scope = _parent_scope(document.path)
         portable_scope = _portable_path_key(projected_scope)
+        if existing_note := note_by_path.get(portable_scope):
+            raise ValueError(
+                "Wiki projection scope collides with an existing source note path: "
+                f"{projected_scope}, {existing_note.path}"
+            )
         if (
             existing_scope := projected_scope_by_portable_path.get(portable_scope)
         ) is not None and existing_scope != projected_scope:

--- a/src/basic_memory/indexing/wiki_projector.py
+++ b/src/basic_memory/indexing/wiki_projector.py
@@ -369,17 +369,24 @@ def plan_wiki_projection(
     existing_by_path = {
         _portable_path_key(document.path): document for document in snapshot.reserved_documents
     }
-    projected_scopes = tuple(
-        sorted(
-            set(scopes)
-            | {
-                _parent_scope(document.path)
-                for document in snapshot.reserved_documents
-                if document.projector_owned
-                and PurePosixPath(document.path).name.casefold() == "index.md"
-            }
-        )
-    )
+    projected_scope_by_portable_path = dict(scope_by_portable_path)
+    for document in snapshot.reserved_documents:
+        if (
+            not document.projector_owned
+            or PurePosixPath(document.path).name.casefold() != "index.md"
+        ):
+            continue
+        projected_scope = _parent_scope(document.path)
+        portable_scope = _portable_path_key(projected_scope)
+        if (
+            existing_scope := projected_scope_by_portable_path.get(portable_scope)
+        ) is not None and existing_scope != projected_scope:
+            raise ValueError(
+                "Wiki projected scopes must be unique when compared as portable paths: "
+                f"{existing_scope}, {projected_scope}"
+            )
+        projected_scope_by_portable_path[portable_scope] = projected_scope
+    projected_scopes = tuple(sorted(projected_scope_by_portable_path.values()))
     rendered: dict[str, bytes] = {}
     for scope in scopes:
         rendered[_reserved_path(scope, "index.md")] = _render_index(

--- a/src/basic_memory/indexing/wiki_projector.py
+++ b/src/basic_memory/indexing/wiki_projector.py
@@ -369,7 +369,18 @@ def plan_wiki_projection(
     existing_by_path = {
         _portable_path_key(document.path): document for document in snapshot.reserved_documents
     }
-    projected_scope_by_portable_path = dict(scope_by_portable_path)
+    projected_scope_by_portable_path: dict[str, str] = {}
+    note_scopes = affected_wiki_scopes(*(note.path for note in notes))
+    for projected_scope in (*note_scopes, *scopes):
+        portable_scope = _portable_path_key(projected_scope)
+        if (
+            existing_scope := projected_scope_by_portable_path.get(portable_scope)
+        ) is not None and existing_scope != projected_scope:
+            raise ValueError(
+                "Wiki projected scopes must be unique when compared as portable paths: "
+                f"{existing_scope}, {projected_scope}"
+            )
+        projected_scope_by_portable_path[portable_scope] = projected_scope
     for document in snapshot.reserved_documents:
         if (
             not document.projector_owned

--- a/src/basic_memory/indexing/wiki_projector.py
+++ b/src/basic_memory/indexing/wiki_projector.py
@@ -375,6 +375,7 @@ def plan_wiki_projection(
             snapshot=snapshot,
             notes=notes,
             scope=scope,
+            projected_scopes=scopes,
             source_watermark=request.through_partition_position,
         )
         rendered[_reserved_path(scope, "log.md")] = _render_log(
@@ -503,6 +504,7 @@ def _render_index(
     snapshot: WikiProjectionSnapshot,
     notes: tuple[WikiSourceNote, ...],
     scope: str,
+    projected_scopes: tuple[str, ...],
     source_watermark: int,
 ) -> bytes:
     direct_notes = sorted(
@@ -519,6 +521,10 @@ def _render_index(
         if not _is_descendant(note.path, scope):
             continue
         child_scope = _direct_child_scope(scope, note.path)
+        if child_scope is not None:
+            child_scope_set.add(child_scope)
+    for projected_scope in projected_scopes:
+        child_scope = _direct_child_projected_scope(scope, projected_scope)
         if child_scope is not None:
             child_scope_set.add(child_scope)
     child_scopes = sorted(child_scope_set)
@@ -808,6 +814,18 @@ def _direct_child_scope(scope: str, note_path: str) -> str | None:
         return None
     prefix = f"{scope}/" if scope else ""
     child_name = note_parent[len(prefix) :].split("/", maxsplit=1)[0]
+    return f"{scope}/{child_name}" if scope else child_name
+
+
+def _direct_child_projected_scope(scope: str, projected_scope: str) -> str | None:
+    if (
+        not projected_scope
+        or projected_scope == scope
+        or not _is_descendant(projected_scope, scope)
+    ):
+        return None
+    prefix = f"{scope}/" if scope else ""
+    child_name = projected_scope[len(prefix) :].split("/", maxsplit=1)[0]
     return f"{scope}/{child_name}" if scope else child_name
 
 

--- a/src/basic_memory/indexing/wiki_projector.py
+++ b/src/basic_memory/indexing/wiki_projector.py
@@ -369,13 +369,24 @@ def plan_wiki_projection(
     existing_by_path = {
         _portable_path_key(document.path): document for document in snapshot.reserved_documents
     }
+    projected_scopes = tuple(
+        sorted(
+            set(scopes)
+            | {
+                _parent_scope(document.path)
+                for document in snapshot.reserved_documents
+                if document.projector_owned
+                and PurePosixPath(document.path).name.casefold() == "index.md"
+            }
+        )
+    )
     rendered: dict[str, bytes] = {}
     for scope in scopes:
         rendered[_reserved_path(scope, "index.md")] = _render_index(
             snapshot=snapshot,
             notes=notes,
             scope=scope,
-            projected_scopes=scopes,
+            projected_scopes=projected_scopes,
             source_watermark=request.through_partition_position,
         )
         rendered[_reserved_path(scope, "log.md")] = _render_log(

--- a/src/basic_memory/indexing/wiki_projector.py
+++ b/src/basic_memory/indexing/wiki_projector.py
@@ -325,6 +325,18 @@ def plan_wiki_projection(
         new_changes,
         repair_complete_projection=projector_only_advance,
     )
+    projector_owned_index_scopes = {
+        _parent_scope(document.path)
+        for document in snapshot.reserved_documents
+        if document.projector_owned and PurePosixPath(document.path).name.casefold() == "index.md"
+    }
+    retained_scope_ancestors = {
+        scope
+        for document in snapshot.reserved_documents
+        if document.projector_owned and PurePosixPath(document.path).name.casefold() == "index.md"
+        for scope in affected_wiki_scopes(document.path)
+    }
+    scopes = tuple(sorted(set(scopes) | (retained_scope_ancestors - projector_owned_index_scopes)))
     all_projection_paths: list[str | None] = [note.path for note in notes]
     all_projection_paths.extend(document.path for document in snapshot.reserved_documents)
     all_projection_paths.extend(change.path for change in changes)

--- a/tests/indexing/test_wiki_projector.py
+++ b/tests/indexing/test_wiki_projector.py
@@ -502,6 +502,46 @@ def test_incremental_projection_rejects_case_folded_existing_empty_scope() -> No
         plan_wiki_projection(_request(position=1, scopes=()), snapshot)
 
 
+def test_incremental_projection_validates_existing_scope_against_unchanged_notes() -> None:
+    historical_note = WikiSourceNote(
+        path="foo/historical.md",
+        permalink="foo/historical",
+        title="Historical",
+        note_type="Note",
+        checksum="historical-checksum",
+    )
+    changed_note = WikiSourceNote(
+        path="other/changed.md",
+        permalink="other/changed",
+        title="Changed",
+        note_type="Note",
+        checksum="changed-checksum",
+    )
+    change = WikiSourceChange(
+        partition_position=1,
+        operation=WikiChangeOperation.updated,
+        path=changed_note.path,
+        permalink=changed_note.permalink,
+        title=changed_note.title,
+        accepted_at=ACCEPTED_AT,
+        materialized=True,
+        source="web",
+    )
+    snapshot = WikiProjectionSnapshot(
+        project_id="project-88",
+        project_name="Project 88",
+        source_partition_position=1,
+        current_output_watermark=0,
+        source_accepted_at=ACCEPTED_AT,
+        notes=(historical_note, changed_note),
+        changes=(change,),
+        reserved_documents=(_reserved("Foo/index.md", b"# Foo\n"),),
+    )
+
+    with pytest.raises(ValueError, match="projected scopes must be unique"):
+        plan_wiki_projection(_request(position=1, scopes=()), snapshot)
+
+
 def test_projection_bytes_match_the_shared_contract_fixture() -> None:
     fixture_path = (
         Path(__file__).parents[1] / "fixtures" / "wiki_projector" / "basic_projection.json"

--- a/tests/indexing/test_wiki_projector.py
+++ b/tests/indexing/test_wiki_projector.py
@@ -542,6 +542,39 @@ def test_incremental_projection_validates_existing_scope_against_unchanged_notes
         plan_wiki_projection(_request(position=1, scopes=()), snapshot)
 
 
+def test_incremental_projection_rejects_existing_scope_at_source_note_path() -> None:
+    note = WikiSourceNote(
+        path="foo.md",
+        permalink="foo",
+        title="Foo",
+        note_type="Note",
+        checksum="foo-checksum",
+    )
+    change = WikiSourceChange(
+        partition_position=1,
+        operation=WikiChangeOperation.created,
+        path=note.path,
+        permalink=note.permalink,
+        title=note.title,
+        accepted_at=ACCEPTED_AT,
+        materialized=True,
+        source="web",
+    )
+    snapshot = WikiProjectionSnapshot(
+        project_id="project-88",
+        project_name="Project 88",
+        source_partition_position=1,
+        current_output_watermark=0,
+        source_accepted_at=ACCEPTED_AT,
+        notes=(note,),
+        changes=(change,),
+        reserved_documents=(_reserved("foo.md/index.md", b"# Foo folder\n"),),
+    )
+
+    with pytest.raises(ValueError, match="scope collides with an existing source note path"):
+        plan_wiki_projection(_request(position=1, scopes=()), snapshot)
+
+
 def test_projection_bytes_match_the_shared_contract_fixture() -> None:
     fixture_path = (
         Path(__file__).parents[1] / "fixtures" / "wiki_projector" / "basic_projection.json"

--- a/tests/indexing/test_wiki_projector.py
+++ b/tests/indexing/test_wiki_projector.py
@@ -399,6 +399,28 @@ def test_projection_renders_root_and_affected_directory_indexes_and_logs() -> No
     assert plan.result.state == WikiProjectionState.current
 
 
+def test_requested_empty_folder_links_parent_indexes() -> None:
+    snapshot = WikiProjectionSnapshot(
+        project_id="project-88",
+        project_name="Project 88",
+        source_partition_position=0,
+        current_output_watermark=0,
+        source_accepted_at=ACCEPTED_AT,
+        notes=(),
+        changes=(),
+    )
+
+    plan = plan_wiki_projection(
+        _request(position=0, scopes=("guides/setup",)),
+        snapshot,
+    )
+
+    rendered = {write.path: write.content.decode() for write in plan.writes}
+    assert "[[guides/index|Guides]]" in rendered["index.md"]
+    assert "[[guides/setup/index|Setup]]" in rendered["guides/index.md"]
+    assert "No concepts have been projected" in rendered["guides/setup/index.md"]
+
+
 def test_projection_bytes_match_the_shared_contract_fixture() -> None:
     fixture_path = (
         Path(__file__).parents[1] / "fixtures" / "wiki_projector" / "basic_projection.json"

--- a/tests/indexing/test_wiki_projector.py
+++ b/tests/indexing/test_wiki_projector.py
@@ -421,6 +421,54 @@ def test_requested_empty_folder_links_parent_indexes() -> None:
     assert "No concepts have been projected" in rendered["guides/setup/index.md"]
 
 
+def test_incremental_projection_preserves_existing_empty_folder_links() -> None:
+    empty_snapshot = WikiProjectionSnapshot(
+        project_id="project-88",
+        project_name="Project 88",
+        source_partition_position=0,
+        current_output_watermark=0,
+        source_accepted_at=ACCEPTED_AT,
+        notes=(),
+        changes=(),
+    )
+    initial = plan_wiki_projection(
+        _request(position=0, scopes=("guides/setup",)),
+        empty_snapshot,
+    )
+    overview = WikiSourceNote(
+        path="overview.md",
+        permalink="overview",
+        title="Overview",
+        note_type="Note",
+        checksum="overview-checksum",
+    )
+    overview_change = WikiSourceChange(
+        partition_position=1,
+        operation=WikiChangeOperation.created,
+        path=overview.path,
+        permalink=overview.permalink,
+        title=overview.title,
+        accepted_at=ACCEPTED_AT,
+        materialized=True,
+        source="web",
+    )
+    incremental_snapshot = replace(
+        empty_snapshot,
+        source_partition_position=1,
+        notes=(overview,),
+        changes=(overview_change,),
+        reserved_documents=tuple(_reserved(write.path, write.content) for write in initial.writes),
+    )
+
+    incremental = plan_wiki_projection(
+        _request(position=1, scopes=()),
+        incremental_snapshot,
+    )
+
+    rendered = {write.path: write.content.decode() for write in incremental.writes}
+    assert "[[guides/index|Guides]]" in rendered["index.md"]
+
+
 def test_projection_bytes_match_the_shared_contract_fixture() -> None:
     fixture_path = (
         Path(__file__).parents[1] / "fixtures" / "wiki_projector" / "basic_projection.json"

--- a/tests/indexing/test_wiki_projector.py
+++ b/tests/indexing/test_wiki_projector.py
@@ -575,6 +575,46 @@ def test_incremental_projection_rejects_existing_scope_at_source_note_path() -> 
         plan_wiki_projection(_request(position=1, scopes=()), snapshot)
 
 
+def test_incremental_projection_validates_retained_scope_ancestors() -> None:
+    historical_note = WikiSourceNote(
+        path="foo/historical.md",
+        permalink="foo/historical",
+        title="Historical",
+        note_type="Note",
+        checksum="historical-checksum",
+    )
+    changed_note = WikiSourceNote(
+        path="other/changed.md",
+        permalink="other/changed",
+        title="Changed",
+        note_type="Note",
+        checksum="changed-checksum",
+    )
+    change = WikiSourceChange(
+        partition_position=1,
+        operation=WikiChangeOperation.updated,
+        path=changed_note.path,
+        permalink=changed_note.permalink,
+        title=changed_note.title,
+        accepted_at=ACCEPTED_AT,
+        materialized=True,
+        source="web",
+    )
+    snapshot = WikiProjectionSnapshot(
+        project_id="project-88",
+        project_name="Project 88",
+        source_partition_position=1,
+        current_output_watermark=0,
+        source_accepted_at=ACCEPTED_AT,
+        notes=(historical_note, changed_note),
+        changes=(change,),
+        reserved_documents=(_reserved("Foo/deep/index.md", b"# Deep\n"),),
+    )
+
+    with pytest.raises(ValueError, match="projected scopes must be unique"):
+        plan_wiki_projection(_request(position=1, scopes=()), snapshot)
+
+
 def test_projection_bytes_match_the_shared_contract_fixture() -> None:
     fixture_path = (
         Path(__file__).parents[1] / "fixtures" / "wiki_projector" / "basic_projection.json"

--- a/tests/indexing/test_wiki_projector.py
+++ b/tests/indexing/test_wiki_projector.py
@@ -615,6 +615,42 @@ def test_incremental_projection_validates_retained_scope_ancestors() -> None:
         plan_wiki_projection(_request(position=1, scopes=()), snapshot)
 
 
+def test_incremental_projection_materializes_missing_retained_scope_ancestors() -> None:
+    note = WikiSourceNote(
+        path="other/changed.md",
+        permalink="other/changed",
+        title="Changed",
+        note_type="Note",
+        checksum="changed-checksum",
+    )
+    change = WikiSourceChange(
+        partition_position=1,
+        operation=WikiChangeOperation.updated,
+        path=note.path,
+        permalink=note.permalink,
+        title=note.title,
+        accepted_at=ACCEPTED_AT,
+        materialized=True,
+        source="web",
+    )
+    snapshot = WikiProjectionSnapshot(
+        project_id="project-88",
+        project_name="Project 88",
+        source_partition_position=1,
+        current_output_watermark=0,
+        source_accepted_at=ACCEPTED_AT,
+        notes=(note,),
+        changes=(change,),
+        reserved_documents=(_reserved("foo/deep/index.md", b"# Deep\n"),),
+    )
+
+    plan = plan_wiki_projection(_request(position=1, scopes=()), snapshot)
+
+    rendered = {write.path: write.content.decode() for write in plan.writes}
+    assert "foo/index.md" in rendered
+    assert "[[foo/index|Foo]]" in rendered["index.md"]
+
+
 def test_projection_bytes_match_the_shared_contract_fixture() -> None:
     fixture_path = (
         Path(__file__).parents[1] / "fixtures" / "wiki_projector" / "basic_projection.json"

--- a/tests/indexing/test_wiki_projector.py
+++ b/tests/indexing/test_wiki_projector.py
@@ -469,6 +469,39 @@ def test_incremental_projection_preserves_existing_empty_folder_links() -> None:
     assert "[[guides/index|Guides]]" in rendered["index.md"]
 
 
+def test_incremental_projection_rejects_case_folded_existing_empty_scope() -> None:
+    note = WikiSourceNote(
+        path="foo/note.md",
+        permalink="foo/note",
+        title="Note",
+        note_type="Note",
+        checksum="note-checksum",
+    )
+    change = WikiSourceChange(
+        partition_position=1,
+        operation=WikiChangeOperation.created,
+        path=note.path,
+        permalink=note.permalink,
+        title=note.title,
+        accepted_at=ACCEPTED_AT,
+        materialized=True,
+        source="web",
+    )
+    snapshot = WikiProjectionSnapshot(
+        project_id="project-88",
+        project_name="Project 88",
+        source_partition_position=1,
+        current_output_watermark=0,
+        source_accepted_at=ACCEPTED_AT,
+        notes=(note,),
+        changes=(change,),
+        reserved_documents=(_reserved("Foo/index.md", b"# Foo\n"),),
+    )
+
+    with pytest.raises(ValueError, match="projected scopes must be unique"):
+        plan_wiki_projection(_request(position=1, scopes=()), snapshot)
+
+
 def test_projection_bytes_match_the_shared_contract_fixture() -> None:
     fixture_path = (
         Path(__file__).parents[1] / "fixtures" / "wiki_projector" / "basic_projection.json"


### PR DESCRIPTION
## Summary

- include explicitly projected empty scopes when generating parent directory indexes
- preserve intermediate parent links for nested empty folders
- cover root, parent, and leaf index output with a projector regression test

## Tests

- `uv run pytest -q tests/indexing/test_wiki_projector.py` (81 passed)
- `uv run ruff check src/basic_memory/indexing/wiki_projector.py tests/indexing/test_wiki_projector.py`
- `uv run ruff format --check src/basic_memory/indexing/wiki_projector.py tests/indexing/test_wiki_projector.py`
- `git diff --check`