### PR TITLE
fix(core): keep deleted wiki folders deleted

### DIFF
--- a/src/basic_memory/indexing/wiki_projector.py
+++ b/src/basic_memory/indexing/wiki_projector.py
@@ -255,6 +255,30 @@ def plan_wiki_projection(
     snapshot: WikiProjectionSnapshot,
 ) -> WikiProjectionPlan:
     """Plan deterministic OKF index/log writes without performing I/O."""
+    return _plan_wiki_projection(request, snapshot, created_scopes=())
+
+
+def plan_wiki_folder_creation(
+    request: WikiProjectionRequest,
+    snapshot: WikiProjectionSnapshot,
+) -> WikiProjectionPlan:
+    """Plan a synchronous folder creation against the current accepted snapshot."""
+    if request.reason is not WikiProjectionReason.folder_created:
+        raise ValueError("Wiki folder creation requires the folder_created reason")
+    return _plan_wiki_projection(
+        request,
+        snapshot,
+        created_scopes=request.requested_scopes,
+    )
+
+
+def _plan_wiki_projection(
+    request: WikiProjectionRequest,
+    snapshot: WikiProjectionSnapshot,
+    *,
+    created_scopes: tuple[str, ...],
+) -> WikiProjectionPlan:
+    """Share deterministic planning while keeping folder creation out of queued runs."""
     if request.project_id != snapshot.project_id:
         raise ValueError("Wiki projection request and snapshot project_id differ")
     if request.through_partition_position < snapshot.current_output_watermark:
@@ -330,6 +354,7 @@ def plan_wiki_projection(
         snapshot,
         notes,
         new_changes,
+        created_scopes=created_scopes,
         repair_complete_projection=projector_only_advance,
     )
     projector_owned_index_scopes = {
@@ -518,6 +543,7 @@ def _projection_scopes(
     notes: tuple[WikiSourceNote, ...],
     new_changes: tuple[WikiSourceChange, ...],
     *,
+    created_scopes: tuple[str, ...],
     repair_complete_projection: bool,
 ) -> tuple[str, ...]:
     current_paths = [note.path for note in notes]
@@ -536,8 +562,14 @@ def _projection_scopes(
         while scope != PurePosixPath("."):
             scopes.add(scope.as_posix())
             scope = scope.parent
-    if request.reason == WikiProjectionReason.folder_created:
-        return tuple(sorted(scopes))
+    # A missing scope may only be established by the synchronous folder-creation
+    # planner. Durable queued requests carry no folder-lifetime proof, so replaying
+    # one after deletion cannot resurrect its reserved documents.
+    for created_scope in created_scopes:
+        scope = PurePosixPath(created_scope)
+        while scope != PurePosixPath("."):
+            current_scopes.add(scope.as_posix())
+            scope = scope.parent
     return tuple(sorted(scopes & current_scopes))
 
 

--- a/src/basic_memory/indexing/wiki_projector.py
+++ b/src/basic_memory/indexing/wiki_projector.py
@@ -31,6 +31,7 @@ class WikiProjectionReason(StrEnum):
     """Why a projector run was requested."""
 
     accepted_note = "accepted_note"
+    folder_created = "folder_created"
     project_created = "project_created"
     import_rebuild = "import_rebuild"
     manual_rebuild = "manual_rebuild"
@@ -317,11 +318,17 @@ def plan_wiki_projection(
         for note in snapshot.notes
         if PurePosixPath(note.path).name.lower() not in RESERVED_WIKI_FILENAMES
     )
+    note_by_path = {_portable_path_key(note.path): note for note in notes}
+    for requested_scope in request.requested_scopes:
+        if existing_note := note_by_path.get(_portable_path_key(requested_scope)):
+            raise ValueError(
+                "Wiki projection scope collides with an existing source note path: "
+                f"{requested_scope}, {existing_note.path}"
+            )
     scopes = _projection_scopes(
         request,
         snapshot,
         notes,
-        changes,
         new_changes,
         repair_complete_projection=projector_only_advance,
     )
@@ -363,7 +370,6 @@ def plan_wiki_projection(
                 "Wiki source change permalink collides with a generated document identity: "
                 f"{change.permalink}"
             )
-    note_by_path = {_portable_path_key(note.path): note for note in notes}
     scope_by_portable_path: dict[str, str] = {}
     for scope in scopes:
         portable_scope = _portable_path_key(scope)
@@ -510,17 +516,18 @@ def _projection_scopes(
     request: WikiProjectionRequest,
     snapshot: WikiProjectionSnapshot,
     notes: tuple[WikiSourceNote, ...],
-    changes: tuple[WikiSourceChange, ...],
     new_changes: tuple[WikiSourceChange, ...],
     *,
     repair_complete_projection: bool,
 ) -> tuple[str, ...]:
+    current_paths = [note.path for note in notes]
+    current_paths.extend(document.path for document in snapshot.reserved_documents)
+    current_scopes = set(affected_wiki_scopes(*current_paths))
     if request.is_full_rebuild or repair_complete_projection:
-        paths = [note.path for note in notes]
-        paths.extend(document.path for document in snapshot.reserved_documents)
-        paths.extend(change.path for change in changes)
-        paths.extend(change.previous_path for change in changes if change.previous_path is not None)
-        return affected_wiki_scopes(*paths)
+        # Historical changes feed logs, but only current notes and reserved documents prove
+        # that a directory still exists. Otherwise a rebuild after a directory delete would
+        # recreate that directory's projector-owned index and log.
+        return tuple(sorted(current_scopes))
     paths = [change.path for change in new_changes]
     paths.extend(change.previous_path for change in new_changes if change.previous_path is not None)
     scopes = set(affected_wiki_scopes(*paths))
@@ -529,7 +536,9 @@ def _projection_scopes(
         while scope != PurePosixPath("."):
             scopes.add(scope.as_posix())
             scope = scope.parent
-    return tuple(sorted(scopes))
+    if request.reason == WikiProjectionReason.folder_created:
+        return tuple(sorted(scopes))
+    return tuple(sorted(scopes & current_scopes))
 
 
 def _without_projection_metadata(content: bytes) -> bytes:

--- a/tests/index/test_local_wiki_projection.py
+++ b/tests/index/test_local_wiki_projection.py
@@ -128,7 +128,7 @@ async def test_local_wiki_rejects_incomplete_filesystem_scan(
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Symlink setup requires extra privileges")
 @pytest.mark.asyncio
-async def test_local_wiki_refuses_symlinked_projection_parent(
+async def test_local_wiki_rejects_source_tree_replaced_by_symlink(
     config_home,
     session_maker,
     test_project,
@@ -136,35 +136,39 @@ async def test_local_wiki_refuses_symlinked_projection_parent(
 ):
     outside = tmp_path / "outside"
     outside.mkdir()
-    (config_home / "linked").symlink_to(outside, target_is_directory=True)
-    accepted_at = datetime.now(UTC)
-    async with db.scoped_session(session_maker) as session:
-        project = await session.get(Project, test_project.id)
-        assert project is not None
-        project.partition_position = 1
-        session.add(
-            AcceptedProjectNoteChange(
-                project_id=test_project.id,
-                project_external_id=test_project.external_id,
-                partition_position=1,
-                entity_id=1,
-                note_external_id="deleted-note",
-                permalink="linked/note",
-                title="Deleted note",
-                operation="deleted",
-                file_path="linked/note.md",
-                accepted_at=accepted_at,
-                materialized_at=accepted_at,
-                source="delete_note",
-            )
-        )
+    linked = config_home / "linked"
+    linked.mkdir()
+    source_note = linked / "note.md"
+    source_note.write_text("# Note\n", encoding="utf-8")
 
     inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
 
-    with pytest.raises(LocalWikiWriteConflict, match="crosses a symlink.*linked/index.md"):
+    # A symlink changes the source-tree identity even when the note bytes are
+    # unchanged, so the all-input preflight rejects the stale inspection.
+    source_note.rename(outside / "note.md")
+    linked.rmdir()
+    linked.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(LocalWikiWriteConflict, match="inputs changed after planning"):
         await apply_local_wiki_projection(inspection, session_maker=session_maker)
 
-    assert list(outside.iterdir()) == []
+    assert [path.name for path in outside.iterdir()] == ["note.md"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Symlink setup requires extra privileges")
+def test_local_wiki_destination_guard_rejects_symlinked_parent(tmp_path):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (project_root / "linked").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(LocalWikiWriteConflict, match="crosses a symlink.*linked/index.md"):
+        local_wiki_projection._require_safe_projection_destination(
+            project_root=project_root,
+            target=project_root / "linked" / "index.md",
+            relative_path="linked/index.md",
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_wiki_projector.py
+++ b/tests/indexing/test_wiki_projector.py
@@ -411,7 +411,11 @@ def test_requested_empty_folder_links_parent_indexes() -> None:
     )
 
     plan = plan_wiki_projection(
-        _request(position=0, scopes=("guides/setup",)),
+        _request(
+            position=0,
+            reason=WikiProjectionReason.folder_created,
+            scopes=("guides/setup",),
+        ),
         snapshot,
     )
 
@@ -432,7 +436,11 @@ def test_incremental_projection_preserves_existing_empty_folder_links() -> None:
         changes=(),
     )
     initial = plan_wiki_projection(
-        _request(position=0, scopes=("guides/setup",)),
+        _request(
+            position=0,
+            reason=WikiProjectionReason.folder_created,
+            scopes=("guides/setup",),
+        ),
         empty_snapshot,
     )
     overview = WikiSourceNote(
@@ -837,6 +845,47 @@ def test_requested_scopes_cannot_omit_a_changed_note_scope() -> None:
         "secret/log.md",
     }
     assert plan.result.output_watermark == 3
+
+
+def test_stale_accepted_change_does_not_recreate_deleted_folder() -> None:
+    deleted_change = WikiSourceChange(
+        partition_position=1,
+        operation=WikiChangeOperation.created,
+        path="deleted/note.md",
+        permalink="deleted/note",
+        title="Deleted note",
+        accepted_at=ACCEPTED_AT,
+        materialized=True,
+        source="web",
+    )
+    snapshot = WikiProjectionSnapshot(
+        project_id="project-88",
+        project_name="Project 88",
+        source_partition_position=1,
+        current_output_watermark=0,
+        source_accepted_at=ACCEPTED_AT,
+        notes=(),
+        changes=(deleted_change,),
+    )
+
+    incremental = plan_wiki_projection(
+        _request(position=1, scopes=("deleted",)),
+        snapshot,
+    )
+    rebuilt = plan_wiki_projection(
+        _request(
+            position=1,
+            reason=WikiProjectionReason.manual_rebuild,
+            scopes=(),
+        ),
+        snapshot,
+    )
+
+    assert {write.path for write in incremental.writes} == {"index.md", "log.md"}
+    assert {write.path for write in rebuilt.writes} == {"index.md", "log.md"}
+    assert "Deleted note" in next(
+        write.content.decode() for write in rebuilt.writes if write.path == "log.md"
+    )
 
 
 def test_full_rebuild_covers_every_note_directory() -> None:

--- a/tests/indexing/test_wiki_projector.py
+++ b/tests/indexing/test_wiki_projector.py
@@ -21,6 +21,7 @@ from basic_memory.indexing.wiki_projector import (
     WikiSourceNote,
     WIKI_LOG_ENTRY_LIMIT,
     affected_wiki_scopes,
+    plan_wiki_folder_creation,
     plan_wiki_projection,
 )
 
@@ -410,7 +411,7 @@ def test_requested_empty_folder_links_parent_indexes() -> None:
         changes=(),
     )
 
-    plan = plan_wiki_projection(
+    plan = plan_wiki_folder_creation(
         _request(
             position=0,
             reason=WikiProjectionReason.folder_created,
@@ -425,6 +426,30 @@ def test_requested_empty_folder_links_parent_indexes() -> None:
     assert "No concepts have been projected" in rendered["guides/setup/index.md"]
 
 
+def test_queued_folder_creation_cannot_resurrect_a_missing_scope() -> None:
+    snapshot = WikiProjectionSnapshot(
+        project_id="project-88",
+        project_name="Project 88",
+        source_partition_position=0,
+        current_output_watermark=0,
+        source_accepted_at=ACCEPTED_AT,
+        notes=(),
+        changes=(),
+    )
+
+    plan = plan_wiki_projection(
+        _request(
+            position=0,
+            reason=WikiProjectionReason.folder_created,
+            scopes=("guides/setup",),
+        ),
+        snapshot,
+    )
+
+    assert {write.path for write in plan.writes} == {"index.md", "log.md"}
+    assert all(not write.path.startswith("guides/") for write in plan.writes)
+
+
 def test_incremental_projection_preserves_existing_empty_folder_links() -> None:
     empty_snapshot = WikiProjectionSnapshot(
         project_id="project-88",
@@ -435,7 +460,7 @@ def test_incremental_projection_preserves_existing_empty_folder_links() -> None:
         notes=(),
         changes=(),
     )
-    initial = plan_wiki_projection(
+    initial = plan_wiki_folder_creation(
         _request(
             position=0,
             reason=WikiProjectionReason.folder_created,


### PR DESCRIPTION
## Summary

- derive projected Wiki scopes from current notes and reserved documents instead of historical paths alone
- add an explicit `folder_created` projection reason so intentionally empty folders remain supported
- prevent stale incremental or rebuild work from recreating projector-owned `index.md` and `log.md` after a folder is deleted

## Verification

- `uv run pytest -q tests/indexing/test_wiki_projector.py` (88 passed)
- `just fast-check` formatting and lint passed; typecheck could not resolve the optional `pymilvus` extra in the isolated worktree

## Context

Prerequisite for basicmachines-co/basic-memory-cloud#1931.
