### PR TITLE
fix(mcp): route identifiers by the session's own project set

### DIFF
--- a/src/basic_memory/mcp/project_context.py
+++ b/src/basic_memory/mcp/project_context.py
@@ -848,22 +848,38 @@ async def resolve_project_and_path(
                 )
                 return active_project, resolved_path, True
 
-        project_prefix, remainder = _split_project_prefix(normalized_path)
         include_project = config.permalinks_include_project
-        # Trigger: memory URL begins with a potential project segment
-        # Why: allow project-scoped memory URLs without requiring a separate project parameter
-        # Outcome: attempt to resolve the prefix as a project and route to it
-        if project_prefix:
-            # Deferred: ToolError lives in FastMCP's runtime, which must not load at CLI startup (#886).
-            from fastmcp.exceptions import ToolError
 
-            if cached_project and _project_matches_identifier(cached_project, project_prefix):
-                resolved_project = await resolve_project_parameter(project_prefix, context=context)
-                if resolved_project and generate_permalink(resolved_project) != generate_permalink(
-                    project_prefix
-                ):
+        # --- The routed project claims its own prefix, with no lookup at all ---
+        # Trigger: the URL's leading segments spell the project this call is
+        #   already routed to.
+        # Why: a project name may contain '/', so how many segments its prefix
+        #   spans is a fact about that project, not about the string.
+        #   _split_project_prefix guesses one segment, so
+        #   'memory://research/2026/notes/x' offered 'research' to the resolver
+        #   below — which, in a config that also holds a project named
+        #   'research', answered with that one, returned it as the active
+        #   project, and cached it over the project the client was opened for
+        #   (#1432). The identity needed to settle this is already in hand, so
+        #   claim it with the same splitter every other project set uses.
+        # Outcome: the remainder is what is left after the segments the project
+        #   really spans, and no /v2/projects/resolve round trip is spent.
+        if cached_project is not None:
+            claimed = _split_project_permalink_prefix(
+                normalized_path,
+                # Both spellings _project_matches_identifier accepted, so the
+                # widening is in how many segments match, not in which names do.
+                (generate_permalink(cached_project.name), cached_project.permalink),
+            )
+            # A prefix with no remainder names the project itself, not a path in
+            # it: 'memory://main' stays a note called 'main' in the active
+            # project, exactly as _split_project_prefix's shape check required.
+            if claimed is not None and claimed[1]:
+                claimed_prefix, remainder = claimed
+                resolved_project = await resolve_project_parameter(claimed_prefix, context=context)
+                if resolved_project and generate_permalink(resolved_project) != claimed_prefix:
                     raise ValueError(
-                        f"Project is constrained to '{resolved_project}', cannot use '{project_prefix}'."
+                        f"Project is constrained to '{resolved_project}', cannot use '{claimed_prefix}'."
                     )
 
                 resolved_path = _canonical_memory_path_for_active_route(
@@ -873,6 +889,22 @@ async def resolve_project_and_path(
                     cached_workspace=cached_workspace,
                 )
                 return cached_project, resolved_path, True
+
+        project_prefix, remainder = _split_project_prefix(normalized_path)
+        # Trigger: memory URL begins with a potential project segment that is not
+        #   the routed project's own.
+        # Why: allow project-scoped memory URLs without requiring a separate project parameter
+        # Outcome: attempt to resolve the prefix as a project and route to it.
+        #   No set in hand names this project, so this branch resolves a *name*
+        #   through the API and keeps the single-segment guess: a project whose
+        #   permalink spans several segments is reachable through every caller
+        #   that detects its prefix first (all of them do), and buying the
+        #   multi-segment reading here too would mean a project-list fetch on
+        #   every cross-project memory:// read, on top of the resolve it already
+        #   costs.
+        if project_prefix:
+            # Deferred: ToolError lives in FastMCP's runtime, which must not load at CLI startup (#886).
+            from fastmcp.exceptions import ToolError
 
             try:
                 from basic_memory.mcp.tools.utils import call_post
@@ -943,11 +975,29 @@ async def resolve_project_and_path(
         return active_project, resolved_path, True
 
 
+@dataclass(frozen=True)
+class DetectedProjectRoute:
+    """The project an identifier's leading segments name, plus the id that pins it.
+
+    ``project`` is the routing identifier callers hand to ``get_project_client``;
+    ``project_id`` is the external_id of the exact project that claimed the
+    segments, or None for a locally routed session, whose config holds no UUIDs
+    and which has no second workspace to be confused with. Callers pass both,
+    the way the posix verbs pass ``ProjectPathRoute``'s pair: a project name is
+    unique only inside one workspace, so handing on the name alone lets it be
+    re-resolved against a different accessible workspace that happens to hold
+    the same permalink (#1432).
+    """
+
+    project: str
+    project_id: Optional[str] = None
+
+
 async def detect_project_from_memory_url_prefix(
     identifier: str,
     config: BasicMemoryConfig,
     context: Optional[Context] = None,
-) -> Optional[str]:
+) -> Optional[DetectedProjectRoute]:
     """Resolve a project from a memory URL prefix, including workspace-qualified URLs."""
     if not identifier.strip().startswith("memory://"):
         return None
@@ -970,11 +1020,51 @@ async def detect_project_from_identifier_prefix(
     identifier: str,
     config: BasicMemoryConfig,
     context: Optional[Context] = None,
-) -> Optional[str]:
-    """Resolve a project from a plain permalink, memory URL, or workspace route prefix."""
+) -> Optional[DetectedProjectRoute]:
+    """Resolve a project from a plain permalink, memory URL, or workspace route prefix.
+
+    Detection, not resolution. A leading segment that names no project is the
+    normal case on this surface — 'specs/search-spec' is an ordinary permalink,
+    and a search query is arbitrary text — so the answer for it is None and the
+    caller's active/default project applies. That is why these tools do not
+    adopt the posix verbs' refusal rule (#1421): there a first segment naming
+    nothing is an error, here it is the common input.
+
+    What they do adopt is the *set*, and its precedence. A path-shaped
+    identifier names a project only when a project set the session already holds
+    claims its leading segments, and every set is claimed by the same
+    ``split_project_permalink_prefix``, so how many segments a project spans
+    stays a fact about the known projects rather than a guess about the string:
+
+    1. the local config (``detect_project_from_url_prefix``), free to read;
+    2. ``addressable_projects`` — the session's own mount table, the same set
+       ``ls /`` advertises and ``resolve_project_path_route`` routes by. In a
+       hosted session that listing comes from the session's own tenant route, so
+       it is exactly the projects of the workspace this session is bound to;
+    3. then, and only then, an explicitly workspace-qualified
+       '<workspace>/<project>/<path>' route, for projects in workspaces this
+       session's own route does not list.
+
+    Mounts before workspace routes is ``resolve_project_path_route``'s order,
+    for its reason: only one reading of '<name>/...' can win, and a name ``ls
+    /`` advertises must address that mount or we advertise an address that
+    resolves somewhere else. Reading it the other way here meant `ls team/docs`
+    and `read_note("team/docs/x")` disagreed about what 'team' named. It is also
+    the cheaper order — a mount hit never builds the account-wide workspace
+    index at all.
+
+    Nothing is resolved by *searching* for a name. The deleted fallback did: it
+    split one leading segment off and handed it to the account-wide workspace
+    index, which answered with a project in whichever accessible workspace held
+    that permalink — preferring the ``is_default`` workspace when several did.
+    An ordinary project-relative path therefore read another workspace's
+    same-named project, silently (#1432), and a project whose permalink spans
+    two segments ('Research/2026') was unreachable, because one segment was all
+    the split ever offered.
+    """
     local_project = detect_project_from_url_prefix(identifier, config)
     if local_project is not None:
-        return local_project
+        return DetectedProjectRoute(project=local_project)
 
     normalized_identifier = normalize_project_reference(_identifier_path(identifier)).strip("/")
     if "/" not in normalized_identifier:
@@ -984,39 +1074,56 @@ async def detect_project_from_identifier_prefix(
         # Outcome: keep unqualified search/title input on the active/default project route.
         return None
 
-    if _workspace_identifier_discovery_available(identifier, config):
-        try:
-            workspace_resolution = await resolve_workspace_qualified_identifier(
-                identifier,
-                context=context,
-            )
-        except ValueError as exc:
-            message = str(exc).lower()
-            if any(error in message for error in _WORKSPACE_DISCOVERY_FALLBACK_ERRORS):
-                return None
-            raise
+    # --- Rule 2: the session's own mount table, when it is not the local config ---
+    # Trigger: this session's own project-less route is a tenant, so its mounts
+    #   live in that tenant's project listing rather than in local config.
+    # Why: a locally routed session's mount table IS ``config.projects``, which
+    #   rule 1 just claimed against with this same splitter, so asking again
+    #   there is provably the same answer for no reason. A cloud session's local
+    #   config holds at most a placeholder, so rule 1 saw nothing and this is the
+    #   first set that can speak for it.
+    # Outcome: leading segments naming an addressable project route there, with
+    #   the mount's id so the name is never re-resolved elsewhere. One
+    #   per-request memoized listing, and no workspace discovery at all.
+    # ``addressable_projects``/``_claim_mount_prefix`` are defined in the
+    # project-qualified routing section below; one mount table serves both.
+    if _session_routes_to_cloud():
+        claimed = _claim_mount_prefix(
+            normalized_identifier,
+            await addressable_projects(context=context),
+        )
+        # A claim with no remainder names the project itself, not a path in it —
+        # a bare project name is a title to look up, not a route.
+        # ``detect_project_from_url_prefix`` holds the same line for rule 1.
+        if claimed is not None and claimed[1]:
+            mount, _ = claimed
+            return DetectedProjectRoute(project=mount.name, project_id=mount.external_id)
 
-        if workspace_resolution is not None:
-            return workspace_resolution.project_identifier
+    # --- Rule 3: an explicitly workspace-qualified route ---
+    if not _workspace_identifier_discovery_available(identifier, config):
+        return None
 
-        project_prefix, _ = _split_project_prefix(normalized_identifier)
-        if project_prefix is None:
+    try:
+        workspace_resolution = await resolve_workspace_qualified_identifier(
+            identifier,
+            context=context,
+        )
+    except ValueError as exc:
+        message = str(exc).lower()
+        if any(error in message for error in _WORKSPACE_DISCOVERY_FALLBACK_ERRORS):
             return None
+        raise
 
-        try:
-            project_resolution = await resolve_workspace_project_identifier(
-                project_prefix,
-                context=context,
-            )
-        except ValueError as exc:
-            message = str(exc).lower()
-            if any(error in message for error in _WORKSPACE_DISCOVERY_FALLBACK_ERRORS):
-                return None
-            raise
-
-        return project_resolution.qualified_name
-
-    return None
+    if workspace_resolution is None:
+        return None
+    # The entry is already in hand, so the external_id rides along for the same
+    # reason the mount table's does: the qualified *name* alone could be
+    # re-resolved against a workspace holding a project literally named
+    # '<workspace>/<project>'.
+    return DetectedProjectRoute(
+        project=workspace_resolution.project_identifier,
+        project_id=workspace_resolution.entry.project.external_id,
+    )
 
 
 # --- Project-qualified path routing (POSIX tools, #1415) ---

--- a/src/basic_memory/mcp/project_context.py
+++ b/src/basic_memory/mcp/project_context.py
@@ -404,9 +404,30 @@ async def invalidate_workspace_project_index(context: Optional[Context] = None) 
 
 
 async def invalidate_project_caches(context: Optional[Context] = None) -> None:
-    """Invalidate project identity caches after a project lifecycle change."""
+    """Invalidate project identity caches after a project lifecycle change.
+
+    The one place that answers "a project changed in this session", so every
+    session-scoped cache whose contents are *projects* is cleared here — a
+    fourth one belongs on this list too. Today that is three: the active
+    project (with the default-project name it carries), the account-wide
+    workspace/project index, and the session's own project listing.
+
+    The session listing is the one that decides which first path segment names a
+    project (``addressable_projects``), so leaving it behind made a project
+    created mid-session unaddressable by name and a deleted one keep routing to
+    its dead external_id — for ``ls "/"`` and the posix resolver, and, once
+    identifier detection started reading the same mount table, for ``read_note``
+    and ``search_notes`` as well (#1432 review).
+
+    Deliberately NOT cleared: ``active_workspace`` and ``available_workspaces``
+    hold workspace metadata — tenant id, slug, type — which no project
+    lifecycle change touches, and no MCP tool creates or deletes a workspace.
+    """
     await _clear_cached_active_project(context)
     await invalidate_workspace_project_index(context)
+    # Defined beside the cache it clears, in the project-qualified routing
+    # section below.
+    await invalidate_session_project_list(context)
 
 
 async def _fetch_workspace_project_entries(
@@ -1263,6 +1284,17 @@ def _session_routes_to_cloud() -> bool:
     )
 
     return is_factory_mode() or (_explicit_routing() and not _force_local_mode())
+
+
+async def invalidate_session_project_list(context: Optional[Context] = None) -> None:
+    """Invalidate the cached listing of this session's own reachable projects.
+
+    Lives beside the cache it clears, and is called from
+    ``invalidate_project_caches`` — the one function that answers "a project
+    changed in this session".
+    """
+    if context:
+        await context.set_state(_SESSION_PROJECT_LIST_STATE_KEY, None)
 
 
 async def _session_project_list(context: Optional[Context] = None) -> ProjectList:

--- a/src/basic_memory/mcp/project_context.py
+++ b/src/basic_memory/mcp/project_context.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import time
 from contextlib import asynccontextmanager, nullcontext
 from dataclasses import dataclass
 from typing import (
@@ -1262,9 +1263,43 @@ class AddressableProject:
     external_id: Optional[str] = None
 
 
-# The session's own project listing, memoized for one MCP request: routing and
-# the mount view ask the same question, so a request pays for it at most once.
+# The session's own project listing. Routing and the mount view ask the same
+# question, so it is memoized — but in *session* state, which fastmcp keys by
+# session id and persists across tool calls, not for one request as this comment
+# used to claim. That is the whole finding: a project created out of band — by a
+# teammate, or by the CLI — stayed invisible for the life of the session,
+# because in-session invalidation only covers changes this session caused.
 _SESSION_PROJECT_LIST_STATE_KEY = "session_project_list"
+# Written whenever the listing above is fetched, so its age is a fact rather
+# than an assumption. A separate key on purpose: folding a timestamp into the
+# stored ProjectList would break a live session whose state was written by the
+# previous deploy.
+_SESSION_PROJECT_LIST_FETCHED_AT_STATE_KEY = "session_project_list_fetched_at"
+
+# How long a session may answer from that snapshot before a read refetches it.
+#
+# Age is the trigger, deliberately, and not a lookup miss. The sibling snapshot
+# does refresh on a miss (resolve_workspace_project_identifier, #956) because
+# its miss is terminal: an explicitly named project that must resolve or raise,
+# so the retry costs one listing per *failing* call. A miss against the mount
+# table is the ordinary answer instead — most path-shaped identifiers
+# ('specs/search-spec') are not project references at all, which is exactly why
+# detection returns None for them rather than refusing — so a miss-triggered
+# refresh would put a fetch on the hottest path in the tool surface and let one
+# non-existent identifier drive a listing per lookup.
+#
+# An age bound cannot be influenced by what the caller asks for. Whatever
+# arrives, a session spends at most one extra project listing per interval, and
+# a session that never reads spends none. It is also strictly less than this
+# code path used to cost: before #1432 an unqualified prefix rebuilt the whole
+# account-wide workspace index — a control-plane call plus one listing per
+# accessible workspace — on *every* miss.
+#
+# Applied in the loader rather than at a call site, so identifier detection, the
+# posix path resolver, and the `ls "/"` mount view get the same freshness from
+# one place. A miss-triggered refresh could not have covered `ls "/"` at all:
+# listing the mounts has no miss to trigger on.
+_SESSION_PROJECT_LIST_MAX_AGE_SECONDS = 60.0
 
 
 def _session_routes_to_cloud() -> bool:
@@ -1291,17 +1326,41 @@ async def invalidate_session_project_list(context: Optional[Context] = None) -> 
 
     Lives beside the cache it clears, and is called from
     ``invalidate_project_caches`` — the one function that answers "a project
-    changed in this session".
+    changed in this session". Invalidation covers the changes this session
+    caused; the age bound below covers the ones it did not.
     """
     if context:
         await context.set_state(_SESSION_PROJECT_LIST_STATE_KEY, None)
+        await context.set_state(_SESSION_PROJECT_LIST_FETCHED_AT_STATE_KEY, None)
+
+
+def _session_project_list_is_fresh(fetched_at: object) -> bool:
+    """True when a stored fetch time is present and inside the age bound.
+
+    A missing or non-numeric timestamp reads as stale: state written before this
+    bound existed carries none, and one listing is the right price for not
+    trusting a snapshot of unknown age. A timestamp in the future reads as stale
+    too — hosted workers do not share a clock, and skew must expire a snapshot
+    early rather than pin it forever.
+    """
+    if not isinstance(fetched_at, (int, float)):
+        return False
+    age = time.time() - fetched_at
+    return 0 <= age <= _SESSION_PROJECT_LIST_MAX_AGE_SECONDS
 
 
 async def _session_project_list(context: Optional[Context] = None) -> ProjectList:
-    """List the projects reachable through this session's own route."""
+    """List the projects reachable through this session's own route.
+
+    Answers from session state while the snapshot is inside
+    ``_SESSION_PROJECT_LIST_MAX_AGE_SECONDS``, and refetches once it is not, so
+    every consumer of ``addressable_projects`` inherits the same bounded
+    freshness without any of them holding a retry of its own.
+    """
     if context:
         cached_raw = await context.get_state(_SESSION_PROJECT_LIST_STATE_KEY)
-        if isinstance(cached_raw, dict):
+        fetched_at = await context.get_state(_SESSION_PROJECT_LIST_FETCHED_AT_STATE_KEY)
+        if isinstance(cached_raw, dict) and _session_project_list_is_fresh(fetched_at):
             return ProjectList.model_validate(cached_raw)
 
     # Deferred imports to avoid circular dependency with the client modules.
@@ -1313,6 +1372,10 @@ async def _session_project_list(context: Optional[Context] = None) -> ProjectLis
 
     if context:
         await context.set_state(_SESSION_PROJECT_LIST_STATE_KEY, project_list.model_dump())
+        # Stamped on every fetch, including a refetch that found nothing changed,
+        # so a run of misses against a genuinely absent project costs one listing
+        # per interval rather than one per lookup.
+        await context.set_state(_SESSION_PROJECT_LIST_FETCHED_AT_STATE_KEY, time.time())
     return project_list
 
 

--- a/src/basic_memory/mcp/resources/notes.py
+++ b/src/basic_memory/mcp/resources/notes.py
@@ -11,6 +11,7 @@ from fastmcp.exceptions import ResourceError, ToolError
 
 from basic_memory.config import ConfigManager
 from basic_memory.mcp.project_context import (
+    DetectedProjectRoute,
     detect_project_from_memory_url_prefix,
     get_project_client,
     resolve_project_and_path,
@@ -33,7 +34,7 @@ class NoteNotFoundError(ResourceError):
     """
 
 
-async def _route_for(identifier: str, context: Context | None) -> str | None:
+async def _route_for(identifier: str, context: Context | None) -> DetectedProjectRoute | None:
     """The project route the URI's prefix names, or None for the default client.
 
     The canonical prefix detection decides, covering configured local projects
@@ -51,7 +52,7 @@ async def _route_for(identifier: str, context: Context | None) -> str | None:
     )
     if route is None or config.permalinks_include_project:
         return route
-    requested = generate_permalink(route)
+    requested = generate_permalink(route.project)
     for configured_name in config.projects:
         if generate_permalink(configured_name) == requested:
             return None
@@ -69,7 +70,13 @@ async def read_note_markdown(identifier: str, context: Context | None) -> str:
     """
     try:
         route = await _route_for(identifier, context)
-        async with get_project_client(route, context) as (client, active_project):
+        # Both routing fields, the way every tool forwards them: the id is what
+        # keeps a cloud route bound to the workspace that answered for it (#1432).
+        async with get_project_client(
+            route.project if route else None,
+            context,
+            project_id=route.project_id if route else None,
+        ) as (client, active_project):
             target, entity_path, _ = await resolve_project_and_path(
                 client, f"memory://{identifier}", active_project.name, context
             )

--- a/src/basic_memory/mcp/tools/build_context.py
+++ b/src/basic_memory/mcp/tools/build_context.py
@@ -270,8 +270,10 @@ async def build_context(
             ConfigManager().config,
             context=context,
         )
-        if detected:
-            project = detected
+        if detected is not None:
+            # The id rides along so the name is never re-resolved against a
+            # different accessible workspace holding the same permalink (#1432).
+            project, project_id = detected.project, detected.project_id
 
     # Convert string depth to integer if needed
     if isinstance(depth, str):

--- a/src/basic_memory/mcp/tools/delete_note.py
+++ b/src/basic_memory/mcp/tools/delete_note.py
@@ -281,8 +281,10 @@ async def delete_note(
             ConfigManager().config,
             context=context,
         )
-        if detected:
-            project = detected
+        if detected is not None:
+            # The id rides along so the name is never re-resolved against a
+            # different accessible workspace holding the same permalink (#1432).
+            project, project_id = detected.project, detected.project_id
 
     async with get_project_client(project, context=context, project_id=project_id) as (
         client,

--- a/src/basic_memory/mcp/tools/edit_note.py
+++ b/src/basic_memory/mcp/tools/edit_note.py
@@ -522,15 +522,21 @@ async def edit_note(
     if project is None and project_id is None:
         config = ConfigManager().config
         if identifier.strip().startswith("memory://"):
-            detected = await detect_project_from_memory_url_prefix(
+            route = await detect_project_from_memory_url_prefix(
                 identifier,
                 config,
                 context=context,
             )
+            if route is not None:
+                # The id rides along so the name is never re-resolved against a
+                # different accessible workspace holding the same permalink (#1432).
+                project, project_id = route.project, route.project_id
         elif _workspace_identifier_discovery_available(
             identifier,
             config,
         ) and is_workspace_qualified_plain_identifier(identifier):
+            # A refusal, not a route: this names the project the ambiguous
+            # identifier *would* have edited, for the message only.
             detected = await detect_project_from_workspace_identifier_prefix(
                 identifier,
                 config,
@@ -552,10 +558,6 @@ async def edit_note(
                     identifier=identifier,
                     detected_project=detected,
                 )
-        else:
-            detected = None
-        if detected:
-            project = detected
 
     with logfire.span(
         "mcp.tool.edit_note",

--- a/src/basic_memory/mcp/tools/posix_tools.py
+++ b/src/basic_memory/mcp/tools/posix_tools.py
@@ -140,6 +140,31 @@ def qualify_listing_paths(payload: dict[str, Any], route: ProjectPathRoute) -> d
     }
 
 
+def qualify_search_paths(payload: dict[str, Any], route: ProjectPathRoute) -> dict[str, Any]:
+    """Re-qualify a search response's per-hit transport paths.
+
+    The third response shape a routed verb can answer with. `find --meta` returns
+    search hits rather than listing nodes, and the rule is per response shape,
+    not per verb: the metadata arm shipped without it and handed back
+    project-relative paths that `cat` then refused — or, worse, opened in a
+    different project mounted under that name (#1435).
+
+    ``file_path`` is the hit's address, the same field the listing nodes carry;
+    ``permalink`` is an identity with its own canonical form and is left alone,
+    exactly as in ``qualify_note_paths``.
+    """
+    prefix = _route_prefix(route)
+    if prefix is None:
+        return payload
+    return {
+        **payload,
+        "results": [
+            {**row, "file_path": _requalified_path(row["file_path"], prefix)}
+            for row in payload["results"]
+        ],
+    }
+
+
 # The manual project holds the non-bundled manual pages as ordinary notes;
 # `man` falls back to it for page reads and searches it in query mode.
 _MANUAL_PROJECT = "manual"
@@ -997,22 +1022,16 @@ async def find(
         route = await resolve_project_path_route(
             path, project=project, project_id=project_id, context=context
         )
+        # The whole route travels, not three fields pulled off it: the arm needs
+        # the project and its id to open the client, route.path to scope the
+        # search, and — the part #1435 missed — the same route again to
+        # re-qualify the paths it answers with.
         return await _find_by_metadata(
-            route_project=route.project,
-            # route.path is the caller's input verbatim when no project prefix
-            # was recognized, so one value covers both routed and raw spellings.
-            # SearchQuery.file_path_prefix is the boundary parser for it: it
-            # reads "./specs" the way the directory listing does, and collapses
-            # every root spelling — including the "" a bare '<project>' routes
-            # to, a mount point rather than a subtree — onto "no scope".
-            scope=route.path,
+            route=route,
             metadata_filters=metadata_filters,
             fields=projected_fields,
             page=page,
             page_size=page_size,
-            # The route's id, not the caller's raw param: it is what keeps a
-            # cloud mount bound to the workspace whose listing advertised it.
-            project_id=route.project_id,
             context=context,
         )
 
@@ -1031,13 +1050,11 @@ async def find(
 
 async def _find_by_metadata(
     *,
-    route_project: Optional[str],
-    scope: str,
+    route: ProjectPathRoute,
     metadata_filters: dict[str, Any],
     fields: Optional[list[MetadataPath]],
     page: int,
     page_size: int,
-    project_id: Optional[str],
     context: Context | None,
 ) -> dict[str, Any]:
     """find's metadata arm: one search call, plus per-hit field projection.
@@ -1045,15 +1062,23 @@ async def _find_by_metadata(
     The listing arm's counterpart to ``find_listing``; `find` has already bounded
     the pagination and refused `name` and `depth` against `meta`.
 
-    The path scope composes server-side as a file-path prefix — the indexed
-    `file_path`, which is where the note actually lives, not its permalink,
-    which stops mirroring that path once a note pins one in frontmatter or is
-    moved with update_permalinks_on_move disabled (the default). It ANDs with
-    the metadata filters in the same WHERE, so the total the server reports is
-    the real match count for the scope that ran, and every page of it is
-    reachable.
+    ``route.project_id`` opens the client, not the caller's raw param: it is what
+    keeps a cloud mount bound to the workspace whose listing advertised it.
+
+    The path scope is ``route.path`` — the caller's input verbatim when no
+    project prefix was recognized, so one value covers both routed and raw
+    spellings. ``SearchQuery.file_path_prefix`` is the boundary parser for it: it
+    reads "./specs" the way the directory listing does, and collapses every root
+    spelling — including the "" a bare '<project>' routes to, a mount point
+    rather than a subtree — onto "no scope". It composes server-side as a
+    file-path prefix — the indexed `file_path`, which is where the note actually
+    lives, not its permalink, which stops mirroring that path once a note pins
+    one in frontmatter or is moved with update_permalinks_on_move disabled (the
+    default). It ANDs with the metadata filters in the same WHERE, so the total
+    the server reports is the real match count for the scope that ran, and every
+    page of it is reachable.
     """
-    async with get_project_client(route_project, context=context, project_id=project_id) as (
+    async with get_project_client(route.project, context=context, project_id=route.project_id) as (
         client,
         active_project,
     ):
@@ -1063,13 +1088,16 @@ async def _find_by_metadata(
         query = SearchQuery(
             # Normalized by the field validator, which maps every root spelling
             # onto None: the predicates are then the whole WHERE.
-            file_path_prefix=scope,
+            file_path_prefix=route.path,
             metadata_filters=metadata_filters,
             entity_types=[SearchItemType.ENTITY],
         )
         search_client = SearchClient(client, active_project.external_id)
         response = await search_client.search(query.model_dump(), page=page, page_size=page_size)
-        payload = response.model_dump(mode="json", exclude_none=True)
+        # Re-qualified before anything reads the rows, so the projection below
+        # carries the same addresses the unprojected response does — the two arms
+        # of one response shape cannot answer with different spellings.
+        payload = qualify_search_paths(response.model_dump(mode="json", exclude_none=True), route)
         if not fields:
             return payload
 

--- a/src/basic_memory/mcp/tools/read_content.py
+++ b/src/basic_memory/mcp/tools/read_content.py
@@ -235,8 +235,10 @@ async def read_content(
             ConfigManager().config,
             context=context,
         )
-        if detected:
-            project = detected
+        if detected is not None:
+            # The id rides along so the name is never re-resolved against a
+            # different accessible workspace holding the same permalink (#1432).
+            project, project_id = detected.project, detected.project_id
 
     logger.info(f"MCP tool call tool=read_content project={project} path={path}")
 

--- a/src/basic_memory/mcp/tools/read_note.py
+++ b/src/basic_memory/mcp/tools/read_note.py
@@ -174,8 +174,10 @@ async def read_note(
             ConfigManager().config,
             context=context,
         )
-        if detected:
-            project = detected
+        if detected is not None:
+            # The id rides along so the name is never re-resolved against a
+            # different accessible workspace holding the same permalink (#1432).
+            project, project_id = detected.project, detected.project_id
 
     with logfire.span(
         "mcp.tool.read_note",

--- a/src/basic_memory/mcp/tools/search.py
+++ b/src/basic_memory/mcp/tools/search.py
@@ -1216,8 +1216,10 @@ async def search_notes(
             ConfigManager().config,
             context=context,
         )
-        if detected:
-            project = detected
+        if detected is not None:
+            # The id rides along so the name is never re-resolved against a
+            # different accessible workspace holding the same permalink (#1432).
+            project, project_id = detected.project, detected.project_id
 
     # Trigger: caller explicitly requests account/workspace-wide search and did not
     # already provide a concrete project route.

--- a/tests/mcp/test_note_resources.py
+++ b/tests/mcp/test_note_resources.py
@@ -10,6 +10,7 @@ from fastmcp import Client
 from fastmcp.exceptions import ResourceError, ToolError
 
 import basic_memory.mcp.resources.notes as notes_module
+from basic_memory.mcp.project_context import DetectedProjectRoute
 from basic_memory.mcp.resources.notes import NOTE_TEMPLATE, note_resource
 from basic_memory.mcp.server import mcp
 from basic_memory.mcp.tools import write_note
@@ -235,7 +236,7 @@ async def test_workspace_qualified_uris_route_through_their_project(
     # with its failures surfacing, not falling back to the default project.
     async def detected(identifier, config, context=None):
         assert identifier == "memory://personal/main/docs/report"
-        return "personal/main"
+        return DetectedProjectRoute(project="personal/main")
 
     monkeypatch.setattr(notes_module, "detect_project_from_memory_url_prefix", detected)
     routes: list[str | None] = []
@@ -269,7 +270,7 @@ async def test_workspace_routes_survive_disabled_project_prefixes(
     monkeypatch.setattr(notes_module, "ConfigManager", StubConfigManager)
 
     async def detected(identifier, config, context=None):
-        return "team-paul/main"
+        return DetectedProjectRoute(project="team-paul/main")
 
     monkeypatch.setattr(notes_module, "detect_project_from_memory_url_prefix", detected)
     routes: list[str | None] = []

--- a/tests/mcp/test_project_context.py
+++ b/tests/mcp/test_project_context.py
@@ -10,7 +10,10 @@ from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, cast
 
 import pytest
+import pytest_asyncio
 
+from basic_memory import db
+from basic_memory.mcp.project_context import DetectedProjectRoute
 from tests.mcp.conftest import ContextState, ctx
 
 
@@ -51,6 +54,26 @@ def _project(
         path=f"/{name}",
         is_default=is_default,
     )
+
+
+def _session_listing(*projects):
+    """Fake the session's own project listing — what ``get_client()`` answers.
+
+    In a hosted session the project-less client IS the session's tenant route,
+    so this listing is exactly the projects of the workspace the session is
+    bound to. That is what makes ``addressable_projects`` able to answer "the
+    session's own workspace" at all, which the account-wide workspace index
+    cannot (#1432).
+    """
+    from basic_memory.schemas.project_info import ProjectList
+
+    async def fake_session_project_list(context=None):
+        return ProjectList(
+            projects=list(projects),
+            default_project=projects[0].name if projects else None,
+        )
+
+    return fake_session_project_list
 
 
 @pytest.mark.asyncio
@@ -899,6 +922,9 @@ async def test_detect_project_from_memory_url_prefix_resolves_workspace_slug(mon
         return index
 
     monkeypatch.setattr(project_context, "_ensure_workspace_project_index", fake_index)
+    # The session's own route lists no project named 'team-paul', so the mount
+    # table declines and the workspace-qualified reading is the one left.
+    monkeypatch.setattr(project_context, "_session_project_list", _session_listing())
     monkeypatch.setattr("basic_memory.mcp.async_client.is_factory_mode", lambda: True)
 
     resolved = await detect_project_from_memory_url_prefix(
@@ -906,7 +932,10 @@ async def test_detect_project_from_memory_url_prefix_resolves_workspace_slug(mon
         BasicMemoryConfig(projects={}),
     )
 
-    assert resolved == "team-paul/main"
+    # The id pins the route to the workspace that answered for it: 'main' names
+    # a project in BOTH workspaces here, so the qualified name alone would be
+    # re-resolved and could land on the other one (#1432).
+    assert resolved == DetectedProjectRoute(project="team-paul/main", project_id="team-main-id")
 
 
 @pytest.mark.asyncio
@@ -930,7 +959,9 @@ async def test_detect_project_from_memory_url_prefix_prefers_local_project_prefi
         ),
     )
 
-    assert resolved == "main"
+    # A locally routed session's config holds no UUIDs and has no second
+    # workspace to be confused with, so the name is the whole identity.
+    assert resolved == DetectedProjectRoute(project="main")
 
 
 @pytest.mark.asyncio
@@ -1039,35 +1070,33 @@ async def test_detect_project_from_identifier_prefix_resolves_workspace_with_loc
         cloud_api_key="bmc_test123",
     )
 
+    expected = DetectedProjectRoute(project="personal/main", project_id="personal-main-id")
     assert (
         await detect_project_from_identifier_prefix(
             "memory://personal/main/main-to-do-list",
             config,
         )
-        == "personal/main"
+        == expected
     )
     assert (
         await detect_project_from_identifier_prefix(
             "personal/main/main-to-do-list",
             config,
         )
-        == "personal/main"
+        == expected
     )
 
 
 @pytest.mark.asyncio
-async def test_detect_project_from_identifier_prefix_falls_back_to_bare_project_name(
-    monkeypatch,
-):
-    """An identifier that is not workspace-qualified still resolves its first
-    segment by searching every accessible workspace for a project of that name.
+async def test_detect_project_prefix_stays_inside_the_sessions_own_workspace(monkeypatch):
+    """A bare first segment never reaches a project in another workspace (#1432).
 
-    This is the legacy detector read_note and search share. The posix path
-    resolver deliberately does NOT use it: a bare first segment that names no
-    addressable mount must refuse rather than reach another workspace's
-    same-named project (#1421), so its rule 4 parses only fully qualified
-    '<workspace>/<project>[/<path>]' routes. Pinned here so the behavior these
-    two tools still depend on is exercised on its own terms.
+    The deleted fallback searched the account-wide index for the segment and
+    answered with whichever workspace held that permalink — preferring the
+    is_default one — so an ordinary project-relative path in a session bound to
+    'beta' read 'acme's same-named project instead. The session's own mount
+    table is now the only set consulted, and it names no 'notes', so the
+    identifier stays unrouted and the caller's active project applies.
     """
     import basic_memory.mcp.project_context as project_context
     from basic_memory.config import BasicMemoryConfig
@@ -1077,21 +1106,28 @@ async def test_detect_project_from_identifier_prefix_falls_back_to_bare_project_
         detect_project_from_identifier_prefix,
     )
 
-    personal = _workspace(
-        tenant_id="personal-tenant",
+    beta = _workspace(
+        tenant_id="beta-tenant",
+        workspace_type="organization",
+        slug="beta",
+        name="Beta",
+        role="editor",
+    )
+    acme = _workspace(
+        tenant_id="acme-tenant",
         workspace_type="personal",
-        slug="personal",
-        name="Personal",
+        slug="acme",
+        name="Acme",
         role="owner",
         is_default=True,
     )
+    session_project = _project("research", id=1, external_id="beta-research-id")
+    other_project = _project("notes", id=2, external_id="acme-notes-id")
     index = _build_workspace_project_index(
-        (personal,),
+        (beta, acme),
         (
-            WorkspaceProjectEntry(
-                workspace=personal,
-                project=_project("notes", id=1, external_id="personal-notes-id"),
-            ),
+            WorkspaceProjectEntry(workspace=beta, project=session_project),
+            WorkspaceProjectEntry(workspace=acme, project=other_project),
         ),
     )
 
@@ -1099,24 +1135,214 @@ async def test_detect_project_from_identifier_prefix_falls_back_to_bare_project_
         return index
 
     monkeypatch.setattr(project_context, "_ensure_workspace_project_index", fake_index)
-    # A hosted (factory) session is what makes workspace discovery available to
-    # an identifier that is not itself workspace-qualified.
+    monkeypatch.setattr(project_context, "_session_project_list", _session_listing(session_project))
     monkeypatch.setattr("basic_memory.mcp.async_client.is_factory_mode", lambda: True)
 
-    # BasicMemoryConfig always materializes a placeholder 'main' entry, so the
-    # local-prefix check ahead of the fallback sees a config that names no 'notes'.
+    # BasicMemoryConfig always materializes a placeholder 'main' entry, so an
+    # empty projects dict is what a hosted session's config really looks like.
     config = BasicMemoryConfig(projects={}, cloud_api_key="bmc_test123")
+    context = ContextState()
 
-    # 'notes/...' names no workspace, so the qualified parse declines and the
-    # bare first segment is resolved across workspaces instead.
     assert (
-        await detect_project_from_identifier_prefix("notes/to-do-list", config) == "personal/notes"
+        await detect_project_from_identifier_prefix("notes/foo", config, context=ctx(context))
+        is None
     )
 
-    # A first segment that names no project anywhere is an ordinary path, not a
-    # route: the lookup miss stays best-effort and leaves the identifier unrouted
-    # rather than becoming the caller's error.
-    assert await detect_project_from_identifier_prefix("absent/to-do-list", config) is None
+    # The session's own mount still routes, and carries the id that pins it.
+    assert await detect_project_from_identifier_prefix(
+        "research/foo", config, context=ctx(context)
+    ) == DetectedProjectRoute(project="research", project_id="beta-research-id")
+
+    # The addressable spelling reaches the other workspace, as it always did.
+    assert await detect_project_from_identifier_prefix(
+        "acme/notes/foo", config, context=ctx(context)
+    ) == DetectedProjectRoute(project="acme/notes", project_id="acme-notes-id")
+
+
+@pytest.mark.asyncio
+async def test_detect_project_prefix_prefers_a_mount_over_a_same_named_workspace(monkeypatch):
+    """A name the session mounts addresses that mount, not a workspace slug.
+
+    ``resolve_project_path_route`` settled this precedence for the posix verbs:
+    only one reading of '<name>/...' can win, and a name ``ls /`` advertises has
+    to address that mount or the advertised address resolves somewhere else.
+    Reading the workspace first here is what made `ls team/docs/x` and
+    `read_note("team/docs/x")` disagree about what 'team' named.
+    """
+    import basic_memory.mcp.project_context as project_context
+    from basic_memory.config import BasicMemoryConfig
+    from basic_memory.mcp.project_context import (
+        WorkspaceProjectEntry,
+        _build_workspace_project_index,
+        detect_project_from_identifier_prefix,
+    )
+
+    beta = _workspace(
+        tenant_id="beta-tenant",
+        workspace_type="organization",
+        slug="beta",
+        name="Beta",
+        role="editor",
+    )
+    team = _workspace(
+        tenant_id="team-tenant",
+        workspace_type="organization",
+        slug="team",
+        name="Team",
+        role="editor",
+    )
+    mount = _project("team", id=1, external_id="beta-team-id")
+    other = _project("docs", id=2, external_id="team-docs-id")
+    index = _build_workspace_project_index(
+        (beta, team),
+        (
+            WorkspaceProjectEntry(workspace=beta, project=mount),
+            WorkspaceProjectEntry(workspace=team, project=other),
+        ),
+    )
+
+    async def fake_index(context=None, force_refresh=False):
+        raise AssertionError("a mount hit must not build the account-wide workspace index")
+
+    monkeypatch.setattr(project_context, "_ensure_workspace_project_index", fake_index)
+    monkeypatch.setattr(project_context, "_session_project_list", _session_listing(mount))
+    monkeypatch.setattr("basic_memory.mcp.async_client.is_factory_mode", lambda: True)
+
+    config = BasicMemoryConfig(projects={}, cloud_api_key="bmc_test123")
+    context = ContextState()
+
+    assert await detect_project_from_identifier_prefix(
+        "team/docs/x", config, context=ctx(context)
+    ) == DetectedProjectRoute(project="team", project_id="beta-team-id")
+    assert index.entries  # the index exists; the mount hit simply never asked for it
+
+
+@pytest.mark.asyncio
+async def test_detect_project_prefix_claims_a_multi_segment_project(monkeypatch):
+    """A project whose permalink spans several segments is addressable (#1432).
+
+    ``split_project_permalink_prefix`` claims as many leading segments as the
+    known project actually spans, so 'Research/2026' consumes two. The deleted
+    fallback split exactly one segment off and looked up 'research', which named
+    no project and left the identifier unrouted.
+    """
+    import basic_memory.mcp.project_context as project_context
+    from basic_memory.config import BasicMemoryConfig
+    from basic_memory.mcp.project_context import (
+        WorkspaceProjectEntry,
+        _build_workspace_project_index,
+        detect_project_from_identifier_prefix,
+    )
+
+    beta = _workspace(
+        tenant_id="beta-tenant",
+        workspace_type="organization",
+        slug="beta",
+        name="Beta",
+        role="editor",
+    )
+    nested = _project("Research/2026", id=1, external_id="beta-research-2026-id")
+    index = _build_workspace_project_index(
+        (beta,), (WorkspaceProjectEntry(workspace=beta, project=nested),)
+    )
+
+    async def fake_index(context=None, force_refresh=False):
+        return index
+
+    monkeypatch.setattr(project_context, "_ensure_workspace_project_index", fake_index)
+    monkeypatch.setattr(project_context, "_session_project_list", _session_listing(nested))
+    monkeypatch.setattr("basic_memory.mcp.async_client.is_factory_mode", lambda: True)
+
+    config = BasicMemoryConfig(projects={}, cloud_api_key="bmc_test123")
+    context = ContextState()
+
+    assert await detect_project_from_identifier_prefix(
+        "research/2026/notes/x", config, context=ctx(context)
+    ) == DetectedProjectRoute(project="Research/2026", project_id="beta-research-2026-id")
+
+    # The project's own name is a title to look up, not a route: a claim with no
+    # remainder leaves the identifier unrouted, exactly as the local set does.
+    assert (
+        await detect_project_from_identifier_prefix("research/2026", config, context=ctx(context))
+        is None
+    )
+
+
+@pytest_asyncio.fixture
+async def shadowed_nested_projects(config_manager, engine_factory, tmp_path_factory):
+    """Two projects whose permalinks prefix one another: 'research', 'research/2026'.
+
+    The pair is what makes the single-segment guess visibly wrong rather than
+    merely lossy — the shorter name is a real project, so splitting one segment
+    off 'research/2026/notes/x' resolves, and resolves to the wrong one.
+    """
+    from basic_memory.config_models import ProjectEntry
+    from basic_memory.repository.project_repository import ProjectRepository
+
+    _, session_maker = engine_factory
+    created = []
+    for name in ("research", "Research/2026"):
+        path = tmp_path_factory.mktemp("nested-project-home")
+        async with db.scoped_session(session_maker) as session:
+            created.append(
+                await ProjectRepository().create(
+                    session,
+                    {
+                        "name": name,
+                        "description": name,
+                        "path": str(path),
+                        "is_active": True,
+                        "is_default": False,
+                    },
+                )
+            )
+        config = config_manager.load_config()
+        config.projects[name] = ProjectEntry(path=str(path))
+        config_manager.save_config(config)
+    return created
+
+
+@pytest.mark.asyncio
+async def test_memory_url_prefix_is_claimed_by_the_routed_projects_own_permalink(
+    client, test_project, shadowed_nested_projects, monkeypatch
+):
+    """A memory URL routes to the project its prefix names, however many segments
+    that project spans (#1432).
+
+    The prefix split guessed one segment, so 'memory://research/2026/notes/x'
+    offered 'research' to /v2/projects/resolve — a real, different project —
+    which then came back as the active project and was cached over the project
+    the client had been opened for. The identity is already in hand here, so the
+    routed project claims its own permalink instead and no lookup runs at all.
+    """
+    monkeypatch.delenv("BASIC_MEMORY_MCP_PROJECT", raising=False)
+    from basic_memory.config import ConfigManager
+    from basic_memory.mcp.project_context import (
+        detect_project_from_identifier_prefix,
+        get_project_client,
+        resolve_project_and_path,
+    )
+
+    identifier = "memory://research/2026/notes/x"
+    detected = await detect_project_from_identifier_prefix(identifier, ConfigManager().config)
+    assert detected == DetectedProjectRoute(project="Research/2026")
+
+    context = ContextState()
+    async with get_project_client(
+        detected.project, ctx(context), project_id=detected.project_id
+    ) as (routed_client, active_project):
+        resolved_project, entity_path, is_memory_url = await resolve_project_and_path(
+            routed_client, identifier, active_project.name, ctx(context)
+        )
+
+    assert is_memory_url
+    # The project the URL names, not the one a single leading segment spells.
+    assert resolved_project.name == "Research/2026"
+    assert entity_path == "research/2026/notes/x"
+    # ...and the request's cached active project still points at it, rather than
+    # at the shorter project the resolve round trip used to substitute.
+    cached = await context.get_state("active_project")
+    assert cached["name"] == "Research/2026"
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_project_path_routing.py
+++ b/tests/mcp/test_project_path_routing.py
@@ -19,14 +19,18 @@ import pytest
 
 import basic_memory.mcp.async_client as async_client
 import basic_memory.mcp.project_context as project_context
+from basic_memory.config import ConfigManager
 from basic_memory.config_models import ProjectEntry
 from basic_memory.mcp.project_context import (
     AddressableProject,
+    DetectedProjectRoute,
     ProjectPathRoute,
     ProjectPrefixConflictError,
     AmbiguousMountError,
     UnqualifiedPathRefusedError,
     _agreed_route_project,
+    detect_project_from_identifier_prefix,
+    invalidate_project_caches,
     resolve_project_path_route,
     resolve_workspace_project_identifier,
     resolve_workspace_qualified_identifier,
@@ -535,10 +539,16 @@ async def test_env_constraint_prevents_refusal_for_empty_input(multi_project_con
 
 @dataclass
 class _CloudSession:
-    """What a stood-up cloud session exposes to a test."""
+    """What a stood-up cloud session exposes to a test.
+
+    ``tenant`` is the live listing the fake client serves, so a test can add or
+    remove a project the way create_memory_project/delete_project do and then
+    assert what the session sees next. ``projects`` is the set it started with.
+    """
 
     projects: tuple[ProjectItem, ...]
     listings: list[ProjectList]
+    tenant: list[ProjectItem]
 
 
 def _routes_to_project(route: ProjectPathRoute, permalink: str) -> bool:
@@ -584,7 +594,7 @@ def cloud_session(monkeypatch, config_manager):
             )
             for index, name in enumerate(names)
         )
-        project_list = ProjectList(projects=list(projects), default_project=default)
+        tenant = list(projects)
         workspace = WorkspaceInfo(
             tenant_id="team-tenant",
             workspace_type="organization",
@@ -601,6 +611,7 @@ def cloud_session(monkeypatch, config_manager):
             yield object()
 
         async def fake_list_projects(self) -> ProjectList:
+            project_list = ProjectList(projects=list(tenant), default_project=default)
             listings.append(project_list)
             return project_list
 
@@ -618,9 +629,126 @@ def cloud_session(monkeypatch, config_manager):
             "get_available_workspaces",
             fake_get_available_workspaces,
         )
-        return _CloudSession(projects=projects, listings=listings)
+        return _CloudSession(projects=projects, listings=listings, tenant=tenant)
 
     return build
+
+
+# --- project lifecycle inside one session ---
+# The session's project listing is memoized per MCP request, and a hosted
+# session's request can outlive a project lifecycle change: an agent calls
+# `ls "/"`, then create_memory_project, then addresses the new project. That
+# snapshot decides which first segment names a project, so it has to be part of
+# what "a project changed" invalidates (#1432 review).
+
+
+@pytest.mark.asyncio
+async def test_project_created_mid_session_is_addressable_without_a_restart(cloud_session):
+    """A project created after the mount snapshot is addressable immediately.
+
+    invalidate_project_caches cleared the active project and the workspace
+    index, but not the session listing, so `ls "/"` kept advertising the old
+    mount table and a plain '<new-project>/path' prefix went undetected —
+    falling through to the default project instead.
+    """
+    session = cloud_session("research", default="research")
+    context = ContextState()
+    config = ConfigManager().config
+
+    advertised = await ls("/", context=ctx(context))
+    assert {node["name"] for node in advertised["nodes"]} == {"research"}
+
+    # What create_memory_project does: the tenant serves the new project, and
+    # the tool invalidates this session's project caches.
+    session.tenant.append(
+        ProjectItem(
+            id=len(session.tenant) + 1,
+            external_id="new-project-external-id",
+            name="new-project",
+            path="/app/data/new-project",
+            is_default=False,
+        )
+    )
+    await invalidate_project_caches(ctx(context))
+
+    advertised = await ls("/", context=ctx(context))
+    assert {node["name"] for node in advertised["nodes"]} == {"new-project", "research"}
+
+    route = await resolve_project_path_route(
+        "new-project/notes/x", project=None, project_id=None, context=ctx(context)
+    )
+    assert route == ProjectPathRoute(
+        project="new-project",
+        path="notes/x",
+        stripped=True,
+        project_id="new-project-external-id",
+    )
+
+    detected = await detect_project_from_identifier_prefix(
+        "new-project/notes/x", config, context=ctx(context)
+    )
+    assert detected == DetectedProjectRoute(
+        project="new-project", project_id="new-project-external-id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_project_deleted_mid_session_stops_resolving(cloud_session):
+    """A deleted project stops being a route rather than keeping its dead id.
+
+    The stale snapshot kept answering with the removed project's external_id,
+    so a plain prefix routed to a UUID the tenant no longer serves.
+    """
+    session = cloud_session("research", "doomed", default="research")
+    context = ContextState()
+    config = ConfigManager().config
+
+    assert await detect_project_from_identifier_prefix(
+        "doomed/notes/x", config, context=ctx(context)
+    ) == DetectedProjectRoute(project="doomed", project_id="doomed-external-id")
+
+    session.tenant[:] = [item for item in session.tenant if item.name != "doomed"]
+    await invalidate_project_caches(ctx(context))
+
+    assert (
+        await detect_project_from_identifier_prefix("doomed/notes/x", config, context=ctx(context))
+        is None
+    )
+    advertised = await ls("/", context=ctx(context))
+    assert {node["name"] for node in advertised["nodes"]} == {"research"}
+
+
+@pytest.mark.asyncio
+async def test_workspace_metadata_survives_a_project_lifecycle_change(cloud_session):
+    """Only project-shaped caches are cleared.
+
+    ``active_workspace`` and ``available_workspaces`` hold tenant id, slug and
+    type — which no project create or delete changes, and which no MCP tool can
+    change at all, since none creates or deletes a workspace. Dropping them
+    would cost a control-plane round trip per project change for nothing.
+    """
+    cloud_session("research", default="research")
+    context = ContextState()
+    workspace = WorkspaceInfo(
+        tenant_id="team-tenant",
+        workspace_type="organization",
+        slug="team",
+        name="Team",
+        role="editor",
+        is_default=True,
+    )
+    await context.set_state("active_workspace", workspace.model_dump())
+    await context.set_state("available_workspaces", [workspace.model_dump()])
+
+    await invalidate_project_caches(ctx(context))
+
+    assert await context.get_state("active_workspace") == workspace.model_dump()
+    assert await context.get_state("available_workspaces") == [workspace.model_dump()]
+    # ...while every cache that holds projects is gone.
+    assert await context.get_state("active_project") is None
+    assert await context.get_state("default_project_name") is None
+    assert await context.get_state("workspace_project_index") is None
+    assert await context.get_state("session_project_list") is None
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_project_path_routing.py
+++ b/tests/mcp/test_project_path_routing.py
@@ -11,6 +11,7 @@ where the project list comes from the tenant instead.
 """
 
 import re
+import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import AsyncIterator, Optional
@@ -640,6 +641,111 @@ def cloud_session(monkeypatch, config_manager):
 # `ls "/"`, then create_memory_project, then addresses the new project. That
 # snapshot decides which first segment names a project, so it has to be part of
 # what "a project changed" invalidates (#1432 review).
+
+
+# --- out-of-band project changes ---
+# Invalidation covers what this session did; the age bound covers what it did
+# not. `session_project_list` is session state — fastmcp keys set_state by
+# session id and persists it across tool calls — so without a bound a project a
+# teammate or the CLI created stayed invisible until the session ended.
+
+
+async def _age_out_session_project_list(context: ContextState) -> None:
+    """Make the stored snapshot older than the bound, without touching clocks.
+
+    The bound is read off a stored fetch time, so moving that timestamp is the
+    honest way to simulate elapsed time: it exercises the real comparison rather
+    than a patched clock.
+    """
+    await context.set_state(
+        project_context._SESSION_PROJECT_LIST_FETCHED_AT_STATE_KEY,
+        time.time() - project_context._SESSION_PROJECT_LIST_MAX_AGE_SECONDS - 1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_out_of_band_project_becomes_addressable_when_the_snapshot_ages_out(
+    cloud_session,
+):
+    """A project this session did not create is reachable without a restart.
+
+    Nothing calls invalidate_project_caches here — that is the point. The
+    snapshot simply ages out, and the mount view, the posix resolver and
+    identifier detection all pick the project up together, because the bound
+    lives in the loader they share.
+    """
+    session = cloud_session("research", default="research")
+    context = ContextState()
+    config = ConfigManager().config
+
+    advertised = await ls("/", context=ctx(context))
+    assert {node["name"] for node in advertised["nodes"]} == {"research"}
+
+    session.tenant.append(
+        ProjectItem(
+            id=len(session.tenant) + 1,
+            external_id="new-project-external-id",
+            name="new-project",
+            path="/app/data/new-project",
+            is_default=False,
+        )
+    )
+
+    # Still inside the bound: the snapshot is authoritative and nothing refetches.
+    assert (
+        await detect_project_from_identifier_prefix(
+            "new-project/notes/x", config, context=ctx(context)
+        )
+        is None
+    )
+
+    await _age_out_session_project_list(context)
+
+    advertised = await ls("/", context=ctx(context))
+    assert {node["name"] for node in advertised["nodes"]} == {"new-project", "research"}
+    assert await detect_project_from_identifier_prefix(
+        "new-project/notes/x", config, context=ctx(context)
+    ) == DetectedProjectRoute(project="new-project", project_id="new-project-external-id")
+    route = await resolve_project_path_route(
+        "new-project/notes/x", project=None, project_id=None, context=ctx(context)
+    )
+    assert route.project == "new-project"
+
+
+@pytest.mark.asyncio
+async def test_a_non_project_identifier_costs_one_listing_per_interval(cloud_session):
+    """The bound the age gate buys: misses cannot drive the refetch rate.
+
+    A miss is the ordinary answer for a path-shaped identifier that is not a
+    project reference, so a refresh triggered by misses would spend a listing
+    per lookup on the hottest path in the tool surface. Age cannot be influenced
+    by what the caller asks for: five identical misses across an expired
+    snapshot cost exactly one refetch.
+    """
+    session = cloud_session("research", default="research")
+    context = ContextState()
+    config = ConfigManager().config
+
+    # Warm both snapshots, so what is counted below is the session listing only
+    # and not the workspace index the rule-3 fall-through builds once.
+    assert (
+        await detect_project_from_identifier_prefix(
+            "specs/search-spec", config, context=ctx(context)
+        )
+        is None
+    )
+    session.listings.clear()
+
+    await _age_out_session_project_list(context)
+    for _ in range(5):
+        assert (
+            await detect_project_from_identifier_prefix(
+                "specs/search-spec", config, context=ctx(context)
+            )
+            is None
+        )
+
+    assert len(session.listings) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_tool_posix.py
+++ b/tests/mcp/test_tool_posix.py
@@ -2177,8 +2177,12 @@ def _path_accepting_posix_verbs() -> set[str]:
 
 def test_path_accepting_verbs_are_the_ones_covered_below():
     """Pins the set the round-trip tests cover. Adding a path-accepting verb
-    fails here, which is the prompt to give it the same guarantee — the class is
-    closed by this enumeration, not by every author remembering."""
+    fails here, which is the prompt to give it the same guarantee.
+
+    One axis only, and #1435 is what showed the second: this guard passed while
+    `find`'s metadata arm skipped the rule, because `find` was already in the
+    set. ``test_every_response_qualifier_is_exercised_by_a_routed_call`` guards
+    the other axis — the response shapes those verbs answer with."""
     assert _path_accepting_posix_verbs() == {"cat", "ls", "find"}
 
 
@@ -2227,6 +2231,125 @@ async def test_find_returned_paths_route_back_to_the_same_project(
 
     assert (await cat(file_node["file_path"]))["title"] == "Second Root Note"
     assert (await ls(dir_node["directory_path"]))["total"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_find_meta_returned_paths_route_back_to_the_same_project(
+    client, test_project, second_project, no_project_constraint
+):
+    """find's metadata arm answers with search hits, and those paths must
+    round-trip exactly like the listing arm's (#1435).
+
+    The two arms of one verb shipped with different answers: `find --meta`
+    returned the API's project-relative 'notes/…', which `cat` then refused as
+    unqualified — or, where another project is mounted as 'notes', opened that
+    one instead.
+    """
+    await write_note(
+        title="Second Meta Note",
+        directory="notes",
+        content="# Second Meta Note",
+        project="second-project",
+        metadata={"status": "active"},
+    )
+
+    found = await find("second-project/notes", meta=["status=active"])
+    row = next(item for item in found["results"] if item["title"] == "Second Meta Note")
+
+    assert row["file_path"] == "second-project/notes/Second Meta Note.md"
+    assert (await cat(row["file_path"]))["title"] == "Second Meta Note"
+
+    # The projection narrows the row but not its address: `fields` hydrates from
+    # the already-re-qualified payload, so both shapes of the metadata response
+    # hand back the same spelling.
+    projected = await find("second-project/notes", meta=["status=active"], fields=["status"])
+    projected_row = next(
+        item for item in projected["results"] if item["title"] == "Second Meta Note"
+    )
+    assert projected_row["file_path"] == row["file_path"]
+    assert projected_row["fields"] == {"status": "active"}
+    assert (await cat(projected_row["file_path"]))["title"] == "Second Meta Note"
+
+
+@pytest.mark.asyncio
+async def test_unrouted_find_meta_keeps_project_relative_paths(
+    client, test_project, second_project, no_project_constraint
+):
+    """The prefix goes back only when the call put it in the path — the same
+    rule the listing arm follows, so an explicit project param keeps its own
+    addressing frame."""
+    await write_note(
+        title="Second Meta Note",
+        directory="notes",
+        content="# Second Meta Note",
+        project="second-project",
+        metadata={"status": "active"},
+    )
+
+    found = await find("notes", meta=["status=active"], project="second-project")
+
+    assert [row["file_path"] for row in found["results"]] == ["notes/Second Meta Note.md"]
+
+
+def _response_qualifiers() -> set[str]:
+    """The module's re-qualification helpers — one per routed response shape."""
+    return {name for name in vars(posix_tools) if name.startswith("qualify_")}
+
+
+@pytest.mark.asyncio
+async def test_every_response_qualifier_is_exercised_by_a_routed_call(
+    client, test_project, second_project, no_project_constraint, monkeypatch
+):
+    """The guard's second axis: response shapes, not verbs (#1435).
+
+    ``test_path_accepting_verbs_are_the_ones_covered_below`` could not catch the
+    metadata arm — `find` was already in its set, and the gap was one arm inside
+    it answering with a *different* response shape. So this drives one routed
+    call per shape and asserts every qualifier the module defines actually
+    fired, and that every path those calls returned routes back.
+
+    What that does and does not close, precisely: a new response shape needs a
+    new ``qualify_*`` helper, and this fails until a routed call here exercises
+    it; a new path-accepting verb fails the verb guard. Neither can force a new
+    arm to re-qualify at all — what covers that is that every shape a routed
+    verb can answer with already has a qualifier, so a new arm either reuses one
+    (and inherits the rule) or introduces one this test then reports.
+    """
+    await write_note(
+        title="Second Round Trip Note",
+        directory="notes",
+        content="# Second Round Trip Note",
+        project="second-project",
+        metadata={"status": "active"},
+    )
+
+    fired: set[str] = set()
+    for name in _response_qualifiers():
+        original = getattr(posix_tools, name)
+
+        def recorder(payload, route, *, _name=name, _original=original):
+            fired.add(_name)
+            return _original(payload, route)
+
+        monkeypatch.setattr(posix_tools, name, recorder)
+
+    listing = await ls("second-project/notes")
+    tree = await find("second-project/notes")
+    hits = await find("second-project/notes", meta=["status=active"])
+    note = await cat("second-project/notes/second-round-trip-note")
+
+    assert fired == _response_qualifiers()
+
+    returned_paths = {note["file_path"]}
+    for payload in (listing, tree):
+        returned_paths.update(
+            node["file_path"] for node in payload["nodes"] if node["type"] == "file"
+        )
+    returned_paths.update(row["file_path"] for row in hits["results"])
+
+    assert returned_paths == {"second-project/notes/Second Round Trip Note.md"}
+    for path in returned_paths:
+        assert (await cat(path))["title"] == "Second Round Trip Note"
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_tool_read_content.py
+++ b/tests/mcp/test_tool_read_content.py
@@ -212,7 +212,10 @@ async def test_read_content_workspace_memory_url_routes_with_local_config(
     @asynccontextmanager
     async def fake_get_project_client(project=None, context=None, project_id=None):
         assert project == "personal/main"
-        assert project_id is None
+        # The workspace-qualified route hands on the entry's id too, so the name
+        # is never re-resolved against a workspace holding a project literally
+        # named 'personal/main' (#1432).
+        assert project_id == "11111111-1111-1111-1111-111111111111"
         yield (
             object(),
             SimpleNamespace(

--- a/tests/mcp/test_tool_search.py
+++ b/tests/mcp/test_tool_search.py
@@ -272,7 +272,10 @@ async def test_search_workspace_memory_url_routes_with_local_config(monkeypatch,
     )
 
     assert captured["project"] == "personal/main"
-    assert captured["project_id"] is None
+    # The workspace-qualified route hands on the entry's id too, so the name is
+    # never re-resolved against a workspace holding a project literally named
+    # 'personal/main' (#1432).
+    assert captured["project_id"] == "11111111-1111-1111-1111-111111111111"
     assert captured["search_project_id"] == "11111111-1111-1111-1111-111111111111"
     payload = cast(dict[str, object], captured["payload"])
     assert payload["permalink"] == "personal/main/tests/search-note"


### PR DESCRIPTION
Closes #1432, closes #1435. Part of #1438.

Both are "an identifier or path is resolved or returned wrongly" in the MCP layer, and both come down to one question: **what does a path-shaped identifier mean for a consumer with no project set in hand?**

## Reproduction (verified against `origin/main` before any change)

**#1432 — bare prefix leaves the session's own workspace.** Session bound to workspace `beta` (projects: `research`); `acme` is another accessible workspace (`is_default`) holding `notes`:

```
detect_project_from_identifier_prefix("notes/foo", config)  ->  'acme/notes'
```

**#1432 (comment) — multi-segment project unreachable.** Session's own listing holds `Research/2026`:

```
detect_project_from_identifier_prefix("research/2026/notes/x", config)  ->  None
```

**#1432 (comment) — `memory://` routes to a different project than the client is open for.** Config holds both `research` and `Research/2026`:

```
resolve_project_and_path(client, "memory://research/2026/notes/x", project="Research/2026")
  ->  (project 'research', 'research/2026/notes/x')
```

It also writes that wrong project into the request's `active_project` cache.

**#1435 — `find --meta` results don't round-trip:**

```
find("second-project/notes", meta=["status=active"])
  ->  file_path 'notes/Second Meta Note.md'   (expected 'second-project/notes/Second Meta Note.md')
```

## The decision for #1432

Three options were on the table: restrict the fallback to the session's workspace, adopt the posix refusal with a candidate list, or prefer the session workspace and fall back.

**Chosen: restrict to the session's own set — and make it the *same* set, with the *same* precedence, that the posix resolver already uses.**

- **Refusal is wrong here.** `resolve_project_path_route` refuses an unaddressable first segment because on that surface a `path` whose first segment names nothing is an error. On `read_note`/`search`, a first segment that names no project is the *common* input — `specs/search-spec` is an ordinary permalink, and a search query is arbitrary text. This function is detection, not resolution: `None` means "not a project reference", and the active project is a correct answer.
- **`addressable_projects()` is the only thing that can answer "the session's own workspace"** in the mode the bug was reported in. The account-wide index cannot: it lists every accessible workspace with nothing marking which is the session's. `addressable_projects()` asks the session's own project-less route, which in a hosted session *is* the bound tenant.
- **No second resolver.** The claiming is done by `split_project_permalink_prefix`, the existing splitter that takes a candidate set — which is also why the multi-segment half falls out for free. The deleted code was a second path splitter (`_split_project_prefix`, one segment) feeding a second lookup that resolved by *form* across workspaces.
- **Mounts before workspace routes.** Adopting the mount table means adopting its precedence, or it is a second rule. Previously `ls team/docs/x` (mount `team`) and `read_note("team/docs/x")` (workspace `team`) disagreed. This is also the cheaper order: a mount hit now builds no workspace index at all, where the deleted fallback always did.

Detection returns `DetectedProjectRoute(project, project_id)`. Returning the name alone was not enough: `get_project_client` re-resolves a bare name through the account-wide index, which prefers the `is_default` workspace on a duplicate permalink — the reported repro. Callers forward both fields, exactly as the posix verbs forward `ProjectPathRoute`'s pair.

### The `memory://` half, and the cost

`resolve_project_and_path` now lets the **project it is already routed to** claim its own permalink with the same splitter — no lookup, no fetch, and it fixes the multi-segment case for every caller (all seven detect the prefix first).

The name-resolving branch below it keeps the single-segment guess, deliberately. Weighed explicitly: it is reached only when no set in hand names the project, it already spends a `/v2/projects/resolve` round trip, and giving it the multi-segment reading would mean a project-list fetch on **every** cross-project `memory://` read on top of that resolve. Local sessions pay nothing for the claim (config is the set); cloud sessions pay one per-request memoized listing that replaces workspace discovery plus per-workspace listings.

**Not overstated:** a `memory://` URL naming a *multi-segment project other than the one already routed to*, with detection bypassed (an explicit `project` param), still resolves by the single-segment name. Every path that detects first — read_note, search, read_content, edit_note, delete_note, build_context, the note resource — is covered.

### Behaviour this removes

A session whose own route lists no projects (a stateless deployment with no injected client factory) loses bare-prefix routing; the `<workspace>/<project>/<path>` spelling still works, and that session's `ls /` already advertised no mounts. Routing and the mount view now agree everywhere.

## #1435

`qualify_search_paths` is the third response shape's qualifier, applied to the metadata arm's payload before field projection so both shapes of that response carry one spelling. `_find_by_metadata` now takes the whole `ProjectPathRoute` instead of three fields pulled off it — it needs the route again to re-qualify.

**The guard.** `test_path_accepting_verbs_are_the_ones_covered_below` could not catch this: `find` was already in its set and the gap was one arm inside it. Added a companion that drives one routed call per response shape, asserts every `qualify_*` helper the module defines actually fired, and asserts every path those calls returned reads the same note through `cat`. Precisely what the two guards close, and what they don't: a new response shape needs a new qualifier and fails the shape guard until a routed call exercises it; a new path-accepting verb fails the verb guard; neither can *force* a new arm to re-qualify — what covers that is that every shape a routed verb answers with already has a qualifier, so a new arm either reuses one or introduces one the shape guard then reports.

## Test evidence

Each hunk reverted individually, with the rest of the change in place:

| reverted hunk | failing tests |
|---|---|
| the mount claim in `detect_project_from_identifier_prefix` | `test_detect_project_prefix_stays_inside_the_sessions_own_workspace`, `test_detect_project_prefix_prefers_a_mount_over_a_same_named_workspace`, `test_detect_project_prefix_claims_a_multi_segment_project` |
| the routed-project claim in `resolve_project_and_path` | `test_memory_url_prefix_is_claimed_by_the_routed_projects_own_permalink` |
| `qualify_search_paths` in `_find_by_metadata` | `test_find_meta_returned_paths_route_back_to_the_same_project`, `test_every_response_qualifier_is_exercised_by_a_routed_call` |

`test_find_meta_returned_paths_route_back_to_the_same_project` asserts a routed `find --meta` result — projected and unprojected — fed back into `cat` reads the same note.

`test_detect_project_from_identifier_prefix_falls_back_to_bare_project_name`, which pinned the deleted behaviour, is replaced by the three tests above. Two tests that asserted the workspace-qualified route forwards a name *without* its id now assert it forwards the id.

## Verification

```
uv run ruff check src tests test-int      All checks passed!
uv run ruff format --check .              1102 files already formatted
uv run ty check src tests test-int        All checks passed!
uv run pytest tests/mcp tests/cli         2290 passed
uv run pytest tests test-int              7415 passed, 58 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp
