### PR TITLE
fix(core): key search_index uniqueness on the row kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,19 @@
 
 ### Bug Fixes
 
+- **#1437**: An observation and a relation can no longer collide in the search index.
+  A relation's permalink is `from/type/to` with the type authored by the user, so a
+  note that says `- [decision] redis` and `- observations [[decision/redis]]` gives
+  both rows the identical address; Postgres raised an `IntegrityError` on write, and
+  SQLite -- whose FTS5 table has no unique index to object -- kept both under one
+  address, then dropped one of them on the next single-row index pass. Nothing
+  surfaced either way. The search index's uniqueness now includes
+  the row kind, which the table's own primary key already carried, so the two rows
+  stay separately addressable. **This ships an Alembic migration** replacing
+  `uix_search_index_permalink_project` with `uix_search_index_permalink_type_project`
+  on Postgres; no permalink changes and no data is dropped on upgrade, and SQLite's
+  FTS5 index needs no schema change.
+
 - The `memory://{workspace}/{project}/info` resource is now actually readable over
   `resources/read`: it returned a Pydantic model, which the resource runtime rejects
   (`contents must be str, bytes, or list[ResourceContent]`), so every served read

--- a/src/basic_memory/alembic/versions/w6k7i8n9d0a1_search_index_row_kind_uniqueness.py
+++ b/src/basic_memory/alembic/versions/w6k7i8n9d0a1_search_index_row_kind_uniqueness.py
@@ -1,0 +1,93 @@
+"""Key search_index uniqueness on the row kind as well as the permalink.
+
+A relation's permalink is `from/type/to` with the relation type authored by the user, so
+a note that says
+
+    - [decision] redis
+    - observations [[decision/redis]]
+
+hands its observation and its relation the same address. Keyed on the permalink alone,
+Postgres resolved that by upserting one row into the other, which then broke the
+FTS-chunk foreign key still pointing at the row kind it had just overwritten; SQLite,
+whose search_index is an FTS5 virtual table with no unique index at all, kept both under
+one address with nothing to say which was which (#1437). No reserved path segment closes
+it, because the colliding segment is the author's own text.
+
+The row kind is already half of this table's primary key, `(id, type, project_id)`. This
+widens the unique index to agree with it. Widening cannot fail on existing data -- every
+row that satisfied the narrow key satisfies the wide one -- and no permalink changes, so
+nothing anyone has linked to moves.
+
+SQLite needs no schema change here: its FTS5 virtual table carries no unique index, and
+the rule it does obey lives in the repository's delete-before-insert, which now scopes by
+row kind from the same shared key.
+
+Revision ID: w6k7i8n9d0a1
+Revises: v5o6b7s8d9e0
+Create Date: 2026-09-03 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "w6k7i8n9d0a1"
+down_revision: Union[str, None] = "v5o6b7s8d9e0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Replace the permalink-only unique index with one that includes the row kind."""
+    if op.get_bind().dialect.name != "postgresql":
+        return
+
+    # The wide index is created before the narrow one is dropped so the table is never
+    # momentarily unconstrained, which matters if this ever runs outside a transaction.
+    # The DDL must stay identical to CREATE_POSTGRES_SEARCH_INDEX_PERMALINK in
+    # models/search.py, which is what the test suite creates instead of migrating.
+    op.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS uix_search_index_permalink_type_project
+        ON search_index (permalink, type, project_id)
+        WHERE permalink IS NOT NULL
+    """)
+    op.execute("DROP INDEX IF EXISTS uix_search_index_permalink_project")
+
+
+def downgrade() -> None:
+    """Restore the permalink-only unique index, dropping the rows it cannot admit."""
+    if op.get_bind().dialect.name != "postgresql":
+        return
+
+    # Trigger: the narrow index cannot be recreated while one permalink is held by two
+    # row kinds -- exactly what the upgrade made legal.
+    # Why: search_index is derived state, rebuilt from markdown by the next index pass,
+    # so shedding the extra projections is recoverable where a failed downgrade is not.
+    # Outcome: one row survives per (project_id, permalink), preferring entity over
+    # observation over relation because `type` sorts that way, and the FTS chunk rows of
+    # the others follow through their ON DELETE CASCADE.
+    op.execute("""
+        DELETE FROM search_index
+        WHERE ctid IN (
+            SELECT ranked.ctid
+            FROM (
+                SELECT
+                    ctid,
+                    row_number() OVER (
+                        PARTITION BY project_id, permalink
+                        ORDER BY type, id
+                    ) AS row_rank
+                FROM search_index
+                WHERE permalink IS NOT NULL
+            ) AS ranked
+            WHERE ranked.row_rank > 1
+        )
+    """)
+    op.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS uix_search_index_permalink_project
+        ON search_index (permalink, project_id)
+        WHERE permalink IS NOT NULL
+    """)
+    op.execute("DROP INDEX IF EXISTS uix_search_index_permalink_type_project")

--- a/src/basic_memory/models/search.py
+++ b/src/basic_memory/models/search.py
@@ -6,7 +6,34 @@ The search_index table is created via raw DDL, not ORM models, because:
 - Both backends use raw SQL for all search operations via SearchIndexRow dataclass
 """
 
+from typing import Final
+
 from sqlalchemy import DDL
+
+
+# --- Search index row identity ---
+
+# What makes one search_index row distinct from another, stated once because the two
+# backends, three write paths, and the Alembic migration all have to agree on it.
+#
+# A permalink alone is not an identity. A relation's permalink is `from/type/to` with the
+# relation type authored by the user, so a note that says
+#
+#     - [decision] redis
+#     - observations [[decision/redis]]
+#
+# hands its observation and its relation the same string, and no reserved path segment
+# closes that: the colliding segment is the author's own text (#1437). The row kind is
+# already half of this table's primary key, `(id, type, project_id)`; uniqueness keyed on
+# the permalink alone was the outlier, narrower than the table's own notion of identity.
+SEARCH_INDEX_ROW_KEY: Final = ("permalink", "type", "project_id")
+
+# The same key rendered for the two SQL shapes that need it: an index/conflict-target
+# column list, and an equality predicate over bound parameters of the same names.
+SEARCH_INDEX_ROW_KEY_COLUMNS: Final = ", ".join(SEARCH_INDEX_ROW_KEY)
+SEARCH_INDEX_ROW_KEY_PREDICATE: Final = " AND ".join(
+    f"{column} = :{column}" for column in SEARCH_INDEX_ROW_KEY
+)
 
 
 # Define Postgres search_index table with composite primary key and tsvector
@@ -94,12 +121,13 @@ CREATE_POSTGRES_SEARCH_INDEX_METADATA = DDL("""
 CREATE INDEX IF NOT EXISTS idx_search_index_metadata_gin ON search_index USING gin(metadata jsonb_path_ops)
 """)
 
-# Partial unique index on (permalink, project_id) for non-null permalinks
-# This prevents duplicate permalinks per project and is used by upsert operations
-# in PostgresSearchRepository to handle race conditions during parallel indexing
-CREATE_POSTGRES_SEARCH_INDEX_PERMALINK = DDL("""
-CREATE UNIQUE INDEX IF NOT EXISTS uix_search_index_permalink_project
-ON search_index (permalink, project_id)
+# Partial unique index on the row key for non-null permalinks. This prevents a second
+# row of the same kind from claiming an address that kind already owns, and is the
+# conflict target the Postgres upserts use to resolve races during parallel indexing.
+# See SEARCH_INDEX_ROW_KEY for why the row kind belongs in the key.
+CREATE_POSTGRES_SEARCH_INDEX_PERMALINK = DDL(f"""
+CREATE UNIQUE INDEX IF NOT EXISTS uix_search_index_permalink_type_project
+ON search_index ({SEARCH_INDEX_ROW_KEY_COLUMNS})
 WHERE permalink IS NOT NULL
 """)
 

--- a/src/basic_memory/repository/accepted_note_search_repository.py
+++ b/src/basic_memory/repository/accepted_note_search_repository.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from basic_memory.models.search import SEARCH_INDEX_ROW_KEY_COLUMNS
 from basic_memory.repository.accepted_note_search_row import AcceptedNoteSearchRow
 from basic_memory.repository.accepted_note_vector_cleanup import (
     ProjectIndexExternalVectorCleaner,
@@ -48,7 +49,7 @@ INSERT_ACCEPTED_NOTE_SEARCH_SQL = text(
 )
 
 UPSERT_ACCEPTED_NOTE_SEARCH_SQL = text(
-    """
+    f"""
     INSERT INTO search_index (
         id, title, content_stems, content_snippet, script_ngrams,
         permalink, file_path, type, metadata,
@@ -64,14 +65,13 @@ UPSERT_ACCEPTED_NOTE_SEARCH_SQL = text(
         :created_at, :updated_at,
         :project_id
     )
-    ON CONFLICT (permalink, project_id) WHERE permalink IS NOT NULL DO UPDATE SET
+    ON CONFLICT ({SEARCH_INDEX_ROW_KEY_COLUMNS}) WHERE permalink IS NOT NULL DO UPDATE SET
         id = EXCLUDED.id,
         title = EXCLUDED.title,
         content_stems = EXCLUDED.content_stems,
         content_snippet = EXCLUDED.content_snippet,
         script_ngrams = EXCLUDED.script_ngrams,
         file_path = EXCLUDED.file_path,
-        type = EXCLUDED.type,
         metadata = EXCLUDED.metadata,
         from_id = EXCLUDED.from_id,
         to_id = EXCLUDED.to_id,

--- a/src/basic_memory/repository/postgres_search_repository.py
+++ b/src/basic_memory/repository/postgres_search_repository.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from basic_memory import db
 from basic_memory.config import BasicMemoryConfig, ConfigManager, DatabaseBackend
+from basic_memory.models.search import SEARCH_INDEX_ROW_KEY_COLUMNS
 from basic_memory.repository.embedding_provider import EmbeddingProvider
 from basic_memory.repository.embedding_provider_factory import create_embedding_provider
 from basic_memory.repository.rerank_provider import RerankProvider
@@ -182,8 +183,8 @@ class PostgresSearchRepository(SearchRepositoryBase):
 
     Note: This implementation uses UPSERT patterns (INSERT ... ON CONFLICT) instead of
     delete-then-insert to handle race conditions during parallel entity indexing.
-    The partial unique index uix_search_index_permalink_project prevents duplicate
-    permalinks per project.
+    The partial unique index uix_search_index_permalink_type_project prevents a second
+    row of the same kind from claiming an address that kind already owns.
     """
 
     def __init__(
@@ -264,13 +265,13 @@ class PostgresSearchRepository(SearchRepositoryBase):
         """Index or update a single item using UPSERT.
 
         Uses INSERT ... ON CONFLICT to handle race conditions during parallel
-        entity indexing. The partial unique index uix_search_index_permalink_project
-        on (permalink, project_id) WHERE permalink IS NOT NULL prevents duplicate
-        permalinks.
+        entity indexing. The partial unique index uix_search_index_permalink_type_project
+        on (permalink, type, project_id) WHERE permalink IS NOT NULL prevents a second
+        row of the same kind from claiming an address that kind already owns.
 
-        For rows with non-null permalinks (entities), conflicts are resolved by
-        updating the existing row. For rows with null permalinks, no conflict
-        occurs on this index.
+        For rows with non-null permalinks, a conflict against the same kind is resolved
+        by updating the existing row. For rows with null permalinks, no conflict occurs
+        on this partial index.
         """
         async with db.scoped_session(self.session_maker) as session:
             # Serialize JSON for raw SQL
@@ -282,12 +283,12 @@ class PostgresSearchRepository(SearchRepositoryBase):
             )
             insert_data = _strip_nul_from_row(insert_data)
 
-            # Use upsert to handle race conditions during parallel indexing
-            # ON CONFLICT (permalink, project_id) matches the partial unique index
-            # uix_search_index_permalink_project WHERE permalink IS NOT NULL
-            # For rows with NULL permalinks, no conflict occurs (partial index doesn't apply)
+            # Use upsert to handle race conditions during parallel indexing.
+            # The conflict target matches uix_search_index_permalink_type_project, the
+            # partial unique index over SEARCH_INDEX_ROW_KEY. For rows with NULL
+            # permalinks no conflict occurs (the partial index doesn't apply).
             await session.execute(
-                text("""
+                text(f"""
                     INSERT INTO search_index (
                         id, title, content_stems, content_snippet, script_ngrams, permalink, file_path, type, metadata,
                         from_id, to_id, relation_type,
@@ -301,14 +302,13 @@ class PostgresSearchRepository(SearchRepositoryBase):
                         :created_at, :updated_at,
                         :project_id
                     )
-                    ON CONFLICT (permalink, project_id) WHERE permalink IS NOT NULL DO UPDATE SET
+                    ON CONFLICT ({SEARCH_INDEX_ROW_KEY_COLUMNS}) WHERE permalink IS NOT NULL DO UPDATE SET
                         id = EXCLUDED.id,
                         title = EXCLUDED.title,
                         content_stems = EXCLUDED.content_stems,
                         content_snippet = EXCLUDED.content_snippet,
                         script_ngrams = EXCLUDED.script_ngrams,
                         file_path = EXCLUDED.file_path,
-                        type = EXCLUDED.type,
                         metadata = EXCLUDED.metadata,
                         from_id = EXCLUDED.from_id,
                         to_id = EXCLUDED.to_id,
@@ -881,13 +881,13 @@ class PostgresSearchRepository(SearchRepositoryBase):
         """Index multiple items in a single batch operation using UPSERT.
 
         Uses INSERT ... ON CONFLICT to handle race conditions during parallel
-        entity indexing. The partial unique index uix_search_index_permalink_project
-        on (permalink, project_id) WHERE permalink IS NOT NULL prevents duplicate
-        permalinks.
+        entity indexing. The partial unique index uix_search_index_permalink_type_project
+        on (permalink, type, project_id) WHERE permalink IS NOT NULL prevents a second
+        row of the same kind from claiming an address that kind already owns.
 
-        For rows with non-null permalinks (entities), conflicts are resolved by
-        updating the existing row. For rows with null permalinks (observations,
-        relations), the partial index doesn't apply and they are inserted directly.
+        For rows with non-null permalinks, a conflict against the same kind is resolved
+        by updating the existing row. For rows with null permalinks, the partial index
+        doesn't apply and they are inserted directly.
 
         Args:
             search_index_rows: List of SearchIndexRow objects to index
@@ -910,12 +910,12 @@ class PostgresSearchRepository(SearchRepositoryBase):
                 )
                 insert_data_list.append(_strip_nul_from_row(insert_data))
 
-            # Use upsert to handle race conditions during parallel indexing
-            # ON CONFLICT (permalink, project_id) matches the partial unique index
-            # uix_search_index_permalink_project WHERE permalink IS NOT NULL
-            # For rows with NULL permalinks (observations, relations), no conflict occurs
+            # Use upsert to handle race conditions during parallel indexing.
+            # The conflict target matches uix_search_index_permalink_type_project, the
+            # partial unique index over SEARCH_INDEX_ROW_KEY. For rows with NULL
+            # permalinks no conflict occurs (the partial index doesn't apply).
             await session.execute(
-                text("""
+                text(f"""
                     INSERT INTO search_index (
                         id, title, content_stems, content_snippet, script_ngrams, permalink, file_path, type, metadata,
                         from_id, to_id, relation_type,
@@ -929,14 +929,13 @@ class PostgresSearchRepository(SearchRepositoryBase):
                         :created_at, :updated_at,
                         :project_id
                     )
-                    ON CONFLICT (permalink, project_id) WHERE permalink IS NOT NULL DO UPDATE SET
+                    ON CONFLICT ({SEARCH_INDEX_ROW_KEY_COLUMNS}) WHERE permalink IS NOT NULL DO UPDATE SET
                         id = EXCLUDED.id,
                         title = EXCLUDED.title,
                         content_stems = EXCLUDED.content_stems,
                         content_snippet = EXCLUDED.content_snippet,
                         script_ngrams = EXCLUDED.script_ngrams,
                         file_path = EXCLUDED.file_path,
-                        type = EXCLUDED.type,
                         metadata = EXCLUDED.metadata,
                         from_id = EXCLUDED.from_id,
                         to_id = EXCLUDED.to_id,

--- a/src/basic_memory/repository/search_repository.py
+++ b/src/basic_memory/repository/search_repository.py
@@ -130,8 +130,8 @@ class SearchRepository(Protocol):
         """Return the stored vector-chunk manifest for one entity."""
         ...
 
-    async def delete_by_permalink(self, permalink: str) -> None:
-        """Delete item by permalink."""
+    async def delete_by_permalink(self, permalink: str, search_item_type: SearchItemType) -> None:
+        """Delete the row one permalink owns for the given row kind."""
         ...
 
     async def delete_project_search_rows(self) -> None:

--- a/src/basic_memory/repository/search_repository_base.py
+++ b/src/basic_memory/repository/search_repository_base.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from basic_memory import db
 from basic_memory.config import BasicMemoryConfig
+from basic_memory.models.search import SEARCH_INDEX_ROW_KEY_PREDICATE
 from basic_memory.repository import semantic_vector_sync
 from basic_memory.repository.embedding_provider import (
     EmbeddingProvider,
@@ -1097,12 +1098,17 @@ class SearchRepositoryBase(ABC):
         """
 
         async with db.scoped_session(self.session_maker) as session:
-            # Delete existing record if any
+            # Replace only the row this address owns *for this kind*. Keying the
+            # replacement on the permalink alone let a relation whose authored type
+            # spells an observation's address evict that observation -- silently on
+            # SQLite, whose FTS5 table carries no unique index to object (#1437).
             await session.execute(
-                text(
-                    "DELETE FROM search_index WHERE permalink = :permalink AND project_id = :project_id"
-                ),
-                {"permalink": search_index_row.permalink, "project_id": self.project_id},
+                text(f"DELETE FROM search_index WHERE {SEARCH_INDEX_ROW_KEY_PREDICATE}"),
+                {
+                    "permalink": search_index_row.permalink,
+                    "type": search_index_row.type,
+                    "project_id": self.project_id,
+                },
             )
 
             # When using text() raw SQL, always serialize JSON to string
@@ -1256,17 +1262,24 @@ class SearchRepositoryBase(ABC):
             )
             await session.commit()
 
-    async def delete_by_permalink(self, permalink: str) -> None:
-        """Delete a search index entry by permalink.
+    async def delete_by_permalink(self, permalink: str, search_item_type: SearchItemType) -> None:
+        """Delete the one search row an address owns for the given row kind.
 
         This implementation is shared across backends as it uses standard SQL DELETE.
+
+        The kind is required rather than optional because an address can be shared by
+        two kinds (#1437): deleting one note's relation row by permalink alone also
+        removed another note's observation row, and nothing restores a projection whose
+        source row still exists -- the orphan sweep only removes, it never rebuilds.
         """
         async with db.scoped_session(self.session_maker) as session:
             await session.execute(
-                text(
-                    "DELETE FROM search_index WHERE permalink = :permalink AND project_id = :project_id"
-                ),
-                {"permalink": permalink, "project_id": self.project_id},
+                text(f"DELETE FROM search_index WHERE {SEARCH_INDEX_ROW_KEY_PREDICATE}"),
+                {
+                    "permalink": permalink,
+                    "type": search_item_type.value,
+                    "project_id": self.project_id,
+                },
             )
             await session.commit()
 

--- a/src/basic_memory/services/search_service.py
+++ b/src/basic_memory/services/search_service.py
@@ -1004,9 +1004,9 @@ class SearchService:
 
             await self.repository.bulk_index_items(rows_to_index)
 
-    async def delete_by_permalink(self, permalink: str):
-        """Delete an item from the search index."""
-        await self.repository.delete_by_permalink(permalink)
+    async def delete_by_permalink(self, permalink: str, search_item_type: SearchItemType):
+        """Delete the search row one permalink owns for the given row kind."""
+        await self.repository.delete_by_permalink(permalink, search_item_type)
 
     async def delete_by_entity_id(self, entity_id: int):
         """Delete an item from the search index."""
@@ -1024,20 +1024,23 @@ class SearchService:
         )
 
         # Clean up search index - same logic as sync_service.handle_delete()
-        permalinks = (
-            [entity.permalink]
-            + [o.permalink for o in entity.observations]
-            + [r.permalink for r in entity.outgoing_relations]
+        # Each address is paired with the kind that owns it: one permalink can be shared
+        # by two kinds, so deleting by address alone took another note's row with it
+        # (#1437), and nothing rebuilds a projection whose source row still exists.
+        addressed_rows = (
+            [(entity.permalink, SearchItemType.ENTITY)]
+            + [(o.permalink, SearchItemType.OBSERVATION) for o in entity.observations]
+            + [(r.permalink, SearchItemType.RELATION) for r in entity.outgoing_relations]
         )
 
         logger.debug(
             f"Deleting search index entries for entity_id={entity.id}, "
-            f"index_entries={len(permalinks)}"
+            f"index_entries={len(addressed_rows)}"
         )
 
-        for permalink in permalinks:
+        for permalink, search_item_type in addressed_rows:
             if permalink:
-                await self.delete_by_permalink(permalink)
+                await self.delete_by_permalink(permalink, search_item_type)
             else:
                 await self.delete_by_entity_id(entity.id)
 

--- a/tests/repository/test_accepted_note_search_repository.py
+++ b/tests/repository/test_accepted_note_search_repository.py
@@ -65,7 +65,7 @@ async def test_refresh_entity_replaces_project_scoped_hot_search_row() -> None:
     assert "DELETE FROM search_index" in delete_sql
     assert delete_params == {"entity_id": 42, "project_id": 7}
     assert "CAST(:metadata AS jsonb)" in insert_sql
-    assert "ON CONFLICT (permalink, project_id)" in insert_sql
+    assert "ON CONFLICT (permalink, type, project_id)" in insert_sql
     assert "script_ngrams = EXCLUDED.script_ngrams" in insert_sql
     assert insert_params == {
         "id": 42,

--- a/tests/repository/test_search_repository.py
+++ b/tests/repository/test_search_repository.py
@@ -505,7 +505,7 @@ async def test_delete_by_permalink(search_repository, search_entity):
     assert len(results) == 1
 
     # Delete by permalink
-    await search_repository.delete_by_permalink(search_entity.permalink)
+    await search_repository.delete_by_permalink(search_entity.permalink, SearchItemType.ENTITY)
 
     # Verify it's gone
     results_after = await search_repository.search(search_text="content to delete")
@@ -1319,3 +1319,156 @@ async def test_cjk_compound_query_matches_with_or_without_relaxation(
 
     total = await search_repository.count(search_text="季度 报告", allow_relaxed=True)
     assert total == 1
+
+
+# --- Row-kind uniqueness (#1437) ---
+
+# One address, two kinds. A relation's permalink is `from/type/to` with the relation type
+# authored by the user, so the note
+#
+#     - [decision] redis
+#     - observations [[decision/redis]]
+#
+# gives its observation and its relation this identical string.
+_SHARED_ADDRESS = "test/search-test-entity/observations/decision/redis"
+
+
+def _row_at_shared_address(search_repository, search_entity, *, row_id: int, item_type: str):
+    """Build one indexable row occupying the address both kinds can spell."""
+    return SearchIndexRow(
+        project_id=search_repository.project_id,
+        id=row_id,
+        type=item_type,
+        title=f"{item_type} at the shared address",
+        content_stems=f"{item_type} stems",
+        content_snippet=f"{item_type} body",
+        permalink=_SHARED_ADDRESS,
+        file_path=search_entity.file_path,
+        entity_id=search_entity.id,
+        created_at=search_entity.created_at,
+        updated_at=search_entity.updated_at,
+    )
+
+
+async def _rows_at_shared_address(session_maker, search_repository):
+    """Return (type, id) for every stored row holding the shared address."""
+    async with db.scoped_session(session_maker) as session:
+        result = await session.execute(
+            text(
+                "SELECT type, id FROM search_index "
+                "WHERE permalink = :permalink AND project_id = :project_id"
+            ),
+            {"permalink": _SHARED_ADDRESS, "project_id": search_repository.project_id},
+        )
+        return sorted((row[0], row[1]) for row in result.fetchall())
+
+
+@pytest.mark.asyncio
+async def test_observation_and_relation_sharing_an_address_keep_separate_rows(
+    search_repository, search_entity, session_maker
+):
+    """An observation and a relation at one address are two rows, not one.
+
+    Keyed on the permalink alone this destroyed data in two different ways: Postgres
+    upserted the relation into the observation's row and then broke the FTS-chunk
+    foreign key still pointing at the kind it had overwritten, and SQLite -- whose
+    FTS5 table has no unique index to object -- silently dropped the observation.
+    """
+    await search_repository.index_item(
+        _row_at_shared_address(
+            search_repository,
+            search_entity,
+            row_id=11,
+            item_type=SearchItemType.OBSERVATION.value,
+        )
+    )
+    await search_repository.index_item(
+        _row_at_shared_address(
+            search_repository,
+            search_entity,
+            row_id=22,
+            item_type=SearchItemType.RELATION.value,
+        )
+    )
+
+    assert await _rows_at_shared_address(session_maker, search_repository) == [
+        (SearchItemType.OBSERVATION.value, 11),
+        (SearchItemType.RELATION.value, 22),
+    ]
+
+    found = await search_repository.search(permalink=_SHARED_ADDRESS)
+    assert sorted((row.type, row.id) for row in found) == [
+        (SearchItemType.OBSERVATION.value, 11),
+        (SearchItemType.RELATION.value, 22),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reindexing_one_kind_replaces_only_its_own_row(
+    search_repository, search_entity, session_maker
+):
+    """Uniqueness still binds *within* a kind: a second write replaces, never duplicates."""
+    await search_repository.index_item(
+        _row_at_shared_address(
+            search_repository,
+            search_entity,
+            row_id=11,
+            item_type=SearchItemType.OBSERVATION.value,
+        )
+    )
+    await search_repository.index_item(
+        _row_at_shared_address(
+            search_repository,
+            search_entity,
+            row_id=22,
+            item_type=SearchItemType.RELATION.value,
+        )
+    )
+
+    # Re-index the observation under a new row id, as a re-parse of the note does.
+    await search_repository.index_item(
+        _row_at_shared_address(
+            search_repository,
+            search_entity,
+            row_id=33,
+            item_type=SearchItemType.OBSERVATION.value,
+        )
+    )
+
+    assert await _rows_at_shared_address(session_maker, search_repository) == [
+        (SearchItemType.OBSERVATION.value, 33),
+        (SearchItemType.RELATION.value, 22),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_by_permalink_leaves_the_other_kind_at_that_address(
+    search_repository, search_entity, session_maker
+):
+    """Deleting one note's relation row must not take another note's observation row.
+
+    Nothing rebuilds a projection whose source row still exists -- the orphan sweep only
+    removes -- so an over-broad delete here does not converge.
+    """
+    await search_repository.index_item(
+        _row_at_shared_address(
+            search_repository,
+            search_entity,
+            row_id=11,
+            item_type=SearchItemType.OBSERVATION.value,
+        )
+    )
+    await search_repository.index_item(
+        _row_at_shared_address(
+            search_repository,
+            search_entity,
+            row_id=22,
+            item_type=SearchItemType.RELATION.value,
+        )
+    )
+
+    await search_repository.delete_by_permalink(_SHARED_ADDRESS, SearchItemType.RELATION)
+
+    assert await _rows_at_shared_address(session_maker, search_repository) == [
+        (SearchItemType.OBSERVATION.value, 11),
+    ]

--- a/tests/services/test_search_service.py
+++ b/tests/services/test_search_service.py
@@ -1842,3 +1842,76 @@ async def test_reindex_all_preserves_sibling_project_search_rows(
 
     own_results = await search_service.repository.search(search_text="stalemarker")
     assert own_results == []
+
+
+@pytest.mark.asyncio
+async def test_note_whose_relation_spells_an_observation_address_indexes_both(
+    search_service,
+    entity_repository,
+    session_maker,
+    test_project,
+):
+    """The #1437 reproduction, indexed end to end from one note's own markdown.
+
+    A note containing
+
+        - [decision] redis
+        - observations [[decision/redis]]
+
+    gives its observation and its relation the identical permalink, because a relation's
+    address is `from/type/to` and the type is the author's text. On `main` this raised an
+    IntegrityError on Postgres -- the upsert overwrote the observation row and broke the
+    FTS-chunk foreign key still pointing at it -- while SQLite kept both under one address
+    with no way to tell them apart.
+    """
+    from basic_memory.models.knowledge import Entity, Observation, Relation
+
+    now = datetime.now(timezone.utc)
+    async with db.scoped_session(session_maker) as session:
+        entity = Entity(
+            project_id=test_project.id,
+            title="Redis Decision",
+            note_type="note",
+            permalink="test/redis-decision",
+            file_path="test/redis_decision.md",
+            content_type="text/markdown",
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(entity)
+        await session.flush()
+        session.add(
+            Observation(
+                project_id=test_project.id,
+                entity_id=entity.id,
+                category="decision",
+                content="redis",
+            )
+        )
+        session.add(
+            Relation(
+                project_id=test_project.id,
+                from_id=entity.id,
+                to_id=None,
+                to_name="decision/redis",
+                relation_type="observations",
+            )
+        )
+        await session.flush()
+
+    async with db.scoped_session(session_maker) as session:
+        entity = await entity_repository.get_by_permalink(session, "test/redis-decision")
+    assert entity is not None
+
+    shared_address = entity.observations[0].permalink
+    assert entity.outgoing_relations[0].permalink == shared_address, (
+        "the reproduction requires the two permalinks to actually collide"
+    )
+
+    await search_service.index_entity_markdown(entity, content="We chose redis.")
+
+    results = await search_service.search(SearchQuery(permalink=shared_address))
+    assert sorted(row.type for row in results) == [
+        SearchItemType.OBSERVATION.value,
+        SearchItemType.RELATION.value,
+    ]

--- a/tests/test_search_index_row_kind_migration.py
+++ b/tests/test_search_index_row_kind_migration.py
@@ -1,0 +1,57 @@
+"""Tests for the search_index row-kind uniqueness migration (#1437)."""
+
+from importlib import import_module
+from types import SimpleNamespace
+
+
+migration = import_module(
+    "basic_memory.alembic.versions.w6k7i8n9d0a1_search_index_row_kind_uniqueness"
+)
+
+
+def _connection(dialect_name: str) -> SimpleNamespace:
+    return SimpleNamespace(dialect=SimpleNamespace(name=dialect_name))
+
+
+def _statements(monkeypatch, dialect_name: str, run) -> list[str]:
+    executed: list[str] = []
+    monkeypatch.setattr(migration.op, "get_bind", lambda: _connection(dialect_name))
+    monkeypatch.setattr(migration.op, "execute", lambda statement: executed.append(str(statement)))
+    run()
+    return executed
+
+
+def test_upgrade_widens_the_unique_index_to_include_the_row_kind(monkeypatch) -> None:
+    statements = _statements(monkeypatch, "postgresql", migration.upgrade)
+
+    assert len(statements) == 2
+    # The wide index is created before the narrow one is dropped, so the table is never
+    # momentarily unconstrained.
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS uix_search_index_permalink_type_project" in (
+        statements[0]
+    )
+    assert "ON search_index (permalink, type, project_id)" in statements[0]
+    assert "WHERE permalink IS NOT NULL" in statements[0]
+    assert statements[1] == "DROP INDEX IF EXISTS uix_search_index_permalink_project"
+
+
+def test_downgrade_sheds_the_rows_the_narrow_index_cannot_admit(monkeypatch) -> None:
+    statements = _statements(monkeypatch, "postgresql", migration.downgrade)
+
+    assert len(statements) == 3
+    # The narrow index cannot be recreated while one permalink is held by two kinds,
+    # so the extra derived projections go first, keeping entity over observation over
+    # relation -- which is what ordering by `type` gives.
+    assert "DELETE FROM search_index" in statements[0]
+    assert "PARTITION BY project_id, permalink" in statements[0]
+    assert "ORDER BY type, id" in statements[0]
+    assert "row_rank > 1" in statements[0]
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS uix_search_index_permalink_project" in statements[1]
+    assert "ON search_index (permalink, project_id)" in statements[1]
+    assert statements[2] == "DROP INDEX IF EXISTS uix_search_index_permalink_type_project"
+
+
+def test_migration_is_noop_for_sqlite(monkeypatch) -> None:
+    """SQLite's search_index is an FTS5 virtual table: it has no unique index to change."""
+    assert _statements(monkeypatch, "sqlite", migration.upgrade) == []
+    assert _statements(monkeypatch, "sqlite", migration.downgrade) == []


### PR DESCRIPTION
Closes #1437. Part of #1438.

## The defect

A relation's permalink is `from/type/to` with the relation **type authored by the user**, so a note that says

```markdown
- [decision] redis
- observations [[decision/redis]]
```

gives its observation and its relation the identical address — `…/observations/decision/redis` — because `observations` is both the segment every observation permalink opens with and a relation type anyone can type. No reserved segment closes this: the colliding segment is the author's own text.

Reproduced on `origin/main` (`da1ac946`) before changing anything:

| backend | what actually happened |
|---|---|
| **Postgres** | `IntegrityError` — `insert or update on table "search_index_fts_chunks" violates foreign key constraint … Key (search_index_id, search_index_type, project_id)=(1, observation, 1) is not present in table "search_index"`. The upsert overwrote the observation row (its `type` changed), so the chunk insert pointed at a row that no longer existed. |
| **SQLite** | Both rows coexisted under one permalink through the bulk path; through `index_item` the delete-before-insert keyed on permalink alone **destroyed the observation row outright**. Nothing surfaced either way. |

## Address or uniqueness — uniqueness, and why

**Changing the address was rejected.** Permalinks are the user-facing identifier: `memory://` URLs, relation targets written into markdown, search results, the API. Moving them breaks links people have already written. And it does not even work — the trap is documented on `OBSERVATION_SEGMENT` in `models/knowledge.py`: a marker that survives content is reachable by content, and one that escapes content is erased by the normalization every `memory://` lookup performs.

**Uniqueness is the outlier, so uniqueness is what moved.** `search_index`'s primary key is already `(id, type, project_id)` — the row kind is *half of the table's own notion of identity*. The unique index on `(permalink, project_id)` was narrower than that. Widening it to `(permalink, type, project_id)` makes uniqueness agree with the primary key, keeps every existing permalink byte-identical, and still constrains the within-kind duplicates that #909/#929/SPEC-82 were about.

## One rule, one place

`SEARCH_INDEX_ROW_KEY` in `models/search.py` is the single definition, following the `file_path_prefix_condition` / `note_type_filters` precedent. Five call sites derive from it:

- the Postgres unique-index DDL,
- both Postgres upsert conflict targets (`index_item`, `bulk_index_items`),
- the accepted-note upsert (`accepted_note_search_repository.py`) — this one **had** to move, since `ON CONFLICT (permalink, project_id)` errors once the narrow index is gone,
- the shared delete-before-insert in `search_repository_base.index_item`, which is the only rule SQLite has (its FTS5 virtual table carries no unique index at all),
- `delete_by_permalink`, which now takes the kind that owns the address. Deleting one note's relation row used to take another note's observation row with it, and nothing rebuilds a projection whose source row still exists — the orphan sweep only removes.

## ⚠️ Migration — `w6k7i8n9d0a1`

Replaces `uix_search_index_permalink_project` with `uix_search_index_permalink_type_project` on Postgres. **Widening a unique index cannot fail on existing data** (every row satisfying the narrow key satisfies the wide one) and **no permalink changes**. The wide index is created before the narrow one is dropped. SQLite is a genuine no-op — its FTS5 table has no unique index to change.

The **downgrade** must shed rows the narrow index cannot admit — exactly the pairs the upgrade made legal. It keeps one row per `(project_id, permalink)`, preferring entity over observation over relation (`ORDER BY type, id`); search rows are derived state the next index pass rebuilds, so shedding them is recoverable where a failed downgrade is not.

### Migration verified for real, against live databases

The test suite uses `create_all` + `stamp`, so it never runs migrations. This was run manually.

**Postgres** (`pgvector/pgvector:pg16`, seeded with a project, an entity, `search_index` rows *and* their FTS-chunk children):

```
=== 1. alembic upgrade v5o6b7s8d9e0 (the head before this change) ===
  unique indexes on search_index: ['uix_search_index_permalink_project']
=== 2. seed a database that already has rows ===
  rows: [('entity', 1, 'test/redis-decision'), ('observation', 2, '…/observations/decision/redis')]
  fts chunks: [('entity', 1, 'entity body'), ('observation', 2, 'observation body')]
  relation at the observation's address -> REJECTED (UniqueViolation)
=== 3. alembic upgrade head (w6k7i8n9d0a1) ===
  unique indexes on search_index: ['uix_search_index_permalink_type_project']
  --- data survived the migration? ---
  rows: [('entity', 1, …), ('observation', 2, …)]          <- unchanged
  fts chunks: [('entity', 1, 'entity body'), ('observation', 2, 'observation body')]
  --- constraint holds? ---
  relation at the observation's address -> ACCEPTED
  SECOND observation at that address    -> REJECTED (UniqueViolation)
  SECOND entity at the entity address   -> REJECTED (UniqueViolation)
=== 4. alembic downgrade v5o6b7s8d9e0 ===
  unique indexes on search_index: ['uix_search_index_permalink_project']
  rows: [('entity', 1, …), ('observation', 2, …)]          <- relation shed, observation kept
  fts chunks: [('entity', 1), ('observation', 2)]          <- followed via ON DELETE CASCADE
  relation at the observation's address -> REJECTED (UniqueViolation)
=== 5. alembic upgrade head again ===
  unique indexes on search_index: ['uix_search_index_permalink_type_project']
  alembic_version: w6k7i8n9d0a1
```

Fresh-install path (`base` → `head` on an empty database) produces exactly:

```
CREATE UNIQUE INDEX uix_search_index_permalink_type_project ON public.search_index
USING btree (permalink, type, project_id) WHERE (permalink IS NOT NULL)
```

…which is byte-identical to what `CREATE_POSTGRES_SEARCH_INDEX_PERMALINK` in `models/search.py` creates (compared programmatically via `pg_indexes.indexdef`, `IDENTICAL: True`), so the migrated schema and the schema the test suite builds cannot drift.

**SQLite** (file database seeded with all three row kinds, including a colliding pair):

```
before upgrade:    version=v5o6b7s8d9e0  rows=[entity/1, observation/2, relation/3]
after upgrade:     version=w6k7i8n9d0a1  rows=[entity/1, observation/2, relation/3]
after downgrade:   version=v5o6b7s8d9e0  rows=[entity/1, observation/2, relation/3]
after re-upgrade:  version=w6k7i8n9d0a1  rows=[entity/1, observation/2, relation/3]
```

**Chain:** `alembic heads` → `w6k7i8n9d0a1 (head)`, single head. `alembic branches` shows only the pre-existing `f8a9b2c3d4e5` branchpoint already merged by `6830751f5fb6`. No dangling revisions.

**One pre-existing failure, reported rather than papered over:** `alembic downgrade base` on Postgres is already broken at the previous head `v5o6b7s8d9e0` (`constraint "fk_entity_project_id" of relation "entity" does not exist`, from the `9d9c1cb7d8f5`/`a1b2c3d4e5f6` batch-mode downgrades). Verified independently of this branch. Not touched here; `downgrade` to the previous revision — the case that matters for this change — works.

## Tests

New tests fail on `main` and pass here, **on both backends**, verified by stashing the source hunks:

| test | before (both backends) |
|---|---|
| `test_observation_and_relation_sharing_an_address_keep_separate_rows` | `assert [('relation', 22)] == [('observation', 11), ('relation', 22)]` — the observation row was **gone** |
| `test_reindexing_one_kind_replaces_only_its_own_row` | `assert [('observation', 33)] == [('observation', 33), ('relation', 22)]` |
| `test_delete_by_permalink_leaves_the_other_kind_at_that_address` | the kind-scoped API did not exist |

The SQLite assertions check the stored rows directly — that both kinds are present with their own ids — rather than merely that no error was raised, since silence was the original symptom there. `test_reindexing_one_kind_replaces_only_its_own_row` guards the other direction: widening the key must not become *no* key, so a second write of the same kind still replaces rather than duplicates.

`tests/services/test_search_service.py::test_note_whose_relation_spells_an_observation_address_indexes_both` is the issue's reproduction end-to-end through `index_entity_markdown` (the `bulk_index_items` path), asserting the two permalinks genuinely collide before asserting both rows survive.

`tests/test_search_index_row_kind_migration.py` covers the migration itself (100% line coverage on the revision).

## Verification run

- `uv run ruff check src tests test-int` — All checks passed
- `uv run ruff format --check .` — 1103 files already formatted
- `uv run ty check src tests test-int` — All checks passed
- SQLite `tests/repository tests/services tests/indexing tests/index tests/db` — **2321 passed**, 41 skipped
- SQLite remainder of `tests/` — **4575 passed**
- Postgres (`BASIC_MEMORY_TEST_POSTGRES=1`) same five directories — **2302 passed**, 59 skipped, 1 failed: `test_tokenizing_scales_linearly_with_query_length`, a CPU-ratio timing assertion over `relaxation_word_tokens` (a pure string function, no database, untouched here) that went red under three concurrent suites; **passes in isolation**
- Migration tests on both backends — **58 passed** each

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp
