### PR TITLE
fix(core): seed agent-task projects with one index pass, and verify recency

### DIFF
--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/driver.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/driver.py
@@ -21,6 +21,8 @@ from mcp.types import CallToolResult
 from rich.console import Console
 
 from basic_memory_benchmarks.agent_tasks.corpus import (
+    RECENT_AGE_DAYS,
+    TIMESTAMPS,
     copy_corpus,
     corpus_checksum,
     snapshot_baseline,
@@ -274,22 +276,76 @@ def _prepare_task_project(
         )
         source_dir = corpus_dir / task.group / "docs"
     copy_corpus(source_dir, project.directory)
+    # `project add` indexes the directory before returning (#1414), and that
+    # index pass rewrites every note (permalink into frontmatter, YAML
+    # normalization), which resets the mtimes copy_corpus just aged. Once is
+    # fine: the pass reads the aged mtime into updated_at, then writes. The
+    # explicit `reindex --full` that used to follow was the workaround for the
+    # pre-#1414 `project add` that did not index at all; kept after the fix it
+    # became a second full pass that read the rewritten mtimes, so every note
+    # looked edited today and the recency task's three-note window returned
+    # the whole corpus (run at-1d26c0609808). One pass, then verify the window
+    # rather than trusting the sequence.
     run_command(prefix + ["project", "add", project.name, str(project.directory)], env=env)
-    # `project add` registers but does not index: without an explicit index
-    # pass the DB stays empty, `status` reports ready vacuously (zero pending
-    # work was ever queued), and every retrieval tool sees an empty project.
-    # The scripted smoke masked this — its canned answers never needed the
-    # index — so the first real-model run surfaced it as 24 empty projects.
-    run_command(prefix + ["reindex", "-p", project.name, "--full", "--search"], env=env)
     settle_index(
         prefix=prefix,
         env=env,
         project_name=project.name,
         timeout_seconds=settle_timeout_seconds,
     )
+    if task.group is None:
+        verify_seeded_recency(prefix=prefix, env=env, project=project)
     if task.group is not None:
         prepared_groups[task.group] = project
     return project
+
+
+# The recency task grades on "the last three days"; the aged corpus puts its
+# gold files RECENT_AGE_DAYS old and everything else DEFAULT_AGE_DAYS old, so
+# any window strictly between the two sees exactly the gold set.
+SEEDED_RECENCY_WINDOW = f"{RECENT_AGE_DAYS + 1}d"
+
+
+def recency_mismatch(recent_relpaths: set[str], expected_relpaths: set[str]) -> str | None:
+    """Describe how the indexed recency window differs from the aged corpus, or None."""
+    if recent_relpaths == expected_relpaths:
+        return None
+    extra = sorted(recent_relpaths - expected_relpaths)
+    missing = sorted(expected_relpaths - recent_relpaths)
+    return f"extra={extra} missing={missing}"
+
+
+def verify_seeded_recency(*, prefix: list[str], env: dict[str, str], project: TaskProject) -> None:
+    """Fail seeding unless the index kept the corpus's aged mtimes.
+
+    The recency task's gold set is TIMESTAMPS. If the index read mtimes after a
+    rewrite, every note is "recent", and the task then fails for a reason that
+    has nothing to do with the surface under test. Checking here turns that
+    into a seeding error with the offending files named, instead of a plausible
+    looking 10/12.
+    """
+    result = run_command(
+        prefix
+        + [
+            "tail",
+            "--project",
+            project.name,
+            "--timeframe",
+            SEEDED_RECENCY_WINDOW,
+            "-n",
+            "100",
+            "--json",
+        ],
+        env=env,
+    )
+    recent = {row["file_path"] for row in json.loads(result.stdout)}
+    mismatch = recency_mismatch(recent, set(TIMESTAMPS))
+    if mismatch is not None:
+        raise RuntimeError(
+            f"seeded project {project.name} does not reflect the corpus's aged mtimes "
+            f"within {SEEDED_RECENCY_WINDOW}: {mismatch}. The index pass read mtimes "
+            "after a rewrite; seed with exactly one index pass after copy_corpus."
+        )
 
 
 def _run_one_task(

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/driver.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/driver.py
@@ -293,6 +293,7 @@ def _prepare_task_project(
         project_name=project.name,
         timeout_seconds=settle_timeout_seconds,
     )
+    verify_seeded_index(prefix=prefix, env=env, project=project)
     if task.group is None:
         verify_seeded_recency(prefix=prefix, env=env, project=project)
     if task.group is not None:
@@ -304,6 +305,53 @@ def _prepare_task_project(
 # gold files RECENT_AGE_DAYS old and everything else DEFAULT_AGE_DAYS old, so
 # any window strictly between the two sees exactly the gold set.
 SEEDED_RECENCY_WINDOW = f"{RECENT_AGE_DAYS + 1}d"
+
+
+# `project add` has indexed since this revision (#1414). Before it, add only
+# registered the project, and the index pass had to be explicit.
+INDEXING_PROJECT_ADD_REVISION = "370ab5b"
+
+
+def verify_seeded_index(*, prefix: list[str], env: dict[str, str], project: TaskProject) -> None:
+    """Fail seeding unless every file in the project is indexed.
+
+    Seeding relies on the `project add` that indexes (#1414). A checkout under
+    test from before that revision registers the project and stops, and the
+    readiness it reports is either absent or vacuous; a settle then returns at
+    once and every retrieval tool sees an empty project. That is what turned an
+    earlier real-model run into 24 empty projects with plausible-looking
+    scores. Reading the count back rejects such a checkout before any task
+    runs, and catches any later cause of the same empty state, grouped corpora
+    included.
+    """
+    completed = run_command(
+        prefix + ["status", "--project", project.name, "--json", "--local"], env=env
+    )
+    payload = json.loads(completed.stdout.strip() or "{}")
+    readiness = payload.get("readiness") if isinstance(payload, dict) else None
+    if (
+        not isinstance(readiness, dict)
+        or not {
+            "phase",
+            "files_on_disk",
+            "indexed_entities",
+        }
+        <= readiness.keys()
+    ):
+        raise RuntimeError(
+            f"`bm status --json` for {project.name} reports no index readiness; the "
+            f"agent-task eval seeds through `project add`, which indexes only from "
+            f"basic-memory {INDEXING_PROJECT_ADD_REVISION} (#1414). Point --bm-local-path "
+            "at that revision or later."
+        )
+    files_on_disk = int(readiness["files_on_disk"])
+    indexed = int(readiness["indexed_entities"])
+    if readiness["phase"] != "idle" or files_on_disk == 0 or indexed != files_on_disk:
+        raise RuntimeError(
+            f"seeded project {project.name} indexed {indexed} of {files_on_disk} files "
+            f"(phase {readiness['phase']!r}); every task would run against an incomplete "
+            "index and score on it."
+        )
 
 
 def recency_mismatch(recent_relpaths: set[str], expected_relpaths: set[str]) -> str | None:

--- a/benchmarks/tests/agent_tasks/test_driver.py
+++ b/benchmarks/tests/agent_tasks/test_driver.py
@@ -12,8 +12,10 @@ import pytest
 from mcp.types import CallToolResult, TextContent
 
 import basic_memory_benchmarks.agent_tasks.driver as driver
+from basic_memory_benchmarks.agent_tasks.corpus import TIMESTAMPS, corpus_files
 import basic_memory_benchmarks.llm.tool_agent as tool_agent
 from basic_memory_benchmarks.agent_tasks.driver import (
+    recency_mismatch,
     SessionTerminatedError,
     SurfaceRuntime,
     build_surface_summary,
@@ -90,10 +92,19 @@ class FakeSession:
         self.stopped = True
 
 
+def _bm_stdout(command: list[str]) -> str:
+    """What the stubbed bm prints: the recency guard's `tail --json` sees the gold set."""
+    if "tail" in command:
+        return json.dumps([{"file_path": relpath} for relpath in TIMESTAMPS])
+    return ""
+
+
 def _stub_bm(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(driver, "resolve_clean_checkout_sha", lambda checkout: "deadbeef")
     monkeypatch.setattr(
-        driver, "run_command", lambda *args, **kwargs: SimpleNamespace(stdout="", stderr="")
+        driver,
+        "run_command",
+        lambda command, **kwargs: SimpleNamespace(stdout=_bm_stdout(command), stderr=""),
     )
     monkeypatch.setattr(
         driver,
@@ -278,12 +289,30 @@ def test_state_graded_task_reindexes_before_grading(
     )
 
     project = "test-run-tasks-complete"
+    # Seeding is one index pass, the one `project add` runs (#1414). A seed-time
+    # `reindex --full` after it would read the mtimes that pass rewrote and make
+    # every note look recent (run at-1d26c0609808).
+    adds = [cmd[cmd.index("add") :] for cmd in commands if "project" in cmd and "add" in cmd]
+    assert adds == [["add", project, str(run_dir_project(commands, project))]]
     reindexes = [cmd[cmd.index("reindex") + 1 :] for cmd in commands if "reindex" in cmd]
     assert reindexes == [
-        ["-p", project, "--full", "--search"],  # seed indexing before the loop
-        ["-p", project, "--search"],  # post-loop: resolve the agent's writes
+        ["-p", project, "--search"],  # post-loop only: resolve the agent's writes
     ]
-    # Settle follows BOTH passes: seed settle, then the pre-grading settle.
+    # The guard reads the recency window back from the seeded project.
+    tails = [cmd[cmd.index("tail") :] for cmd in commands if "tail" in cmd]
+    assert tails == [
+        [
+            "tail",
+            "--project",
+            project,
+            "--timeframe",
+            driver.SEEDED_RECENCY_WINDOW,
+            "-n",
+            "100",
+            "--json",
+        ]
+    ]
+    # Settle follows both passes: seed settle, then the pre-grading settle.
     assert settles == [project, project]
 
 
@@ -577,7 +606,7 @@ def _stub_bm_recording(
 
     def record_command(command: list[str], **kwargs: Any) -> SimpleNamespace:
         commands.append(list(command))
-        return SimpleNamespace(stdout="", stderr="")
+        return SimpleNamespace(stdout=_bm_stdout(command), stderr="")
 
     monkeypatch.setattr(driver, "run_command", record_command)
 
@@ -675,6 +704,9 @@ def test_grouped_manifest_run_shares_projects_and_reports_groups(
     assert added_projects == ["xafs-run-xafs-dp001", "xafs-run-xafs-dp002"]
     assert sorted(settles) == added_projects
     assert len(settles) == 2
+    # Grouped corpora carry no aged-mtime contract, so the recency guard is
+    # specific to the shipped corpus and must not run here.
+    assert not [cmd for cmd in commands if "tail" in cmd]
 
     manifest = json.loads((run_dir / "manifest.json").read_text())
     assert manifest["task_ids"] == MANIFEST_TASK_IDS  # (group, id) order
@@ -960,3 +992,47 @@ def test_transport_refusal_text_never_reaches_the_saved_error_artifact(
     # The operator still learns what the transport refused, and where.
     assert "Illegal header value" in saved_error
     assert "http://localhost/v1" in saved_error
+
+
+def run_dir_project(commands: list[list[str]], project: str) -> Path:
+    """The directory `project add` was given for this project, from the recorded commands."""
+    for cmd in commands:
+        if "add" in cmd and cmd[cmd.index("add") + 1] == project:
+            return Path(cmd[cmd.index("add") + 2])
+    raise AssertionError(f"no project add recorded for {project}")
+
+
+def test_recency_mismatch_names_extra_and_missing_files() -> None:
+    assert recency_mismatch({"a.md", "b.md"}, {"a.md", "b.md"}) is None
+    assert recency_mismatch({"a.md", "c.md"}, {"a.md", "b.md"}) == "extra=['c.md'] missing=['b.md']"
+
+
+def test_seeding_aborts_when_the_index_lost_the_aged_mtimes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every note reading as recent is a seeding failure, not a task result.
+
+    That state produced a plausible 10/12 in run at-1d26c0609808 before it was
+    traced to the seed sequence; the guard turns it into an abort that names
+    the files outside the gold set.
+    """
+    _stub_bm(monkeypatch)
+    whole_corpus = json.dumps([{"file_path": relpath} for relpath in corpus_files(CORPUS_DIR)])
+    monkeypatch.setattr(
+        driver,
+        "run_command",
+        lambda command, **kwargs: SimpleNamespace(
+            stdout=whole_corpus if "tail" in command else "", stderr=""
+        ),
+    )
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(RuntimeError, match="aged mtimes") as excinfo:
+        run_agent_tasks(
+            _config(tmp_path),
+            model_factory=lambda spec: _orphan_agent(),
+            session_factory=lambda runtime: FakeSession(RICH_SURFACE.tool_allowlist),
+        )
+
+    assert "notes/feature-x.md" in str(excinfo.value)
+    assert "missing=[]" in str(excinfo.value)

--- a/benchmarks/tests/agent_tasks/test_driver.py
+++ b/benchmarks/tests/agent_tasks/test_driver.py
@@ -92,8 +92,20 @@ class FakeSession:
         self.stopped = True
 
 
+def _seeded_status(*, indexed: int, files: int, phase: str = "idle") -> str:
+    return json.dumps(
+        {"readiness": {"phase": phase, "files_on_disk": files, "indexed_entities": indexed}}
+    )
+
+
 def _bm_stdout(command: list[str]) -> str:
-    """What the stubbed bm prints: the recency guard's `tail --json` sees the gold set."""
+    """What the stubbed bm prints for the seed guards.
+
+    `status --json` reports a fully indexed project and `tail --json` the aged
+    gold set, so the guards pass unless a test overrides one of them.
+    """
+    if "status" in command:
+        return _seeded_status(indexed=25, files=25)
     if "tail" in command:
         return json.dumps([{"file_path": relpath} for relpath in TIMESTAMPS])
     return ""
@@ -298,7 +310,10 @@ def test_state_graded_task_reindexes_before_grading(
     assert reindexes == [
         ["-p", project, "--search"],  # post-loop only: resolve the agent's writes
     ]
-    # The guard reads the recency window back from the seeded project.
+    # The guards read the index count and the recency window back from the
+    # seeded project (settle_index is stubbed, so these are the only status calls).
+    statuses = [cmd[cmd.index("status") :] for cmd in commands if "status" in cmd]
+    assert statuses == [["status", "--project", project, "--json", "--local"]]
     tails = [cmd[cmd.index("tail") :] for cmd in commands if "tail" in cmd]
     assert tails == [
         [
@@ -705,8 +720,12 @@ def test_grouped_manifest_run_shares_projects_and_reports_groups(
     assert sorted(settles) == added_projects
     assert len(settles) == 2
     # Grouped corpora carry no aged-mtime contract, so the recency guard is
-    # specific to the shipped corpus and must not run here.
+    # specific to the shipped corpus and must not run here; the index-count
+    # guard runs for every seeded project, once per persona.
     assert not [cmd for cmd in commands if "tail" in cmd]
+    # Slice from the verb: the uv prefix carries its own `--project <checkout>`.
+    statuses = sorted(cmd[cmd.index("status") + 2] for cmd in commands if "status" in cmd)
+    assert statuses == added_projects
 
     manifest = json.loads((run_dir / "manifest.json").read_text())
     assert manifest["task_ids"] == MANIFEST_TASK_IDS  # (group, id) order
@@ -1022,7 +1041,7 @@ def test_seeding_aborts_when_the_index_lost_the_aged_mtimes(
         driver,
         "run_command",
         lambda command, **kwargs: SimpleNamespace(
-            stdout=whole_corpus if "tail" in command else "", stderr=""
+            stdout=whole_corpus if "tail" in command else _bm_stdout(command), stderr=""
         ),
     )
     monkeypatch.chdir(tmp_path)
@@ -1036,3 +1055,47 @@ def test_seeding_aborts_when_the_index_lost_the_aged_mtimes(
 
     assert "notes/feature-x.md" in str(excinfo.value)
     assert "missing=[]" in str(excinfo.value)
+
+
+def _run_with_bm_stdout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stdout_for: Any) -> None:
+    _stub_bm(monkeypatch)
+    monkeypatch.setattr(
+        driver,
+        "run_command",
+        lambda command, **kwargs: SimpleNamespace(stdout=stdout_for(command), stderr=""),
+    )
+    monkeypatch.chdir(tmp_path)
+    run_agent_tasks(
+        _config(tmp_path),
+        model_factory=lambda spec: _orphan_agent(),
+        session_factory=lambda runtime: FakeSession(RICH_SURFACE.tool_allowlist),
+    )
+
+
+def test_seeding_rejects_a_checkout_whose_status_has_no_readiness(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pre-#1414 checkout: `project add` registers without indexing and its
+    status carries no readiness. The run must stop naming the revision, not
+    grade an empty index."""
+    with pytest.raises(RuntimeError, match=driver.INDEXING_PROJECT_ADD_REVISION):
+        _run_with_bm_stdout(
+            tmp_path,
+            monkeypatch,
+            lambda command: json.dumps({"total_files": 25}) if "status" in command else "",
+        )
+
+
+def test_seeding_aborts_when_the_project_is_not_fully_indexed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with pytest.raises(RuntimeError, match=r"indexed 0 of 25 files \(phase 'never_indexed'\)"):
+        _run_with_bm_stdout(
+            tmp_path,
+            monkeypatch,
+            lambda command: (
+                _seeded_status(indexed=0, files=25, phase="never_indexed")
+                if "status" in command
+                else _bm_stdout(command)
+            ),
+        )


### PR DESCRIPTION
## Summary

The #1398 confirmation run (at-1d26c0609808) scored posix 10/12 against run 7's 12/12. The two failures were the memory-continue tasks, and one of them was seeded wrong: every note in the project read as edited today, so a three-day recency window returned the whole corpus instead of the three aged-recent notes.

**Cause.** `bm project add` now indexes before returning (#1414). That index pass rewrites every note (writes `permalink:` into frontmatter, normalizes YAML), which resets the mtimes the harness aged just before the add. Once is harmless: the pass reads the aged mtime into `updated_at`, then writes. But the harness still ran its seed-time `reindex --full` afterwards, the workaround for the pre-#1414 `project add` that did not index at all. That second full pass read the rewritten mtimes. Run 7 had exactly one pass (the reindex); this run had two.

Reproduced with a bare `project add` on an aged corpus copy: the aged file's mtime goes from 30 days ago to now.

## Change

- Seed with `project add` alone. The post-loop `reindex --search` that resolves the agent's writes is unchanged.
- `verify_seeded_recency` reads the window back through `bm tail --json` after settle and aborts seeding, naming the files outside the gold set, when the index did not keep the aged mtimes. It is a property check on the seeded project rather than an assertion about the command sequence, so it catches the next cause of the same state too. Grouped corpora carry no aged-mtime contract and skip it.
- Driver tests assert the one-pass sequence plus the guard call, that grouped seeding does not run the guard, and that a whole-corpus window aborts the run with the extra files named.

## Verification

- `just test`, `just lint`, `just typecheck` in `benchmarks/` green.
- LLM-free smoke (`just bench-agent-smoke`) on this commit, then a query of the seeded database: results in a comment below.

Part of #1398 (item 1, the confirmation run) and #1438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp