### PR TITLE
feat(core): record error excerpts on failed agent-task tool turns

### DIFF
--- a/benchmarks/docs/benchmarks.md
+++ b/benchmarks/docs/benchmarks.md
@@ -441,7 +441,9 @@ dataset-driven runs — a corrections re-run changes gold answers without
 touching the corpus — full surface echoes),
 `surface-status.json` (ok/skipped/error per surface, explicit reasons),
 `per-turn.jsonl` (per model turn and tool dispatch: tokens, tool name,
-latency, result size), `per-task-agent.jsonl`, `agent-tasks-summary.json`,
+latency, result size; on error turns also an excerpt of the arguments and of
+the error text the model saw, so a recurring tool error is diagnosable from
+the artifact), `per-task-agent.jsonl`, `agent-tasks-summary.json`,
 `summary.md` (which repeats any skipped surface so the report cannot be
 misread as a completed A/B). `validate-artifacts` remains retrieval-only for now (as for
 concurrent-write); a kind-aware variant is a follow-up.

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/loop.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/loop.py
@@ -12,6 +12,7 @@ spent on real model calls.
 
 from __future__ import annotations
 
+import json
 import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
@@ -74,6 +75,21 @@ def _truncate_result(text: str) -> str:
     if len(text) <= TOOL_RESULT_MAX_CHARS:
         return text
     return text[:TOOL_RESULT_MAX_CHARS] + TRUNCATION_SUFFIX
+
+
+# Enough of an error and its arguments to diagnose it from the artifact, small
+# enough that a task with dozens of failing calls does not bloat per-turn.jsonl.
+ERROR_EXCERPT_MAX_CHARS = 400
+
+
+def _excerpt(text: str) -> str:
+    if len(text) <= ERROR_EXCERPT_MAX_CHARS:
+        return text
+    return text[:ERROR_EXCERPT_MAX_CHARS] + TRUNCATION_SUFFIX
+
+
+def _arguments_excerpt(arguments: dict[str, Any]) -> str:
+    return _excerpt(json.dumps(arguments, default=str, sort_keys=True))
 
 
 def run_agent_loop(
@@ -174,11 +190,17 @@ def run_agent_loop(
                             tool_name=call.name,
                             arguments_chars=len(str(call.arguments)),
                             is_error=True,
+                            arguments_excerpt=_arguments_excerpt(call.arguments),
+                            error_excerpt=_excerpt(str(exc)),
                         )
                     )
                     raise AgentLoopError(exc, stop("error", None)) from exc
                 latency_ms = (time.perf_counter() - dispatch_started) * 1000.0
             fed_back = _truncate_result(outcome.text)
+            # Only failures keep their text: that is what makes a recurring
+            # tool error diagnosable from the artifact without a transcript.
+            arguments_excerpt = _arguments_excerpt(call.arguments) if outcome.is_error else None
+            error_excerpt = _excerpt(fed_back) if outcome.is_error else None
             turn_records.append(
                 TurnRecord(
                     turn_index=len(turn_records),
@@ -188,6 +210,8 @@ def run_agent_loop(
                     arguments_chars=len(str(call.arguments)),
                     result_chars=len(fed_back),
                     is_error=outcome.is_error,
+                    arguments_excerpt=arguments_excerpt,
+                    error_excerpt=error_excerpt,
                 )
             )
             transcript.append(

--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/models.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/models.py
@@ -89,6 +89,13 @@ class TurnRecord(BaseModel):
     arguments_chars: int = 0
     result_chars: int = 0
     is_error: bool = False
+    # Set only on error turns: the arguments that provoked the error and the
+    # text the model was told. Success payloads stay out of the artifact (large,
+    # and reproducible from the corpus); an error that recurs run after run is
+    # not diagnosable from lengths alone, which is what the posix `find` error
+    # in continue-spec9 was across three runs.
+    arguments_excerpt: str | None = None
+    error_excerpt: str | None = None
 
 
 class PredicateResult(BaseModel):

--- a/benchmarks/tests/agent_tasks/test_loop.py
+++ b/benchmarks/tests/agent_tasks/test_loop.py
@@ -166,6 +166,8 @@ def test_off_allowlist_call_never_reaches_dispatch() -> None:
     assert tool_record.kind == "tool"
     assert tool_record.tool_name == "made_up_tool"
     assert tool_record.is_error is True
+    assert tool_record.arguments_excerpt == "{}"
+    assert tool_record.error_excerpt == "tool 'made_up_tool' is not available on this surface"
 
 
 def test_tool_result_truncated_at_fixed_cap() -> None:
@@ -260,6 +262,8 @@ def test_dispatch_error_is_wrapped_and_records_the_dying_call() -> None:
     assert tool_record.kind == "tool"
     assert tool_record.tool_name == "search_notes"
     assert tool_record.is_error is True
+    assert tool_record.arguments_excerpt == '{"q": "x"}'
+    assert tool_record.error_excerpt == str(excinfo.value.cause)
 
 
 def test_wall_clock_gate_between_tool_dispatches() -> None:
@@ -301,3 +305,39 @@ def test_per_turn_records_account_tokens_and_counts() -> None:
     assert tool_record.tool_name == "search_notes"
     assert tool_record.result_chars == len("ok")
     assert result.tool_call_count == 1
+
+
+def test_successful_tool_turns_carry_no_excerpts() -> None:
+    """Excerpts are for diagnosis of failures; success payloads stay out of the artifact."""
+    model = _scripted(
+        [
+            {"tool_calls": [{"name": "search_notes", "arguments": {"q": "x"}}]},
+            {"text": "done"},
+        ]
+    )
+    result = _run(model, RecordingDispatch(ToolOutcome(text="fine", is_error=False)))
+
+    tool_record = result.turn_records[1]
+    assert tool_record.is_error is False
+    assert tool_record.arguments_excerpt is None
+    assert tool_record.error_excerpt is None
+
+
+def test_error_excerpts_are_capped() -> None:
+    from basic_memory_benchmarks.agent_tasks.loop import ERROR_EXCERPT_MAX_CHARS, TRUNCATION_SUFFIX
+
+    long_error = "e" * (ERROR_EXCERPT_MAX_CHARS * 3)
+    long_argument = {"identifier": "a" * (ERROR_EXCERPT_MAX_CHARS * 3)}
+    model = _scripted(
+        [
+            {"tool_calls": [{"name": "search_notes", "arguments": long_argument}]},
+            {"text": "done"},
+        ]
+    )
+    result = _run(model, RecordingDispatch(ToolOutcome(text=long_error, is_error=True)))
+
+    tool_record = result.turn_records[1]
+    assert tool_record.error_excerpt == "e" * ERROR_EXCERPT_MAX_CHARS + TRUNCATION_SUFFIX
+    assert tool_record.arguments_excerpt is not None
+    assert tool_record.arguments_excerpt.endswith(TRUNCATION_SUFFIX)
+    assert len(tool_record.arguments_excerpt) == ERROR_EXCERPT_MAX_CHARS + len(TRUNCATION_SUFFIX)


### PR DESCRIPTION
## Summary

`per-turn.jsonl` recorded only the lengths of a tool call's arguments and result. Good for cost accounting, useless for diagnosis: the posix `find` call in `continue-spec9` failed identically in three A/B runs (7, at-1d26c0609808, at-be78d409d4f8) and nothing in the artifacts said what the agent asked or what it was told.

## Change

- `TurnRecord` gains `arguments_excerpt` and `error_excerpt`, set only on error turns (`is_error`), each capped at 400 characters with the existing truncation suffix. Success payloads stay out of the artifact: they are large and reproducible from the corpus.
- The dispatch-raised path (`AgentLoopError`) records the exception text the same way, so a dead session's last call is diagnosable too.
- Docs: the per-turn artifact description in `docs/benchmarks.md`.

## Tests

Off-surface call and exploding dispatch assert the excerpts; a successful turn asserts both are `None`; a long error and long arguments assert the cap and suffix.

Part of #1398 (follow-up from the confirmation run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp