### PR TITLE
fix(core): record seeding failures against their tasks instead of aborting

### DIFF
--- a/benchmarks/src/basic_memory_benchmarks/agent_tasks/driver.py
+++ b/benchmarks/src/basic_memory_benchmarks/agent_tasks/driver.py
@@ -10,6 +10,7 @@ prompt preamble are identical (the fairness contract).
 from __future__ import annotations
 
 import json
+import subprocess
 from collections import Counter
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -312,6 +313,20 @@ SEEDED_RECENCY_WINDOW = f"{RECENT_AGE_DAYS + 1}d"
 INDEXING_PROJECT_ADD_REVISION = "370ab5b"
 
 
+class SeedingError(RuntimeError):
+    """A seeded project is not fit to run tasks against.
+
+    Recorded against every task that would have used the project, then the
+    run continues: one persona with an unindexable file must not discard the
+    tasks already paid for on the other personas (the first xAFS run lost 27
+    completed tasks this way).
+    """
+
+
+class IncompatibleCheckoutError(RuntimeError):
+    """The checkout under test cannot seed at all; every project would fail the same way."""
+
+
 def verify_seeded_index(*, prefix: list[str], env: dict[str, str], project: TaskProject) -> None:
     """Fail seeding unless every file in the project is indexed.
 
@@ -338,7 +353,7 @@ def verify_seeded_index(*, prefix: list[str], env: dict[str, str], project: Task
         }
         <= readiness.keys()
     ):
-        raise RuntimeError(
+        raise IncompatibleCheckoutError(
             f"`bm status --json` for {project.name} reports no index readiness; the "
             f"agent-task eval seeds through `project add`, which indexes only from "
             f"basic-memory {INDEXING_PROJECT_ADD_REVISION} (#1414). Point --bm-local-path "
@@ -347,7 +362,7 @@ def verify_seeded_index(*, prefix: list[str], env: dict[str, str], project: Task
     files_on_disk = int(readiness["files_on_disk"])
     indexed = int(readiness["indexed_entities"])
     if readiness["phase"] != "idle" or files_on_disk == 0 or indexed != files_on_disk:
-        raise RuntimeError(
+        raise SeedingError(
             f"seeded project {project.name} indexed {indexed} of {files_on_disk} files "
             f"(phase {readiness['phase']!r}); every task would run against an incomplete "
             "index and score on it."
@@ -389,7 +404,7 @@ def verify_seeded_recency(*, prefix: list[str], env: dict[str, str], project: Ta
     recent = {row["file_path"] for row in json.loads(result.stdout)}
     mismatch = recency_mismatch(recent, set(TIMESTAMPS))
     if mismatch is not None:
-        raise RuntimeError(
+        raise SeedingError(
             f"seeded project {project.name} does not reflect the corpus's aged mtimes "
             f"within {SEEDED_RECENCY_WINDOW}: {mismatch}. The index pass read mtimes "
             "after a rewrite; seed with exactly one index pass after copy_corpus."
@@ -804,12 +819,24 @@ def run_agent_tasks(
             tool_defs = [by_name[name] for name in surface.tool_allowlist]
 
             prepared_groups: dict[str, TaskProject] = {}
+            failed_groups: dict[str, str] = {}
             session_error: str | None = None
             for task in tasks:
                 if session_error is not None:
                     results.append(
                         _errored_result(
                             surface.name, task, f"mcp session terminated: {session_error}"
+                        )
+                    )
+                    continue
+                # Trigger: an earlier task in this group already failed to seed.
+                # Why: the group shares one project, so re-seeding would fail the
+                #   same way (and `project add` would refuse the existing name).
+                # Outcome: the task is errored with the group's reason, no bm calls.
+                if task.group is not None and task.group in failed_groups:
+                    results.append(
+                        _errored_result(
+                            surface.name, task, f"seeding failed: {failed_groups[task.group]}"
                         )
                     )
                     continue
@@ -825,6 +852,19 @@ def run_agent_tasks(
                         settle_timeout_seconds=config.settle_timeout_seconds,
                         prepared_groups=prepared_groups,
                     )
+                except (SeedingError, subprocess.CalledProcessError, TimeoutError) as exc:
+                    # A project that failed to seed (guard, bm command, or settle
+                    # timeout) is a recorded, excluded-from-means task result; the
+                    # rest of the run keeps its spend. IncompatibleCheckoutError is
+                    # deliberately not here: it aborts, because every project
+                    # would fail identically.
+                    reason = str(exc)
+                    if task.group is not None:
+                        failed_groups[task.group] = reason
+                    console.print(f"  [{surface.name}] [red]seeding failed[/red]: {reason}")
+                    results.append(_errored_result(surface.name, task, f"seeding failed: {reason}"))
+                    continue
+                try:
                     result = _run_one_task(
                         surface=surface,
                         task=task,

--- a/benchmarks/tests/agent_tasks/test_driver.py
+++ b/benchmarks/tests/agent_tasks/test_driver.py
@@ -1026,14 +1026,14 @@ def test_recency_mismatch_names_extra_and_missing_files() -> None:
     assert recency_mismatch({"a.md", "c.md"}, {"a.md", "b.md"}) == "extra=['c.md'] missing=['b.md']"
 
 
-def test_seeding_aborts_when_the_index_lost_the_aged_mtimes(
+def test_seeding_records_a_project_that_lost_its_aged_mtimes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Every note reading as recent is a seeding failure, not a task result.
 
     That state produced a plausible 10/12 in run at-1d26c0609808 before it was
-    traced to the seed sequence; the guard turns it into an abort that names
-    the files outside the gold set.
+    traced to the seed sequence. The guard records it against the task, naming
+    the files outside the gold set, and the run keeps the other projects' spend.
     """
     _stub_bm(monkeypatch)
     whole_corpus = json.dumps([{"file_path": relpath} for relpath in corpus_files(CORPUS_DIR)])
@@ -1046,18 +1046,24 @@ def test_seeding_aborts_when_the_index_lost_the_aged_mtimes(
     )
     monkeypatch.chdir(tmp_path)
 
-    with pytest.raises(RuntimeError, match="aged mtimes") as excinfo:
-        run_agent_tasks(
-            _config(tmp_path),
-            model_factory=lambda spec: _orphan_agent(),
-            session_factory=lambda runtime: FakeSession(RICH_SURFACE.tool_allowlist),
-        )
+    run_dir = run_agent_tasks(
+        _config(tmp_path),
+        model_factory=lambda spec: _orphan_agent(),
+        session_factory=lambda runtime: FakeSession(RICH_SURFACE.tool_allowlist),
+    )
 
-    assert "notes/feature-x.md" in str(excinfo.value)
-    assert "missing=[]" in str(excinfo.value)
+    rows = [
+        json.loads(line) for line in (run_dir / "per-task-agent.jsonl").read_text().splitlines()
+    ]
+    assert len(rows) == 1
+    assert rows[0]["passed"] is False
+    assert "seeding failed" in rows[0]["error"]
+    assert "aged mtimes" in rows[0]["error"]
+    assert "notes/feature-x.md" in rows[0]["error"]
+    assert "missing=[]" in rows[0]["error"]
 
 
-def _run_with_bm_stdout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stdout_for: Any) -> None:
+def _run_with_bm_stdout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stdout_for: Any) -> Path:
     _stub_bm(monkeypatch)
     monkeypatch.setattr(
         driver,
@@ -1065,7 +1071,7 @@ def _run_with_bm_stdout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stdout_
         lambda command, **kwargs: SimpleNamespace(stdout=stdout_for(command), stderr=""),
     )
     monkeypatch.chdir(tmp_path)
-    run_agent_tasks(
+    return run_agent_tasks(
         _config(tmp_path),
         model_factory=lambda spec: _orphan_agent(),
         session_factory=lambda runtime: FakeSession(RICH_SURFACE.tool_allowlist),
@@ -1086,16 +1092,64 @@ def test_seeding_rejects_a_checkout_whose_status_has_no_readiness(
         )
 
 
-def test_seeding_aborts_when_the_project_is_not_fully_indexed(
+def test_seeding_records_a_partially_indexed_project_against_its_task(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    with pytest.raises(RuntimeError, match=r"indexed 0 of 25 files \(phase 'never_indexed'\)"):
-        _run_with_bm_stdout(
-            tmp_path,
-            monkeypatch,
-            lambda command: (
-                _seeded_status(indexed=0, files=25, phase="never_indexed")
-                if "status" in command
-                else _bm_stdout(command)
-            ),
-        )
+    run_dir = _run_with_bm_stdout(
+        tmp_path,
+        monkeypatch,
+        lambda command: (
+            _seeded_status(indexed=0, files=25, phase="never_indexed")
+            if "status" in command
+            else _bm_stdout(command)
+        ),
+    )
+
+    rows = [
+        json.loads(line) for line in (run_dir / "per-task-agent.jsonl").read_text().splitlines()
+    ]
+    assert len(rows) == 1
+    assert "seeding failed" in rows[0]["error"]
+    assert "indexed 0 of 25 files (phase 'never_indexed')" in rows[0]["error"]
+
+
+def test_a_grouped_seeding_failure_errors_the_whole_group_and_seeds_it_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One persona whose corpus will not fully index must cost exactly its own
+    questions: every task in that group is errored with the same reason, the
+    group is seeded once (no retry that would hit the existing project name),
+    and the other persona runs normally."""
+    config = _manifest_config(tmp_path)
+    commands, settles = _stub_bm_recording(monkeypatch)
+    monkeypatch.setattr(driver, "snapshot_baseline", _forbid_baseline)
+
+    def failing_dp001_status(command: list[str], **kwargs: Any) -> SimpleNamespace:
+        commands.append(list(command))
+        if "status" in command and command[command.index("status") + 2].endswith("xafs-dp001"):
+            return SimpleNamespace(stdout=_seeded_status(indexed=4, files=5), stderr="")
+        return SimpleNamespace(stdout=_bm_stdout(command), stderr="")
+
+    monkeypatch.setattr(driver, "run_command", failing_dp001_status)
+    monkeypatch.chdir(tmp_path)
+    session = FakeSession(RICH_SURFACE.tool_allowlist)
+
+    run_dir = run_agent_tasks(
+        config,
+        model_factory=lambda spec: _xafs_agent(),
+        session_factory=lambda runtime: session,
+        judge_factory=lambda spec: _StubJudgeRunner(),
+    )
+
+    rows = [
+        json.loads(line) for line in (run_dir / "per-task-agent.jsonl").read_text().splitlines()
+    ]
+    by_group: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        by_group.setdefault(row["group"], []).append(row)
+    assert all("seeding failed" in row["error"] for row in by_group["xafs-dp001"])
+    assert all("indexed 4 of 5 files" in row["error"] for row in by_group["xafs-dp001"])
+    assert all(row["error"] is None for row in by_group["xafs-dp002"])
+    adds = [cmd[cmd.index("add") + 1] for cmd in commands if "project" in cmd and "add" in cmd]
+    assert adds.count("xafs-run-xafs-dp001") == 1
+    assert adds.count("xafs-run-xafs-dp002") == 1


### PR DESCRIPTION
## Summary

The seed guards from #1448 raised `RuntimeError`, which the task loop treats as a harness bug and re-raises. The first full xAFS run hit one persona whose corpus had a file the indexer silently dropped (#1451). The abort discarded the 27 tasks already completed and paid for on the other four personas, and no artifacts were written.

## Change

- `SeedingError` for a project that fails to seed (index-count guard, recency guard, a failing `bm` command, or a settle timeout). It is recorded against every task that would have used the project as `seeding failed: …`, excluded from means like any errored task, and the run continues.
- A grouped corpus is seeded once: later tasks in a failed group are errored with the group's reason without another `project add`, which would refuse the existing name anyway.
- `IncompatibleCheckoutError` (a `bm status --json` with no readiness at all, a pre-#1414 checkout) still aborts, since every project would fail identically and the run would spend nothing useful.

## Tests

The two abort tests become record-and-continue tests asserting the `per-task-agent.jsonl` row; a grouped test fails one persona's index count and asserts the whole group is errored with that reason, seeded exactly once, while the other persona runs normally.

Part of #1398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp