### PR TITLE
fix(core): index markdown whose leading fences are not YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,12 +79,13 @@
 
 ### Fixes
 
-- **#1451**: A markdown file whose leading `---` block is not YAML (a letterhead between
+- **#1451**: A markdown file whose leading `---` block is not a YAML mapping (a letterhead between
   horizontal rules) is now indexed as plain markdown instead of being dropped. The parser
   already treated such a block as body; the indexer separately saw fences, tried to write
   a permalink into them, hit the "refusing to update malformed frontmatter" guard, and
   excluded the file while readiness reported idle. The guard stands: the file is never
-  rewritten. Frontmatter is now classified once, by the parser, as present, absent, or
+  rewritten, and `remove_frontmatter` no longer strips such a block from search content.
+  Frontmatter is now classified once, by the parser, as present, absent, or
   malformed, and only the first two are ever written to.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,17 @@
   relations it declares. Rows already lost to the old behavior stay lost; re-index
   the affected notes to bring them back as unresolved.
 
+### Fixes
+
+- **#1451**: A markdown file whose leading `---` block is not YAML (a letterhead between
+  horizontal rules) is now indexed as plain markdown instead of being dropped. The parser
+  already treated such a block as body; the indexer separately saw fences, tried to write
+  a permalink into them, hit the "refusing to update malformed frontmatter" guard, and
+  excluded the file while readiness reported idle. The guard stands: the file is never
+  rewritten. Frontmatter is now classified once, by the parser, as present, absent, or
+  malformed, and only the first two are ever written to.
+
+
 ## v0.23.2 (2026-08-25)
 
 Patch release fixing case-duplicate folder creation.

--- a/src/basic_memory/file_utils.py
+++ b/src/basic_memory/file_utils.py
@@ -480,23 +480,36 @@ def remove_frontmatter(content: str, *, strip: bool = True) -> str:
             reflow the note body (issue #1090 review).
 
     Returns:
-        Content with frontmatter removed, or original content if no frontmatter
+        Content with frontmatter removed, or the original content when there is
+        no frontmatter: no fences, or a fenced block that is not a YAML mapping.
 
     Raises:
-        ParseError: If content starts with frontmatter marker but is malformed
+        ParseError: If content opens with a fence that is never closed
     """
     # Strip BOM before processing
     content = strip_bom(content)
-
     split = _split_frontmatter(content)
-    # Trigger: content does not open with a line-anchored fence
-    # Why: inline `---` is ordinary content, not frontmatter (issue #972)
+    # Trigger: content does not open with a line-anchored fence, or the fenced
+    #   block is not a YAML mapping (a letterhead between horizontal rules, a
+    #   bare scalar, a list).
+    # Why: inline `---` is ordinary content, not frontmatter (issue #972), and a
+    #   fenced block that no frontmatter parser would accept is body text; the
+    #   indexer treats it that way and search must not strip it (#1451).
     # Outcome: return the content untouched (stripped to preserve prior behavior)
-    if split is None:
+    if split is None or not _is_frontmatter_mapping(split[0]):
         return content.strip() if strip else content
-
     _, body = split
     return body.strip() if strip else body
+
+
+def _is_frontmatter_mapping(yaml_block: str) -> bool:
+    """Whether a fenced block is what every frontmatter reader here accepts: a YAML
+    mapping, or empty. The same rule `parse_frontmatter` enforces by raising."""
+    try:
+        loaded = yaml.safe_load(yaml_block)
+    except yaml.YAMLError:
+        return False
+    return loaded is None or isinstance(loaded, dict)
 
 
 def dump_frontmatter(post: frontmatter.Post) -> str:

--- a/src/basic_memory/indexing/batch_indexer.py
+++ b/src/basic_memory/indexing/batch_indexer.py
@@ -19,10 +19,9 @@ from basic_memory.config import BasicMemoryConfig
 from basic_memory.file_utils import (
     ParseError,
     compute_checksum,
-    has_frontmatter,
     remove_frontmatter,
 )
-from basic_memory.markdown.schemas import EntityMarkdown
+from basic_memory.markdown.schemas import FrontmatterState, EntityMarkdown
 from basic_memory.indexing.models import (
     IndexEntitySearchWriter,
     IndexedEntity,
@@ -116,7 +115,7 @@ class _PreparedMarkdownFile:
     content: str
     final_checksum: str
     markdown: EntityMarkdown
-    file_contains_frontmatter: bool
+    frontmatter_state: FrontmatterState
 
 
 @dataclass(slots=True)
@@ -372,7 +371,6 @@ class BatchIndexer:
             raise ValueError(f"Missing content for markdown file: {file.path}")
 
         content = file.content.decode("utf-8")
-        file_contains_frontmatter = has_frontmatter(content)
         final_checksum = await self._resolve_checksum(file)
         entity_markdown = await self.entity_service.entity_parser.parse_markdown_content(
             file_path=Path(file.path),
@@ -386,7 +384,9 @@ class BatchIndexer:
             content=content,
             final_checksum=final_checksum,
             markdown=entity_markdown,
-            file_contains_frontmatter=file_contains_frontmatter,
+            # The parser's classification, not a fence check: a fenced block that is
+            # not YAML must be indexed without ever being rewritten (#1451).
+            frontmatter_state=entity_markdown.frontmatter_state,
         )
 
     async def _normalize_markdown_batch(
@@ -436,7 +436,9 @@ class BatchIndexer:
         # Trigger: markdown file has no frontmatter and sync enforcement is enabled.
         # Why: downstream indexing relies on normalized metadata and stable permalinks.
         # Outcome: write derived metadata back through the storage-agnostic writer.
-        if not prepared.file_contains_frontmatter and self.app_config.ensure_frontmatter_on_sync:
+        #   A "malformed" file matches neither branch: its fenced block is not YAML,
+        #   so no rewrite can know which bytes were metadata; it is indexed as-is.
+        if prepared.frontmatter_state == "absent" and self.app_config.ensure_frontmatter_on_sync:
             frontmatter_updates = {
                 "title": prepared.markdown.frontmatter.title,
                 "type": prepared.markdown.frontmatter.type,
@@ -453,7 +455,7 @@ class BatchIndexer:
         # Why: batch sync keeps permalinks stable without forcing a full rewrite when unchanged.
         # Outcome: only the permalink field is updated when it actually differs.
         elif (
-            prepared.file_contains_frontmatter
+            prepared.frontmatter_state == "present"
             and not self.app_config.disable_permalinks
             and final_permalink != prepared.markdown.frontmatter.permalink
         ):
@@ -472,7 +474,7 @@ class BatchIndexer:
             content=final_content,
             final_checksum=final_checksum,
             markdown=prepared.markdown,
-            file_contains_frontmatter=prepared.file_contains_frontmatter,
+            frontmatter_state=prepared.frontmatter_state,
         )
 
     async def _resolve_batch_permalink(
@@ -481,8 +483,8 @@ class BatchIndexer:
         reserved_permalinks: set[str],
     ) -> str | None:
         should_resolve_permalink = (
-            not prepared.file_contains_frontmatter and self.app_config.ensure_frontmatter_on_sync
-        ) or (prepared.file_contains_frontmatter and not self.app_config.disable_permalinks)
+            prepared.frontmatter_state == "absent" and self.app_config.ensure_frontmatter_on_sync
+        ) or (prepared.frontmatter_state == "present" and not self.app_config.disable_permalinks)
         if not should_resolve_permalink:
             permalink = prepared.markdown.frontmatter.permalink
             if permalink:
@@ -1054,12 +1056,14 @@ class BatchIndexer:
         #          to leave frontmatterless files alone.
         # Why: upsert may still assign a DB permalink even when disk content should stay untouched.
         # Outcome: skip reconciliation writes that would silently inject frontmatter.
+        rewrite_allowed = (
+            self.app_config.ensure_frontmatter_on_sync
+            if prepared.frontmatter_state == "absent"
+            else prepared.frontmatter_state == "present"
+        )
         if (
             self.app_config.disable_permalinks
-            or (
-                not prepared.file_contains_frontmatter
-                and not self.app_config.ensure_frontmatter_on_sync
-            )
+            or not rewrite_allowed
             or entity.permalink is None
             or entity.permalink == prepared.markdown.frontmatter.permalink
         ):
@@ -1083,7 +1087,7 @@ class BatchIndexer:
             content=write_result.content,
             final_checksum=write_result.checksum,
             markdown=prepared.markdown,
-            file_contains_frontmatter=prepared.file_contains_frontmatter,
+            frontmatter_state=prepared.frontmatter_state,
         )
 
     async def _build_prepared_entity(

--- a/src/basic_memory/markdown/entity_parser.py
+++ b/src/basic_memory/markdown/entity_parser.py
@@ -18,6 +18,7 @@ from basic_memory.markdown.plugins import observation_plugin, relation_plugin
 from basic_memory.markdown.schemas import (
     EntityFrontmatter,
     EntityMarkdown,
+    FrontmatterState,
     Observation,
     Relation,
 )
@@ -273,7 +274,7 @@ class EntityParser:
         """
         # Strip BOM before parsing (can be present in files from Windows or certain sources)
         # See issue #452
-        from basic_memory.file_utils import strip_bom
+        from basic_memory.file_utils import has_frontmatter, strip_bom
 
         content = strip_bom(content)
 
@@ -286,6 +287,7 @@ class EntityParser:
         # loads() does Post(content, handler, **metadata), which crashes when
         # the YAML contains reserved keys like 'content' or 'handler'.
         # See basic-memory-cloud#375.
+        frontmatter_state: FrontmatterState = "present" if has_frontmatter(content) else "absent"
         try:
             fm_metadata, fm_content = frontmatter.parse(content)
             post = frontmatter.Post(fm_content)
@@ -298,6 +300,7 @@ class EntityParser:
             # Use Post(content) not Post(content, metadata={})
             # The latter creates {"metadata": {}} in the metadata dict (issue #528)
             post = frontmatter.Post(content)
+            frontmatter_state = "malformed"
 
         # Normalize frontmatter values
         metadata = normalize_frontmatter_metadata(post.metadata)
@@ -379,6 +382,7 @@ class EntityParser:
 
         return EntityMarkdown(
             frontmatter=entity_frontmatter,
+            frontmatter_state=frontmatter_state,
             content=post.content,
             observations=entity_content.observations,
             relations=entity_content.relations,

--- a/src/basic_memory/markdown/entity_parser.py
+++ b/src/basic_memory/markdown/entity_parser.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 import dateparser
 import frontmatter
-import yaml
 from loguru import logger
 from markdown_it import MarkdownIt
 
@@ -274,7 +273,12 @@ class EntityParser:
         """
         # Strip BOM before parsing (can be present in files from Windows or certain sources)
         # See issue #452
-        from basic_memory.file_utils import has_frontmatter, strip_bom
+        from basic_memory.file_utils import (
+            ParseError,
+            has_frontmatter,
+            parse_frontmatter,
+            strip_bom,
+        )
 
         content = strip_bom(content)
 
@@ -287,20 +291,29 @@ class EntityParser:
         # loads() does Post(content, handler, **metadata), which crashes when
         # the YAML contains reserved keys like 'content' or 'handler'.
         # See basic-memory-cloud#375.
-        frontmatter_state: FrontmatterState = "present" if has_frontmatter(content) else "absent"
-        try:
+        # Classify before splitting. python-frontmatter strips a fenced block that
+        # is valid YAML but not a mapping (a bare scalar, a list) as if it were
+        # metadata, silently discarding its text; parse_frontmatter applies the
+        # rule every writer here enforces, so a block it rejects is body (#1451).
+        frontmatter_state: FrontmatterState = "absent"
+        if has_frontmatter(content):
+            try:
+                parse_frontmatter(content)
+                frontmatter_state = "present"
+            except ParseError as e:
+                logger.warning(
+                    f"Failed to parse YAML frontmatter in {file_path}: {e}. "
+                    f"Treating file as plain markdown without frontmatter."
+                )
+                frontmatter_state = "malformed"
+        if frontmatter_state == "present":
             fm_metadata, fm_content = frontmatter.parse(content)
             post = frontmatter.Post(fm_content)
             post.metadata.update(fm_metadata)
-        except yaml.YAMLError as e:
-            logger.warning(
-                f"Failed to parse YAML frontmatter in {file_path}: {e}. "
-                f"Treating file as plain markdown without frontmatter."
-            )
+        else:
             # Use Post(content) not Post(content, metadata={})
             # The latter creates {"metadata": {}} in the metadata dict (issue #528)
             post = frontmatter.Post(content)
-            frontmatter_state = "malformed"
 
         # Normalize frontmatter values
         metadata = normalize_frontmatter_metadata(post.metadata)

--- a/src/basic_memory/markdown/schemas.py
+++ b/src/basic_memory/markdown/schemas.py
@@ -1,7 +1,7 @@
 """Schema models for entity markdown files."""
 
 from datetime import datetime
-from typing import override, TYPE_CHECKING, Any, List, Optional
+from typing import Literal, override, TYPE_CHECKING, Any, List, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -99,10 +99,21 @@ class EntityFrontmatter(BaseModel):
         return permalink if isinstance(permalink, str) else None
 
 
+# What the parser found at the top of the file. "present" is a fenced block
+# that parsed as YAML and can be rewritten field by field; "absent" means no
+# fences, so frontmatter may be injected; "malformed" is a fenced block that is
+# not YAML (a letterhead between horizontal rules, a broken document). The
+# indexer must never rewrite a malformed block, because it cannot know which
+# bytes the author meant as metadata, and must still index the file (#1451).
+type FrontmatterState = Literal["present", "absent", "malformed"]
+
+
 class EntityMarkdown(BaseModel):
     """Complete entity combining frontmatter, content, and metadata."""
 
     frontmatter: EntityFrontmatter
+    # The parser always sets this; the default only serves hand-built values.
+    frontmatter_state: FrontmatterState = "present"
     content: Optional[str] = None
     observations: List[Observation] = []
     relations: List[Relation] = []

--- a/tests/indexing/test_batch_indexer.py
+++ b/tests/indexing/test_batch_indexer.py
@@ -796,7 +796,7 @@ async def test_batch_indexer_uses_parsed_markdown_body_for_malformed_frontmatter
 
 
 @pytest.mark.asyncio
-async def test_batch_indexer_reports_malformed_yaml_without_rewriting_source(
+async def test_batch_indexer_indexes_malformed_yaml_without_rewriting_source(
     app_config,
     entity_service,
     entity_repository,
@@ -835,16 +835,74 @@ async def test_batch_indexer_reports_malformed_yaml_without_rewriting_source(
         parse_max_concurrent=1,
     )
 
-    assert result.indexed == []
-    assert len(result.errors) == 1
-    error_path, error = result.errors[0]
-    assert error_path == path
-    assert "Refusing to update malformed frontmatter" in error
+    # The source stays byte-identical: a fenced block that is not YAML cannot be
+    # rewritten field by field. Before #1451 the indexer also dropped the file
+    # ("Refusing to update malformed frontmatter"), so the note was invisible to
+    # every retrieval tool while readiness reported idle.
+    assert result.errors == []
+    assert len(result.indexed) == 1
     assert (project_config.home / path).read_text(encoding="utf-8") == original_content
-
     async with db.scoped_session(search_service.session_maker) as session:
         entity = await entity_repository.get_by_file_path(session, path)
-    assert entity is None
+    assert entity is not None
+    indexed_content = result.indexed[0].markdown_content
+    assert indexed_content is not None
+    assert "The source file must remain authoritative." in indexed_content
+
+
+@pytest.mark.asyncio
+async def test_batch_indexer_indexes_a_letterhead_between_rules_as_body(
+    app_config,
+    entity_service,
+    entity_repository,
+    relation_repository,
+    search_service,
+    file_service,
+    project_config,
+):
+    """A letter that opens with a horizontal-rule-delimited letterhead has fences
+    but no YAML (`**Bold**` reads as an alias). With permalinks and frontmatter
+    enforcement on, the default configuration, the file must be indexed as-is
+    and never rewritten (#1451, found by the xAFS eval's seed guard)."""
+    path = "pleadings/demand-letter.md"
+    original_content = dedent(
+        """\
+        ---
+        **OSTROWSKI LEGAL PLLC**
+        Carmen Ostrowski, Esq.
+        280 Garfield Place, Brooklyn NY 11215
+        ---
+
+        February 19, 2026
+
+        Re: Demand for repair costs, HIC #0892461.
+        """
+    )
+    await _create_file(project_config.home / path, original_content)
+    batch_indexer = _make_batch_indexer(
+        app_config,
+        entity_service,
+        entity_repository,
+        relation_repository,
+        search_service,
+        file_service,
+    )
+    result = await batch_indexer.index_files(
+        {path: await _load_input(file_service, path)},
+        max_concurrent=1,
+        parse_max_concurrent=1,
+    )
+
+    assert result.errors == []
+    assert len(result.indexed) == 1
+    assert (project_config.home / path).read_text(encoding="utf-8") == original_content
+    async with db.scoped_session(search_service.session_maker) as session:
+        entity = await entity_repository.get_by_file_path(session, path)
+    assert entity is not None
+    assert entity.title == "demand-letter"
+    indexed_content = result.indexed[0].markdown_content
+    assert indexed_content is not None
+    assert "HIC #0892461" in indexed_content
 
 
 @pytest.mark.asyncio

--- a/tests/indexing/test_batch_indexer.py
+++ b/tests/indexing/test_batch_indexer.py
@@ -906,6 +906,65 @@ async def test_batch_indexer_indexes_a_letterhead_between_rules_as_body(
 
 
 @pytest.mark.asyncio
+async def test_batch_indexer_keeps_a_scalar_preamble_in_search_content(
+    app_config,
+    entity_service,
+    entity_repository,
+    relation_repository,
+    search_service,
+    file_service,
+    project_config,
+    monkeypatch,
+):
+    """`---\nACME LEGAL PLLC\n---` is valid YAML but not a mapping. It must be indexed
+    (the writer would refuse it as "must be a YAML dictionary"), and its text must
+    reach the search row on the initial write and survive the deferred refresh,
+    which strips frontmatter through the same `remove_frontmatter` (#1451)."""
+    path = "pleadings/letter.md"
+    original_content = "---\nACME LEGAL PLLC\n123 Main St\n---\n\nDear counsel, HIC #0892461.\n"
+    await _create_file(project_config.home / path, original_content)
+    index_entity_data = AsyncMock()
+    monkeypatch.setattr(search_service, "index_entity_data", index_entity_data)
+    batch_indexer = _make_batch_indexer(
+        app_config,
+        entity_service,
+        entity_repository,
+        relation_repository,
+        search_service,
+        file_service,
+    )
+
+    result = await batch_indexer.index_files(
+        {path: await _load_input(file_service, path)},
+        max_concurrent=1,
+        parse_max_concurrent=1,
+    )
+    await _claim_and_publish_relations(
+        batch_indexer,
+        result,
+        entity_repository=entity_repository,
+        relation_repository=relation_repository,
+        session_maker=search_service.session_maker,
+        max_concurrent=1,
+    )
+
+    assert result.errors == []
+    assert (project_config.home / path).read_text(encoding="utf-8") == original_content
+    # The initial write and the deferred refresh both pass explicit content; the
+    # relation-generation step passes None and lets the writer read the stored
+    # body. Every explicit content must still carry the preamble.
+    contents = [
+        call.kwargs["content"]
+        for call in index_entity_data.await_args_list
+        if call.kwargs["content"] is not None
+    ]
+    assert len(contents) >= 2
+    for content in contents:
+        assert "ACME LEGAL PLLC" in content
+        assert "HIC #0892461" in content
+
+
+@pytest.mark.asyncio
 async def test_batch_indexer_re_raises_fatal_sync_errors(
     app_config,
     entity_service,

--- a/tests/markdown/test_entity_parser_error_handling.py
+++ b/tests/markdown/test_entity_parser_error_handling.py
@@ -424,3 +424,21 @@ async def test_schema_to_markdown_empty_metadata_no_metadata_key():
     assert "title: Empty Metadata Test" in output
     assert "type: note" in output
     assert "permalink: empty-metadata-test" in output
+
+
+@pytest.mark.asyncio
+async def test_parse_file_with_a_scalar_preamble_keeps_it_as_body(tmp_path):
+    """`---\nACME LEGAL PLLC\n---` is valid YAML but not a mapping. python-frontmatter
+    would strip it silently; the parser must classify it malformed and keep the
+    text in the body, or a letterhead vanishes from every read (#1451)."""
+    test_file = tmp_path / "letter.md"
+    test_file.write_text("---\nACME LEGAL PLLC\n---\n\nDear counsel, HIC #0892461.\n")
+
+    parser = EntityParser(tmp_path)
+    result = await parser.parse_file(test_file)
+
+    assert result.frontmatter_state == "malformed"
+    assert result.frontmatter.title == "letter"
+    assert result.content is not None
+    assert "ACME LEGAL PLLC" in result.content
+    assert "HIC #0892461" in result.content

--- a/tests/markdown/test_entity_parser_error_handling.py
+++ b/tests/markdown/test_entity_parser_error_handling.py
@@ -69,6 +69,7 @@ async def test_parse_file_with_completely_invalid_yaml(tmp_path):
     # Parse the file - should not raise exception
     parser = EntityParser(tmp_path)
     result = await parser.parse_file(test_file)
+    assert result.frontmatter_state == "malformed"
 
     # Should successfully parse with defaults
     assert result is not None
@@ -152,6 +153,7 @@ async def test_parse_file_without_frontmatter(tmp_path):
     # Parse the file
     parser = EntityParser(tmp_path)
     result = await parser.parse_file(test_file)
+    assert result.frontmatter_state == "absent"
 
     # Should have defaults
     assert result is not None
@@ -287,6 +289,7 @@ async def test_parse_valid_file_still_works(tmp_path):
     # Parse the file
     parser = EntityParser(tmp_path)
     result = await parser.parse_file(test_file)
+    assert result.frontmatter_state == "present"
 
     # Should parse correctly with all values
     assert result is not None

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -720,3 +720,18 @@ async def test_format_file_handles_a_path_containing_a_quote(tmp_path: Path):
     result = await format_file(test_file, config)
 
     assert result == original_content
+
+
+def test_remove_frontmatter_keeps_a_fenced_block_that_is_not_a_yaml_mapping():
+    """A letterhead between horizontal rules, a bare scalar, or a list is body, not
+    frontmatter; no frontmatter reader accepts it, so search must not lose it (#1451)."""
+    letterhead = "---\n**ACME LEGAL PLLC**\n123 Main St\n---\n\nDear counsel,\n"
+    scalar = "---\nACME LEGAL PLLC\n---\n\nDear counsel,\n"
+    listing = "---\n- one\n- two\n---\n\nDear counsel,\n"
+
+    assert remove_frontmatter(letterhead) == letterhead.strip()
+    assert remove_frontmatter(scalar) == scalar.strip()
+    assert remove_frontmatter(listing) == listing.strip()
+    assert remove_frontmatter(scalar, strip=False) == scalar
+    # An empty block is still frontmatter: every reader accepts it as {}.
+    assert remove_frontmatter("---\n---\n\nbody\n") == "body"


### PR DESCRIPTION
## Summary

Closes #1451. A markdown file that opens with a `---` block that is not YAML (a letterhead between horizontal rules) was never indexed: invisible to search, `read_note`, `cat`, and `grep`, while readiness settled to `idle`. Found by the xAFS eval's seed guard on a persona's gold source file.

## Mechanism

Two definitions of "has frontmatter" disagreed. The parser catches the `yaml.YAMLError` and treats the file as plain markdown. The batch indexer separately ran a fence check, took the "existing frontmatter, update its permalink" branch, and the file service refused ("Refusing to update malformed frontmatter"), which excluded the file from the upsert.

## Change

- `EntityMarkdown.frontmatter_state: "present" | "absent" | "malformed"`, set by the parser in the one place that already decides.
- The indexer's write decisions key on that state: present gets its permalink updated, absent gets frontmatter injected (when `ensure_frontmatter_on_sync`), malformed gets no write at all and is indexed as-is. Same rule on the post-upsert permalink-conflict path.
- The file service's refusal is unchanged. Markdown stays authoritative; a block we cannot parse is never rewritten.

## Consequence

A malformed-frontmatter note is now searchable and readable but carries no permalink. `move_note` writes a permalink on move, so moving such a note fails cleanly with the same refusal and rolls the physical move back. Fixing the file's head, or moving it on disk, resolves it.

## Tests

- `test_batch_indexer_reports_malformed_yaml_without_rewriting_source` becomes `…indexes_malformed_yaml_without_rewriting_source`: file byte-identical, entity present, no errors.
- New: a letterhead between rules under the default configuration is indexed with its body content and the file untouched.
- Parser tests assert the three states.

Static checks clean; `tests/indexing`, `tests/markdown`, `tests/services/test_entity_service_prepare.py`, `tests/utils/test_file_utils.py` pass locally (399). Full matrix in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp