### PR TITLE
fix(mcp): stop a same-named note from being read as its own project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@
 
 ### Bug Fixes
 
+- **#1458**: A note whose file stem equals its project's name is now readable by its bare
+  identifier. `split_project_permalink_prefix` matches a leading path segment against a
+  project's permalink via `generate_permalink`, which drops file extensions -- so a single
+  segment like `moby-dick.txt` in project `moby-dick` collapsed to the project's own
+  permalink with an empty remainder, and `cat`/`find` refused it as "names a project, not a
+  note" instead of resolving the note. A prefix claim that would leave no remainder now
+  requires the raw segment to spell the permalink exactly, extension included; a claim that
+  still has a remainder after it is unaffected, since project names never carry a real
+  extension in that position.
+
 - **#1437**: An observation and a relation can no longer collide in the search index.
   A relation's permalink is `from/type/to` with the type authored by the user, so a
   note that says `- [decision] redis` and `- observations [[decision/redis]]` gives

--- a/src/basic_memory/mcp/project_context.py
+++ b/src/basic_memory/mcp/project_context.py
@@ -339,8 +339,13 @@ async def _resolve_workspace_route(
     #   carries the identity needed to distinguish the real project case.
     # Outcome: retain the exact display-name route to that project root, while
     #   every non-exact spelling continues through the note-safe parser.
+    normalized_rest = generate_permalink(rest, split_extension=False)
     exact_entry = next(
-        (entry for entry in entries_by_permalink.values() if entry.project.name == rest),
+        (
+            entry
+            for entry in entries_by_permalink.values()
+            if generate_permalink(entry.project.name, split_extension=False) == normalized_rest
+        ),
         None,
     )
     claimed = (
@@ -1453,7 +1458,15 @@ def _claim_mount_prefix(
     #   extension-free permalink.
     # Outcome: retain the established exact-name route to that project root;
     #   non-exact names continue through the note-safe permalink matcher.
-    exact = next((project for project in projects if project.name == candidate), None)
+    normalized_candidate = generate_permalink(candidate, split_extension=False)
+    exact = next(
+        (
+            project
+            for project in projects
+            if generate_permalink(project.name, split_extension=False) == normalized_candidate
+        ),
+        None,
+    )
     if exact is not None:
         return exact, ""
 
@@ -1699,7 +1712,21 @@ async def resolve_project_path_route(
     # Outcome: cat("acme/docs/foo", project="acme/docs") reads 'foo', and a path
     #   from a routed ls("acme/docs") round-trips with the project param set.
     if detected is None and explicit is not None:
-        explicit_claim = _split_project_permalink_prefix(candidate, (generate_permalink(explicit),))
+        # Trigger: the candidate is exactly the explicit display-name spelling,
+        #   normalized without discarding its extension.
+        # Why: the permalink parser must preserve a terminal extension to keep a
+        #   same-named note from becoming a root claim, while the explicit
+        #   project supplies the identity that makes this root unambiguous.
+        # Outcome: project="team/docs.txt" plus path="team/docs.txt" names that
+        #   root; a relative "docs.txt" still remains a note inside it.
+        explicit_root = generate_permalink(candidate, split_extension=False) == generate_permalink(
+            explicit, split_extension=False
+        )
+        explicit_claim = (
+            (generate_permalink(explicit), "")
+            if explicit_root
+            else _split_project_permalink_prefix(candidate, (generate_permalink(explicit),))
+        )
         if explicit_claim is not None:
             detected, remainder = explicit, explicit_claim[1]
 

--- a/src/basic_memory/mcp/project_context.py
+++ b/src/basic_memory/mcp/project_context.py
@@ -1425,10 +1425,22 @@ def _claim_mount_prefix(
 ) -> tuple[AddressableProject, str] | None:
     """Return the mount whose permalink claims the candidate's leading segments.
 
-    The mount table is one candidate set among several, so the matching itself
-    lives in ``split_project_permalink_prefix``; this only maps the winning
-    permalink back to the project that owns it.
+    The mount table is one candidate set among several, so permalink matching
+    lives in ``split_project_permalink_prefix``. The table also preserves the
+    exact display name, which is the only evidence that distinguishes a project
+    literally named ``docs.txt`` from a note named ``docs.txt`` in project
+    ``docs``.
     """
+    # Trigger: the whole candidate exactly spells an addressable display name.
+    # Why: generic permalink parsing cannot distinguish an extension-bearing
+    #   project name from a same-named note because both normalize to the same
+    #   extension-free permalink.
+    # Outcome: retain the established exact-name route to that project root;
+    #   non-exact names continue through the note-safe permalink matcher.
+    exact = next((project for project in projects if project.name == candidate), None)
+    if exact is not None:
+        return exact, ""
+
     # Two addressable projects can share a permalink ('My Docs' beside
     # 'my-docs'). add_project refuses that now, so only a config written before
     # the check, or edited by hand, still holds one. Record the pair rather than

--- a/src/basic_memory/mcp/project_context.py
+++ b/src/basic_memory/mcp/project_context.py
@@ -331,7 +331,23 @@ async def _resolve_workspace_route(
                 f"Matches: {details}"
             )
 
-    claimed = _split_project_permalink_prefix(rest, entries_by_permalink)
+    # Trigger: the whole project half exactly spells a display name whose
+    #   extension is absent from its stored permalink (for example `docs.txt`
+    #   and `docs`).
+    # Why: the permalink-only parser must preserve that extension to keep a
+    #   same-named note from becoming a project-root claim; this workspace set
+    #   carries the identity needed to distinguish the real project case.
+    # Outcome: retain the exact display-name route to that project root, while
+    #   every non-exact spelling continues through the note-safe parser.
+    exact_entry = next(
+        (entry for entry in entries_by_permalink.values() if entry.project.name == rest),
+        None,
+    )
+    claimed = (
+        (exact_entry.project.permalink, "")
+        if exact_entry is not None
+        else _split_project_permalink_prefix(rest, entries_by_permalink)
+    )
     if claimed is None:
         if any(
             failed_workspace.tenant_id == workspace.tenant_id

--- a/src/basic_memory/mcp/project_context.py
+++ b/src/basic_memory/mcp/project_context.py
@@ -1458,15 +1458,15 @@ def _claim_mount_prefix(
     #   extension-free permalink.
     # Outcome: retain the established exact-name route to that project root;
     #   non-exact names continue through the note-safe permalink matcher.
-    normalized_candidate = generate_permalink(candidate, split_extension=False)
-    exact = next(
-        (
+    exact = next((project for project in projects if project.name == candidate), None)
+    if exact is None:
+        normalized_candidate = generate_permalink(candidate, split_extension=False)
+        normalized_matches = [
             project
             for project in projects
             if generate_permalink(project.name, split_extension=False) == normalized_candidate
-        ),
-        None,
-    )
+        ]
+        exact = normalized_matches[0] if len(normalized_matches) == 1 else None
     if exact is not None:
         return exact, ""
 

--- a/src/basic_memory/mcp/project_context_identifiers.py
+++ b/src/basic_memory/mcp/project_context_identifiers.py
@@ -121,6 +121,16 @@ def split_project_permalink_prefix(
     right when one project's permalink prefixes another's ('research' beside
     'research/2026'). Returns None when no permalink claims the leading
     segments; the remainder has no leading slash and is "" at the root.
+
+    A claim that would leave no remainder must spell the permalink exactly,
+    extension included. Dropping an extension only when a match would swallow
+    the whole path stops a same-named note ('moby-dick.txt' in project
+    'moby-dick') from being misread as the project itself with nothing after
+    it — the project's own name never has a real extension, so this costs
+    nothing when the leading segments genuinely are the bare project name,
+    and is exactly the case where extension-stripping ordinarily helps: a
+    remainder still follows, so what the leading segments spell before their
+    own extension is irrelevant (#1458).
     """
     segments = normalize_project_reference(identifier_path(path)).strip("/").split("/")
     # An empty interior segment ('a//b') names nothing. Matching around it would
@@ -134,7 +144,9 @@ def split_project_permalink_prefix(
         depth = permalink.count("/") + 1
         if depth > len(segments) or depth <= claimed_depth:
             continue
-        if generate_permalink("/".join(segments[:depth])) != permalink:
+        leaves_no_remainder = depth == len(segments)
+        prefix = "/".join(segments[:depth])
+        if generate_permalink(prefix, split_extension=not leaves_no_remainder) != permalink:
             continue
         claimed = (permalink, "/".join(segments[depth:]))
         claimed_depth = depth

--- a/src/basic_memory/mcp/project_context_identifiers.py
+++ b/src/basic_memory/mcp/project_context_identifiers.py
@@ -126,11 +126,10 @@ def split_project_permalink_prefix(
     extension included. Dropping an extension only when a match would swallow
     the whole path stops a same-named note ('moby-dick.txt' in project
     'moby-dick') from being misread as the project itself with nothing after
-    it — the project's own name never has a real extension, so this costs
-    nothing when the leading segments genuinely are the bare project name,
-    and is exactly the case where extension-stripping ordinarily helps: a
-    remainder still follows, so what the leading segments spell before their
-    own extension is irrelevant (#1458).
+    it. Callers that also know project display names may recover an exact-name
+    project-root match before calling this permalink-only parser; a remainder
+    still permits extension stripping because the leading segments
+    unambiguously form a prefix (#1458).
     """
     segments = normalize_project_reference(identifier_path(path)).strip("/").split("/")
     # An empty interior segment ('a//b') names nothing. Matching around it would

--- a/tests/mcp/test_project_path_routing.py
+++ b/tests/mcp/test_project_path_routing.py
@@ -325,6 +325,22 @@ async def test_agreeing_prefix_strips_with_explicit_project(multi_project_config
 
 
 @pytest.mark.asyncio
+async def test_same_named_note_is_not_read_as_its_own_project(multi_project_config):
+    """A note whose file stem equals its project's name resolves as a
+    project-relative path, not as a prefix claim with an empty remainder
+    (#1458). Without the fix, rule 3b's extension-stripping match claims
+    'second-project.txt' as the project itself, leaving 'cat' unable to tell
+    it apart from a bare project-root reference."""
+    route = await resolve_project_path_route(
+        "second-project.txt", project="second-project", project_id=None
+    )
+
+    assert route == ProjectPathRoute(
+        project="second-project", path="second-project.txt", stripped=False
+    )
+
+
+@pytest.mark.asyncio
 async def test_conflicting_prefix_raises_naming_both(multi_project_config):
     """The conflict message names both projects and offers both spellings."""
     with pytest.raises(ProjectPrefixConflictError) as excinfo:
@@ -364,6 +380,25 @@ def test_split_project_permalink_prefix_matches_whole_permalinks_longest_first()
         "my-research",
         "notes",
     )
+
+
+def test_split_project_permalink_prefix_does_not_swallow_a_same_named_note():
+    """A note whose file stem equals its project's name must not be misread as
+    the project itself with no remainder (#1458). Extension-stripping is only
+    safe when a remainder still follows the claimed segments; a match that
+    would leave nothing after it must spell the permalink exactly, extension
+    included, or it is a note living at the project's root, not the project."""
+    permalinks = ["moby-dick"]
+
+    assert split_project_permalink_prefix("moby-dick.txt", permalinks) is None
+    # A real path under the project still strips the extension-free segment.
+    assert split_project_permalink_prefix("moby-dick/moby-dick.txt", permalinks) == (
+        "moby-dick",
+        "moby-dick.txt",
+    )
+    # The bare project name (no extension to mistakenly drop) still claims the
+    # whole path with an empty remainder.
+    assert split_project_permalink_prefix("moby-dick", permalinks) == ("moby-dick", "")
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_project_path_routing.py
+++ b/tests/mcp/test_project_path_routing.py
@@ -295,6 +295,21 @@ async def test_colliding_mounts_only_fail_the_paths_that_name_them(
 
 
 @pytest.mark.asyncio
+async def test_colliding_mount_exact_root_prefers_raw_display_name(
+    config_manager, tmp_path_factory
+):
+    """An exact raw name remains the root escape hatch when normalized names collide."""
+    config = config_manager.load_config()
+    config.projects["My Docs"] = ProjectEntry(path=str(tmp_path_factory.mktemp("root-dup-a")))
+    config.projects["my-docs"] = ProjectEntry(path=str(tmp_path_factory.mktemp("root-dup-b")))
+    config_manager.save_config(config)
+
+    route = await resolve_project_path_route("my-docs", project=None, project_id=None)
+
+    assert route == ProjectPathRoute(project="my-docs", path="", stripped=True)
+
+
+@pytest.mark.asyncio
 async def test_sibling_slash_bearing_project_conflicts_with_its_prefix(
     config_manager, tmp_path_factory
 ):

--- a/tests/mcp/test_project_path_routing.py
+++ b/tests/mcp/test_project_path_routing.py
@@ -126,6 +126,21 @@ async def test_single_segment_project_names_project_root(multi_project_config):
 
 
 @pytest.mark.asyncio
+async def test_extension_bearing_project_name_names_project_root(config_manager, tmp_path_factory):
+    """An exact display name remains a project-root escape hatch even when its
+    extension would be stripped from the project's permalink."""
+    config = config_manager.load_config()
+    config.projects["docs.txt"] = ProjectEntry(
+        path=str(tmp_path_factory.mktemp("extension-project"))
+    )
+    config_manager.save_config(config)
+
+    route = await resolve_project_path_route("docs.txt", project=None, project_id=None)
+
+    assert route == ProjectPathRoute(project="docs.txt", path="", stripped=True)
+
+
+@pytest.mark.asyncio
 async def test_memory_url_prefix_routes(multi_project_config):
     route = await resolve_project_path_route(
         "memory://second-project/notes/foo", project=None, project_id=None

--- a/tests/mcp/test_project_path_routing.py
+++ b/tests/mcp/test_project_path_routing.py
@@ -1048,6 +1048,19 @@ async def test_cloud_workspace_qualified_project_root_routes(cloud_session):
 
 
 @pytest.mark.asyncio
+async def test_cross_workspace_extension_bearing_project_name_routes_root(cloud_session):
+    """Workspace discovery preserves exact display names whose extension is
+    absent from the stored permalink."""
+    cloud_session("research", "engineering", "docs.txt")
+
+    route = await resolve_project_path_route("team/docs.txt", project=None, project_id=None)
+
+    assert route == ProjectPathRoute(
+        project="team/docs", path="", stripped=True, project_id="docs-external-id"
+    )
+
+
+@pytest.mark.asyncio
 async def test_cloud_workspace_route_matches_multi_segment_project_permalink(cloud_session):
     """A workspace route splits project from path by matching that workspace's
     project permalinks, not by taking one segment. The mount table learned this

--- a/tests/mcp/test_project_path_routing.py
+++ b/tests/mcp/test_project_path_routing.py
@@ -141,6 +141,20 @@ async def test_extension_bearing_project_name_names_project_root(config_manager,
 
 
 @pytest.mark.asyncio
+async def test_extension_bearing_project_name_root_accepts_normalized_spelling(
+    config_manager, tmp_path_factory
+):
+    config = config_manager.load_config()
+    config.projects["My Docs.txt"] = ProjectEntry(path=str(tmp_path_factory.mktemp("my-docs-txt")))
+    config.projects["Research"] = ProjectEntry(path=str(tmp_path_factory.mktemp("research")))
+    config_manager.save_config(config)
+
+    route = await resolve_project_path_route("my-docs.txt", project=None, project_id=None)
+
+    assert route == ProjectPathRoute(project="My Docs.txt", path="", stripped=True)
+
+
+@pytest.mark.asyncio
 async def test_memory_url_prefix_routes(multi_project_config):
     route = await resolve_project_path_route(
         "memory://second-project/notes/foo", project=None, project_id=None
@@ -1058,6 +1072,30 @@ async def test_cross_workspace_extension_bearing_project_name_routes_root(cloud_
     assert route == ProjectPathRoute(
         project="team/docs", path="", stripped=True, project_id="docs-external-id"
     )
+
+
+@pytest.mark.asyncio
+async def test_cross_workspace_extension_project_root_accepts_normalized_spelling(cloud_session):
+    """Workspace display-name matching retains the usual case and spacing normalization."""
+    cloud_session("research", "engineering", "My Docs.txt")
+
+    route = await resolve_project_path_route("team/my-docs.txt", project=None, project_id=None)
+
+    assert route == ProjectPathRoute(
+        project="team/my-docs", path="", stripped=True, project_id="my-docs-external-id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_cross_workspace_extension_project_name_routes_root(cloud_session):
+    """An explicit qualified display name makes its extension-bearing root unambiguous."""
+    cloud_session("research", "engineering", "docs.txt")
+
+    route = await resolve_project_path_route(
+        "team/docs.txt", project="team/docs.txt", project_id=None
+    )
+
+    assert route == ProjectPathRoute(project="team/docs.txt", path="", stripped=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #1458.

## What changes

`split_project_permalink_prefix` matches leading path segments against known project permalinks. Because `generate_permalink` normally drops file extensions, a single-segment note whose file stem equals its project name—such as `moby-dick.txt` in project `moby-dick`—was mistaken for the project root. POSIX reads then rejected it as a project rather than reading the note.

The permalink-only parser now preserves an extension when a match would consume the entire identifier. That prevents `moby-dick.txt` from matching project permalink `moby-dick`; qualified paths such as `moby-dick/moby-dick.txt` and bare project permalinks such as `moby-dick` continue to work.

Project mount routing also retains exact display-name identity before falling back to permalink parsing. This matters for a valid project literally named `docs.txt`: the exact identifier `docs.txt` still routes to that project root even though its permalink is `docs`. The mount table is the correct layer for this exception because it knows both the display name and permalink; the generic parser cannot distinguish that project from a note using strings alone.

Workspace-qualified routing applies the same identity check against the projects discovered inside that workspace, so `team/docs.txt` can name the root of an extension-bearing project without weakening the permalink-only parser.

## Testing

- Added a pure parser regression for the same-named note case.
- Added an end-to-end routing regression proving `second-project.txt` stays a note inside `second-project`.
- Added an end-to-end routing regression proving an exact `docs.txt` project name still routes to its project root.
- Added a cross-workspace regression proving `team/docs.txt` routes the same project root.
- `uv run pytest tests/mcp/test_project_path_routing.py -q` — 71 passed.
- `just fast-check` — Ruff checks and formatting passed; after installing the repository's `milvus` extra, the full `ty check src tests test-int` passed.

## Other

- Added an Unreleased changelog entry.
- Both commits carry DCO sign-offs.
