### PR TITLE
feat(core): agent-curated BEAM ingestion

### DIFF
--- a/benchmarks/docs/benchmarks.md
+++ b/benchmarks/docs/benchmarks.md
@@ -282,6 +282,49 @@ chat/probing file there, so the run manifest's dataset checksum pins the exact
 converted inputs. Tiers 100K/500K/1M share a layout and are supported; the
 10M tier's combined plan-N layout is rejected in v1.
 
+### Curated ingestion mode
+
+Raw mode stores each chat session as a note. Curated mode is the product
+path: a curator model reads the same sessions in order and writes knowledge
+notes through Basic Memory's canonical write path (`write_note` /
+`edit_note` on a warm `bm mcp` session), one fresh project per conversation.
+The project's notes are then copied out as the group's docs, in the raw
+layout, so retrieval, QA, and BEAM scoring run on the curated dataset with
+no changes. The per-ability delta between the two datasets is the result.
+
+```bash
+BM_LOCAL_PATH=.. just bench-curate-beam-100k            # -> benchmarks/generated/beam-100k-curated
+BM_LOCAL_PATH=.. just bench-run-beam-100k-curated       # grouped retrieval, bm-local only
+just bench-qa benchmarks/runs/<run-id>                  # same answerer/judge as the raw run
+just bench-beam-score benchmarks/runs/<run-id>
+```
+
+The curator is blind. Each call sees one session's transcript, the running
+date anchor (carried forward as in raw mode), and an index of the notes
+written so far (title, directory, one-line gist; the oldest entries are
+elided past `MAX_INDEX_CHARS`). It never sees the probe questions or the
+ability names; the prompt template is fixed and its sha256 is recorded in
+`conversion.json`. The reply is a JSON list of at most
+`--max-notes-per-session` operations, `create` (a full note) or `append`
+(new observation and relation lines under an existing title). An append to
+an unknown title creates; a create for a known title appends, so earlier
+sessions' facts are never overwritten. A malformed reply costs that
+session's facts, counted per conversation. A curator transport failure
+excludes the conversation (recorded under `excluded_conversations`, its
+queries dropped) and the run continues.
+
+Provenance: `conversion.json` carries the raw input's manifest sha256, the
+curator spec and temperature, the prompt sha256, per-conversation token
+and note counts, and per-file sha256 of every doc. Group ids and query ids
+are the raw dataset's, so rows compare one to one.
+
+Retrieval ground truth is a message-to-doc mapping, which curated notes do
+not have. The curated `queries.json` carries empty `ground_truth`
+(`metadata.raw_ground_truth` keeps the raw ids) and
+`metadata.ingestion_mode: curated`; recall columns read n/a for this
+dataset. The comparison is the nugget score per ability, raw versus
+curated, answered and judged by the same models on the same day.
+
 ### Scoring definition
 
 - Every probe's reference answer is pre-decomposed upstream into atomic

--- a/benchmarks/justfile
+++ b/benchmarks/justfile
@@ -104,6 +104,33 @@ bench-run-beam-100k:
       {{bm_local_path_flag}} \
       --allow-provider-skip
 
+# Agent-curated ingestion of the raw BEAM 100K tier (docs/benchmarks.md 6b, curated mode).
+# The curator writes knowledge notes through `bm mcp`; output has the raw layout.
+bench-curate-beam-100k model="openai-compat:claude-sonnet-5@https://api.anthropic.com/v1" *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ -z "{{bm_local_path}}" ]]; then
+        echo "BM_LOCAL_PATH must point to the Basic Memory git checkout under test" >&2
+        exit 2
+    fi
+    uv run bm-bench curate beam \
+      --input-dir {{beam_100k_output_dir}} \
+      --output-dir {{beam_100k_output_dir}}-curated \
+      --model "{{model}}" \
+      --model-temperature omit \
+      --bm-local-path "{{bm_local_path}}" {{args}}
+
+# Grouped retrieval over the curated BEAM 100K dataset (bm-local only: mem0 has no curated notes)
+bench-run-beam-100k-curated:
+    uv run bm-bench run retrieval \
+      --dataset-id beam-100k-curated \
+      --dataset-path {{beam_100k_output_dir}}-curated/conversion.json \
+      --corpus-dir {{beam_100k_output_dir}}-curated/groups \
+      --queries-path {{beam_100k_output_dir}}-curated/queries.json \
+      --providers bm-local \
+      {{bm_local_path_flag}} \
+      --strict-providers
+
 # BEAM nugget/ordering scoring over a run's stored QA answers
 bench-beam-score run_dir judge="claude:claude-sonnet-4-6":
     uv run bm-bench run beam-score --run-dir "{{run_dir}}" --judge "{{judge}}"

--- a/benchmarks/src/basic_memory_benchmarks/cli.py
+++ b/benchmarks/src/basic_memory_benchmarks/cli.py
@@ -66,6 +66,31 @@ app.add_typer(datasets_app, name="datasets")
 app.add_typer(convert_app, name="convert")
 app.add_typer(run_app, name="run")
 app.add_typer(sample_app, name="sample")
+curate_app = typer.Typer(
+    help="Agent-curated ingestion: a curator model writes notes from raw transcripts"
+)
+app.add_typer(curate_app, name="curate")
+
+
+def parse_model_temperature(value: str) -> float | None:
+    """'omit'/'none' -> None (parameter not sent); otherwise a finite float."""
+    if value.strip().lower() in {"omit", "none"}:
+        return None
+    try:
+        temperature = float(value)
+    except ValueError:
+        raise typer.BadParameter(
+            f"--model-temperature must be a number or 'omit', got {value!r}"
+        ) from None
+    # nan/inf parse cleanly and pass config validation, but JSON has no
+    # encoding for them: httpx raises a bare ValueError when it serializes
+    # the request body. That escapes the handled transports, so a run
+    # dies mid-flight after setup with no artifacts written.
+    if not math.isfinite(temperature):
+        raise typer.BadParameter(
+            f"--model-temperature must be a finite number or 'omit', got {value!r}"
+        )
+    return temperature
 
 
 @datasets_app.command("fetch")
@@ -336,6 +361,76 @@ def sample_xafs(
     console.print(f"Readable form + gold files: [cyan]{output / 'sample.md'}[/cyan]")
 
 
+@curate_app.command("beam")
+def curate_beam_command(
+    input_dir: Path = typer.Option(
+        Path("benchmarks/generated/beam-100k"),
+        "--input-dir",
+        help="A raw `convert beam` output dir (conversion.json + queries.json)",
+    ),
+    output_dir: Path = typer.Option(Path("benchmarks/generated/beam-100k-curated"), "--output-dir"),
+    model: str = typer.Option(
+        ..., "--model", help="Curator: openai-compat:<model>@<base_url> or claude:<model>"
+    ),
+    model_temperature: str = typer.Option(
+        "omit",
+        "--model-temperature",
+        help="Sampling temperature for the curator, or 'omit' (Claude 5 rejects the parameter)",
+    ),
+    bm_local_path: str | None = typer.Option(None, "--bm-local-path"),
+    conversations: str | None = typer.Option(
+        None, "--conversations", help="Comma-separated BEAM conversation ids, e.g. 1,2"
+    ),
+    max_conversations: int | None = typer.Option(None, "--max-conversations"),
+    max_notes_per_session: int = typer.Option(8, "--max-notes-per-session"),
+    settle_timeout: float = typer.Option(180.0, "--settle-timeout"),
+    tool_timeout: float = typer.Option(120.0, "--tool-timeout"),
+) -> None:
+    """Curate a raw BEAM tier into knowledge notes through the write path.
+
+    The curator sees each chat session, the running date, and the notes it
+    has written; never the probes. Output has the raw layout, so
+    `run retrieval`, `run qa`, and `run beam-score` run on it unchanged
+    (docs/benchmarks.md 6b, curated mode).
+    """
+    from basic_memory_benchmarks.curation.beam import CurationConfig, curate_beam
+    from basic_memory_benchmarks.llm.runners import create_runner
+
+    temperature = parse_model_temperature(model_temperature)
+    try:
+        runner = create_runner(model, temperature=temperature)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    selected = (
+        tuple(part.strip() for part in conversations.split(",") if part.strip())
+        if conversations
+        else ()
+    )
+    config = CurationConfig(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        model_spec=model,
+        model_temperature=temperature,
+        bm_local_path=bm_local_path,
+        conversations=selected,
+        max_conversations=max_conversations,
+        max_notes_per_session=max_notes_per_session,
+        settle_timeout_seconds=settle_timeout,
+        tool_timeout_seconds=tool_timeout,
+    )
+    output = curate_beam(config, runner=runner, progress=console.print)
+    manifest = json.loads((output / "conversion.json").read_text(encoding="utf-8"))
+    totals = manifest["totals"]
+    console.print(
+        f"Curated {totals['conversations']} conversations: {totals['docs']} docs, "
+        f"{totals['queries']} queries, tokens {totals['input_tokens']}+{totals['output_tokens']}"
+    )
+    excluded = manifest["excluded_conversations"]
+    if excluded:
+        console.print(f"[yellow]Excluded {len(excluded)} conversation(s)[/yellow]: {excluded}")
+    console.print(f"Conversion manifest: [cyan]{output / 'conversion.json'}[/cyan]")
+
+
 @run_app.command("retrieval")
 def run_retrieval_command(
     providers: str = typer.Option("bm-local,mem0-local", "--providers"),
@@ -563,23 +658,7 @@ def run_agent_tasks_command(
             raise typer.BadParameter(f"--model-header must be 'Name=value', got {raw_header!r}")
         header_pairs[name.strip()] = value.strip()
 
-    if model_temperature.strip().lower() in {"omit", "none"}:
-        temperature: float | None = None
-    else:
-        try:
-            temperature = float(model_temperature)
-        except ValueError:
-            raise typer.BadParameter(
-                f"--model-temperature must be a number or 'omit', got {model_temperature!r}"
-            ) from None
-        # nan/inf parse cleanly and pass config validation, but JSON has no
-        # encoding for them: httpx raises a bare ValueError when it serializes
-        # the request body. That escapes _post's handled transports, so the run
-        # dies mid-flight after surface setup with no artifacts written.
-        if not math.isfinite(temperature):
-            raise typer.BadParameter(
-                f"--model-temperature must be a finite number or 'omit', got {model_temperature!r}"
-            )
+    temperature = parse_model_temperature(model_temperature)
 
     # Fail fast at parse time: a bad model spec (including claude:) and a
     # missing judge for judge-graded tasks must not survive to mid-run.

--- a/benchmarks/src/basic_memory_benchmarks/converters/beam_to_corpus.py
+++ b/benchmarks/src/basic_memory_benchmarks/converters/beam_to_corpus.py
@@ -63,7 +63,7 @@ class RenderedGroup:
     doc_id_for_message: dict[int, str]  # global message id -> owning source_doc_id
 
 
-def _clean_message_content(content: str) -> str:
+def clean_message_content(content: str) -> str:
     # Strip the leakage marker first, then collapse whitespace so each turn
     # stays on one line and bullet-level chunking stays intact.
     stripped = _INDEX_MARKER_PATTERN.sub("", content)
@@ -79,7 +79,7 @@ def _clean_message_content(content: str) -> str:
     return " ".join(stripped.split())
 
 
-def _batch_anchor(batch_messages: list[BeamMessage], batch_time_anchor: str | None) -> str | None:
+def batch_anchor(batch_messages: list[BeamMessage], batch_time_anchor: str | None) -> str | None:
     if batch_time_anchor:
         return batch_time_anchor
     for message in batch_messages:
@@ -105,7 +105,7 @@ def render_raw_group(
 
     for batch in conversation.batches:
         batch_messages = [message for session in batch.turns for message in session]
-        anchor = _batch_anchor(batch_messages, batch.time_anchor)
+        anchor = batch_anchor(batch_messages, batch.time_anchor)
         if anchor:
             current_anchor = anchor
 
@@ -132,7 +132,7 @@ def render_raw_group(
             ]
             for message in session:
                 doc_id_for_message[message.id] = doc_id
-                content = _clean_message_content(message.content)
+                content = clean_message_content(message.content)
                 if not content:
                     continue
                 speaker = "User" if message.role == "user" else "Assistant"

--- a/benchmarks/src/basic_memory_benchmarks/curation/__init__.py
+++ b/benchmarks/src/basic_memory_benchmarks/curation/__init__.py
@@ -1,0 +1,1 @@
+"""Agent-curated ingestion: an LLM writes knowledge notes from raw transcripts."""

--- a/benchmarks/src/basic_memory_benchmarks/curation/beam.py
+++ b/benchmarks/src/basic_memory_benchmarks/curation/beam.py
@@ -1,0 +1,549 @@
+"""Agent-curated ingestion for BEAM (#1398 item 4).
+
+Raw mode (``convert beam``) stores each chat session as a note. Curated mode
+runs a curator model over the same sessions, in order, and writes knowledge
+notes through Basic Memory's canonical write path (``write_note`` /
+``edit_note`` on a warm ``bm mcp`` session). The project's notes then become
+the group's docs in a dataset with the raw layout, so the existing retrieval,
+QA, and BEAM scoring stages run on it unchanged. The per-ability delta
+between the two datasets is the measurement.
+
+The curator is blind: it sees the session transcript, the running date
+anchor, and an index of the notes it has written so far. It never sees the
+probe questions or the ability names.
+
+Retrieval ground truth is a message-to-doc mapping, which curated notes do
+not have. The curated ``queries.json`` therefore carries empty ground truth
+and ``ingestion_mode: curated``; recall columns read n/a, the nugget scores
+are the comparison.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from mcp.types import CallToolResult
+
+from basic_memory_benchmarks.bm_runtime import (
+    WarmMcpClient,
+    isolated_bm_env,
+    resolve_bm_command_prefix,
+    settle_index,
+)
+from basic_memory_benchmarks.converters.beam_to_corpus import batch_anchor, clean_message_content
+from basic_memory_benchmarks.datasets.beam import BeamConversation, BeamMessage, load_beam_tier
+from basic_memory_benchmarks.llm.runners import LLMRunner, LLMRunnerError, create_runner
+from basic_memory_benchmarks.utils import run_command, sha256_file, utc_now_iso
+
+NOTE_DIRECTORIES = ("people", "places", "topics", "events", "preferences", "plans")
+
+# The curator's whole instruction set. Fixed for every session and every
+# conversation, and hashed into the provenance manifest. Nothing here names a
+# probe ability; the abilities are what the notes are later tested on.
+CURATOR_PROMPT_TEMPLATE = """\
+You maintain a personal knowledge base about the user in this conversation, as markdown notes.
+Today's date: {anchor}.
+
+Below is one chat session between the user and an assistant, then the notes that already exist.
+Update the knowledge base so that later questions about the user can be answered from the notes alone.
+
+Rules:
+- Record facts about the user: people in their life, places, preferences, plans, decisions, events, possessions, health, work, money, and dates.
+- One note per entity or topic. Reuse an existing note when one exists (op "append"); otherwise create one (op "create").
+- Every observation has a category in brackets and, when the fact is tied to a time, the resolved calendar date. Resolve "today", "yesterday", "last week" against today's date and write the date.
+- When a fact changes or contradicts an earlier note, append an observation marked [update] giving the new fact, the date, and what it replaces. Never delete anything.
+- Preserve specifics exactly: names, numbers, amounts, dates, and the order in which events happened.
+- Link related notes with [[Note Title]] under a Relations heading.
+- Directories: {directories}.
+
+Reply with JSON only, no prose, in this shape:
+{{"notes": [{{"op": "create", "title": "...", "directory": "...", "gist": "one line", "content": "markdown"}}]}}
+
+For "create", content is the full note: a "# Title" line, a "## Observations" list of "- [category] fact (date)" lines, and a "## Relations" list of "- relation [[Other Note]]" lines.
+For "append", content is only the new lines to add: observations and relations, same formats.
+At most {max_notes} operations. If nothing in the session is worth recording, reply {{"notes": []}}.
+
+## Session ({anchor})
+{transcript}
+
+## Existing notes (title | directory | gist)
+{index}
+"""
+
+# Cap on the existing-notes index shown to the curator; beyond this the oldest
+# entries are elided so the prompt cost stays bounded across ~90 sessions.
+MAX_INDEX_CHARS = 6_000
+
+
+@dataclass(frozen=True)
+class CurationConfig:
+    input_dir: Path
+    output_dir: Path
+    model_spec: str
+    model_temperature: float | None
+    bm_local_path: str | None
+    conversations: tuple[str, ...] = ()
+    max_conversations: int | None = None
+    max_notes_per_session: int = 8
+    settle_timeout_seconds: float = 180.0
+    tool_timeout_seconds: float = 120.0
+
+
+@dataclass(frozen=True)
+class NoteOperation:
+    op: str  # "create" | "append"
+    title: str
+    directory: str
+    gist: str
+    content: str
+
+
+@dataclass(frozen=True)
+class NoteIndexEntry:
+    title: str
+    directory: str
+    gist: str
+
+
+@dataclass
+class ConversationCurationStats:
+    conversation_id: str
+    group_id: str
+    sessions: int = 0
+    model_calls: int = 0
+    notes_created: int = 0
+    notes_appended: int = 0
+    notes_dropped: int = 0
+    malformed_responses: int = 0
+    tool_errors: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    wall_seconds: float = 0.0
+    doc_count: int = 0
+    error: str | None = None
+    docs_sha256: dict[str, str] = field(default_factory=dict)
+
+
+class NoteWriter(Protocol):
+    """The slice of a warm ``bm mcp`` session the curator drives."""
+
+    def start(self) -> None: ...
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult: ...
+    def stop(self) -> None: ...
+
+
+WriterFactory = Callable[[list[str], dict[str, str], Path], NoteWriter]
+
+
+def default_writer_factory(prefix: list[str], env: dict[str, str], project_dir: Path) -> NoteWriter:
+    return WarmMcpClient(
+        command=prefix[0],
+        args=prefix[1:] + ["mcp"],
+        env=env,
+        required_tool="write_note",
+    )
+
+
+# --- Prompt assembly ---
+
+
+def render_session_transcript(messages: list[BeamMessage]) -> str:
+    lines: list[str] = []
+    for message in messages:
+        content = clean_message_content(message.content)
+        if not content:
+            continue
+        speaker = "User" if message.role == "user" else "Assistant"
+        lines.append(f"- **{speaker}:** {content}")
+    return "\n".join(lines)
+
+
+def render_note_index(entries: list[NoteIndexEntry]) -> str:
+    if not entries:
+        return "(none yet)"
+    rows = [f"- {entry.title} | {entry.directory} | {entry.gist}" for entry in entries]
+    text = "\n".join(rows)
+    if len(text) <= MAX_INDEX_CHARS:
+        return text
+    # Keep the newest entries: they are the ones a session is most likely to
+    # extend, and the elision is stated so the curator knows the list is partial.
+    kept: list[str] = []
+    size = 0
+    for row in reversed(rows):
+        if size + len(row) + 1 > MAX_INDEX_CHARS:
+            break
+        kept.append(row)
+        size += len(row) + 1
+    kept.reverse()
+    return f"(… {len(rows) - len(kept)} older notes not shown)\n" + "\n".join(kept)
+
+
+def build_curator_prompt(
+    *, anchor: str | None, transcript: str, index: list[NoteIndexEntry], max_notes: int
+) -> str:
+    return CURATOR_PROMPT_TEMPLATE.format(
+        anchor=anchor or "unknown",
+        directories=", ".join(NOTE_DIRECTORIES),
+        max_notes=max_notes,
+        transcript=transcript,
+        index=render_note_index(index),
+    )
+
+
+def prompt_sha256() -> str:
+    return hashlib.sha256(CURATOR_PROMPT_TEMPLATE.encode("utf-8")).hexdigest()
+
+
+# --- Response parsing ---
+
+
+def parse_note_operations(text: str) -> list[NoteOperation]:
+    """Parse the curator's JSON reply. Raises ValueError on any shape problem."""
+    body = text.strip()
+    if body.startswith("```"):
+        body = body.split("\n", 1)[1] if "\n" in body else ""
+        body = body.rsplit("```", 1)[0]
+    payload = json.loads(body)
+    if not isinstance(payload, dict) or not isinstance(payload.get("notes"), list):
+        raise ValueError("curator reply must be an object with a 'notes' list")
+    operations: list[NoteOperation] = []
+    for raw in payload["notes"]:
+        if not isinstance(raw, dict):
+            raise ValueError("each note operation must be an object")
+        op = raw.get("op")
+        if op not in ("create", "append"):
+            raise ValueError(f"unknown note op {op!r}")
+        title = raw.get("title")
+        content = raw.get("content")
+        if not isinstance(title, str) or not title.strip():
+            raise ValueError("note operation needs a non-empty title")
+        if not isinstance(content, str) or not content.strip():
+            raise ValueError(f"note operation for {title!r} needs non-empty content")
+        raw_directory = raw.get("directory")
+        directory = raw_directory if raw_directory in NOTE_DIRECTORIES else "topics"
+        raw_gist = raw.get("gist")
+        gist = raw_gist.strip()[:160] if isinstance(raw_gist, str) else ""
+        operations.append(
+            NoteOperation(
+                op=op,
+                title=title.strip(),
+                directory=directory,
+                gist=gist,
+                content=content.strip(),
+            )
+        )
+    return operations
+
+
+# --- Applying operations ---
+
+
+def apply_note_operation(
+    writer: NoteWriter,
+    *,
+    project: str,
+    operation: NoteOperation,
+    index: dict[str, NoteIndexEntry],
+    stats: ConversationCurationStats,
+) -> None:
+    # An "append" to a note that does not exist yet is a create: the curator's
+    # index view can lag by one session when the prompt index was elided.
+    if operation.op == "append" and operation.title in index:
+        result = writer.call_tool(
+            "edit_note",
+            {
+                "identifier": operation.title,
+                "operation": "append",
+                "content": "\n" + operation.content + "\n",
+                "project": project,
+            },
+        )
+        if result.isError:
+            stats.tool_errors += 1
+            return
+        stats.notes_appended += 1
+        if operation.gist:
+            existing = index[operation.title]
+            index[operation.title] = NoteIndexEntry(
+                existing.title, existing.directory, operation.gist
+            )
+        return
+    if operation.op == "create" and operation.title in index:
+        # A second create for a known title is an update in disguise; append
+        # the new body rather than overwrite what earlier sessions recorded.
+        result = writer.call_tool(
+            "edit_note",
+            {
+                "identifier": operation.title,
+                "operation": "append",
+                "content": "\n" + operation.content + "\n",
+                "project": project,
+            },
+        )
+        if result.isError:
+            stats.tool_errors += 1
+            return
+        stats.notes_appended += 1
+        return
+    result = writer.call_tool(
+        "write_note",
+        {
+            "title": operation.title,
+            "directory": operation.directory,
+            "content": operation.content,
+            "project": project,
+            "note_type": "note",
+        },
+    )
+    if result.isError:
+        stats.tool_errors += 1
+        return
+    stats.notes_created += 1
+    index[operation.title] = NoteIndexEntry(operation.title, operation.directory, operation.gist)
+
+
+def curate_session(
+    *,
+    runner: LLMRunner,
+    writer: NoteWriter,
+    project: str,
+    messages: list[BeamMessage],
+    anchor: str | None,
+    index: dict[str, NoteIndexEntry],
+    stats: ConversationCurationStats,
+    max_notes: int,
+) -> None:
+    transcript = render_session_transcript(messages)
+    if not transcript:
+        return
+    prompt = build_curator_prompt(
+        anchor=anchor, transcript=transcript, index=list(index.values()), max_notes=max_notes
+    )
+    result = runner.complete(prompt)
+    stats.model_calls += 1
+    stats.input_tokens += result.input_tokens
+    stats.output_tokens += result.output_tokens
+    try:
+        operations = parse_note_operations(result.text)
+    except (ValueError, json.JSONDecodeError):
+        # A malformed reply costs one session's facts, not the conversation:
+        # counted, and visible in the manifest as a quality signal.
+        stats.malformed_responses += 1
+        return
+    for operation in operations[:max_notes]:
+        apply_note_operation(writer, project=project, operation=operation, index=index, stats=stats)
+    stats.notes_dropped += max(0, len(operations) - max_notes)
+
+
+def curate_conversation(
+    conversation: BeamConversation,
+    *,
+    group_id: str,
+    config: CurationConfig,
+    prefix: list[str],
+    runner: LLMRunner,
+    writer_factory: WriterFactory,
+) -> ConversationCurationStats:
+    """Curate one conversation into a fresh project and copy its notes out."""
+    started = time.monotonic()
+    stats = ConversationCurationStats(
+        conversation_id=conversation.conversation_id, group_id=group_id
+    )
+    home = config.output_dir / ".bm-homes" / group_id
+    if home.exists():
+        shutil.rmtree(home)
+    project_dir = home / "project"
+    project_dir.mkdir(parents=True)
+    (home / "default-home").mkdir(parents=True)
+    env = isolated_bm_env(home)
+    run_command(prefix + ["project", "add", group_id, str(project_dir)], env=env)
+
+    writer = writer_factory(prefix, env, project_dir)
+    writer.start()
+    index: dict[str, NoteIndexEntry] = {}
+    current_anchor: str | None = None
+    try:
+        for batch in conversation.batches:
+            batch_messages = [message for session in batch.turns for message in session]
+            anchor = batch_anchor(batch_messages, batch.time_anchor)
+            if anchor:
+                current_anchor = anchor
+            for session in batch.turns:
+                stats.sessions += 1
+                curate_session(
+                    runner=runner,
+                    writer=writer,
+                    project=group_id,
+                    messages=session,
+                    anchor=current_anchor,
+                    index=index,
+                    stats=stats,
+                    max_notes=config.max_notes_per_session,
+                )
+    except LLMRunnerError as exc:
+        # The curator's transport died mid-conversation. A half-curated
+        # project would score as a real result, so the conversation is
+        # excluded, with the reason recorded, and the run continues.
+        stats.error = f"curator failed after {stats.sessions} sessions: {exc}"
+    finally:
+        writer.stop()
+
+    if stats.error is None:
+        run_command(prefix + ["reindex", "-p", group_id, "--search"], env=env)
+        settle_index(
+            prefix=prefix,
+            env=env,
+            project_name=group_id,
+            timeout_seconds=config.settle_timeout_seconds,
+        )
+        docs_dir = config.output_dir / "groups" / group_id / "docs"
+        if docs_dir.exists():
+            shutil.rmtree(docs_dir)
+        docs_dir.mkdir(parents=True)
+        for note_path in sorted(project_dir.rglob("*.md")):
+            relative = note_path.relative_to(project_dir)
+            target = docs_dir / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(note_path, target)
+            stats.docs_sha256[relative.as_posix()] = sha256_file(target)
+        stats.doc_count = len(stats.docs_sha256)
+    stats.wall_seconds = round(time.monotonic() - started, 2)
+    return stats
+
+
+# --- Dataset assembly ---
+
+
+def _load_input_manifest(input_dir: Path) -> dict[str, Any]:
+    manifest_path = input_dir / "conversion.json"
+    if not manifest_path.exists():
+        raise ValueError(f"no conversion.json under {input_dir}; run `convert beam` first")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("converter", {}).get("mode") != "raw":
+        raise ValueError(f"{manifest_path} is not a raw BEAM conversion")
+    return manifest
+
+
+def _select_conversations(
+    conversations: list[BeamConversation], config: CurationConfig
+) -> list[BeamConversation]:
+    if config.conversations:
+        wanted = set(config.conversations)
+        selected = [c for c in conversations if c.conversation_id in wanted]
+        missing = sorted(wanted - {c.conversation_id for c in selected})
+        if missing:
+            raise ValueError(f"unknown BEAM conversations {missing}")
+    else:
+        selected = list(conversations)
+    if config.max_conversations is not None:
+        selected = selected[: config.max_conversations]
+    return selected
+
+
+def curated_queries(raw_queries: list[dict[str, Any]], group_ids: set[str]) -> list[dict[str, Any]]:
+    """The raw queries for the curated groups, with retrieval ground truth withdrawn."""
+    queries: list[dict[str, Any]] = []
+    for query in raw_queries:
+        if query["group"] not in group_ids:
+            continue
+        rewritten = dict(query)
+        metadata = dict(query.get("metadata", {}))
+        metadata["ingestion_mode"] = "curated"
+        metadata["raw_ground_truth"] = list(query.get("ground_truth", []))
+        rewritten["ground_truth"] = []
+        rewritten["metadata"] = metadata
+        queries.append(rewritten)
+    return queries
+
+
+def curate_beam(
+    config: CurationConfig,
+    *,
+    runner: LLMRunner | None = None,
+    writer_factory: WriterFactory = default_writer_factory,
+    progress: Callable[[str], None] = lambda line: None,
+) -> Path:
+    """Curate a raw-converted BEAM tier into a sibling curated dataset. Returns output_dir."""
+    manifest = _load_input_manifest(config.input_dir)
+    dataset_root = Path(manifest["dataset_root"])
+    tier = str(manifest["tier"])
+    raw_dataset_id = str(manifest["dataset_id"])
+    dataset_id = f"{raw_dataset_id}-curated"
+    raw_queries = json.loads((config.input_dir / "queries.json").read_text(encoding="utf-8"))
+
+    conversations = _select_conversations(load_beam_tier(dataset_root, tier), config)
+    prefix = resolve_bm_command_prefix(config.bm_local_path)
+    curator = runner or create_runner(config.model_spec, temperature=config.model_temperature)
+
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    stats_by_group: list[ConversationCurationStats] = []
+    for conversation in conversations:
+        # Same group ids as the raw dataset, so query ids line up row for row.
+        group_id = f"{raw_dataset_id}-c{int(conversation.conversation_id):02d}"
+        progress(f"curating {group_id} ({len(conversation.batches)} batches)")
+        stats = curate_conversation(
+            conversation,
+            group_id=group_id,
+            config=config,
+            prefix=prefix,
+            runner=curator,
+            writer_factory=writer_factory,
+        )
+        stats_by_group.append(stats)
+        progress(
+            f"  {group_id}: sessions={stats.sessions} notes={stats.notes_created}+{stats.notes_appended} "
+            f"tokens={stats.input_tokens}+{stats.output_tokens} "
+            f"malformed={stats.malformed_responses} tool_errors={stats.tool_errors}"
+            + (f" ERROR: {stats.error}" if stats.error else "")
+        )
+
+    curated_groups = {stats.group_id for stats in stats_by_group if stats.error is None}
+    queries = curated_queries(raw_queries, curated_groups)
+    (config.output_dir / "queries.json").write_text(json.dumps(queries, indent=2), encoding="utf-8")
+
+    conversion_manifest = {
+        "dataset_id": dataset_id,
+        "tier": tier,
+        "source_url": manifest.get("source_url"),
+        "citation": manifest.get("citation"),
+        "license_note": manifest.get("license_note"),
+        "dataset_root": str(dataset_root),
+        "converter": {
+            "mode": "curated",
+            "raw_input_dir": str(config.input_dir),
+            "raw_conversion_sha256": sha256_file(config.input_dir / "conversion.json"),
+            "curator_model_spec": config.model_spec,
+            "curator_temperature": config.model_temperature,
+            "curator_prompt_sha256": prompt_sha256(),
+            "max_notes_per_session": config.max_notes_per_session,
+            "conversations": list(config.conversations) or None,
+            "max_conversations": config.max_conversations,
+        },
+        "created_at_utc": utc_now_iso(),
+        "conversations": [asdict(stats) for stats in stats_by_group],
+        "excluded_conversations": [
+            {"group_id": stats.group_id, "error": stats.error}
+            for stats in stats_by_group
+            if stats.error is not None
+        ],
+        "totals": {
+            "conversations": len(curated_groups),
+            "sessions": sum(s.sessions for s in stats_by_group),
+            "model_calls": sum(s.model_calls for s in stats_by_group),
+            "input_tokens": sum(s.input_tokens for s in stats_by_group),
+            "output_tokens": sum(s.output_tokens for s in stats_by_group),
+            "docs": sum(s.doc_count for s in stats_by_group),
+            "queries": len(queries),
+        },
+    }
+    (config.output_dir / "conversion.json").write_text(
+        json.dumps(conversion_manifest, indent=2), encoding="utf-8"
+    )
+    return config.output_dir

--- a/benchmarks/src/basic_memory_benchmarks/llm/runners.py
+++ b/benchmarks/src/basic_memory_benchmarks/llm/runners.py
@@ -152,6 +152,7 @@ class OpenAICompatRunner(LLMRunner):
         api_key: str | None = None,
         timeout_seconds: float = 300.0,
         max_retries: int = 2,
+        temperature: float | None = 0.0,
     ) -> None:
         self.model = model
         self.base_url = base_url.rstrip("/")
@@ -159,16 +160,21 @@ class OpenAICompatRunner(LLMRunner):
         self._api_key = api_key
         self._timeout_seconds = timeout_seconds
         self._max_retries = max_retries
+        # None omits the parameter: Claude 5 models reject any temperature
+        # ("`temperature` is deprecated for this model"); local servers default
+        # to nonzero sampling unless pinned, so 0 stays the default.
+        self._temperature = temperature
 
     def complete(self, prompt: str) -> LLMResult:
         headers = {"Content-Type": "application/json"}
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"
-        body = {
+        body: dict[str, Any] = {
             "model": self.model,
             "messages": [{"role": "user", "content": prompt}],
-            "temperature": 0,
         }
+        if self._temperature is not None:
+            body["temperature"] = self._temperature
         last_error: Exception | None = None
         for _ in range(self._max_retries + 1):
             started = time.perf_counter()
@@ -197,7 +203,9 @@ class OpenAICompatRunner(LLMRunner):
         )
 
 
-def create_runner(spec: str, *, api_key: str | None = None) -> LLMRunner:
+def create_runner(
+    spec: str, *, api_key: str | None = None, temperature: float | None = 0.0
+) -> LLMRunner:
     """Build a runner from a spec string.
 
     Formats: ``claude:<model>`` or ``openai-compat:<model>@<base_url>``.
@@ -212,7 +220,9 @@ def create_runner(spec: str, *, api_key: str | None = None) -> LLMRunner:
                 f"openai-compat spec must be 'openai-compat:<model>@<base_url>', got: {spec}"
             )
         resolved_api_key = api_key if api_key is not None else os.getenv("OPENAI_API_KEY")
-        return OpenAICompatRunner(model=model, base_url=base_url, api_key=resolved_api_key)
+        return OpenAICompatRunner(
+            model=model, base_url=base_url, api_key=resolved_api_key, temperature=temperature
+        )
     raise ValueError(
         f"Unknown runner spec '{spec}'. Expected 'claude:<model>' or "
         f"'openai-compat:<model>@<base_url>'."

--- a/benchmarks/tests/curation/test_beam_curation.py
+++ b/benchmarks/tests/curation/test_beam_curation.py
@@ -1,0 +1,342 @@
+"""Curated BEAM ingestion: blind curator, canonical write path, raw layout out."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp.types import CallToolResult
+
+import basic_memory_benchmarks.curation.beam as curation
+from basic_memory_benchmarks.converters.beam_to_corpus import convert_beam_to_corpus
+from basic_memory_benchmarks.curation.beam import (
+    CURATOR_PROMPT_TEMPLATE,
+    MAX_INDEX_CHARS,
+    CurationConfig,
+    NoteIndexEntry,
+    curate_beam,
+    parse_note_operations,
+    render_note_index,
+)
+from basic_memory_benchmarks.llm.runners import LLMResult, LLMRunner, LLMRunnerError
+from beam_fixture import write_beam_tier
+
+
+class ScriptedRunner(LLMRunner):
+    """Returns canned replies in order; a callable reply raises instead."""
+
+    spec = "scripted:curator"
+
+    def __init__(self, replies: list[str | Callable[[], str]]) -> None:
+        self.replies = list(replies)
+        self.prompts: list[str] = []
+
+    def complete(self, prompt: str) -> LLMResult:
+        self.prompts.append(prompt)
+        reply = self.replies.pop(0) if self.replies else '{"notes": []}'
+        text = reply() if callable(reply) else reply
+        return LLMResult(
+            text=text, model="scripted", input_tokens=100, output_tokens=10, latency_ms=1.0
+        )
+
+
+class FileWriter:
+    """Stands in for the warm `bm mcp` session: writes notes as files in the project."""
+
+    def __init__(self, project_dir: Path) -> None:
+        self.project_dir = project_dir
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.started = False
+        self.stopped = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        self.calls.append((name, dict(arguments)))
+        if name == "write_note":
+            path = self.project_dir / arguments["directory"] / f"{arguments['title']}.md"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(f"---\ntitle: {arguments['title']}\n---\n{arguments['content']}\n")
+            return CallToolResult(content=[], isError=False)
+        if name == "edit_note":
+            matches = list(self.project_dir.rglob(f"{arguments['identifier']}.md"))
+            if not matches:
+                return CallToolResult(content=[], isError=True)
+            with matches[0].open("a") as handle:
+                handle.write(arguments["content"])
+            return CallToolResult(content=[], isError=False)
+        raise AssertionError(f"unexpected tool {name}")
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+def _raw_dataset(tmp_path: Path) -> Path:
+    chats_root = write_beam_tier(tmp_path / "chats")
+    raw_dir = tmp_path / "raw"
+    convert_beam_to_corpus(dataset_root=chats_root, output_dir=raw_dir, tier="100K")
+    return raw_dir
+
+
+def _config(tmp_path: Path, **overrides: Any) -> CurationConfig:
+    values: dict[str, Any] = {
+        "input_dir": tmp_path / "raw",
+        "output_dir": tmp_path / "curated",
+        "model_spec": "scripted:curator",
+        "model_temperature": None,
+        "bm_local_path": None,
+    }
+    values.update(overrides)
+    return CurationConfig(**values)
+
+
+def _stub_bm(monkeypatch: pytest.MonkeyPatch) -> tuple[list[list[str]], list[str]]:
+    commands: list[list[str]] = []
+    settles: list[str] = []
+    monkeypatch.setattr(curation, "resolve_bm_command_prefix", lambda bm_local_path: ["bm"])
+
+    def record_command(command: list[str], **kwargs: Any) -> None:
+        commands.append(list(command))
+
+    def record_settle(
+        *, prefix: list[str], env: dict[str, str], project_name: str, timeout_seconds: float
+    ):
+        settles.append(project_name)
+        return (0.0, "status-json")
+
+    monkeypatch.setattr(curation, "run_command", record_command)
+    monkeypatch.setattr(curation, "settle_index", record_settle)
+    return commands, settles
+
+
+def _ops(*notes: dict[str, Any]) -> str:
+    return json.dumps({"notes": list(notes)})
+
+
+# --- parsing ---
+
+
+def test_parse_note_operations_accepts_fenced_json_and_normalizes_directory() -> None:
+    text = '```json\n{"notes": [{"op": "create", "title": " Alice ", "directory": "nowhere", "gist": "friend", "content": "# Alice\\n## Observations\\n- [role] friend"}]}\n```'
+    (operation,) = parse_note_operations(text)
+    assert operation.title == "Alice"
+    assert operation.directory == "topics"
+    assert operation.gist == "friend"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        '{"notes": [{"op": "delete", "title": "Alice", "content": "x"}]}',
+        '{"notes": [{"op": "create", "title": "", "content": "x"}]}',
+        '{"notes": [{"op": "create", "title": "Alice", "content": ""}]}',
+        '{"items": []}',
+        "[]",
+    ],
+)
+def test_parse_note_operations_rejects_bad_shapes(text: str) -> None:
+    with pytest.raises(ValueError):
+        parse_note_operations(text)
+
+
+def test_render_note_index_elides_oldest_entries_past_the_cap() -> None:
+    entries = [NoteIndexEntry(f"Note {i:04d}", "topics", "x" * 100) for i in range(200)]
+    text = render_note_index(entries)
+    assert len(text) <= MAX_INDEX_CHARS + 60
+    assert text.startswith("(… ")
+    assert "Note 0199" in text
+    assert "Note 0000" not in text
+
+
+def test_prompt_never_names_probe_abilities() -> None:
+    lowered = CURATOR_PROMPT_TEMPLATE.lower()
+    for ability in (
+        "contradiction",
+        "temporal reasoning",
+        "knowledge update",
+        "abstention",
+        "event ordering",
+    ):
+        assert ability not in lowered
+
+
+# --- end to end on the fixture tier ---
+
+
+def test_curate_beam_writes_notes_through_the_writer_and_emits_the_raw_layout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _raw_dataset(tmp_path)
+    commands, settles = _stub_bm(monkeypatch)
+    writers: dict[Path, FileWriter] = {}
+
+    def writer_factory(prefix: list[str], env: dict[str, str], project_dir: Path) -> FileWriter:
+        writers[project_dir] = FileWriter(project_dir)
+        return writers[project_dir]
+
+    runner = ScriptedRunner(
+        [
+            _ops(
+                {
+                    "op": "create",
+                    "title": "Alice",
+                    "directory": "people",
+                    "gist": "sister",
+                    "content": "# Alice\n## Observations\n- [relationship] sister (2024-03-15)",
+                }
+            ),
+            _ops(
+                {
+                    "op": "append",
+                    "title": "Alice",
+                    "directory": "people",
+                    "gist": "moved",
+                    "content": "- [update] moved to Paris (2024-03-20)",
+                },
+                {
+                    "op": "create",
+                    "title": "Paris",
+                    "directory": "places",
+                    "gist": "city",
+                    "content": "# Paris\n## Relations\n- home_of [[Alice]]",
+                },
+            ),
+            "this is not json",
+        ]
+    )
+
+    output = curate_beam(_config(tmp_path), runner=runner, writer_factory=writer_factory)
+
+    manifest = json.loads((output / "conversion.json").read_text())
+    assert manifest["dataset_id"] == "beam-100k-curated"
+    assert manifest["converter"]["mode"] == "curated"
+    assert manifest["converter"]["curator_prompt_sha256"]
+    assert manifest["excluded_conversations"] == []
+    stats = {row["group_id"]: row for row in manifest["conversations"]}
+    first = stats["beam-100k-c01"]
+    assert first["notes_created"] == 2
+    assert first["notes_appended"] == 1
+    assert first["malformed_responses"] == 1
+    assert first["error"] is None
+    assert first["model_calls"] == first["sessions"]
+
+    # Notes reached the project through write_note / edit_note and were copied out.
+    alice = output / "groups" / "beam-100k-c01" / "docs" / "people" / "Alice.md"
+    assert alice.exists()
+    assert "moved to Paris" in alice.read_text()
+    assert (output / "groups" / "beam-100k-c01" / "docs" / "places" / "Paris.md").exists()
+    assert first["docs_sha256"] and set(first["docs_sha256"]) == {
+        "people/Alice.md",
+        "places/Paris.md",
+    }
+
+    # Each group: one project add, one reindex, one settle; the writer was started and stopped.
+    adds = [cmd for cmd in commands if "add" in cmd]
+    assert sorted(cmd[cmd.index("add") + 1] for cmd in adds) == ["beam-100k-c01", "beam-100k-c02"]
+    assert sorted(settles) == ["beam-100k-c01", "beam-100k-c02"]
+    assert all(writer.started and writer.stopped for writer in writers.values())
+
+    # Queries keep the raw ids and withdraw retrieval ground truth.
+    raw_queries = json.loads((tmp_path / "raw" / "queries.json").read_text())
+    queries = json.loads((output / "queries.json").read_text())
+    assert [q["id"] for q in queries] == [q["id"] for q in raw_queries]
+    assert all(q["ground_truth"] == [] for q in queries)
+    assert all(q["metadata"]["ingestion_mode"] == "curated" for q in queries)
+    assert any(q["metadata"]["raw_ground_truth"] for q in queries)
+
+    # The curator saw the session, the date, and its own index; never a probe.
+    assert any("Existing notes" in prompt for prompt in runner.prompts)
+    assert all("probe" not in prompt.lower() for prompt in runner.prompts)
+
+
+def test_a_curator_transport_failure_excludes_that_conversation_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _raw_dataset(tmp_path)
+    _stub_bm(monkeypatch)
+
+    def boom() -> str:
+        raise LLMRunnerError("endpoint down")
+
+    # Conversation 1 gets an empty reply per session; conversation 2's first call dies.
+    replies: list[str | Callable[[], str]] = []
+    raw_manifest = json.loads((tmp_path / "raw" / "conversion.json").read_text())
+    assert [row["conversation_id"] for row in raw_manifest["conversations"]] == ["1", "2"]
+    from basic_memory_benchmarks.datasets.beam import load_beam_tier
+
+    sessions_one = sum(len(b.turns) for b in load_beam_tier(tmp_path / "chats", "100K")[0].batches)
+    replies.extend(['{"notes": []}'] * sessions_one)
+    replies.append(boom)
+    runner = ScriptedRunner(replies)
+
+    output = curate_beam(
+        _config(tmp_path), runner=runner, writer_factory=lambda p, e, d: FileWriter(d)
+    )
+
+    manifest = json.loads((output / "conversion.json").read_text())
+    assert [row["group_id"] for row in manifest["excluded_conversations"]] == ["beam-100k-c02"]
+    assert "endpoint down" in manifest["excluded_conversations"][0]["error"]
+    assert not (output / "groups" / "beam-100k-c02").exists()
+    queries = json.loads((output / "queries.json").read_text())
+    assert {q["group"] for q in queries} == {"beam-100k-c01"}
+    assert manifest["totals"]["conversations"] == 1
+
+
+def test_append_to_unknown_title_creates_and_create_of_known_title_appends(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _raw_dataset(tmp_path)
+    _stub_bm(monkeypatch)
+    writer_holder: list[FileWriter] = []
+
+    def writer_factory(prefix: list[str], env: dict[str, str], project_dir: Path) -> FileWriter:
+        writer = FileWriter(project_dir)
+        writer_holder.append(writer)
+        return writer
+
+    runner = ScriptedRunner(
+        [
+            _ops(
+                {
+                    "op": "append",
+                    "title": "Bob",
+                    "directory": "people",
+                    "gist": "",
+                    "content": "- [role] colleague",
+                }
+            ),
+            _ops(
+                {
+                    "op": "create",
+                    "title": "Bob",
+                    "directory": "people",
+                    "gist": "",
+                    "content": "# Bob\n- [role] manager now",
+                }
+            ),
+        ]
+    )
+
+    curate_beam(
+        _config(tmp_path, conversations=("1",)), runner=runner, writer_factory=writer_factory
+    )
+
+    names = [name for name, _ in writer_holder[0].calls]
+    assert names[:2] == ["write_note", "edit_note"]
+
+
+def test_unknown_conversation_ids_fail_fast(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _raw_dataset(tmp_path)
+    _stub_bm(monkeypatch)
+    with pytest.raises(ValueError, match="unknown BEAM conversations"):
+        curate_beam(
+            _config(tmp_path, conversations=("9",)),
+            runner=ScriptedRunner([]),
+            writer_factory=lambda p, e, d: FileWriter(d),
+        )


### PR DESCRIPTION
## Summary

#1398 item 4. Raw BEAM mode stores each chat session as a note. This adds curated mode, the product path: a curator model reads the same sessions in order and writes knowledge notes through Basic Memory's canonical write path (`write_note` / `edit_note` on a warm `bm mcp` session), one fresh project per conversation. The project's notes are copied out as the group's docs in the raw layout, so `run retrieval`, `run qa`, and `run beam-score` run on the curated dataset with no changes. The per-ability delta between raw and curated is the measurement.

## Design

- `bm-bench curate beam --input-dir <raw tier> --output-dir <raw tier>-curated --model … --model-temperature omit --bm-local-path ..`
- One completion per session. The reply is JSON: at most `--max-notes-per-session` operations, `create` (full note) or `append` (new observation/relation lines under an existing title). Append to an unknown title creates; create for a known title appends. Earlier sessions' facts are never overwritten.
- Blind: the prompt has the transcript, the running date anchor, and an index of notes written so far. Never the probes or ability names. Tested by asserting the template names no ability.
- Failure handling: a malformed reply costs one session's facts and is counted; a curator transport failure excludes that conversation (recorded, queries dropped) and the run continues.
- Provenance in `conversion.json`: raw manifest sha256, curator spec and temperature, prompt sha256, per-conversation tokens and note counts, per-file sha256 of docs. Group and query ids match the raw dataset one to one. Retrieval ground truth is withdrawn (`ingestion_mode: curated`, `raw_ground_truth` kept); the nugget score per ability is the comparison.
- `OpenAICompatRunner` gains a `temperature` (None omits it; Claude 5 rejects the parameter); `create_runner` threads it; the agent-tasks CLI's parsing becomes `parse_model_temperature`, shared.

Recipes: `bench-curate-beam-100k`, `bench-run-beam-100k-curated`. Docs: 6b "Curated ingestion mode".

## Tests

`tests/curation/test_beam_curation.py`: parsing (fenced JSON, directory fallback, five rejected shapes), index elision, prompt blindness, an end-to-end run on the fixture tier with a scripted curator and a file-backed writer (notes through the writer, docs copied, queries rewritten, manifest totals, one add/reindex/settle per group), transport failure excluding one conversation only, append/create title handling, unknown conversation ids failing fast. Full `just test` green; pyright clean.

## Next

A one-conversation pilot with Sonnet 5 to measure real curation tokens, then the 100K tier, then raw and curated through the same QA and judge on the same day, reported on #1398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp