### PR TITLE
feat(core): curate BEAM conversations in parallel

### DIFF
--- a/benchmarks/src/basic_memory_benchmarks/cli.py
+++ b/benchmarks/src/basic_memory_benchmarks/cli.py
@@ -385,6 +385,9 @@ def curate_beam_command(
     max_notes_per_session: int = typer.Option(8, "--max-notes-per-session"),
     settle_timeout: float = typer.Option(180.0, "--settle-timeout"),
     tool_timeout: float = typer.Option(120.0, "--tool-timeout"),
+    workers: int = typer.Option(
+        1, "--workers", min=1, help="Conversations curated concurrently (each has its own bm mcp)"
+    ),
 ) -> None:
     """Curate a raw BEAM tier into knowledge notes through the write path.
 
@@ -417,6 +420,7 @@ def curate_beam_command(
         max_notes_per_session=max_notes_per_session,
         settle_timeout_seconds=settle_timeout,
         tool_timeout_seconds=tool_timeout,
+        workers=workers,
     )
     output = curate_beam(config, runner=runner, progress=console.print)
     manifest = json.loads((output / "conversion.json").read_text(encoding="utf-8"))

--- a/benchmarks/src/basic_memory_benchmarks/curation/beam.py
+++ b/benchmarks/src/basic_memory_benchmarks/curation/beam.py
@@ -25,6 +25,7 @@ import json
 import shutil
 import time
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
@@ -94,6 +95,9 @@ class CurationConfig:
     max_notes_per_session: int = 8
     settle_timeout_seconds: float = 180.0
     tool_timeout_seconds: float = 120.0
+    # Conversations are independent (own home, project, MCP session), so they
+    # curate in parallel; one conversation is ~80 serial model calls.
+    workers: int = 1
 
 
 @dataclass(frozen=True)
@@ -483,8 +487,8 @@ def curate_beam(
     curator = runner or create_runner(config.model_spec, temperature=config.model_temperature)
 
     config.output_dir.mkdir(parents=True, exist_ok=True)
-    stats_by_group: list[ConversationCurationStats] = []
-    for conversation in conversations:
+
+    def curate_one(conversation: BeamConversation) -> ConversationCurationStats:
         # Same group ids as the raw dataset, so query ids line up row for row.
         group_id = f"{raw_dataset_id}-c{int(conversation.conversation_id):02d}"
         progress(f"curating {group_id} ({len(conversation.batches)} batches)")
@@ -496,13 +500,20 @@ def curate_beam(
             runner=curator,
             writer_factory=writer_factory,
         )
-        stats_by_group.append(stats)
         progress(
             f"  {group_id}: sessions={stats.sessions} notes={stats.notes_created}+{stats.notes_appended} "
             f"tokens={stats.input_tokens}+{stats.output_tokens} "
-            f"malformed={stats.malformed_responses} tool_errors={stats.tool_errors}"
-            + (f" ERROR: {stats.error}" if stats.error else "")
+            f"malformed={stats.malformed_responses} tool_errors={stats.tool_errors} "
+            f"wall={stats.wall_seconds}s" + (f" ERROR: {stats.error}" if stats.error else "")
         )
+        return stats
+
+    # Manifest order is dataset order whatever the completion order was.
+    if config.workers > 1:
+        with ThreadPoolExecutor(max_workers=config.workers) as pool:
+            stats_by_group = list(pool.map(curate_one, conversations))
+    else:
+        stats_by_group = [curate_one(conversation) for conversation in conversations]
 
     curated_groups = {stats.group_id for stats in stats_by_group if stats.error is None}
     queries = curated_queries(raw_queries, curated_groups)
@@ -525,6 +536,7 @@ def curate_beam(
             "max_notes_per_session": config.max_notes_per_session,
             "conversations": list(config.conversations) or None,
             "max_conversations": config.max_conversations,
+            "workers": config.workers,
         },
         "created_at_utc": utc_now_iso(),
         "conversations": [asdict(stats) for stats in stats_by_group],

--- a/benchmarks/tests/curation/test_beam_curation.py
+++ b/benchmarks/tests/curation/test_beam_curation.py
@@ -340,3 +340,36 @@ def test_unknown_conversation_ids_fail_fast(
             runner=ScriptedRunner([]),
             writer_factory=lambda p, e, d: FileWriter(d),
         )
+
+
+def test_workers_curate_in_parallel_and_keep_dataset_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two conversations, two workers: same manifest as serial, in dataset order."""
+    _raw_dataset(tmp_path)
+    _stub_bm(monkeypatch)
+    import threading
+
+    lock = threading.Lock()
+    seen_threads: set[int] = set()
+
+    class ThreadAwareRunner(ScriptedRunner):
+        def complete(self, prompt: str) -> LLMResult:
+            with lock:
+                seen_threads.add(threading.get_ident())
+            return super().complete(prompt)
+
+    output = curate_beam(
+        _config(tmp_path, workers=2),
+        runner=ThreadAwareRunner([]),
+        writer_factory=lambda p, e, d: FileWriter(d),
+    )
+
+    manifest = json.loads((output / "conversion.json").read_text())
+    assert [row["group_id"] for row in manifest["conversations"]] == [
+        "beam-100k-c01",
+        "beam-100k-c02",
+    ]
+    assert manifest["converter"]["workers"] == 2
+    assert manifest["totals"]["conversations"] == 2
+    assert len(seen_threads) == 2


### PR DESCRIPTION
## Summary

Follow-up to #1461. The one-conversation pilot measured 78 sessions, 78 curator calls, 312K input and 51K output tokens, 56 notes plus 88 appends, 0 malformed replies, 0 tool errors, 20 minutes wall. Twenty conversations serially would be nearly seven hours.

`--workers N` curates N conversations at a time on a thread pool. Each conversation already has its own isolated home, project, and `bm mcp` session, so nothing is shared but the curator runner, whose `complete` is one HTTP call per invocation. Manifest order stays dataset order regardless of completion order; `converter.workers` is recorded in `conversion.json`.

Test: two conversations with two workers produce the serial manifest in dataset order and the runner is invoked from two threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp