### PR TITLE
fix(core): keep BEAM curation alive through server startup failures, and resume

### DIFF
--- a/benchmarks/src/basic_memory_benchmarks/cli.py
+++ b/benchmarks/src/basic_memory_benchmarks/cli.py
@@ -388,6 +388,14 @@ def curate_beam_command(
     workers: int = typer.Option(
         1, "--workers", min=1, help="Conversations curated concurrently (each has its own bm mcp)"
     ),
+    startup_timeout: float = typer.Option(
+        180.0, "--startup-timeout", help="Seconds to wait for each bm mcp server to come up"
+    ),
+    resume: bool = typer.Option(
+        False,
+        "--resume",
+        help="Reuse groups already curated with this curator and prompt (per-group curation.json)",
+    ),
 ) -> None:
     """Curate a raw BEAM tier into knowledge notes through the write path.
 
@@ -421,6 +429,8 @@ def curate_beam_command(
         settle_timeout_seconds=settle_timeout,
         tool_timeout_seconds=tool_timeout,
         workers=workers,
+        startup_timeout_seconds=startup_timeout,
+        resume=resume,
     )
     output = curate_beam(config, runner=runner, progress=console.print)
     manifest = json.loads((output / "conversion.json").read_text(encoding="utf-8"))

--- a/benchmarks/src/basic_memory_benchmarks/curation/beam.py
+++ b/benchmarks/src/basic_memory_benchmarks/curation/beam.py
@@ -39,6 +39,7 @@ from basic_memory_benchmarks.bm_runtime import (
     resolve_bm_command_prefix,
     settle_index,
 )
+from basic_memory_benchmarks.concurrent_write import resolve_clean_checkout_sha
 from basic_memory_benchmarks.converters.beam_to_corpus import batch_anchor, clean_message_content
 from basic_memory_benchmarks.datasets.beam import BeamConversation, BeamMessage, load_beam_tier
 from basic_memory_benchmarks.llm.runners import LLMRunner, LLMRunnerError, create_runner
@@ -367,6 +368,7 @@ def curate_conversation(
     *,
     group_id: str,
     chat_sha256: str,
+    bm_identity: str,
     config: CurationConfig,
     prefix: list[str],
     runner: LLMRunner,
@@ -383,7 +385,7 @@ def curate_conversation(
     project_dir = home / "project"
     project_dir.mkdir(parents=True)
     (home / "default-home").mkdir(parents=True)
-    env = isolated_bm_env(home)
+    env = {**isolated_bm_env(home), **CURATION_ENV_OVERRIDES}
     writer = writer_factory(prefix, env, project_dir)
     try:
         run_command(prefix + ["project", "add", group_id, str(project_dir)], env=env)
@@ -444,17 +446,41 @@ def curate_conversation(
         stats.doc_count = len(stats.docs_sha256)
     stats.wall_seconds = round(time.monotonic() - started, 2)
     if stats.error is None:
-        write_curation_record(config, stats, chat_sha256=chat_sha256)
+        write_curation_record(config, stats, chat_sha256=chat_sha256, bm_identity=bm_identity)
     return stats
 
 
-def resume_key(config: CurationConfig, chat_sha256: str) -> dict[str, Any]:
+# Curation servers never embed: the curator only writes notes, and the eval
+# ingest embeds the copied docs anyway. Loading the embedding model in every
+# curator server and embedding every note as it lands is what made four
+# workers grind a laptop to a halt.
+CURATION_ENV_OVERRIDES: dict[str, str] = {"BASIC_MEMORY_SEMANTIC_SEARCH_ENABLED": "false"}
+
+
+def resolve_bm_identity(config: CurationConfig, prefix: list[str]) -> str:
+    """The Basic Memory that writes the notes: a clean checkout SHA, or the installed version.
+
+    write_note and edit_note decide the resulting paths and bytes, so a record
+    from one BM is not a record for another.
+    """
+    if config.bm_local_path:
+        return f"checkout:{resolve_clean_checkout_sha(Path(config.bm_local_path))}"
+    version = run_command(prefix + ["--version"]).stdout.strip()
+    if not version:
+        raise ValueError(
+            "`bm --version` printed nothing; cannot identify the installed Basic Memory"
+        )
+    return f"installed:{version}"
+
+
+def resume_key(config: CurationConfig, chat_sha256: str, bm_identity: str) -> dict[str, Any]:
     """Every input that changes a group's curated output.
 
     A record is reusable only when all of these match the current run: the
-    curator and its sampling temperature, the prompt, the note cap, and the
-    exact source chat the conversation was curated from. Anything else would
-    let a rebuilt manifest advertise settings its docs were not produced under.
+    curator and its sampling temperature, the prompt, the note cap, the exact
+    source chat the conversation was curated from, and the Basic Memory that
+    wrote the notes. Anything else would let a rebuilt manifest advertise
+    settings its docs were not produced under.
     """
     return {
         "curator_model_spec": config.model_spec,
@@ -462,32 +488,43 @@ def resume_key(config: CurationConfig, chat_sha256: str) -> dict[str, Any]:
         "curator_prompt_sha256": prompt_sha256(),
         "max_notes_per_session": config.max_notes_per_session,
         "chat_sha256": chat_sha256,
+        "bm_identity": bm_identity,
+        "env_overrides": dict(CURATION_ENV_OVERRIDES),
     }
 
 
 def write_curation_record(
-    config: CurationConfig, stats: ConversationCurationStats, *, chat_sha256: str
+    config: CurationConfig,
+    stats: ConversationCurationStats,
+    *,
+    chat_sha256: str,
+    bm_identity: str,
 ) -> None:
-    record = {"key": resume_key(config, chat_sha256), "stats": asdict(stats)}
+    record = {"key": resume_key(config, chat_sha256, bm_identity), "stats": asdict(stats)}
     path = config.output_dir / "groups" / stats.group_id / CURATION_RECORD
     path.write_text(json.dumps(record, indent=2), encoding="utf-8")
 
 
 def load_curation_record(
-    config: CurationConfig, group_id: str, *, chat_sha256: str
+    config: CurationConfig, group_id: str, *, chat_sha256: str, bm_identity: str
 ) -> ConversationCurationStats | None:
-    """A finished group's stats, only when its resume key matches this run exactly."""
+    """A finished group's stats, only when its resume key matches this run exactly
+    and the docs on disk are exactly the recorded set."""
     path = config.output_dir / "groups" / group_id / CURATION_RECORD
     if not path.exists():
         return None
     record = json.loads(path.read_text(encoding="utf-8"))
-    if record.get("key") != resume_key(config, chat_sha256):
+    if record.get("key") != resume_key(config, chat_sha256, bm_identity):
         return None
     docs_dir = config.output_dir / "groups" / group_id / "docs"
     stats = ConversationCurationStats(**record["stats"])
+    on_disk = {doc.relative_to(docs_dir).as_posix() for doc in docs_dir.rglob("*.md")}
+    # A stray file (an interrupted re-curation copied it before the record was
+    # replaced) would be ingested by every provider; the set must match exactly.
+    if on_disk != set(stats.docs_sha256):
+        return None
     for relative, digest in stats.docs_sha256.items():
-        doc = docs_dir / relative
-        if not doc.exists() or sha256_file(doc) != digest:
+        if sha256_file(docs_dir / relative) != digest:
             return None
     return stats
 
@@ -556,7 +593,20 @@ def curate_beam(
     }
 
     conversations = _select_conversations(load_beam_tier(dataset_root, tier), config)
+    # The manifest's checksums are what provenance pins; the loader reads the
+    # live files. A chat edited since `convert beam` would be curated under the
+    # old checksum, so the two must agree before any curator call is paid for.
+    for conversation in conversations:
+        live_sha = sha256_file(
+            dataset_root / tier / conversation.conversation_id / conversation.source_chat_file
+        )
+        if live_sha != chat_sha_by_conversation[conversation.conversation_id]:
+            raise ValueError(
+                f"BEAM conversation {conversation.conversation_id}: {conversation.source_chat_file} "
+                f"differs from the raw conversion manifest; rerun `convert beam` first"
+            )
     prefix = resolve_bm_command_prefix(config.bm_local_path)
+    bm_identity = resolve_bm_identity(config, prefix)
     curator = runner or create_runner(config.model_spec, temperature=config.model_temperature)
     factory = writer_factory or make_writer_factory(config)
 
@@ -567,7 +617,9 @@ def curate_beam(
         group_id = f"{raw_dataset_id}-c{int(conversation.conversation_id):02d}"
         chat_sha256 = chat_sha_by_conversation[conversation.conversation_id]
         if config.resume:
-            finished = load_curation_record(config, group_id, chat_sha256=chat_sha256)
+            finished = load_curation_record(
+                config, group_id, chat_sha256=chat_sha256, bm_identity=bm_identity
+            )
             if finished is not None:
                 progress(f"resuming {group_id}: {finished.doc_count} docs already curated")
                 return finished
@@ -576,6 +628,7 @@ def curate_beam(
             conversation,
             group_id=group_id,
             chat_sha256=chat_sha256,
+            bm_identity=bm_identity,
             config=config,
             prefix=prefix,
             runner=curator,
@@ -614,6 +667,8 @@ def curate_beam(
             "curator_model_spec": config.model_spec,
             "curator_temperature": config.model_temperature,
             "curator_prompt_sha256": prompt_sha256(),
+            "bm_identity": bm_identity,
+            "env_overrides": dict(CURATION_ENV_OVERRIDES),
             "max_notes_per_session": config.max_notes_per_session,
             "conversations": list(config.conversations) or None,
             "max_conversations": config.max_conversations,

--- a/benchmarks/src/basic_memory_benchmarks/curation/beam.py
+++ b/benchmarks/src/basic_memory_benchmarks/curation/beam.py
@@ -366,6 +366,7 @@ def curate_conversation(
     conversation: BeamConversation,
     *,
     group_id: str,
+    chat_sha256: str,
     config: CurationConfig,
     prefix: list[str],
     runner: LLMRunner,
@@ -443,32 +444,44 @@ def curate_conversation(
         stats.doc_count = len(stats.docs_sha256)
     stats.wall_seconds = round(time.monotonic() - started, 2)
     if stats.error is None:
-        write_curation_record(config, stats)
+        write_curation_record(config, stats, chat_sha256=chat_sha256)
     return stats
 
 
-def write_curation_record(config: CurationConfig, stats: ConversationCurationStats) -> None:
-    record = {
+def resume_key(config: CurationConfig, chat_sha256: str) -> dict[str, Any]:
+    """Every input that changes a group's curated output.
+
+    A record is reusable only when all of these match the current run: the
+    curator and its sampling temperature, the prompt, the note cap, and the
+    exact source chat the conversation was curated from. Anything else would
+    let a rebuilt manifest advertise settings its docs were not produced under.
+    """
+    return {
         "curator_model_spec": config.model_spec,
+        "curator_temperature": config.model_temperature,
         "curator_prompt_sha256": prompt_sha256(),
         "max_notes_per_session": config.max_notes_per_session,
-        "stats": asdict(stats),
+        "chat_sha256": chat_sha256,
     }
+
+
+def write_curation_record(
+    config: CurationConfig, stats: ConversationCurationStats, *, chat_sha256: str
+) -> None:
+    record = {"key": resume_key(config, chat_sha256), "stats": asdict(stats)}
     path = config.output_dir / "groups" / stats.group_id / CURATION_RECORD
     path.write_text(json.dumps(record, indent=2), encoding="utf-8")
 
 
-def load_curation_record(config: CurationConfig, group_id: str) -> ConversationCurationStats | None:
-    """A finished group's stats, only when it was curated with this curator and prompt."""
+def load_curation_record(
+    config: CurationConfig, group_id: str, *, chat_sha256: str
+) -> ConversationCurationStats | None:
+    """A finished group's stats, only when its resume key matches this run exactly."""
     path = config.output_dir / "groups" / group_id / CURATION_RECORD
     if not path.exists():
         return None
     record = json.loads(path.read_text(encoding="utf-8"))
-    if (
-        record.get("curator_model_spec") != config.model_spec
-        or record.get("curator_prompt_sha256") != prompt_sha256()
-        or record.get("max_notes_per_session") != config.max_notes_per_session
-    ):
+    if record.get("key") != resume_key(config, chat_sha256):
         return None
     docs_dir = config.output_dir / "groups" / group_id / "docs"
     stats = ConversationCurationStats(**record["stats"])
@@ -538,6 +551,9 @@ def curate_beam(
     raw_dataset_id = str(manifest["dataset_id"])
     dataset_id = f"{raw_dataset_id}-curated"
     raw_queries = json.loads((config.input_dir / "queries.json").read_text(encoding="utf-8"))
+    chat_sha_by_conversation = {
+        str(row["conversation_id"]): str(row["chat_sha256"]) for row in manifest["conversations"]
+    }
 
     conversations = _select_conversations(load_beam_tier(dataset_root, tier), config)
     prefix = resolve_bm_command_prefix(config.bm_local_path)
@@ -549,8 +565,9 @@ def curate_beam(
     def curate_one(conversation: BeamConversation) -> ConversationCurationStats:
         # Same group ids as the raw dataset, so query ids line up row for row.
         group_id = f"{raw_dataset_id}-c{int(conversation.conversation_id):02d}"
+        chat_sha256 = chat_sha_by_conversation[conversation.conversation_id]
         if config.resume:
-            finished = load_curation_record(config, group_id)
+            finished = load_curation_record(config, group_id, chat_sha256=chat_sha256)
             if finished is not None:
                 progress(f"resuming {group_id}: {finished.doc_count} docs already curated")
                 return finished
@@ -558,6 +575,7 @@ def curate_beam(
         stats = curate_conversation(
             conversation,
             group_id=group_id,
+            chat_sha256=chat_sha256,
             config=config,
             prefix=prefix,
             runner=curator,

--- a/benchmarks/src/basic_memory_benchmarks/curation/beam.py
+++ b/benchmarks/src/basic_memory_benchmarks/curation/beam.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import hashlib
 import json
 import shutil
+import subprocess
 import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -98,6 +99,11 @@ class CurationConfig:
     # Conversations are independent (own home, project, MCP session), so they
     # curate in parallel; one conversation is ~80 serial model calls.
     workers: int = 1
+    # `bm mcp` loads the embedding model at startup; with several servers
+    # starting on a loaded machine that took over 30s and aborted a whole run.
+    startup_timeout_seconds: float = 180.0
+    # Reuse a group's curation.json when its curator spec and prompt match.
+    resume: bool = False
 
 
 @dataclass(frozen=True)
@@ -146,13 +152,23 @@ class NoteWriter(Protocol):
 WriterFactory = Callable[[list[str], dict[str, str], Path], NoteWriter]
 
 
-def default_writer_factory(prefix: list[str], env: dict[str, str], project_dir: Path) -> NoteWriter:
-    return WarmMcpClient(
-        command=prefix[0],
-        args=prefix[1:] + ["mcp"],
-        env=env,
-        required_tool="write_note",
-    )
+def make_writer_factory(config: CurationConfig) -> WriterFactory:
+    def factory(prefix: list[str], env: dict[str, str], project_dir: Path) -> NoteWriter:
+        return WarmMcpClient(
+            command=prefix[0],
+            args=prefix[1:] + ["mcp"],
+            env=env,
+            startup_timeout_seconds=config.startup_timeout_seconds,
+            request_timeout_seconds=config.tool_timeout_seconds,
+            required_tool="write_note",
+        )
+
+    return factory
+
+
+# The per-group record a finished conversation leaves beside its docs, so a
+# relaunch can resume instead of paying for the conversation again.
+CURATION_RECORD = "curation.json"
 
 
 # --- Prompt assembly ---
@@ -367,10 +383,17 @@ def curate_conversation(
     project_dir.mkdir(parents=True)
     (home / "default-home").mkdir(parents=True)
     env = isolated_bm_env(home)
-    run_command(prefix + ["project", "add", group_id, str(project_dir)], env=env)
-
     writer = writer_factory(prefix, env, project_dir)
-    writer.start()
+    try:
+        run_command(prefix + ["project", "add", group_id, str(project_dir)], env=env)
+        writer.start()
+    except (subprocess.CalledProcessError, TimeoutError, RuntimeError) as exc:
+        # The project could not be registered or the server did not come up
+        # (a loaded machine starting several servers at once). One
+        # conversation is lost and recorded; the others keep running.
+        stats.error = f"bm setup failed: {exc}"
+        stats.wall_seconds = round(time.monotonic() - started, 2)
+        return stats
     index: dict[str, NoteIndexEntry] = {}
     current_anchor: str | None = None
     try:
@@ -419,6 +442,40 @@ def curate_conversation(
             stats.docs_sha256[relative.as_posix()] = sha256_file(target)
         stats.doc_count = len(stats.docs_sha256)
     stats.wall_seconds = round(time.monotonic() - started, 2)
+    if stats.error is None:
+        write_curation_record(config, stats)
+    return stats
+
+
+def write_curation_record(config: CurationConfig, stats: ConversationCurationStats) -> None:
+    record = {
+        "curator_model_spec": config.model_spec,
+        "curator_prompt_sha256": prompt_sha256(),
+        "max_notes_per_session": config.max_notes_per_session,
+        "stats": asdict(stats),
+    }
+    path = config.output_dir / "groups" / stats.group_id / CURATION_RECORD
+    path.write_text(json.dumps(record, indent=2), encoding="utf-8")
+
+
+def load_curation_record(config: CurationConfig, group_id: str) -> ConversationCurationStats | None:
+    """A finished group's stats, only when it was curated with this curator and prompt."""
+    path = config.output_dir / "groups" / group_id / CURATION_RECORD
+    if not path.exists():
+        return None
+    record = json.loads(path.read_text(encoding="utf-8"))
+    if (
+        record.get("curator_model_spec") != config.model_spec
+        or record.get("curator_prompt_sha256") != prompt_sha256()
+        or record.get("max_notes_per_session") != config.max_notes_per_session
+    ):
+        return None
+    docs_dir = config.output_dir / "groups" / group_id / "docs"
+    stats = ConversationCurationStats(**record["stats"])
+    for relative, digest in stats.docs_sha256.items():
+        doc = docs_dir / relative
+        if not doc.exists() or sha256_file(doc) != digest:
+            return None
     return stats
 
 
@@ -471,7 +528,7 @@ def curate_beam(
     config: CurationConfig,
     *,
     runner: LLMRunner | None = None,
-    writer_factory: WriterFactory = default_writer_factory,
+    writer_factory: WriterFactory | None = None,
     progress: Callable[[str], None] = lambda line: None,
 ) -> Path:
     """Curate a raw-converted BEAM tier into a sibling curated dataset. Returns output_dir."""
@@ -485,12 +542,18 @@ def curate_beam(
     conversations = _select_conversations(load_beam_tier(dataset_root, tier), config)
     prefix = resolve_bm_command_prefix(config.bm_local_path)
     curator = runner or create_runner(config.model_spec, temperature=config.model_temperature)
+    factory = writer_factory or make_writer_factory(config)
 
     config.output_dir.mkdir(parents=True, exist_ok=True)
 
     def curate_one(conversation: BeamConversation) -> ConversationCurationStats:
         # Same group ids as the raw dataset, so query ids line up row for row.
         group_id = f"{raw_dataset_id}-c{int(conversation.conversation_id):02d}"
+        if config.resume:
+            finished = load_curation_record(config, group_id)
+            if finished is not None:
+                progress(f"resuming {group_id}: {finished.doc_count} docs already curated")
+                return finished
         progress(f"curating {group_id} ({len(conversation.batches)} batches)")
         stats = curate_conversation(
             conversation,
@@ -498,7 +561,7 @@ def curate_beam(
             config=config,
             prefix=prefix,
             runner=curator,
-            writer_factory=writer_factory,
+            writer_factory=factory,
         )
         progress(
             f"  {group_id}: sessions={stats.sessions} notes={stats.notes_created}+{stats.notes_appended} "
@@ -537,6 +600,8 @@ def curate_beam(
             "conversations": list(config.conversations) or None,
             "max_conversations": config.max_conversations,
             "workers": config.workers,
+            "startup_timeout_seconds": config.startup_timeout_seconds,
+            "resume": config.resume,
         },
         "created_at_utc": utc_now_iso(),
         "conversations": [asdict(stats) for stats in stats_by_group],

--- a/benchmarks/tests/curation/test_beam_curation.py
+++ b/benchmarks/tests/curation/test_beam_curation.py
@@ -345,23 +345,30 @@ def test_unknown_conversation_ids_fail_fast(
 def test_workers_curate_in_parallel_and_keep_dataset_order(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Two conversations, two workers: same manifest as serial, in dataset order."""
+    """Two conversations, two workers: both are in flight at once (each
+    conversation's first curator call waits for the other's, which only
+    resolves with two workers), and the manifest keeps dataset order."""
     _raw_dataset(tmp_path)
     _stub_bm(monkeypatch)
     import threading
 
+    barrier = threading.Barrier(2)
     lock = threading.Lock()
-    seen_threads: set[int] = set()
+    first_calls = 0
 
-    class ThreadAwareRunner(ScriptedRunner):
+    class BarrierRunner(ScriptedRunner):
         def complete(self, prompt: str) -> LLMResult:
+            nonlocal first_calls
             with lock:
-                seen_threads.add(threading.get_ident())
+                first_calls += 1
+                is_first_of_two = first_calls <= 2
+            if is_first_of_two:
+                barrier.wait(timeout=10)
             return super().complete(prompt)
 
     output = curate_beam(
         _config(tmp_path, workers=2),
-        runner=ThreadAwareRunner([]),
+        runner=BarrierRunner([]),
         writer_factory=lambda p, e, d: FileWriter(d),
     )
 
@@ -372,7 +379,6 @@ def test_workers_curate_in_parallel_and_keep_dataset_order(
     ]
     assert manifest["converter"]["workers"] == 2
     assert manifest["totals"]["conversations"] == 2
-    assert len(seen_threads) == 2
 
 
 def test_a_server_that_fails_to_start_excludes_that_conversation_only(

--- a/benchmarks/tests/curation/test_beam_curation.py
+++ b/benchmarks/tests/curation/test_beam_curation.py
@@ -373,3 +373,64 @@ def test_workers_curate_in_parallel_and_keep_dataset_order(
     assert manifest["converter"]["workers"] == 2
     assert manifest["totals"]["conversations"] == 2
     assert len(seen_threads) == 2
+
+
+def test_a_server_that_fails_to_start_excludes_that_conversation_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The first full run died on `Timed out starting bm mcp session` from one
+    conversation on a loaded machine; the whole run aborted with no manifest."""
+    _raw_dataset(tmp_path)
+    _stub_bm(monkeypatch)
+
+    class DeadWriter(FileWriter):
+        def start(self) -> None:
+            raise TimeoutError("Timed out starting bm mcp session")
+
+    def writer_factory(prefix: list[str], env: dict[str, str], project_dir: Path) -> FileWriter:
+        return (
+            DeadWriter(project_dir)
+            if project_dir.parent.name.endswith("c02")
+            else FileWriter(project_dir)
+        )
+
+    output = curate_beam(
+        _config(tmp_path), runner=ScriptedRunner([]), writer_factory=writer_factory
+    )
+
+    manifest = json.loads((output / "conversion.json").read_text())
+    assert [row["group_id"] for row in manifest["excluded_conversations"]] == ["beam-100k-c02"]
+    assert "bm setup failed" in manifest["excluded_conversations"][0]["error"]
+    assert manifest["totals"]["conversations"] == 1
+    assert (output / "groups" / "beam-100k-c01" / "curation.json").exists()
+    assert not (output / "groups" / "beam-100k-c02" / "curation.json").exists()
+
+
+def test_resume_reuses_finished_groups_and_recurates_on_prompt_or_model_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _raw_dataset(tmp_path)
+    _stub_bm(monkeypatch)
+    first = ScriptedRunner([])
+    curate_beam(_config(tmp_path), runner=first, writer_factory=lambda p, e, d: FileWriter(d))
+    calls_first = len(first.prompts)
+    assert calls_first > 0
+
+    # Same curator and prompt: nothing is re-run, the manifest is rebuilt from records.
+    second = ScriptedRunner([])
+    output = curate_beam(
+        _config(tmp_path, resume=True), runner=second, writer_factory=lambda p, e, d: FileWriter(d)
+    )
+    assert second.prompts == []
+    manifest = json.loads((output / "conversion.json").read_text())
+    assert manifest["totals"]["conversations"] == 2
+    assert manifest["converter"]["resume"] is True
+
+    # A different curator spec invalidates the records: everything is curated again.
+    third = ScriptedRunner([])
+    curate_beam(
+        _config(tmp_path, resume=True, model_spec="scripted:other"),
+        runner=third,
+        writer_factory=lambda p, e, d: FileWriter(d),
+    )
+    assert len(third.prompts) == calls_first

--- a/benchmarks/tests/curation/test_beam_curation.py
+++ b/benchmarks/tests/curation/test_beam_curation.py
@@ -12,6 +12,7 @@ from mcp.types import CallToolResult
 
 import basic_memory_benchmarks.curation.beam as curation
 from basic_memory_benchmarks.converters.beam_to_corpus import convert_beam_to_corpus
+from basic_memory_benchmarks.datasets.beam import load_beam_tier
 from basic_memory_benchmarks.curation.beam import (
     CURATOR_PROMPT_TEMPLATE,
     MAX_INDEX_CHARS,
@@ -266,8 +267,6 @@ def test_a_curator_transport_failure_excludes_that_conversation_only(
     replies: list[str | Callable[[], str]] = []
     raw_manifest = json.loads((tmp_path / "raw" / "conversion.json").read_text())
     assert [row["conversation_id"] for row in raw_manifest["conversations"]] == ["1", "2"]
-    from basic_memory_benchmarks.datasets.beam import load_beam_tier
-
     sessions_one = sum(len(b.turns) for b in load_beam_tier(tmp_path / "chats", "100K")[0].batches)
     replies.extend(['{"notes": []}'] * sessions_one)
     replies.append(boom)
@@ -432,11 +431,36 @@ def test_resume_reuses_finished_groups_and_recurates_on_prompt_or_model_change(
     assert manifest["totals"]["conversations"] == 2
     assert manifest["converter"]["resume"] is True
 
-    # A different curator spec invalidates the records: everything is curated again.
-    third = ScriptedRunner([])
+    # Any input that changes the output invalidates the records: curator spec,
+    # temperature, note cap, and the source chat itself. Each one alone
+    # curates everything again.
+    for overrides in (
+        {"model_spec": "scripted:other"},
+        {"model_temperature": 0.3},
+        {"max_notes_per_session": 3},
+    ):
+        runner = ScriptedRunner([])
+        curate_beam(
+            _config(tmp_path, resume=True, **overrides),
+            runner=runner,
+            writer_factory=lambda p, e, d: FileWriter(d),
+        )
+        assert len(runner.prompts) == calls_first, overrides
+        # restore the baseline records for the next case
+        curate_beam(
+            _config(tmp_path),
+            runner=ScriptedRunner([]),
+            writer_factory=lambda p, e, d: FileWriter(d),
+        )
+
+    # A regenerated raw input with different chat content is a different source.
+    raw_manifest_path = tmp_path / "raw" / "conversion.json"
+    raw_manifest = json.loads(raw_manifest_path.read_text())
+    raw_manifest["conversations"][0]["chat_sha256"] = "0" * 64
+    raw_manifest_path.write_text(json.dumps(raw_manifest))
+    fourth = ScriptedRunner([])
     curate_beam(
-        _config(tmp_path, resume=True, model_spec="scripted:other"),
-        runner=third,
-        writer_factory=lambda p, e, d: FileWriter(d),
+        _config(tmp_path, resume=True), runner=fourth, writer_factory=lambda p, e, d: FileWriter(d)
     )
-    assert len(third.prompts) == calls_first
+    sessions_one = sum(len(b.turns) for b in load_beam_tier(tmp_path / "chats", "100K")[0].batches)
+    assert len(fourth.prompts) == sessions_one

--- a/benchmarks/tests/curation/test_beam_curation.py
+++ b/benchmarks/tests/curation/test_beam_curation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -100,8 +101,10 @@ def _stub_bm(monkeypatch: pytest.MonkeyPatch) -> tuple[list[list[str]], list[str
     settles: list[str] = []
     monkeypatch.setattr(curation, "resolve_bm_command_prefix", lambda bm_local_path: ["bm"])
 
-    def record_command(command: list[str], **kwargs: Any) -> None:
+    def record_command(command: list[str], **kwargs: Any) -> SimpleNamespace:
         commands.append(list(command))
+        stdout = "Basic Memory version: test" if "--version" in command else ""
+        return SimpleNamespace(stdout=stdout, stderr="")
 
     def record_settle(
         *, prefix: list[str], env: dict[str, str], project_name: str, timeout_seconds: float
@@ -453,14 +456,86 @@ def test_resume_reuses_finished_groups_and_recurates_on_prompt_or_model_change(
             writer_factory=lambda p, e, d: FileWriter(d),
         )
 
-    # A regenerated raw input with different chat content is a different source.
-    raw_manifest_path = tmp_path / "raw" / "conversion.json"
-    raw_manifest = json.loads(raw_manifest_path.read_text())
-    raw_manifest["conversations"][0]["chat_sha256"] = "0" * 64
-    raw_manifest_path.write_text(json.dumps(raw_manifest))
+    # A regenerated raw input with different chat content is a different source
+    # for that conversation only: it is curated again, the other is resumed.
+    chat = tmp_path / "chats" / "100K" / "1" / "chat.json"
+    chat.write_text(chat.read_text().replace("}", "} ", 1))
+    convert_beam_to_corpus(
+        dataset_root=tmp_path / "chats", output_dir=tmp_path / "raw", tier="100K"
+    )
     fourth = ScriptedRunner([])
     curate_beam(
         _config(tmp_path, resume=True), runner=fourth, writer_factory=lambda p, e, d: FileWriter(d)
     )
     sessions_one = sum(len(b.turns) for b in load_beam_tier(tmp_path / "chats", "100K")[0].batches)
     assert len(fourth.prompts) == sessions_one
+
+
+def test_curation_servers_run_with_semantic_search_off(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _raw_dataset(tmp_path)
+    _stub_bm(monkeypatch)
+    envs: list[dict[str, str]] = []
+
+    def writer_factory(prefix: list[str], env: dict[str, str], project_dir: Path) -> FileWriter:
+        envs.append(env)
+        return FileWriter(project_dir)
+
+    curate_beam(_config(tmp_path), runner=ScriptedRunner([]), writer_factory=writer_factory)
+
+    assert envs and all(env["BASIC_MEMORY_SEMANTIC_SEARCH_ENABLED"] == "false" for env in envs)
+
+
+def test_resume_is_keyed_on_the_bm_that_wrote_the_notes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _raw_dataset(tmp_path)
+    _stub_bm(monkeypatch)
+    curate_beam(
+        _config(tmp_path), runner=ScriptedRunner([]), writer_factory=lambda p, e, d: FileWriter(d)
+    )
+    manifest = json.loads((tmp_path / "curated" / "conversion.json").read_text())
+    assert manifest["converter"]["bm_identity"] == "installed:Basic Memory version: test"
+
+    monkeypatch.setattr(curation, "resolve_bm_identity", lambda config, prefix: "installed:other")
+    runner = ScriptedRunner([])
+    curate_beam(
+        _config(tmp_path, resume=True), runner=runner, writer_factory=lambda p, e, d: FileWriter(d)
+    )
+    assert runner.prompts, "a different Basic Memory must not reuse the records"
+
+
+def test_a_live_chat_that_differs_from_the_manifest_fails_fast(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _raw_dataset(tmp_path)
+    _stub_bm(monkeypatch)
+    chat = tmp_path / "chats" / "100K" / "1" / "chat.json"
+    chat.write_text(chat.read_text().replace("}", "} ", 1))
+    runner = ScriptedRunner([])
+    with pytest.raises(ValueError, match="differs from the raw conversion manifest"):
+        curate_beam(_config(tmp_path), runner=runner, writer_factory=lambda p, e, d: FileWriter(d))
+    assert runner.prompts == []
+
+
+def test_a_stray_doc_invalidates_the_resume_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _raw_dataset(tmp_path)
+    _stub_bm(monkeypatch)
+    curate_beam(
+        _config(tmp_path), runner=ScriptedRunner([]), writer_factory=lambda p, e, d: FileWriter(d)
+    )
+    stray = tmp_path / "curated" / "groups" / "beam-100k-c01" / "docs" / "topics" / "Stray.md"
+    stray.parent.mkdir(parents=True, exist_ok=True)
+    stray.write_text("# Stray\n")
+
+    runner = ScriptedRunner([])
+    curate_beam(
+        _config(tmp_path, resume=True), runner=runner, writer_factory=lambda p, e, d: FileWriter(d)
+    )
+
+    sessions_one = sum(len(b.turns) for b in load_beam_tier(tmp_path / "chats", "100K")[0].batches)
+    assert len(runner.prompts) == sessions_one
+    assert not stray.exists()


### PR DESCRIPTION
## Summary

The first full BEAM curation run (20 conversations, 4 workers) aborted on `TimeoutError: Timed out starting bm mcp session` with no manifest written. Four curators, the xAFS eval, and a retrieval run were starting `bm mcp` servers on one machine (load average above 40); one server exceeded the 30-second startup timeout, and that exception was not a handled per-conversation failure.

## Change

- Project registration or server start failing (`CalledProcessError`, `TimeoutError`, `RuntimeError`) is a per-conversation error: recorded under `excluded_conversations`, and the run continues.
- `--startup-timeout` (default 180s) sizes the server wait for a loaded machine.
- Each finished group writes `groups/<gid>/curation.json`: stats, curator spec, prompt sha256, `max_notes_per_session`, and per-file doc sha256s. `--resume` reuses a group only when all of those match the current run and the docs are intact; otherwise it is curated again. A relaunch no longer re-pays for finished conversations (about $1.70 each on Sonnet 5).

## Tests

A writer whose `start` raises `TimeoutError` excludes only its conversation and leaves no record; resume reuses both groups without a single curator call, and a different curator spec invalidates the records and curates everything again. Harness suite green; pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp