### PR TITLE
fix(core): surface the HTTP error body in completion-runner failures

### DIFF
--- a/benchmarks/src/basic_memory_benchmarks/llm/runners.py
+++ b/benchmarks/src/basic_memory_benchmarks/llm/runners.py
@@ -195,6 +195,14 @@ class OpenAICompatRunner(LLMRunner):
                     output_tokens=int(usage.get("completion_tokens") or 0),
                     latency_ms=(time.perf_counter() - started) * 1000.0,
                 )
+            except httpx.HTTPStatusError as exc:
+                # The status alone ("400 Bad Request") cannot tell a spent
+                # credit balance from a rejected parameter; the body can. Six
+                # BEAM conversations were excluded as bare 400s before this.
+                error_body = exc.response.text.strip().replace("\n", " ")[:300]
+                last_error = LLMRunnerError(
+                    f"HTTP {exc.response.status_code} from {exc.request.url}: {error_body}"
+                )
             except (httpx.HTTPError, KeyError, IndexError, json.JSONDecodeError) as exc:
                 last_error = exc
         raise LLMRunnerError(

--- a/benchmarks/tests/llm/test_runners.py
+++ b/benchmarks/tests/llm/test_runners.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+
+import httpx
 import subprocess
 
 import pytest
@@ -146,3 +148,23 @@ class TestClaudeCLIRunner:
         runner = ClaudeCLIRunner(model="claude-haiku-4-5", max_retries=1)
         assert runner.complete("hello").text == "ok"
         assert attempts["count"] == 2
+
+
+def test_openai_compat_error_includes_the_response_body(monkeypatch):
+    """A 400 with a JSON error body must surface the body: it is what says
+    "credit balance too low" versus "temperature is deprecated"."""
+    request = httpx.Request("POST", "https://api.example.test/v1/chat/completions")
+
+    def fake_post(url, **kwargs):
+        return httpx.Response(
+            400,
+            json={"error": {"message": "Your credit balance is too low to access the API."}},
+            request=request,
+        )
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    runner = OpenAICompatRunner(model="m", base_url="https://api.example.test/v1", max_retries=0)
+    with pytest.raises(LLMRunnerError) as excinfo:
+        runner.complete("hello")
+    assert "HTTP 400" in str(excinfo.value)
+    assert "credit balance is too low" in str(excinfo.value)


### PR DESCRIPTION
## Summary

The OpenAI-compatible completion runner reported only the status line on a failed call: `Client error '400 Bad Request' for url …`. Tonight six BEAM conversations were excluded with exactly that message; the response body was "Your credit balance is too low to access the Anthropic API", which is a different action from a rejected parameter. The runner now records status, URL, and the first 300 characters of the body in the `LLMRunnerError`, so the curation manifest and any QA artifact say why.

Test: a 400 with a JSON error body surfaces the body text in the raised error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp