### PR TITLE
fix(core): run claude -p judges and answerers without the operator's MCP servers

### DIFF
--- a/benchmarks/src/basic_memory_benchmarks/llm/runners.py
+++ b/benchmarks/src/basic_memory_benchmarks/llm/runners.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import tempfile
 import time
+from pathlib import Path
 from typing import Any
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -74,6 +76,14 @@ def _claude_result_event(payload: object) -> dict[str, Any]:
     raise LLMRunnerError(f"claude -p emitted {type(payload).__name__}, expected an object or array")
 
 
+def empty_mcp_config_path() -> Path:
+    """A persistent empty MCP config for `claude -p --strict-mcp-config`."""
+    path = Path(tempfile.gettempdir()) / "bm-bench-empty-mcp.json"
+    if not path.exists():
+        path.write_text('{"mcpServers": {}}\n', encoding="utf-8")
+    return path
+
+
 class ClaudeCLIRunner(LLMRunner):
     """Run prompts through ``claude -p`` (plan-billed, no API key required).
 
@@ -107,6 +117,15 @@ class ClaudeCLIRunner(LLMRunner):
             "json",
             "--max-turns",
             "1",
+            # A plain `claude -p` boots the operator's whole Claude Code
+            # configuration: every configured MCP server (npx-launched browser
+            # tooling among them) starts for one answer, per call. Four hundred
+            # judge calls did that to a laptop. An empty strict MCP config keeps
+            # the OAuth login and drops the servers; --bare would drop them too
+            # but forces API-key auth, which is not the account these runs bill.
+            "--strict-mcp-config",
+            "--mcp-config",
+            str(empty_mcp_config_path()),
         ]
         last_error: Exception | None = None
         for _ in range(self._max_retries + 1):

--- a/benchmarks/tests/llm/test_runners.py
+++ b/benchmarks/tests/llm/test_runners.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import httpx
 import subprocess
@@ -80,6 +81,13 @@ class TestClaudeCLIRunner:
         assert captured["input"] == "What is the capital of France?"
         assert "--max-turns" in captured["command"]
         assert "claude-haiku-4-5" in captured["command"]
+        # No MCP servers per call: the operator's browser tooling must not boot
+        # for a one-line judgment, and OAuth login must still apply (no --bare).
+        command = captured["command"]
+        assert "--strict-mcp-config" in command
+        assert "--bare" not in command
+        config_path = Path(command[command.index("--mcp-config") + 1])
+        assert json.loads(config_path.read_text()) == {"mcpServers": {}}
 
     def test_parses_the_event_array_claude_code_2_1_prints(self, monkeypatch):
         """`--output-format json` became an array of session events; the result


### PR DESCRIPTION
## Summary

The `claude:` runner shells out to `claude -p` for QA answers and judge verdicts. A plain `claude -p` boots the operator's whole Claude Code configuration for one answer: every configured MCP server starts per call, including npx-launched browser tooling (`chrome-devtools-mcp`, `playwriter`) at 60 to 80% CPU each. The BEAM QA stage makes 400 such calls; tonight's first attempt pushed the laptop's load average past 100 and was killed.

Verified by listing child processes of a `claude -p` call: default spawns the two npx servers plus the Basic Memory plugin hook; with `--strict-mcp-config --mcp-config <empty>` only the plugin hook remains.

## Change

The runner passes `--strict-mcp-config --mcp-config <persistent empty config>` on every call. This keeps the OAuth login. `--bare` (or `CLAUDE_CODE_SIMPLE=1`) would also drop the hook, but both force API-key auth ("Not logged in") and would bill the API key rather than the subscription.

Test: the command carries the flags and not `--bare`, and the referenced file is `{"mcpServers": {}}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp