### PR TITLE
fix(core): sandbox the bm-local provider's default project home

### DIFF
--- a/benchmarks/src/basic_memory_benchmarks/providers/bm_local.py
+++ b/benchmarks/src/basic_memory_benchmarks/providers/bm_local.py
@@ -47,15 +47,23 @@ class BasicMemoryLocalProvider(BenchmarkProvider):
         # The directory is FRESH per provider instance: a persistent shared
         # home rots across basic-memory versions (alembic migrations from a
         # newer dev build brick older binaries) and leaks projects between
-        # runs. BASIC_MEMORY_HOME is dropped for the same reason.
+        # runs.
+        #
+        # BASIC_MEMORY_HOME must point inside the sandbox too. Unset, Basic
+        # Memory registers its default project at ~/basic-memory, so every
+        # provider instance indexed the operator's personal notes (485 of them
+        # on 2026-09-03, embedded per run) into the benchmark database. Same
+        # rule as bm_runtime.isolated_bm_env.
         if self._config_dir is None:
             root = Path("benchmarks/.bm-homes")
             root.mkdir(parents=True, exist_ok=True)
             self._config_dir = Path(tempfile.mkdtemp(prefix="bm-home-", dir=root))
+        default_home = self._config_dir / "default-home"
+        default_home.mkdir(exist_ok=True)
         env = dict(os.environ)
         env.pop("BASIC_MEMORY_CLOUD_MODE", None)
-        env.pop("BASIC_MEMORY_HOME", None)
         env["BASIC_MEMORY_CONFIG_DIR"] = str(self._config_dir)
+        env["BASIC_MEMORY_HOME"] = str(default_home)
         return env
 
     def _project_name(self, run_config: RunConfig) -> str:

--- a/benchmarks/tests/providers/test_bm_local_provider.py
+++ b/benchmarks/tests/providers/test_bm_local_provider.py
@@ -179,3 +179,20 @@ def test_row_to_hit_without_title_omits_key() -> None:
         {"entity_id": 1, "matched_chunk": "text", "file_path": "doc.md"}
     )
     assert "title" not in hit.metadata
+
+
+def test_isolated_env_sandboxes_the_default_project_home(monkeypatch, tmp_path: Path) -> None:
+    """Unset, Basic Memory registers its default project at ~/basic-memory and
+    every provider instance indexed the operator's personal notes."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BASIC_MEMORY_HOME", "/Users/someone/basic-memory")
+    monkeypatch.setenv("BASIC_MEMORY_CLOUD_MODE", "true")
+    provider = BasicMemoryLocalProvider()
+
+    env = provider._isolated_bm_env()
+
+    config_dir = Path(env["BASIC_MEMORY_CONFIG_DIR"])
+    assert config_dir.is_relative_to(tmp_path / "benchmarks" / ".bm-homes")
+    assert env["BASIC_MEMORY_HOME"] == str(config_dir / "default-home")
+    assert (config_dir / "default-home").is_dir()
+    assert "BASIC_MEMORY_CLOUD_MODE" not in env


### PR DESCRIPTION
## Summary

The bm-local retrieval provider scopes `BASIC_MEMORY_CONFIG_DIR` to a fresh benchmark directory but drops `BASIC_MEMORY_HOME`. Unset, Basic Memory registers its default project at `~/basic-memory`. Result: every provider instance indexed and embedded the operator's personal knowledge base (485 notes on this machine on 2026-09-03) into the benchmark database, on every retrieval run, including the 2026-09-01 baseline.

Group-scoped queries never read that project, so recorded results are unaffected. The cost was CPU (485 notes embedded per run) and an isolation leak. An index pass can rewrite frontmatter; none was rewritten here (checked: no file under `~/basic-memory` modified in 24 hours; every note already carries a permalink).

## Change

`BASIC_MEMORY_HOME` now points at `<config dir>/default-home`, created fresh per provider instance, the same rule `bm_runtime.isolated_bm_env` already applies for the agent-task harness.

Test: the env carries a `BASIC_MEMORY_HOME` under the benchmark config dir, the directory exists, and `BASIC_MEMORY_CLOUD_MODE` is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp