### PR TITLE
feat(core): resume an interrupted BEAM scoring pass

### DIFF
--- a/benchmarks/src/basic_memory_benchmarks/cli.py
+++ b/benchmarks/src/basic_memory_benchmarks/cli.py
@@ -837,6 +837,11 @@ def run_beam_score_command(
     ),
     source: str = typer.Option("auto", "--source", help="qa | rejudge | auto"),
     max_workers: int = typer.Option(4, "--max-workers"),
+    resume: bool = typer.Option(
+        False,
+        "--resume",
+        help="Keep cases already scored by this judge without error; judge only the rest",
+    ),
 ) -> None:
     """Score a BEAM run's stored QA answers with the nugget methodology.
 
@@ -845,7 +850,7 @@ def run_beam_score_command(
     per-ability scores (never just an overall average).
     """
     out = run_beam_score_stage(
-        run_dir=run_dir, judge_spec=judge, source=source, max_workers=max_workers
+        run_dir=run_dir, judge_spec=judge, source=source, max_workers=max_workers, resume=resume
     )
     console.print(f"BEAM scoring complete: [green]{out}[/green]")
     console.print(f"See [cyan]{out / 'beam-summary.md'}[/cyan]")

--- a/benchmarks/src/basic_memory_benchmarks/runner.py
+++ b/benchmarks/src/basic_memory_benchmarks/runner.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from basic_memory_benchmarks.exceptions import ProviderSkippedError
 from basic_memory_benchmarks.fairness import validate_fairness
 from basic_memory_benchmarks.models import (
+    BeamCaseScore,
     DatasetProvenance,
     PerQueryRetrievalResult,
     ProviderStatus,
@@ -430,12 +431,34 @@ def run_diagnose_stage(
     return out_path
 
 
+def _reusable_beam_scores(run_dir: Path, judge_spec: str) -> list[BeamCaseScore]:
+    """Cases already judged by this judge without error, from a prior scoring pass.
+
+    The judge is part of the key: a different judge re-scores everything, so
+    one summary never mixes verdicts from two judges.
+    """
+    summary_path = run_dir / "beam-summary.json"
+    beam_jsonl = run_dir / "per-query-beam.jsonl"
+    if not summary_path.exists() or not beam_jsonl.exists():
+        return []
+    previous = json.loads(summary_path.read_text(encoding="utf-8"))
+    if previous.get("judge") != judge_spec:
+        return []
+    rows = [
+        BeamCaseScore.model_validate(json.loads(line))
+        for line in beam_jsonl.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    return [row for row in rows if row.error is None]
+
+
 def run_beam_score_stage(
     *,
     run_dir: Path,
     judge_spec: str,
     source: str = "auto",
     max_workers: int = 4,
+    resume: bool = False,
 ) -> Path:
     """Apply BEAM nugget/ordering scoring to a run's stored QA answers.
 
@@ -449,6 +472,7 @@ def run_beam_score_stage(
     from basic_memory_benchmarks.scoring.beam import (
         build_beam_summary_markdown,
         score_beam_cases,
+        summarize_beam_cases,
     )
 
     qa_cases, chosen = _load_qa_cases(run_dir, source)
@@ -469,9 +493,29 @@ def run_beam_score_stage(
         )
 
     judge = create_runner(judge_spec)
-    case_scores, summaries = score_beam_cases(
-        qa_cases, retrieval_rows, judge=judge, max_workers=max_workers
-    )
+    # Trigger: --resume after an interrupted pass (a judge transport failing
+    #   part way, e.g. the claude CLI's session limit after 130 of 400 cases).
+    # Why: every scored case cost a judge call; re-judging them pays again and
+    #   can hit the same limit before reaching the cases that still need it.
+    # Outcome: cases this judge already scored are kept, only the rest are
+    #   judged, and the summary is rebuilt over the whole set.
+    reused = _reusable_beam_scores(run_dir, judge_spec) if resume else []
+    reused_keys = {(case.provider, case.query_id) for case in reused}
+    pending = [case for case in qa_cases if (case.provider, case.query_id) not in reused_keys]
+    new_scores, _ = score_beam_cases(pending, retrieval_rows, judge=judge, max_workers=max_workers)
+    by_key = {(case.provider, case.query_id): case for case in [*reused, *new_scores]}
+    case_scores = [by_key[(case.provider, case.query_id)] for case in qa_cases]
+    providers: list[str] = []
+    cases_by_provider: dict[str, list[BeamCaseScore]] = {}
+    for case in case_scores:
+        if case.provider not in cases_by_provider:
+            providers.append(case.provider)
+            cases_by_provider[case.provider] = []
+        cases_by_provider[case.provider].append(case)
+    summaries = [
+        summarize_beam_cases(provider, cases_by_provider[provider], judge.spec)
+        for provider in providers
+    ]
 
     beam_jsonl = run_dir / "per-query-beam.jsonl"
     with beam_jsonl.open("w", encoding="utf-8") as file:

--- a/benchmarks/tests/test_beam_scoring.py
+++ b/benchmarks/tests/test_beam_scoring.py
@@ -546,6 +546,76 @@ class TestBeamScoreStage:
             )
         assert not (tmp_path / "per-query-beam.jsonl").exists()
 
+    def test_resume_judges_only_the_cases_the_last_pass_could_not(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """The claude CLI judge hit its session limit after 130 of 400 raw cases;
+        a re-run without resume would re-pay for those 130 and could hit the
+        limit again before reaching the 270 that still needed a verdict."""
+        from basic_memory_benchmarks import runner as runner_module
+        from basic_memory_benchmarks.llm.runners import LLMResult, LLMRunner, LLMRunnerError
+
+        self._write_rows(
+            tmp_path,
+            [
+                _retrieval_row("q1", "information_extraction", ["States March 29"]),
+                _retrieval_row("q2", "preference_following", ["Prefers tea"]),
+            ],
+        )
+        self._write_qa(
+            tmp_path / "per-query-qa.jsonl",
+            [_qa_case("q1", "March 29"), _qa_case("q2", "tea, always")],
+        )
+
+        class LimitedJudge(LLMRunner):
+            spec = "fake:test"
+
+            def __init__(self) -> None:
+                self.calls = 0
+                self.failing = True
+
+            def complete(self, prompt: str) -> LLMResult:
+                self.calls += 1
+                if self.failing and "tea" in prompt:
+                    raise LLMRunnerError("session limit")
+                return LLMResult(
+                    text='{"score": 1.0, "reason": "stated"}',
+                    model="fake",
+                    input_tokens=1,
+                    output_tokens=1,
+                    latency_ms=0.0,
+                )
+
+        judge = LimitedJudge()
+        monkeypatch.setattr("basic_memory_benchmarks.llm.runners.create_runner", lambda spec: judge)
+
+        runner_module.run_beam_score_stage(run_dir=tmp_path, judge_spec="fake:test", max_workers=1)
+        first = json.loads((tmp_path / "beam-summary.json").read_text())["providers"][0]
+        assert first["error_count"] == 1
+        calls_first = judge.calls
+
+        judge.failing = False
+        runner_module.run_beam_score_stage(
+            run_dir=tmp_path, judge_spec="fake:test", max_workers=1, resume=True
+        )
+        assert judge.calls == calls_first + 1, "only the errored case was judged again"
+        second = json.loads((tmp_path / "beam-summary.json").read_text())["providers"][0]
+        assert second["error_count"] == 0
+        rows = [
+            BeamCaseScore.model_validate(json.loads(line))
+            for line in (tmp_path / "per-query-beam.jsonl").read_text().splitlines()
+        ]
+        assert [row.query_id for row in rows] == ["q1", "q2"]
+        assert all(row.error is None for row in rows)
+
+        # A different judge re-scores everything: verdicts from two judges never mix.
+        judge.spec = "fake:other"
+        judge.calls = 0
+        runner_module.run_beam_score_stage(
+            run_dir=tmp_path, judge_spec="fake:other", max_workers=1, resume=True
+        )
+        assert judge.calls == 2
+
     def test_source_rejudge_selects_rejudged_answers(self, tmp_path: Path, monkeypatch) -> None:
         from basic_memory_benchmarks import runner as runner_module
 


### PR DESCRIPTION
## Summary

Closes #1468. `run beam-score` judged all 400 cases of a run and wrote its artifacts at the end. When the judge transport failed part way (tonight the claude CLI hit the subscription's session limit after 130 of 400 raw cases and 34 of 400 curated cases), the errored rows were recorded and a re-run re-judged everything, paying again for the cases that had succeeded and likely hitting the same limit before reaching the rest.

## Change

`--resume` keeps cases already scored by the same `--judge` without error, judges only the remaining ones, and rebuilds the per-ability summary over the whole set. The judge spec is the key: a different judge re-scores everything, so a summary never mixes two judges' verdicts. Same rule as `curate beam --resume`.

Test: a judge that fails on one of two cases, then a resumed pass that makes exactly one more call and ends with zero errors, then a different judge spec that re-scores both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pmKq6bqCi6Zp6BTHuZjrp