### PR TITLE
fix(core): use bounded SQLite pooling on Windows

### DIFF
--- a/.github/workflows/sqlite-lifecycle.yml
+++ b/.github/workflows/sqlite-lifecycle.yml
@@ -40,15 +40,18 @@ jobs:
       - name: Verify actual interpreter and SQLite
         run: uv run python -c "import sys, sqlite3; print(sys.version); print(sqlite3.sqlite_version); assert sys.version_info[:2] == (3, 12)"
       - name: Run real SQLite probes without test selection caching
-        run: uv run pytest test-int/test_sqlite_lifecycle_integration.py -v -s --no-cov --timeout=240 --junitxml=sqlite-lifecycle.xml
+        shell: bash
+        run: uv run pytest test-int/test_sqlite_lifecycle_integration.py -v -s --no-cov --timeout=240 --junitxml=sqlite-lifecycle.xml 2>&1 | tee sqlite-lifecycle.log
       - name: Reproduce reported MCP pagination and high-volume writes
         if: always() && !cancelled()
+        shell: bash
         run: >-
           uv run pytest
           test-int/mcp/test_chatgpt_tools_integration.py::test_chatgpt_search_pagination_default
           test-int/mcp/test_concurrent_write_integration.py::test_concurrent_write_high_volume
           -v -s --no-cov --timeout=120 --timeout-method=thread
           -o faulthandler_timeout=60 --junitxml=sqlite-mcp.xml
+          2>&1 | tee sqlite-mcp.log
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -56,3 +59,5 @@ jobs:
           path: |
             sqlite-lifecycle.xml
             sqlite-mcp.xml
+            sqlite-lifecycle.log
+            sqlite-mcp.log

--- a/.github/workflows/sqlite-lifecycle.yml
+++ b/.github/workflows/sqlite-lifecycle.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/workflows/sqlite-lifecycle.yml'
       - 'test-int/test_sqlite_lifecycle_integration.py'
+      - 'test-int/test_db_wal_mode.py'
       - 'src/basic_memory/db.py'
       - 'src/basic_memory/cli/commands/command_utils.py'
       - 'src/basic_memory/cli/commands/db.py'
@@ -41,7 +42,7 @@ jobs:
         run: uv run python -c "import sys, sqlite3; print(sys.version); print(sqlite3.sqlite_version); assert sys.version_info[:2] == (3, 12)"
       - name: Run real SQLite probes without test selection caching
         shell: bash
-        run: uv run pytest test-int/test_sqlite_lifecycle_integration.py -v -s --no-cov --timeout=240 --junitxml=sqlite-lifecycle.xml 2>&1 | tee sqlite-lifecycle.log
+        run: uv run pytest test-int/test_sqlite_lifecycle_integration.py test-int/test_db_wal_mode.py -v -s --no-cov --timeout=240 --junitxml=sqlite-lifecycle.xml 2>&1 | tee sqlite-lifecycle.log
       - name: Reproduce reported MCP pagination and high-volume writes
         if: always() && !cancelled()
         shell: bash

--- a/.github/workflows/sqlite-lifecycle.yml
+++ b/.github/workflows/sqlite-lifecycle.yml
@@ -1,0 +1,42 @@
+name: SQLite lifecycle probes
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/sqlite-lifecycle.yml'
+      - 'test-int/test_sqlite_lifecycle_integration.py'
+      - 'src/basic_memory/db.py'
+      - 'src/basic_memory/cli/commands/command_utils.py'
+
+permissions:
+  contents: read
+
+jobs:
+  lifecycle:
+    name: SQLite lifecycle (${{ matrix.os }}, Python 3.12)
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    env:
+      UV_PYTHON: '3.12'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - run: pip install uv
+      - run: uv venv
+      - run: uv pip install -e ".[dev,pdf]"
+      - name: Verify actual interpreter and SQLite
+        run: uv run python -c "import sys, sqlite3; print(sys.version); print(sqlite3.sqlite_version); assert sys.version_info[:2] == (3, 12)"
+      - name: Run real SQLite probes without test selection caching
+        run: uv run pytest test-int/test_sqlite_lifecycle_integration.py -v -s --no-cov --timeout=240 --junitxml=sqlite-lifecycle.xml
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: sqlite-lifecycle-${{ matrix.os }}
+          path: sqlite-lifecycle.xml

--- a/.github/workflows/sqlite-lifecycle.yml
+++ b/.github/workflows/sqlite-lifecycle.yml
@@ -8,17 +8,23 @@ on:
       - 'test-int/test_sqlite_lifecycle_integration.py'
       - 'src/basic_memory/db.py'
       - 'src/basic_memory/cli/commands/command_utils.py'
+      - 'src/basic_memory/cli/commands/db.py'
+      - 'src/basic_memory/index/local_schedulers.py'
+      - 'src/basic_memory/index/note_content_materialization.py'
+      - 'test-int/mcp/test_chatgpt_tools_integration.py'
+      - 'test-int/mcp/test_concurrent_write_integration.py'
 
 permissions:
   contents: read
 
 jobs:
   lifecycle:
-    name: SQLite lifecycle (${{ matrix.os }}, Python 3.12)
+    name: SQLite lifecycle (${{ matrix.os }}, Python 3.12, run ${{ matrix.repetition }})
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
+        repetition: [1, 2, 3]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     env:
@@ -35,8 +41,18 @@ jobs:
         run: uv run python -c "import sys, sqlite3; print(sys.version); print(sqlite3.sqlite_version); assert sys.version_info[:2] == (3, 12)"
       - name: Run real SQLite probes without test selection caching
         run: uv run pytest test-int/test_sqlite_lifecycle_integration.py -v -s --no-cov --timeout=240 --junitxml=sqlite-lifecycle.xml
+      - name: Reproduce reported MCP pagination and high-volume writes
+        if: always() && !cancelled()
+        run: >-
+          uv run pytest
+          test-int/mcp/test_chatgpt_tools_integration.py::test_chatgpt_search_pagination_default
+          test-int/mcp/test_concurrent_write_integration.py::test_concurrent_write_high_volume
+          -v -s --no-cov --timeout=120 --timeout-method=thread
+          -o faulthandler_timeout=60 --junitxml=sqlite-mcp.xml
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: sqlite-lifecycle-${{ matrix.os }}
-          path: sqlite-lifecycle.xml
+          name: sqlite-lifecycle-${{ matrix.os }}-${{ matrix.repetition }}
+          path: |
+            sqlite-lifecycle.xml
+            sqlite-mcp.xml

--- a/src/basic_memory/db.py
+++ b/src/basic_memory/db.py
@@ -296,10 +296,18 @@ def _create_sqlite_engine(
             pool_size=1,
             max_overflow=0,
         )
+    elif os.name == "nt":
+        # Windows NullPool storms SQLite with connections, while the default
+        # pool's overflow still reproduced lock starvation in native CI (#1430).
+        # Queue excess callers before SQLite instead of adding competing writers.
+        engine = create_async_engine(
+            db_url,
+            connect_args=connect_args,
+            poolclass=AsyncAdaptedQueuePool,
+            pool_size=5,
+            max_overflow=0,
+        )
     else:
-        # Reuse the bounded file-backed pool on every platform. Windows NullPool
-        # opened a connection per transaction and reproduced lock failures under
-        # concurrent writes (#1430); queueing bounds contention without retries.
         engine = create_async_engine(db_url, connect_args=connect_args)
 
     # Enable WAL mode for better concurrency and reliability

--- a/src/basic_memory/db.py
+++ b/src/basic_memory/db.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     async_scoped_session,
 )
-from sqlalchemy.pool import AsyncAdaptedQueuePool, NullPool
+from sqlalchemy.pool import AsyncAdaptedQueuePool
 
 
 # -----------------------------------------------------------------------------
@@ -296,15 +296,10 @@ def _create_sqlite_engine(
             pool_size=1,
             max_overflow=0,
         )
-    elif os.name == "nt":
-        # Use NullPool for Windows filesystem databases to avoid connection pooling issues
-        engine = create_async_engine(
-            db_url,
-            connect_args=connect_args,
-            poolclass=NullPool,  # Disable connection pooling on Windows
-            echo=False,
-        )
     else:
+        # Reuse the bounded file-backed pool on every platform. Windows NullPool
+        # opened a connection per transaction and reproduced lock failures under
+        # concurrent writes (#1430); queueing bounds contention without retries.
         engine = create_async_engine(db_url, connect_args=connect_args)
 
     # Enable WAL mode for better concurrency and reliability

--- a/test-int/test_db_wal_mode.py
+++ b/test-int/test_db_wal_mode.py
@@ -154,10 +154,10 @@ async def test_windows_locking_mode_when_on_windows(tmp_path, monkeypatch, confi
 @pytest.mark.skipif(
     __import__("os").name != "nt", reason="Windows-specific test - only runs on Windows platform"
 )
-async def test_null_pool_on_windows(tmp_path, monkeypatch):
-    """Test that NullPool is used on Windows to avoid connection pooling issues."""
+async def test_bounded_pool_on_windows(tmp_path, monkeypatch):
+    """Windows queues excess callers instead of opening competing SQLite writers."""
     from basic_memory.db import engine_session_factory, DatabaseType
-    from sqlalchemy.pool import NullPool
+    from sqlalchemy.pool import AsyncAdaptedQueuePool
 
     # Set HOME environment variable
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -166,8 +166,9 @@ async def test_null_pool_on_windows(tmp_path, monkeypatch):
     db_path = tmp_path / "test_windows_pool.db"
 
     async with engine_session_factory(db_path, DatabaseType.FILESYSTEM) as (engine, _):
-        # Engine should be using NullPool on Windows
-        assert isinstance(engine.pool, NullPool)
+        assert isinstance(engine.pool, AsyncAdaptedQueuePool)
+        assert engine.pool.size() == 5
+        assert engine.pool._max_overflow == 0
 
 
 @pytest.mark.asyncio

--- a/test-int/test_sqlite_lifecycle_integration.py
+++ b/test-int/test_sqlite_lifecycle_integration.py
@@ -40,8 +40,8 @@ async def test_file_sqlite_concurrent_writes_commit_and_dispose(tmp_path: Path) 
             await connection.execute(text("CREATE VIRTUAL TABLE notes_fts USING fts5(body)"))
 
         async def write_notes(writer: int) -> None:
-            for index in range(20):
-                note_id = writer * 20 + index
+            for index in range(40):
+                note_id = writer * 40 + index
                 async with engine.begin() as connection:
                     await connection.execute(
                         text("INSERT INTO notes VALUES (:id, :body)"),
@@ -58,15 +58,15 @@ async def test_file_sqlite_concurrent_writes_commit_and_dispose(tmp_path: Path) 
                     ).scalar_one() == "searchable note"
 
         async with asyncio.timeout(90), asyncio.TaskGroup() as writers:
-            for writer in range(32):
+            for writer in range(64):
                 writers.create_task(write_notes(writer))
         async with engine.connect() as connection:
-            assert (await connection.execute(text("SELECT count(*) FROM notes"))).scalar() == 640
+            assert (await connection.execute(text("SELECT count(*) FROM notes"))).scalar() == 2560
             assert (
                 await connection.execute(
                     text("SELECT count(*) FROM notes_fts WHERE notes_fts MATCH 'searchable'")
                 )
-            ).scalar() == 640
+            ).scalar() == 2560
             assert (await connection.execute(text("PRAGMA integrity_check"))).scalar() == "ok"
     finally:
         await asyncio.wait_for(engine.dispose(), 15)

--- a/test-int/test_sqlite_lifecycle_integration.py
+++ b/test-int/test_sqlite_lifecycle_integration.py
@@ -1,0 +1,126 @@
+"""Real file-backed SQLite contention and CLI-exit probes for #1430/#1322.
+
+No platform simulation: Windows CI selects the production Windows engine path.
+The CLI probe disables embeddings to isolate database lifecycle from ONNX work.
+"""
+
+import asyncio
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+import pytest
+from sqlalchemy import event, text
+
+from basic_memory.db import DatabaseType, _create_sqlite_engine
+
+
+@pytest.mark.asyncio
+async def test_file_sqlite_concurrent_writes_commit_and_dispose(tmp_path: Path) -> None:
+    engine = _create_sqlite_engine(
+        DatabaseType.get_db_url(tmp_path / "contention.db", DatabaseType.FILESYSTEM),
+        DatabaseType.FILESYSTEM,
+    )
+    connections = 0
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def count_connection(connection: object, record: object) -> None:
+        nonlocal connections
+        connections += 1
+
+    started = time.monotonic()
+    try:
+        async with engine.begin() as connection:
+            assert (await connection.execute(text("PRAGMA journal_mode"))).scalar() == "wal"
+            assert (await connection.execute(text("PRAGMA busy_timeout"))).scalar() == 10000
+            await connection.execute(text("CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT)"))
+            await connection.execute(text("CREATE VIRTUAL TABLE notes_fts USING fts5(body)"))
+
+        async def write_notes(writer: int) -> None:
+            for index in range(20):
+                note_id = writer * 20 + index
+                async with engine.begin() as connection:
+                    await connection.execute(
+                        text("INSERT INTO notes VALUES (:id, :body)"),
+                        {"id": note_id, "body": "searchable note"},
+                    )
+                    await connection.execute(
+                        text("INSERT INTO notes_fts(rowid, body) VALUES (:id, :body)"),
+                        {"id": note_id, "body": "searchable note"},
+                    )
+                    assert (
+                        await connection.execute(
+                            text("SELECT body FROM notes WHERE id = :id"), {"id": note_id}
+                        )
+                    ).scalar_one() == "searchable note"
+
+        async with asyncio.timeout(90), asyncio.TaskGroup() as writers:
+            for writer in range(32):
+                writers.create_task(write_notes(writer))
+        async with engine.connect() as connection:
+            assert (await connection.execute(text("SELECT count(*) FROM notes"))).scalar() == 640
+            assert (
+                await connection.execute(
+                    text("SELECT count(*) FROM notes_fts WHERE notes_fts MATCH 'searchable'")
+                )
+            ).scalar() == 640
+            assert (await connection.execute(text("PRAGMA integrity_check"))).scalar() == "ok"
+    finally:
+        await asyncio.wait_for(engine.dispose(), 15)
+        print(
+            f"pool={type(engine.pool).__name__} connections={connections} "
+            f"elapsed={time.monotonic() - started:.2f}s"
+        )
+
+
+def test_reindex_subprocess_exits_after_full_and_incremental_sqlite_runs(tmp_path: Path) -> None:
+    project = tmp_path / "notes"
+    project.mkdir()
+    for index in range(15):
+        (project / f"note-{index}.md").write_text(
+            f"# Note {index}\n\n- [fact] searchable lifecycle probe\n", encoding="utf-8"
+        )
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "projects": {"probe": {"path": str(project), "mode": "local"}},
+                "default_project": "probe",
+                "semantic_search_enabled": False,
+                "auto_update": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("BASIC_MEMORY_") and key != "PYTEST_CURRENT_TEST"
+    }
+    environment["BASIC_MEMORY_CONFIG_DIR"] = str(config_dir)
+    environment["PYTHONUTF8"] = "1"
+    # Native thread stacks survive in the CI artifact if the child wedges.
+    entrypoint = (
+        "import faulthandler; faulthandler.dump_traceback_later(60); "
+        "from basic_memory.cli.main import app; app()"
+    )
+    for arguments in (["reindex", "--full"], ["reindex"]):
+        try:
+            result = subprocess.run(
+                [sys.executable, "-c", entrypoint, *arguments],
+                env=environment,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                timeout=90,
+            )
+        except subprocess.TimeoutExpired as error:
+            pytest.fail(f"CLI did not exit: {arguments}\n{error.stdout}\n{error.stderr}")
+        print(result.stdout)
+        print(result.stderr)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Reindex complete!" in result.stdout


### PR DESCRIPTION
## Why

The unchanged Windows NullPool configuration failed real concurrent SQLite writes in all three native Python 3.12 CI repetitions with `database is locked`. All three Linux repetitions passed. This addresses the reproduced lock-contention symptom in #1430.

Baseline: https://github.com/basicmachines-co/basic-memory/actions/runs/33988134362

## What Changed

- Replace Windows-only NullPool selection for file-backed SQLite with a five-connection pool and no overflow. Linux/macOS remain unchanged.
- Real file-backed SQLite regression: 64 writers x 40 operations, FTS writes, WAL/busy-timeout assertions, counts, integrity, and disposal.
- Real CLI subprocess regression: full then incremental reindex must exit.
- Repeat native Windows/Linux Python 3.12 runs three times, including the exact reported MCP pagination and concurrent-write tests, with timeout thread dumps, console logs, and JUnit artifacts. Console logs survive hard pytest timeouts that prevent JUnit finalization.

## Implementation Details

No database/platform mocks. No retries, increased timeouts, locks, or pragma changes. In-memory SQLite retains its separate single-connection pool. Native pooling, connection counts, and elapsed times are logged.

The default pool (five connections plus ten overflow) still failed one of three Windows repetitions in run 33989416492. Windows now queues excess callers before SQLite instead of opening overflow connections.

## Testing

- `uv run pytest test-int/test_sqlite_lifecycle_integration.py tests/db/test_memory_db_session_isolation.py --no-cov -q --timeout=240`: four tests passed locally.
- `just fast-check`: lint, format, and full typecheck passed.
- Local `codex review --uncommitted`: no actionable regressions.
- Native CI comparison on the fix head is pending.

## Risks / Follow-ups

The original silent hang has not been reproduced. #1322 remains separate: the subprocess baseline disables semantic search and does not exercise its FastEmbed/ONNX workload. Do not treat this as proof that either silent-hang report is resolved.

Related: #1430, #1322.
