### PR TITLE
fix(mcp): round-trip find note-type predicates

### DIFF
--- a/src/basic_memory/man/man1/find(1).md
+++ b/src/basic_memory/man/man1/find(1).md
@@ -122,6 +122,13 @@ mis-spelled multi-character operator: `status==active`, `status=>active` and
 and `>3`. An unquoted value may therefore not begin with `=`, `<` or `>`;
 quote one that genuinely does, as in `range=">=5"`.
 
+String equality and `in` predicates on `type` or `note_type` use the same
+normalization as note-type search: `Chapter` and `chapter` match the same
+notes, as do `LiteraryDevice` and `literary_device`. A `metadata.note_type`
+value returned by find can be reused in its next `--meta` predicate.
+Other metadata keys remain case-sensitive; null, numeric, range, and array
+predicates keep their existing frontmatter comparison behavior.
+
 ## OPTIONS
 
 - **--name** — file-name glob, e.g. `"*.md"`; omitted matches everything.

--- a/src/basic_memory/mcp/tools/posix_tools.py
+++ b/src/basic_memory/mcp/tools/posix_tools.py
@@ -949,6 +949,9 @@ async def find(
             with "=" — the other operators compare against the value, and a
             comparison with null is never true. Keys accept dot-paths
             ("review.approved"); "note_type" aliases the frontmatter "type" key.
+            String equality and "in" on either type spelling use normalized
+            note-type matching ("LiteraryDevice" matches "literary_device").
+            Other metadata keys and operators retain their usual comparisons.
             Any other operator fails fast naming the supported set.
         fields: Frontmatter fields to return per hit (dot-paths allowed), e.g.
             ["title", "priority"]. Requires `meta`. A field missing on a hit
@@ -1117,11 +1120,28 @@ async def _find_by_metadata(
         # Import here to avoid circular import
         from basic_memory.mcp.clients import KnowledgeClient, SearchClient
 
+        # Type equality/membership must use the same normalization as the type
+        # displayed in search hits. Raw frontmatter comparisons made those
+        # displayed values fail when fed back into find (#1428).
+        note_types: list[str] | None = None
+        type_filter = metadata_filters.get("type")
+        if isinstance(type_filter, str):
+            note_types = [type_filter]
+        elif isinstance(type_filter, dict) and "$in" in type_filter:
+            values = type_filter["$in"]
+            if isinstance(values, list) and values and all(isinstance(v, str) for v in values):
+                note_types = values
+        if note_types is not None:
+            metadata_filters = {
+                key: value for key, value in metadata_filters.items() if key != "type"
+            }
+
         query = SearchQuery(
             # Normalized by the field validator, which maps every root spelling
             # onto None: the predicates are then the whole WHERE.
             file_path_prefix=route.path,
             metadata_filters=metadata_filters,
+            note_types=note_types,
             entity_types=[SearchItemType.ENTITY],
         )
         search_client = SearchClient(client, active_project.external_id)

--- a/test-int/cli/test_find_note_type_integration.py
+++ b/test-int/cli/test_find_note_type_integration.py
@@ -1,0 +1,142 @@
+"""Real CLI note-type predicates must accept authored and displayed spellings."""
+
+import json
+
+from typer.testing import CliRunner
+
+from basic_memory.cli.main import app
+import pytest
+
+pytestmark = pytest.mark.usefixtures("app")
+
+runner = CliRunner()
+
+
+def test_find_chapter_type_round_trip(app_config, test_project, config_manager):
+    write = runner.invoke(
+        app,
+        [
+            "tool",
+            "write-note",
+            "--title",
+            "Chapter One",
+            "--folder",
+            "chapters",
+            "--content",
+            "---\ntype: Chapter\nchapter_number: 1\n---\nChapter body.",
+        ],
+    )
+    assert write.exit_code == 0, write.output
+    permalink = json.loads(write.stdout)["permalink"]
+
+    authored = runner.invoke(app, ["find", "--meta", "note_type=Chapter", "--json"])
+    assert authored.exit_code == 0, authored.output
+    rows = json.loads(authored.stdout)["results"]
+    assert [row["permalink"] for row in rows] == [permalink]
+    displayed_type = rows[0]["metadata"]["note_type"]
+    assert displayed_type == "chapter"
+
+    repeated = runner.invoke(app, ["find", "--meta", f"note_type={displayed_type}", "--json"])
+    assert repeated.exit_code == 0, repeated.output
+    assert [row["permalink"] for row in json.loads(repeated.stdout)["results"]] == [permalink]
+
+
+def test_find_multiword_type_round_trip(app_config, test_project, config_manager):
+    write = runner.invoke(
+        app,
+        [
+            "tool",
+            "write-note",
+            "--title",
+            "Metaphor",
+            "--folder",
+            "devices",
+            "--content",
+            "---\ntype: LiteraryDevice\n---\nA comparison.",
+        ],
+    )
+    assert write.exit_code == 0, write.output
+    permalink = json.loads(write.stdout)["permalink"]
+
+    authored = runner.invoke(app, ["find", "--meta", "type=LiteraryDevice", "--json"])
+    assert authored.exit_code == 0, authored.output
+    rows = json.loads(authored.stdout)["results"]
+    assert [row["permalink"] for row in rows] == [permalink]
+    displayed_type = rows[0]["metadata"]["note_type"]
+    assert displayed_type == "literary_device"
+
+    repeated = runner.invoke(app, ["find", "--meta", f"note_type={displayed_type}", "--json"])
+    assert repeated.exit_code == 0, repeated.output
+    assert [row["permalink"] for row in json.loads(repeated.stdout)["results"]] == [permalink]
+
+
+def test_find_type_membership_preserves_scope_and_other_predicates(
+    app_config, test_project, config_manager
+):
+    chapter = runner.invoke(
+        app,
+        [
+            "tool",
+            "write-note",
+            "--title",
+            "Chapter One",
+            "--folder",
+            "book",
+            "--content",
+            "---\ntype: Chapter\nstatus: Active\nchapter_number: 1\n---\nBody.",
+        ],
+    )
+    assert chapter.exit_code == 0, chapter.output
+    device = runner.invoke(
+        app,
+        [
+            "tool",
+            "write-note",
+            "--title",
+            "Metaphor",
+            "--folder",
+            "book",
+            "--content",
+            "---\ntype: LiteraryDevice\nstatus: inactive\n---\nBody.",
+        ],
+    )
+    assert device.exit_code == 0, device.output
+    outside = runner.invoke(
+        app,
+        [
+            "tool",
+            "write-note",
+            "--title",
+            "Other Chapter",
+            "--folder",
+            "other",
+            "--content",
+            "---\ntype: Chapter\nstatus: Active\n---\nBody.",
+        ],
+    )
+    assert outside.exit_code == 0, outside.output
+
+    result = runner.invoke(
+        app,
+        [
+            "find",
+            "book",
+            "--meta",
+            "note_type in chapter,LiteraryDevice",
+            "--meta",
+            "status=Active",
+            "--fields",
+            "chapter_number",
+            "--plain",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert 'book/Chapter One.md\t{"chapter_number":1}' in result.stdout
+    assert "Metaphor" not in result.stdout
+    assert "Other Chapter" not in result.stdout
+
+    case_sensitive = runner.invoke(
+        app, ["find", "book", "--meta", "note_type=Chapter", "--meta", "status=active", "--json"]
+    )
+    assert case_sensitive.exit_code == 0, case_sensitive.output
+    assert json.loads(case_sensitive.stdout)["results"] == []


### PR DESCRIPTION
## Why

Fixes #1428. `find --meta note_type=Chapter` returned a row displaying `chapter`, but feeding that value back returned no rows. The same mismatch affected `LiteraryDevice` / `literary_device`.

## What Changed

- Route string equality and all-string `in` predicates for `type` / `note_type` through the existing normalized note-type search filter.
- Keep other metadata predicates and file-path scoping intact.
- Document the matching behavior and add three clear real CLI integration tests, without database or platform mocks.

## Implementation Details

The shared CLI/MCP find translation extracts eligible type predicates into `SearchQuery.note_types`. Existing search normalization and legacy spelling compatibility apply on both backends; no new SQL, migrations, canonical note rewrites, or normalization rules are introduced. Null, numeric, range, and array predicates retain their existing metadata comparisons.

## Testing

- With the translation disabled, the two round-trip tests reproduce the exact bug: returned `chapter` and `literary_device` values produce empty second queries.
- `uv run pytest test-int/cli/test_find_note_type_integration.py --no-cov -q`: 3 passed on SQLite.
- `BASIC_MEMORY_TEST_POSTGRES=1 uv run pytest test-int/cli/test_find_note_type_integration.py --no-cov -q`: 3 passed on real Postgres.
- `just fast-check`: passed lint, formatting, and full typecheck.
- `just doctor`: passed.
- `codex review --uncommitted`: no actionable defects; independently ran the three new integration tests successfully.
- Broader existing CLI/MCP suite is running; full CI will validate this head.

## Risks / Follow-ups

Type string equality/membership now intentionally accepts normalized equivalents. Ordinary metadata keys remain case-sensitive. The public metadata-filter API itself is unchanged; this fixes the find translation shared by CLI and MCP.
