### PR TITLE
feat(core): let a subclass write inside the accept transaction

### DIFF
--- a/src/basic_memory/services/note_content_writes.py
+++ b/src/basic_memory/services/note_content_writes.py
@@ -163,8 +163,10 @@ class NoteContentMutationService:
         self,
         session: AsyncSession,
         *,
+        project_external_id: str,
         change: AcceptedNoteMutationChange,
         mutation_kind: NoteContentMutationKind,
+        source: str,
     ) -> None:
         """Contribute to the accept transaction, before it commits.
 
@@ -174,6 +176,11 @@ class NoteContentMutationService:
         note -- a hosted deployment recording a durable marker, say -- otherwise
         has to re-implement the whole method body to reach inside the
         transaction, and then silently owns a copy of it.
+
+        The mutation's own identifying context is passed in rather than left for
+        the subclass to re-derive: the project is addressed by external id here,
+        while the accepted change carries only the tenant-internal integer, and
+        the source has already been through the actor resolver.
 
         Raising rolls the accepted mutation back with it, which is the intended
         behaviour: a marker that cannot be written must not leave a note
@@ -362,8 +369,10 @@ class NoteContentMutationService:
                     )
                     await self.on_accepted_mutation(
                         session,
+                        project_external_id=project_external_id,
                         change=result.change,
                         mutation_kind="create",
+                        source=actor_context.source,
                     )
                 accepted = await self._finish_mutation(result)
             return accepted
@@ -427,8 +436,10 @@ class NoteContentMutationService:
                     )
                     await self.on_accepted_mutation(
                         session,
+                        project_external_id=project_external_id,
                         change=result.change,
                         mutation_kind="update",
+                        source=actor_context.source,
                     )
                 accepted = await self._finish_mutation(result)
         except AcceptedNoteMutationRejected as error:
@@ -506,8 +517,10 @@ class NoteContentMutationService:
                     )
                     await self.on_accepted_mutation(
                         session,
+                        project_external_id=project_external_id,
                         change=result.change,
                         mutation_kind="edit",
+                        source=actor_context.source,
                     )
                 accepted = await self._finish_mutation(result)
         except AcceptedNoteMutationRejected as error:

--- a/src/basic_memory/services/note_content_writes.py
+++ b/src/basic_memory/services/note_content_writes.py
@@ -17,11 +17,14 @@ from basic_memory.indexing.accepted_note_mutation_runner import (
     AcceptedNoteEditMutation,
     AcceptedNoteMoveMutation,
     AcceptedNoteMutationActor,
+    AcceptedNoteMutationChange,
     AcceptedNoteMutationDependencies,
     AcceptedNoteMutationRejected,
     AcceptedNoteMutationRejection,
     AcceptedNoteMutationResult,
     AcceptedNoteUpdateMutation,
+    load_existing_markdown_note_content,
+    reject_stale_base_checksum,
     run_accepted_note_create,
     run_accepted_note_delete,
     run_accepted_note_edit,
@@ -155,6 +158,28 @@ class NoteContentMutationService:
         self.content_freshener = content_freshener
         self.actor_resolver = actor_resolver
         self.read_cache = read_cache
+
+    async def on_accepted_mutation(
+        self,
+        session: AsyncSession,
+        *,
+        change: AcceptedNoteMutationChange,
+        mutation_kind: NoteContentMutationKind,
+    ) -> None:
+        """Contribute to the accept transaction, before it commits.
+
+        A no-op here, and the only supported way to write a row atomically with
+        an accepted note. `accepted_note_transaction` opens and closes inside the
+        mutation methods, so a caller that needs its own row to land with the
+        note -- a hosted deployment recording a durable marker, say -- otherwise
+        has to re-implement the whole method body to reach inside the
+        transaction, and then silently owns a copy of it.
+
+        Raising rolls the accepted mutation back with it, which is the intended
+        behaviour: a marker that cannot be written must not leave a note
+        accepted as though it had been.
+        """
+        return None
 
     async def _publish_relation_generation(
         self,
@@ -335,6 +360,11 @@ class NoteContentMutationService:
                         ),
                         dependencies=self.mutation_dependencies,
                     )
+                    await self.on_accepted_mutation(
+                        session,
+                        change=result.change,
+                        mutation_kind="create",
+                    )
                 accepted = await self._finish_mutation(result)
             return accepted
         except AcceptedNoteMutationRejected as error:
@@ -395,6 +425,11 @@ class NoteContentMutationService:
                         ),
                         dependencies=self.mutation_dependencies,
                     )
+                    await self.on_accepted_mutation(
+                        session,
+                        change=result.change,
+                        mutation_kind="update",
+                    )
                 accepted = await self._finish_mutation(result)
         except AcceptedNoteMutationRejected as error:
             raise note_content_mutation_error_from_rejection(error.rejection) from error
@@ -408,10 +443,23 @@ class NoteContentMutationService:
         data: EditEntityRequest,
         user_profile_id: UUID | None,
         source: str,
+        base_checksum: str | None = None,
         actor_kind: str | None = None,
         actor_name: str | None = None,
     ) -> AcceptedNoteChange:
-        """PATCH a markdown note using the latest accepted DB content as the base."""
+        """PATCH a markdown note using the latest accepted DB content as the base.
+
+        ``base_checksum`` is the same optional optimistic-concurrency
+        precondition ``update_note`` takes: the db_checksum the caller last
+        read. When supplied, an accepted revision that has moved since is
+        rejected with a structured 409 so the caller rebases rather than
+        patching a note it never saw. It stays optional because the ordinary
+        PATCH caller -- an assistant appending to a note through MCP -- has no
+        synced revision to condition on.
+
+        The read shares this transaction with the edit, so the runner plans
+        against the same db_version the precondition just checked.
+        """
         actor_context = self._resolve_actor(
             "edit",
             user_profile_id=user_profile_id,
@@ -430,6 +478,17 @@ class NoteContentMutationService:
                 invalidate_on_rejection=freshening_may_have_published,
             ):
                 async with accepted_note_transaction(self.session_maker) as session:
+                    if base_checksum is not None:
+                        _, _, current_note_content = await load_existing_markdown_note_content(
+                            session,
+                            project_external_id=project_external_id,
+                            entity_external_id=entity_external_id,
+                            dependencies=self.mutation_dependencies,
+                        )
+                        if current_note_content.db_checksum != base_checksum:
+                            reject_stale_base_checksum(
+                                current_db_checksum=current_note_content.db_checksum
+                            )
                     result = await run_accepted_note_edit(
                         session,
                         request=AcceptedNoteEditMutation(
@@ -444,6 +503,11 @@ class NoteContentMutationService:
                             source=actor_context.source,
                         ),
                         dependencies=self.mutation_dependencies,
+                    )
+                    await self.on_accepted_mutation(
+                        session,
+                        change=result.change,
+                        mutation_kind="edit",
                     )
                 accepted = await self._finish_mutation(result)
         except AcceptedNoteMutationRejected as error:

--- a/tests/cloud/test_cloud_services.py
+++ b/tests/cloud/test_cloud_services.py
@@ -1108,9 +1108,11 @@ async def test_on_accepted_mutation_runs_inside_the_accept_transaction(monkeypat
     seen: list[tuple[object, str]] = []
 
     class HookedService(NoteContentMutationService):
-        async def on_accepted_mutation(self, session, *, change, mutation_kind) -> None:
+        async def on_accepted_mutation(
+            self, session, *, project_external_id, change, mutation_kind, source
+        ) -> None:
             order.append("hook")
-            seen.append((change, mutation_kind))
+            seen.append((project_external_id, change, mutation_kind, source))
 
     service = HookedService(
         session_maker=tenant_session_maker,
@@ -1128,7 +1130,7 @@ async def test_on_accepted_mutation_runs_inside_the_accept_transaction(monkeypat
     assert order.index("hook") < order.index("transaction_closed"), (
         "the hook must write inside the transaction that accepted the note"
     )
-    assert seen == [(returned, "create")]
+    assert seen == [("project-123", returned, "create", "api")]
 
 
 @pytest.mark.asyncio

--- a/tests/cloud/test_cloud_services.py
+++ b/tests/cloud/test_cloud_services.py
@@ -13,6 +13,7 @@ from basic_memory.indexing.accepted_note_mutation_runner import (
     AcceptedNoteDeleteMutation,
     AcceptedNoteEditMutation,
     AcceptedNoteMoveMutation,
+    AcceptedNoteMutationChange,
     AcceptedNoteMutationDependencies,
     AcceptedNoteMutationRejectKind,
     AcceptedNoteMutationRejected,
@@ -47,6 +48,7 @@ from basic_memory.services.directory_deletes import (
 from basic_memory.services.note_content_reads import NoteContentQueryService
 from basic_memory.services.note_content_writes import (
     NoteContentMutationActorContext,
+    NoteContentMutationKind,
     NoteContentMutationService,
     NoteContentMutationServiceError,
 )
@@ -1087,6 +1089,7 @@ async def test_on_accepted_mutation_runs_inside_the_accept_transaction(monkeypat
     order: list[str] = []
 
     class RecordingSession(FakeSession):
+        @override
         async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
             order.append("transaction_closed")
             return None
@@ -1105,11 +1108,18 @@ async def test_on_accepted_mutation_runs_inside_the_accept_transaction(monkeypat
 
     monkeypatch.setattr(note_content_writes, "run_accepted_note_create", fake_runner)
 
-    seen: list[tuple[object, str]] = []
+    seen: list[tuple[str, object, str, str]] = []
 
     class HookedService(NoteContentMutationService):
+        @override
         async def on_accepted_mutation(
-            self, session, *, project_external_id, change, mutation_kind, source
+            self,
+            session: AsyncSession,
+            *,
+            project_external_id: str,
+            change: AcceptedNoteMutationChange,
+            mutation_kind: NoteContentMutationKind,
+            source: str,
         ) -> None:
             order.append("hook")
             seen.append((project_external_id, change, mutation_kind, source))

--- a/tests/cloud/test_cloud_services.py
+++ b/tests/cloud/test_cloud_services.py
@@ -1073,3 +1073,153 @@ def test_directory_delete_service_rejects_project_traversal() -> None:
         assert error.detail == "Invalid directory path"
     else:  # pragma: no cover
         raise AssertionError("expected DirectoryDeleteServiceError")
+
+
+@pytest.mark.asyncio
+async def test_on_accepted_mutation_runs_inside_the_accept_transaction(monkeypatch) -> None:
+    """The hook exists so a subclass can write its own row atomically with the note.
+
+    If it ran after the transaction closed it would be worth nothing: the row it
+    writes could be lost while the note stayed accepted, which is exactly the
+    split a hosted deployment cannot tolerate. Assert the ordering, not just
+    that it was called.
+    """
+    order: list[str] = []
+
+    class RecordingSession(FakeSession):
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            order.append("transaction_closed")
+            return None
+
+    class RecordingSessionMaker:
+        def __call__(self) -> RecordingSession:
+            return RecordingSession()
+
+    tenant_session_maker = cast(async_sessionmaker[AsyncSession], RecordingSessionMaker())
+    returned = SimpleNamespace(status_code=201, payload={"ok": True})
+    mutation_result = AcceptedNoteMutationResult(change=cast(Any, returned))
+
+    async def fake_runner(_session, *, request, dependencies):
+        order.append("runner")
+        return mutation_result
+
+    monkeypatch.setattr(note_content_writes, "run_accepted_note_create", fake_runner)
+
+    seen: list[tuple[object, str]] = []
+
+    class HookedService(NoteContentMutationService):
+        async def on_accepted_mutation(self, session, *, change, mutation_kind) -> None:
+            order.append("hook")
+            seen.append((change, mutation_kind))
+
+    service = HookedService(
+        session_maker=tenant_session_maker,
+        mutation_dependencies=cast(AcceptedNoteMutationDependencies, object()),
+    )
+
+    await service.create_note(
+        project_external_id="project-123",
+        data=EntitySchema(title="Created", directory="notes", content="# Created"),
+        user_profile_id=uuid4(),
+        source="api",
+    )
+
+    assert order.index("runner") < order.index("hook"), "the hook sees the accepted change"
+    assert order.index("hook") < order.index("transaction_closed"), (
+        "the hook must write inside the transaction that accepted the note"
+    )
+    assert seen == [(returned, "create")]
+
+
+@pytest.mark.asyncio
+async def test_the_default_on_accepted_mutation_changes_nothing(monkeypatch) -> None:
+    """Local runtimes must be unaffected: the base hook is a no-op."""
+    returned = SimpleNamespace(status_code=201, payload={"ok": True})
+
+    async def fake_runner(_session, *, request, dependencies):
+        return AcceptedNoteMutationResult(change=cast(Any, returned))
+
+    monkeypatch.setattr(note_content_writes, "run_accepted_note_create", fake_runner)
+
+    service = NoteContentMutationService(
+        session_maker=cast(async_sessionmaker[AsyncSession], FakeSessionMaker()),
+        mutation_dependencies=cast(AcceptedNoteMutationDependencies, object()),
+    )
+
+    accepted = await service.create_note(
+        project_external_id="project-123",
+        data=EntitySchema(title="Created", directory="notes", content="# Created"),
+        user_profile_id=uuid4(),
+        source="api",
+    )
+
+    assert accepted is returned
+
+
+@pytest.mark.asyncio
+async def test_edit_note_rejects_a_stale_base_checksum(monkeypatch) -> None:
+    """PATCH gains the precondition PUT already had.
+
+    Without it a caller that read revision N patches revision N+5 blind, and the
+    only way to condition an edit was to re-implement this method outside core.
+    """
+    ran: list[str] = []
+
+    async def fake_runner(_session, *, request, dependencies):
+        ran.append("runner")
+        return AcceptedNoteMutationResult(change=cast(Any, SimpleNamespace(status_code=200)))
+
+    async def fake_load(_session, *, project_external_id, entity_external_id, dependencies):
+        return (None, None, SimpleNamespace(db_checksum="checksum-now"))
+
+    monkeypatch.setattr(note_content_writes, "run_accepted_note_edit", fake_runner)
+    monkeypatch.setattr(note_content_writes, "load_existing_markdown_note_content", fake_load)
+
+    service = NoteContentMutationService(
+        session_maker=cast(async_sessionmaker[AsyncSession], FakeSessionMaker()),
+        mutation_dependencies=cast(AcceptedNoteMutationDependencies, object()),
+    )
+
+    with pytest.raises(NoteContentMutationServiceError) as rejected:
+        await service.edit_note(
+            project_external_id="project-123",
+            entity_external_id="note-1",
+            data=EditEntityRequest(operation="append", content="more"),
+            user_profile_id=uuid4(),
+            source="api",
+            base_checksum="checksum-the-caller-read",
+        )
+
+    assert rejected.value.status_code == 409
+    assert ran == [], "a stale precondition must reject before the edit runs"
+
+
+@pytest.mark.asyncio
+async def test_edit_note_without_a_base_checksum_reads_no_precondition(monkeypatch) -> None:
+    """The ordinary PATCH caller has no synced revision, so none is imposed."""
+    reads: list[str] = []
+
+    async def fake_runner(_session, *, request, dependencies):
+        return AcceptedNoteMutationResult(change=cast(Any, SimpleNamespace(status_code=200)))
+
+    async def fake_load(_session, **_kwargs):
+        reads.append("read")
+        return (None, None, SimpleNamespace(db_checksum="checksum-now"))
+
+    monkeypatch.setattr(note_content_writes, "run_accepted_note_edit", fake_runner)
+    monkeypatch.setattr(note_content_writes, "load_existing_markdown_note_content", fake_load)
+
+    service = NoteContentMutationService(
+        session_maker=cast(async_sessionmaker[AsyncSession], FakeSessionMaker()),
+        mutation_dependencies=cast(AcceptedNoteMutationDependencies, object()),
+    )
+
+    await service.edit_note(
+        project_external_id="project-123",
+        entity_external_id="note-1",
+        data=EditEntityRequest(operation="append", content="more"),
+        user_profile_id=uuid4(),
+        source="api",
+    )
+
+    assert reads == []


### PR DESCRIPTION
## Why

`accepted_note_transaction` opens and closes inside `create_note`, `update_note` and `edit_note`. A caller that needs its own row to land atomically with an accepted note has no way in, so the only option is to re-implement the whole method body — which silently forks a copy of core's accept path.

basic-memory-cloud has four such copies today (`create_note`, `update_note`, `edit_note`, `move_note`), added across #1602, #1825 and #1826. They are currently verbatim, but nothing detects divergence: a pin bump is easy to review for breakage and nearly impossible to review for semantic drift across four hand-copied bodies.

## What

**`on_accepted_mutation`** — a no-op hook on `NoteContentMutationService`, called with the open session and the accepted change just before the transaction closes. Raising rolls the mutation back with it, which is the intent: a marker that cannot be written must not leave a note accepted as though it had been.

It receives the mutation's own identifying context (external project id, source) rather than making subclasses re-derive it from the request — the accepted change carries only the tenant-internal integer project id.

**`edit_note` gains `base_checksum`** — the same optional optimistic-concurrency precondition `update_note` has had since #1445. PATCH could not be conditioned on the revision the caller read, so a caller that read revision N patched revision N+5 blind. The read shares the edit's transaction, so the runner plans against the same `db_version` the precondition checked. It stays optional: the ordinary PATCH caller, an assistant appending through MCP, has no synced revision to condition on.

I deliberately did not mirror the update runner's `base_checksum` enforcement, which is entangled with relay/hot-doc semantics (#1589 Phase G) specific to PUT. `edit_note` does the plain compare, inside the same transaction.

`move_note` is untouched — its Cloud copy exists for browser-outbox preconditions (#1602), a separate concern.

## Effect downstream

Cloud drops three copies of the accept path for three delegating wrappers, and its gateway loses 140 lines.

## Testing

Four new tests in `tests/cloud/test_cloud_services.py`. Both guards were verified load-bearing — the hook moved after the commit and the precondition disabled, each with its test confirmed failing first. `tests/cloud`, `tests/api/v2` and `tests/indexing` green (980 passed); ruff clean.

Local runtimes are unaffected: the base hook is a no-op and the precondition is opt-in.

## Note for review

This branch is based on the commit basic-memory-cloud currently pins (`dd0bd558`), not on `main`, so the downstream pin moves by exactly this change. It needs a rebase over the 29 commits `main` has gained since — one of which, `0a4cf86e`, touches the accept path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgsDmZtzdbh3WmqXjUsvwV