### PR TITLE
fix(core): project accepted note filenames using canonical metadata

### DIFF
--- a/src/basic_memory/indexing/wiki_projector.py
+++ b/src/basic_memory/indexing/wiki_projector.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 from hashlib import sha256
 import json
 from pathlib import PurePosixPath, PureWindowsPath
+import re
 import unicodedata
 
 from basic_memory.runtime.project_partition import RuntimeProjectNoteOperation
@@ -705,10 +706,19 @@ def _render_log_entry(change: WikiSourceChange) -> str:
         case WikiChangeOperation.moved:
             if change.previous_path is None:
                 raise ValueError("Moved Wiki change requires previous_path")
-            description = f"Moved `{change.previous_path}` to {current_note}"
+            description = f"Moved {_render_path_text(change.previous_path)} to {current_note}"
         case WikiChangeOperation.deleted:
-            description = f"Deleted `{change.path}`"
+            description = f"Deleted {_render_path_text(change.path)}"
     return f"- {timestamp} — {description}"
+
+
+def _render_path_text(path: str) -> str:
+    """Render an accepted location literally, including embedded backticks."""
+    longest_run = max((len(run) for run in re.findall(r"`+", path)), default=0)
+    delimiter = "`" * (longest_run + 1)
+    # Padding keeps source backticks separate from the enclosing delimiter;
+    # CommonMark removes these surrounding spaces from the rendered code span.
+    return f"{delimiter} {path} {delimiter}" if longest_run else f"`{path}`"
 
 
 def _render_document(
@@ -759,14 +769,12 @@ def _normalize_note_path(path: str) -> str:
         or PurePosixPath(normalized).suffix.lower() not in RUNTIME_MARKDOWN_FILE_SUFFIXES
     ):
         raise ValueError(f"Wiki note path must be project-relative Markdown: {path}")
-    if "::" in normalized or any(character in normalized for character in "\r\n[]|`<>"):
-        raise ValueError(f"Wiki note path contains unsupported Markdown delimiters: {path}")
-    _validate_portable_path_components(normalized, path_kind="note path", source=path)
-    _reject_reserved_wiki_directory_components(
-        PurePosixPath(normalized).parts[:-1],
-        path_kind="note path",
-        source=path,
-    )
+    # The adapter supplies accepted metadata and canonical link identities. The
+    # source basename is only a location: it is never a generated filename or a
+    # wikilink target. Only its parent becomes an index/log output scope.
+    if any(unicodedata.category(character) == "Cc" for character in normalized):
+        raise ValueError(f"Wiki note path contains a control character: {path}")
+    _normalize_scope(_parent_scope(normalized))
     return normalized
 
 
@@ -863,12 +871,12 @@ def _escape_generated_markdown_text(value: str) -> str:
 
 
 def _require_unique_paths(
-    values: tuple[object, ...],
+    values: tuple[WikiSourceNote | WikiReservedDocument, ...],
     *,
     label: str,
     case_sensitive: bool = True,
 ) -> None:
-    paths = [getattr(value, "path") for value in values]
+    paths = [value.path for value in values]
     if not case_sensitive:
         paths = [_portable_path_key(path) for path in paths]
     if len(paths) != len(set(paths)):

--- a/tests/index/test_local_wiki_projection.py
+++ b/tests/index/test_local_wiki_projection.py
@@ -427,3 +427,38 @@ async def test_local_wiki_requires_existing_project_directory(
 
     with pytest.raises(ValueError, match="Local project directory does not exist"):
         await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "Session [Image 1].md",
+        pytest.param(
+            "Topic: Details.md",
+            marks=pytest.mark.skipif(
+                sys.platform == "win32", reason="Windows cannot store colons in source filenames"
+            ),
+        ),
+    ],
+)
+async def test_local_wiki_projects_existing_filename_without_rewriting_source(
+    config_home,
+    session_maker,
+    test_project,
+    filename,
+):
+    note = config_home / "notes" / filename
+    note.parent.mkdir()
+    content = b"---\ntitle: Accepted Title\npermalink: stable-address\n---\n\n# Body\n"
+    note.write_bytes(content)
+
+    inspection = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+    await apply_local_wiki_projection(inspection, session_maker=session_maker)
+
+    assert note.read_bytes() == content
+    assert "[[stable-address|Accepted Title]]" in (note.parent / "index.md").read_text()
+    assert "[[notes/index|Notes]]" in (config_home / "index.md").read_text()
+    replay = await inspect_local_wiki_projection(test_project, session_maker=session_maker)
+    assert replay.state is LocalWikiState.current
+    assert replay.plan.writes == ()

--- a/tests/indexing/test_wiki_projector.py
+++ b/tests/indexing/test_wiki_projector.py
@@ -6,6 +6,8 @@ from hashlib import sha256
 import json
 from pathlib import Path
 
+from markdown_it import MarkdownIt
+
 import pytest
 
 from basic_memory.indexing.wiki_projector import (
@@ -191,7 +193,7 @@ def test_source_note_rejects_missing_metadata() -> None:
     ),
 )
 def test_source_note_rejects_nonportable_path_components(path: str) -> None:
-    with pytest.raises(ValueError, match="Wiki (path|note path)"):
+    with pytest.raises(ValueError, match="Wiki (path|note path|scope)"):
         WikiSourceNote(
             path=path,
             permalink="note",
@@ -1195,24 +1197,87 @@ def test_noncanonical_paths_are_rejected_at_the_contract_boundary(path: str) -> 
 @pytest.mark.parametrize(
     "path",
     (
-        "notes/closing].md",
-        "notes/opening[.md",
+        "notes/Session [Image 1].md",
+        "notes/Topic: Details.md",
         "notes/alias|target.md",
         "notes/code`span.md",
-        "notes/html<tag.md",
-        "notes/line\nbreak.md",
+        "notes/code``span.md",
+        "notes/html<tag>.md",
         "notes/cross::project.md",
+        "notes/CON.md",
+        'notes/question?star*quote".md',
     ),
 )
-def test_wikilink_delimiters_are_rejected_at_the_contract_boundary(path: str) -> None:
-    with pytest.raises(ValueError, match="unsupported Markdown delimiters"):
-        WikiSourceNote(
+@pytest.mark.parametrize(
+    "reason", [WikiProjectionReason.manual_rebuild, WikiProjectionReason.accepted_note]
+)
+def test_projection_uses_accepted_metadata_for_punctuated_filenames(
+    path: str, reason: WikiProjectionReason
+) -> None:
+    note = WikiSourceNote(
+        path=path,
+        permalink="stable-address",
+        title="Accepted title",
+        note_type="Note",
+        checksum="sum",
+    )
+    changes = tuple(
+        WikiSourceChange(
+            partition_position=position,
+            operation=operation,
             path=path,
-            permalink="unsupported",
-            title="Unsupported",
-            note_type="Note",
-            checksum="checksum",
+            previous_path=path if operation is WikiChangeOperation.moved else None,
+            permalink=note.permalink,
+            title=note.title,
+            accepted_at=ACCEPTED_AT,
+            materialized=True,
+            source="web",
         )
+        for position, operation in enumerate(WikiChangeOperation, start=1)
+    )
+    snapshot = replace(
+        _snapshot(),
+        notes=(note,),
+        changes=changes,
+        source_partition_position=len(changes),
+        current_output_watermark=0,
+    )
+    request = _request(position=len(changes), reason=reason, scopes=affected_wiki_scopes(path))
+
+    plan = plan_wiki_projection(request, snapshot)
+    rendered = {write.path: write.content.decode() for write in plan.writes}
+
+    assert note.path == path
+    assert plan.result.state is WikiProjectionState.current
+    assert set(rendered) == {"index.md", "log.md", "notes/index.md", "notes/log.md"}
+    assert "[[notes/index|Notes]]" in rendered["index.md"]
+    assert "[[stable-address|Accepted title]]" in rendered["notes/index.md"]
+    assert "Created [[stable-address|Accepted title]]" in rendered["notes/log.md"]
+    assert "Updated [[stable-address|Accepted title]]" in rendered["notes/log.md"]
+    # Historical locations are display text, never link targets or Markdown syntax.
+    tokens = MarkdownIt().parse(rendered["notes/log.md"].split("\n---\n", 1)[1])
+    code_paths = [
+        child.content
+        for token in tokens
+        for child in token.children or []
+        if child.type == "code_inline"
+    ]
+    assert code_paths == [path, path]
+    replay = plan_wiki_projection(
+        request,
+        replace(
+            snapshot,
+            current_output_watermark=len(changes),
+            reserved_documents=tuple(_reserved(write.path, write.content) for write in plan.writes),
+        ),
+    )
+    assert replay.writes == ()
+
+
+@pytest.mark.parametrize("path", ("notes/line\nbreak.md", "notes/null\x00byte.md"))
+def test_source_paths_reject_control_characters(path: str) -> None:
+    with pytest.raises(ValueError, match="control character"):
+        WikiSourceNote(path=path, permalink="note", title="Note", note_type="Note", checksum="sum")
 
 
 @pytest.mark.parametrize("path", ("", "note.txt"))


### PR DESCRIPTION
## Why

Wiki rebuilds abort on already-accepted source filenames such as `Session [Image 1].md` and `Topic: Details.md`. The snapshot constructor applies generated-path restrictions to the source basename even though the adapter already supplies the note's title and canonical permalink. Production manual rebuild job 16511347 exhausted six attempts with zero writes.

Refs basicmachines-co/basic-memory-cloud#1971.

## What Changed

- Accept punctuation and Windows-reserved basenames in existing source note locations, including historical move/delete paths.
- Continue linking notes using the canonical permalink supplied by the adapter; source filenames do not become link targets.
- Render historical paths as literal code spans with a delimiter long enough for embedded backticks.
- Replace snapshot validation's `tuple[object]` and dynamic `getattr` with the concrete source/reserved-document union.

## Implementation Details

The planner remains a pure function over typed snapshots. Source basenames are locations; their parent directories become generated index/log scopes. Parent scopes retain the existing portability, reserved-name, and Markdown-target validation. Project-relative path, control-character, canonical-permalink, ownership, checksum, and watermark checks remain enforced. No source files are renamed or rewritten, and there is no new parser, service hierarchy, or fallback.

## Testing

- Original source failed all 18 new punctuated-filename projection cases.
- `.venv/bin/pytest tests/indexing/test_wiki_projector.py tests/index/test_local_wiki_projection.py -q --tb=short`: 124 passed.
- `.venv/bin/pytest tests/cli/test_wiki_command.py -q --tb=short --no-cov`: 8 passed.
- `just fast-check`: passed, including full `ty` checks over source, unit tests, and integration tests (worktree installed with the optional Milvus dependency).
- Tests exercise full and incremental planning, canonical links, created/updated/moved/deleted history, Markdown-rendered literal paths, real local source-to-output writes, source-byte preservation, and idempotent replay. Existing fixture bytes remain unchanged.

## Risks / Follow-ups

Cloud must update its Core dependency and deploy before this changes production behavior. This PR does not change the Wiki tenant rollout or deploy anything. Existing directory names that cannot safely serve as generated Wiki output scopes still fail explicitly; supporting those scopes requires a separate identity/navigation contract, not silently sanitizing source paths.
