### PR TITLE
feat(core): enforce one-way locked notes in mutation APIs

### DIFF
--- a/docs/LOCKED_NOTES.md
+++ b/docs/LOCKED_NOTES.md
@@ -1,0 +1,31 @@
+# Locked notes
+
+Set the YAML boolean `locked: true` in a note's frontmatter to protect it from
+Basic Memory content mutations:
+
+```yaml
+---
+title: Release Runbook
+locked: true
+---
+```
+
+An agent can create a locked note or lock an existing note through a write or edit.
+After that, API writes, edits, overwrites, and deletes return HTTP 423 with an
+explanation. MCP and CLI note tools use that same API contract. Incoming metadata,
+replacement Markdown, or find/replace operations cannot remove or weaken the lock:
+the check uses the existing canonical Markdown before preparing the proposed edit.
+
+Deleting a directory containing a locked note is rejected before deleting any of
+its notes. Imports also refuse to overwrite locked files. Moves remain allowed
+and preserve the lock, including when the move updates a permalink. Reads and
+indexing remain available.
+
+This is a one-way switch through the note API, not filesystem access control. To
+unlock a note, edit its Markdown file directly and remove `locked: true` or set it
+to `false`. Normal local reconciliation picks up that edit. There is no API unlock
+flag, privileged unlock endpoint, or distinction between human and agent callers.
+Agents with direct filesystem access can edit the file; that is outside this contract.
+
+Only a YAML boolean enables the lock; the string `"true"` is ordinary metadata.
+Schema validation enforcement and Teams authorization are separate features.

--- a/docs/LOCKED_NOTES.md
+++ b/docs/LOCKED_NOTES.md
@@ -16,8 +16,8 @@ explanation. MCP and CLI note tools use that same API contract. Incoming metadat
 replacement Markdown, or find/replace operations cannot remove or weaken the lock:
 the check uses the existing canonical Markdown before preparing the proposed edit.
 
-Deleting a directory containing a locked note is rejected before deleting any of
-its notes. Imports also refuse to overwrite locked files. Moves remain allowed
+API deletion of a directory containing a locked note is rejected before deleting any of
+its notes. Moves remain allowed
 and preserve the lock, including when the move updates a permalink. Reads and
 indexing remain available.
 
@@ -25,7 +25,11 @@ This is a one-way switch through the note API, not filesystem access control. To
 unlock a note, edit its Markdown file directly and remove `locked: true` or set it
 to `false`. Normal local reconciliation picks up that edit. There is no API unlock
 flag, privileged unlock endpoint, or distinction between human and agent callers.
-Agents with direct filesystem access can edit the file; that is outside this contract.
+Imports are raw file writes and are outside this contract, even when invoked through an
+import endpoint. They may overwrite locked files. Direct filesystem edits and deletion
+of a file or its directory also override the lock; normal indexing reconciles the result.
+Basic Memory does not block or undo those changes. Agents with direct filesystem access
+can therefore bypass this API-only protection.
 
 Only a YAML boolean enables the lock; the string `"true"` is ordinary metadata.
 Schema validation enforcement and Teams authorization are separate features.

--- a/src/basic_memory/deps/services.py
+++ b/src/basic_memory/deps/services.py
@@ -11,6 +11,7 @@ behavior of its own:
 - local note-content, indexing, and background-scheduler runtimes
 """
 
+from functools import partial
 from pathlib import Path
 from typing import Annotated
 
@@ -42,6 +43,7 @@ from basic_memory.index.local_notes import (
     LocalCurrentNoteContentFreshener,
     LocalDirectoryDeleteRelationCleanupRefresher,
     LocalDirectoryFileDeleteEnqueuer,
+    check_local_directory_file_locks,
 )
 from basic_memory.repository import NoteContentRepository
 from basic_memory.repository.accepted_note_repositories import AcceptedNoteRepositories
@@ -183,6 +185,7 @@ async def get_directory_delete_service(
                 external_vector_cleaner=search_service.repository
             ),
             file_delete_enqueuer=LocalDirectoryFileDeleteEnqueuer(file_service=file_service),
+            check_file_locks=partial(check_local_directory_file_locks, file_service),
             relation_cleanup_refresher=LocalDirectoryDeleteRelationCleanupRefresher(
                 session_maker=session_maker,
                 entity_repository=entity_repository,

--- a/src/basic_memory/importers/base.py
+++ b/src/basic_memory/importers/base.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
 from basic_memory.markdown.markdown_processor import MarkdownProcessor
-from basic_memory.markdown.note_lock import LOCKED_NOTE_MESSAGE, note_is_locked
 from basic_memory.markdown.schemas import EntityMarkdown
 from basic_memory.read_cache import ReadCacheInvalidator, invalidate_cache
 from basic_memory.schemas.importer import ImportResult
@@ -88,11 +87,6 @@ class Importer[T: ImportResult]:
         Returns:
             Checksum of written file.
         """
-        # Imports are API/CLI writes too; they must not overwrite a protected file.
-        if await self.file_service.exists(file_path):
-            existing_content = await self.file_service.read_file_content(file_path)
-            if note_is_locked(existing_content):
-                raise ValueError(LOCKED_NOTE_MESSAGE)
         content = self.markdown_processor.to_markdown_string(entity)
 
         # Trigger: one imported file can become visible before the remaining batch completes.

--- a/src/basic_memory/importers/base.py
+++ b/src/basic_memory/importers/base.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
 from basic_memory.markdown.markdown_processor import MarkdownProcessor
+from basic_memory.markdown.note_lock import LOCKED_NOTE_MESSAGE, note_is_locked
 from basic_memory.markdown.schemas import EntityMarkdown
 from basic_memory.read_cache import ReadCacheInvalidator, invalidate_cache
 from basic_memory.schemas.importer import ImportResult
@@ -87,6 +88,11 @@ class Importer[T: ImportResult]:
         Returns:
             Checksum of written file.
         """
+        # Imports are API/CLI writes too; they must not overwrite a protected file.
+        if await self.file_service.exists(file_path):
+            existing_content = await self.file_service.read_file_content(file_path)
+            if note_is_locked(existing_content):
+                raise ValueError(LOCKED_NOTE_MESSAGE)
         content = self.markdown_processor.to_markdown_string(entity)
 
         # Trigger: one imported file can become visible before the remaining batch completes.

--- a/src/basic_memory/index/local_notes.py
+++ b/src/basic_memory/index/local_notes.py
@@ -18,18 +18,29 @@ from basic_memory import db
 from basic_memory.config import BasicMemoryConfig
 from basic_memory.file_utils import FileError
 from basic_memory.indexing.accepted_note_mutation_runner import AcceptedNoteMutationPreparer
-from basic_memory.indexing.directory_delete_runner import DirectoryFileDeleteEnqueueError
+from basic_memory.indexing.directory_delete_runner import (
+    DirectoryDeleteRejected,
+    DirectoryDeleteRejection,
+    DirectoryDeleteRejectKind,
+    DirectoryFileDeleteEnqueueError,
+)
 from basic_memory.indexing.note_file_delete_runner import run_note_file_delete
 from basic_memory.markdown import EntityParser
 from basic_memory.markdown.markdown_processor import MarkdownProcessor
+from basic_memory.markdown.note_lock import LOCKED_NOTE_MESSAGE, note_is_locked
 from basic_memory.models import Project
 from basic_memory.repository.accepted_note_repositories import AcceptedNoteRepositories
 from basic_memory.repository.entity_repository import EntityRepository
-from basic_memory.runtime.cleanup import RuntimeFileDeleteResult, RuntimeNoteFileDeleteJobRequest
+from basic_memory.runtime.cleanup import (
+    RuntimeDirectoryFileSnapshot,
+    RuntimeFileDeleteResult,
+    RuntimeNoteFileDeleteJobRequest,
+)
 from basic_memory.runtime.storage import (
     RuntimeFileChecksum,
     RuntimeFilePath,
     runtime_content_type_is_markdown,
+    runtime_file_path_is_markdown_note,
 )
 from basic_memory.services.exceptions import FileOperationError
 from basic_memory.services.file_service import FileService
@@ -168,6 +179,28 @@ class LocalCurrentNoteContentFreshener:
 
 
 # --- Directory-Delete File Cleanup ---
+
+
+async def check_local_directory_file_locks(
+    file_service: FileService,
+    files: Sequence[RuntimeDirectoryFileSnapshot],
+) -> None:
+    """Reject API directory deletion when an existing local note is locked."""
+    for snapshot in files:
+        if not runtime_file_path_is_markdown_note(snapshot.file_path):
+            continue
+        # Raw filesystem deletion is outside the lock contract. Missing files do
+        # not need protection, and the ordinary index pass reconciles their rows.
+        if not await file_service.exists(snapshot.file_path):
+            continue
+        content = await file_service.read_file_content(snapshot.file_path)
+        if note_is_locked(content):
+            raise DirectoryDeleteRejected(
+                DirectoryDeleteRejection(
+                    kind=DirectoryDeleteRejectKind.locked,
+                    detail=LOCKED_NOTE_MESSAGE,
+                )
+            )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/basic_memory/indexing/accepted_note_mutation_runner.py
+++ b/src/basic_memory/indexing/accepted_note_mutation_runner.py
@@ -32,6 +32,7 @@ from basic_memory.indexing.accepted_note_write_runner import (
 )
 from basic_memory.indexing.relation_persistence import RelationGenerationPublication
 from basic_memory.models import Entity, NoteContent, Project
+from basic_memory.markdown.note_lock import LOCKED_NOTE_MESSAGE, note_is_locked
 from basic_memory.repository import NoteContentVersionConflict
 from basic_memory.repository.note_file_vacate_repository import NoteFileVacateRepository
 from basic_memory.services.exceptions import EntityAlreadyExistsError
@@ -78,6 +79,7 @@ class AcceptedNoteMutationRejectKind(StrEnum):
     conflict = "conflict"
     not_found = "not_found"
     unsupported_media_type = "unsupported_media_type"
+    locked = "locked"
 
     @property
     def http_status_code(self) -> int:
@@ -91,6 +93,8 @@ class AcceptedNoteMutationRejectKind(StrEnum):
                 return 404
             case AcceptedNoteMutationRejectKind.unsupported_media_type:
                 return 415
+            case AcceptedNoteMutationRejectKind.locked:
+                return 423
 
 
 @dataclass(frozen=True, slots=True)
@@ -657,6 +661,7 @@ async def run_accepted_note_delete(
     )
     if note_content is not None:
         await session.refresh(note_content)
+        reject_locked_note(note_content)
     change = await delete_accepted_note(
         session,
         project_id=project.id,
@@ -822,6 +827,7 @@ async def _run_accepted_note_update(
             dependencies=dependencies,
             missing_kind=AcceptedNoteMutationRejectKind.conflict,
         )
+        reject_locked_note(current_note_content)
         await session.refresh(entity)
         if not runtime_content_type_is_markdown(entity):
             reject_accepted_note_mutation(
@@ -1043,6 +1049,7 @@ async def _run_accepted_note_edit(
         entity_external_id=request.entity_external_id,
         dependencies=dependencies,
     )
+    reject_locked_note(current_note_content)
     preparer = dependencies.preparer_factory.create_note_preparer(project)
     try:
         prepared_write = await prepare_accepted_note_edit(
@@ -1445,6 +1452,12 @@ def reject_accepted_note_file_path_conflict(
             AcceptedNoteMutationRejectKind.conflict,
             "Note already exists. Use edit_note to modify it, or delete it first.",
         )
+
+
+def reject_locked_note(note_content: NoteContent) -> None:
+    """Check the accepted predecessor before the proposed content can change policy."""
+    if note_is_locked(note_content.markdown_content):
+        reject_accepted_note_mutation(AcceptedNoteMutationRejectKind.locked, LOCKED_NOTE_MESSAGE)
 
 
 def reject_accepted_note_mutation(

--- a/src/basic_memory/indexing/directory_delete_runner.py
+++ b/src/basic_memory/indexing/directory_delete_runner.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Literal, NotRequired, Protocol, TypedDict
@@ -31,6 +31,7 @@ from basic_memory.runtime.storage import ProjectExternalId, ProjectId, RuntimeFi
 from basic_memory.utils import valid_project_path_value
 
 type DirectoryDeleteFileStatus = Literal["complete", "pending", "failed"]
+type DirectoryFileLockCheck = Callable[[Sequence[RuntimeDirectoryFileSnapshot]], Awaitable[None]]
 
 
 class DirectoryDeleteRejectKind(StrEnum):
@@ -157,6 +158,7 @@ class DirectoryDeleteRuntime:
     # None means this runtime has no inline reindex path; the surviving source ids
     # are still surfaced on the accepted result for deferred (queued) consumers.
     relation_cleanup_refresher: DirectoryDeleteRelationCleanupRefresher | None = None
+    check_file_locks: DirectoryFileLockCheck | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -564,6 +566,7 @@ async def accept_directory_delete(
     *,
     request: DirectoryDeleteAcceptanceRequest,
     store: DirectoryDeleteAcceptanceStore,
+    check_file_locks: DirectoryFileLockCheck | None = None,
 ) -> DirectoryDeleteAcceptance:
     """Accept a directory delete into DB state before post-commit cleanup jobs."""
     try:
@@ -594,6 +597,11 @@ async def accept_directory_delete(
     )
     if not file_snapshots:
         return DirectoryDeleteAcceptance(project_id=project_id, files=())
+
+    # Local files may have acquired a lock since the last index pass. Check them
+    # before accepting any deletion; hosted runtimes use accepted Markdown below.
+    if check_file_locks is not None:
+        await check_file_locks(file_snapshots)
 
     delete_result = await store.delete_directory_entities(
         session,
@@ -658,6 +666,7 @@ async def run_directory_delete(
         session,
         request=request,
         store=runtime.store,
+        check_file_locks=runtime.check_file_locks,
     )
     return await finish_directory_delete_acceptance(
         request=request,

--- a/src/basic_memory/indexing/directory_delete_runner.py
+++ b/src/basic_memory/indexing/directory_delete_runner.py
@@ -11,6 +11,7 @@ from sqlalchemy import bindparam, delete, exists, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from basic_memory.models import Entity, NoteContent, Project, Relation
+from basic_memory.markdown.note_lock import LOCKED_NOTE_MESSAGE, note_is_locked
 from basic_memory.repository.accepted_note_vector_cleanup import (
     ProjectIndexExternalVectorCleaner,
     delete_project_index_vector_rows,
@@ -37,6 +38,7 @@ class DirectoryDeleteRejectKind(StrEnum):
 
     bad_request = "bad_request"
     not_found = "not_found"
+    locked = "locked"
 
     @property
     def http_status_code(self) -> int:
@@ -46,6 +48,8 @@ class DirectoryDeleteRejectKind(StrEnum):
                 return 400
             case DirectoryDeleteRejectKind.not_found:
                 return 404
+            case DirectoryDeleteRejectKind.locked:
+                return 423
 
 
 @dataclass(frozen=True, slots=True)
@@ -257,6 +261,21 @@ class RepositoryDirectoryDeleteAcceptanceStore:
         )
         if not current_directory_entity_ids:
             return DirectoryEntityDeleteResult()
+
+        # A bulk delete must not bypass a note's lock or partially delete its siblings.
+        # Read accepted Markdown under the existing mutation fence, before any deletes.
+        note_contents = await session.execute(
+            select(NoteContent.markdown_content).where(
+                NoteContent.entity_id.in_(current_directory_entity_ids)
+            )
+        )
+        if any(note_is_locked(content) for content in note_contents.scalars()):
+            raise DirectoryDeleteRejected(
+                DirectoryDeleteRejection(
+                    kind=DirectoryDeleteRejectKind.locked,
+                    detail=LOCKED_NOTE_MESSAGE,
+                )
+            )
 
         # Capture surviving sources before the delete: Relation.to_id CASCADE will drop
         # the relation table rows for incoming links from entities outside the directory,

--- a/src/basic_memory/markdown/note_lock.py
+++ b/src/basic_memory/markdown/note_lock.py
@@ -1,0 +1,23 @@
+"""API write protection carried by canonical Markdown, not indexed metadata."""
+
+from basic_memory.file_utils import ParseError, has_frontmatter, parse_frontmatter
+
+
+LOCKED_NOTE_MESSAGE = (
+    "This note is locked (locked: true). Basic Memory cannot edit, overwrite, delete, "
+    "or unlock it. Remove locked: true by editing the Markdown file directly to unlock it."
+)
+
+
+def note_is_locked(markdown_content: str) -> bool:
+    """Only the YAML boolean true opts a note into API write protection."""
+    if not has_frontmatter(markdown_content):
+        return False
+    try:
+        metadata = parse_frontmatter(markdown_content)
+    except ParseError:
+        # Offline malformed notes remain supported resources, not valid lock declarations.
+        # API edits cannot reach this escape hatch: the accepted locked predecessor is
+        # checked before any proposed replacement can introduce malformed frontmatter.
+        return False
+    return metadata.get("locked") is True

--- a/src/basic_memory/services/directory_deletes.py
+++ b/src/basic_memory/services/directory_deletes.py
@@ -83,6 +83,7 @@ class DirectoryDeleteService:
                     session,
                     request=request,
                     store=self.runtime.store,
+                    check_file_locks=self.runtime.check_file_locks,
                 )
                 delete_may_have_committed = bool(accepted.files)
         except DirectoryDeleteRejected as error:

--- a/test-int/test_locked_notes.py
+++ b/test-int/test_locked_notes.py
@@ -229,7 +229,7 @@ async def test_replacement_body_can_lock_an_unlocked_note(
 
 
 @pytest.mark.asyncio
-async def test_import_cannot_overwrite_locked_note(
+async def test_import_can_overwrite_locked_note_as_raw_file_write(
     client: AsyncClient, test_project: Project, locked_note: LockedNote
 ) -> None:
     response = await client.post(
@@ -250,6 +250,76 @@ async def test_import_cannot_overwrite_locked_note(
             )
         },
     )
-    assert response.status_code == 500, response.text
-    assert "locked: true" in response.text
-    await assert_note_unchanged(client, locked_note)
+    assert response.status_code == 200, response.text
+    content = locked_note[1].read_text(encoding="utf-8")
+    assert "Overwrite attempt" in content
+    assert "locked: true" not in content
+    await run_local_project_index_for_project(
+        test_project,
+        runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+        force_full=True,
+    )
+    read = await client.get(locked_note[0])
+    assert read.status_code == 200, read.text
+    assert "Overwrite attempt" in read.json()["content"]
+
+
+@pytest.mark.asyncio
+async def test_api_directory_delete_observes_offline_lock_before_indexing(
+    client: AsyncClient, test_project: Project
+) -> None:
+    base = f"/v2/projects/{test_project.external_id}/knowledge"
+    created = await client.post(
+        f"{base}/entities",
+        json={"title": "Offline lock", "directory": "protected", "content": "Original"},
+    )
+    assert created.status_code == 202, created.text
+    path = Path(test_project.path) / created.json()["file_path"]
+    locked_bytes = path.read_bytes().replace(b"---\n", b"---\nlocked: true\n", 1)
+    path.write_bytes(locked_bytes)
+    sibling = await client.post(
+        f"{base}/entities",
+        json={"title": "Sibling", "directory": "protected", "content": "Keep sibling too"},
+    )
+    assert sibling.status_code == 202, sibling.text
+    sibling_path = Path(test_project.path) / sibling.json()["file_path"]
+    sibling_bytes = sibling_path.read_bytes()
+
+    # No watcher or reindex: the API must inspect the local lock before deleting
+    # any sibling, not accept partial deletion from an older unlocked DB snapshot.
+    response = await client.post(f"{base}/delete-directory", json={"directory": "protected"})
+    assert response.status_code == 423, response.text
+    assert path.read_bytes() == locked_bytes
+    assert sibling_path.read_bytes() == sibling_bytes
+    assert (await client.get(f"{base}/entities/{created.json()['external_id']}")).status_code == 200
+    assert (await client.get(f"{base}/entities/{sibling.json()['external_id']}")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_raw_file_deletion_overrides_lock(
+    client: AsyncClient, test_project: Project, locked_note: LockedNote
+) -> None:
+    locked_note[1].unlink()
+    await run_local_project_index_for_project(
+        test_project,
+        runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+        force_full=True,
+    )
+    assert not locked_note[1].exists()
+    assert (await client.get(locked_note[0])).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_raw_directory_deletion_overrides_lock(
+    client: AsyncClient, test_project: Project, locked_note: LockedNote
+) -> None:
+    directory = locked_note[1].parent
+    locked_note[1].unlink()
+    directory.rmdir()
+    await run_local_project_index_for_project(
+        test_project,
+        runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+        force_full=True,
+    )
+    assert not directory.exists()
+    assert (await client.get(locked_note[0])).status_code == 404

--- a/test-int/test_locked_notes.py
+++ b/test-int/test_locked_notes.py
@@ -1,0 +1,255 @@
+"""Real API and file regressions for the one-way locked-note contract."""
+
+import json
+from pathlib import Path
+
+from httpx import AsyncClient
+import pytest
+import pytest_asyncio
+
+from basic_memory.models import Project
+from basic_memory.index.local_project import (
+    LocalProjectIndexRuntimeFactory,
+    run_local_project_index_for_project,
+)
+
+type LockedNote = tuple[str, Path, bytes]
+
+
+@pytest_asyncio.fixture
+async def locked_note(client: AsyncClient, test_project: Project) -> LockedNote:
+    response = await client.post(
+        f"/v2/projects/{test_project.external_id}/knowledge/entities",
+        json={
+            "title": "Runbook",
+            "directory": "protected",
+            "content": "---\nlocked: true\n---\n\nKeep this exact content.\n",
+        },
+    )
+    assert response.status_code == 202, response.text
+    note = response.json()
+    path = Path(test_project.path) / note["file_path"]
+    return (
+        f"/v2/projects/{test_project.external_id}/knowledge/entities/{note['external_id']}",
+        path,
+        path.read_bytes(),
+    )
+
+
+async def assert_note_unchanged(client: AsyncClient, note: LockedNote) -> None:
+    url, path, original = note
+    assert path.read_bytes() == original
+    response = await client.get(url)
+    assert response.status_code == 200
+    assert response.json()["content"] == original.decode("utf-8")
+    assert response.json()["db_version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_locked_note_rejects_append(client: AsyncClient, locked_note: LockedNote) -> None:
+    response = await client.patch(
+        locked_note[0], json={"operation": "append", "content": "Sneaky edit"}
+    )
+    assert response.status_code == 423, response.text
+    assert "locked: true" in response.text
+    await assert_note_unchanged(client, locked_note)
+
+
+@pytest.mark.asyncio
+async def test_directory_delete_still_accepts_offline_malformed_notes(
+    client: AsyncClient, test_project: Project
+) -> None:
+    directory = Path(test_project.path) / "malformed"
+    directory.mkdir()
+    note_path = directory / "broken.md"
+    note_path.write_text("---\ntitle: [unclosed\n---\n\nOriginal\n", encoding="utf-8")
+    await run_local_project_index_for_project(
+        test_project,
+        runtime_factory=LocalProjectIndexRuntimeFactory(batch_size=10),
+        force_full=True,
+    )
+    response = await client.post(
+        f"/v2/projects/{test_project.external_id}/knowledge/delete-directory",
+        json={"directory": "malformed"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["successful_deletes"] == 1
+    assert not note_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_locked_note_rejects_metadata_unlock(
+    client: AsyncClient, locked_note: LockedNote
+) -> None:
+    response = await client.patch(
+        locked_note[0],
+        json={"operation": "append", "content": "Sneaky edit", "metadata": {"locked": False}},
+    )
+    assert response.status_code == 423, response.text
+    await assert_note_unchanged(client, locked_note)
+
+
+@pytest.mark.asyncio
+async def test_locked_note_rejects_frontmatter_find_replace(
+    client: AsyncClient, locked_note: LockedNote
+) -> None:
+    response = await client.patch(
+        locked_note[0],
+        json={"operation": "find_replace", "find_text": "locked: true", "content": "locked: false"},
+    )
+    assert response.status_code == 423, response.text
+    await assert_note_unchanged(client, locked_note)
+
+
+@pytest.mark.asyncio
+async def test_locked_note_rejects_replacement_body_unlock(
+    client: AsyncClient, locked_note: LockedNote
+) -> None:
+    response = await client.put(
+        locked_note[0],
+        json={
+            "title": "Runbook",
+            "directory": "protected",
+            "content": "---\nlocked: false\n---\n\nReplacement",
+            "entity_metadata": {"locked": False},
+        },
+    )
+    assert response.status_code == 423, response.text
+    await assert_note_unchanged(client, locked_note)
+
+
+@pytest.mark.asyncio
+async def test_locked_note_rejects_replacement_omitting_lock(
+    client: AsyncClient, locked_note: LockedNote
+) -> None:
+    response = await client.put(
+        locked_note[0],
+        json={"title": "Runbook", "directory": "protected", "content": "No frontmatter"},
+    )
+    assert response.status_code == 423, response.text
+    await assert_note_unchanged(client, locked_note)
+
+
+@pytest.mark.asyncio
+async def test_locked_note_rejects_delete(client: AsyncClient, locked_note: LockedNote) -> None:
+    response = await client.delete(locked_note[0])
+    assert response.status_code == 423, response.text
+    await assert_note_unchanged(client, locked_note)
+
+
+@pytest.mark.asyncio
+async def test_directory_delete_rejects_locked_note_before_deleting_siblings(
+    client: AsyncClient, test_project: Project, locked_note: LockedNote
+) -> None:
+    base = f"/v2/projects/{test_project.external_id}/knowledge"
+    sibling = await client.post(
+        f"{base}/entities",
+        json={"title": "Sibling", "directory": "protected", "content": "Keep sibling too"},
+    )
+    assert sibling.status_code == 202, sibling.text
+    sibling_path = Path(test_project.path) / sibling.json()["file_path"]
+    sibling_bytes = sibling_path.read_bytes()
+    response = await client.post(f"{base}/delete-directory", json={"directory": "protected"})
+    assert response.status_code == 423, response.text
+    assert sibling_path.read_bytes() == sibling_bytes
+    sibling_read = await client.get(f"{base}/entities/{sibling.json()['external_id']}")
+    assert sibling_read.status_code == 200
+    await assert_note_unchanged(client, locked_note)
+
+
+@pytest.mark.asyncio
+async def test_offline_edit_can_unlock_note(client: AsyncClient, locked_note: LockedNote) -> None:
+    url, path, original = locked_note
+    path.write_bytes(original.replace(b"locked: true", b"locked: false"))
+    response = await client.patch(url, json={"operation": "append", "content": "Allowed now"})
+    assert response.status_code == 202, response.text
+    assert "Allowed now" in path.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_agent_can_lock_existing_note_but_cannot_unlock_it(
+    client: AsyncClient, test_project: Project
+) -> None:
+    base = f"/v2/projects/{test_project.external_id}/knowledge/entities"
+    created = await client.post(
+        base, json={"title": "New lock", "directory": "", "content": "Original"}
+    )
+    assert created.status_code == 202, created.text
+    url = f"{base}/{created.json()['external_id']}"
+    locked = await client.patch(
+        url, json={"operation": "append", "content": "Final edit", "metadata": {"locked": True}}
+    )
+    assert locked.status_code == 202, locked.text
+    path = Path(test_project.path) / locked.json()["file_path"]
+    original = path.read_bytes()
+    unlock = await client.patch(
+        url, json={"operation": "append", "content": "", "metadata": {"locked": False}}
+    )
+    assert unlock.status_code == 423, unlock.text
+    assert path.read_bytes() == original
+    reread = await client.get(url)
+    assert reread.json()["content"] == original.decode("utf-8")
+    assert reread.json()["db_version"] == locked.json()["db_version"]
+
+
+@pytest.mark.asyncio
+async def test_move_preserves_locked_note_protection(
+    client: AsyncClient, locked_note: LockedNote
+) -> None:
+    url, original_path, _ = locked_note
+    moved = await client.put(f"{url}/move", json={"destination_path": "archive/Runbook.md"})
+    assert moved.status_code == 202, moved.text
+    assert not original_path.exists()
+    blocked = await client.patch(url, json={"operation": "append", "content": "Still forbidden"})
+    assert blocked.status_code == 423, blocked.text
+    read = await client.get(url)
+    assert read.json()["content"] == moved.json()["content"]
+    assert read.json()["db_version"] == moved.json()["db_version"]
+
+
+@pytest.mark.asyncio
+async def test_replacement_body_can_lock_an_unlocked_note(
+    client: AsyncClient, test_project: Project
+) -> None:
+    base = f"/v2/projects/{test_project.external_id}/knowledge/entities"
+    created = await client.post(
+        base, json={"title": "Body lock", "directory": "", "content": "Original"}
+    )
+    assert created.status_code == 202, created.text
+    url = f"{base}/{created.json()['external_id']}"
+    locked = await client.put(
+        url,
+        json={"title": "Body lock", "directory": "", "content": "---\nlocked: true\n---\nFinal"},
+    )
+    assert locked.status_code == 202, locked.text
+    blocked = await client.delete(url)
+    assert blocked.status_code == 423, blocked.text
+    read = await client.get(url)
+    assert read.json()["content"] == locked.json()["content"]
+
+
+@pytest.mark.asyncio
+async def test_import_cannot_overwrite_locked_note(
+    client: AsyncClient, test_project: Project, locked_note: LockedNote
+) -> None:
+    response = await client.post(
+        f"/v2/projects/{test_project.external_id}/import/memory-json",
+        data={"directory": "."},
+        files={
+            "file": (
+                "memory.json",
+                json.dumps(
+                    {
+                        "type": "entity",
+                        "entityType": "protected",
+                        "name": "Runbook",
+                        "observations": ["Overwrite attempt"],
+                    }
+                ),
+                "application/json",
+            )
+        },
+    )
+    assert response.status_code == 500, response.text
+    assert "locked: true" in response.text
+    await assert_note_unchanged(client, locked_note)

--- a/tests/indexing/test_directory_delete_runner.py
+++ b/tests/indexing/test_directory_delete_runner.py
@@ -474,6 +474,7 @@ async def test_repository_directory_delete_store_captures_relation_sources() -> 
             [
                 FakeExecuteResult(),  # sorted note_content lock fence
                 FakeExecuteResult(scalar_values=[7, 8]),  # current directory members
+                FakeExecuteResult(scalar_values=[]),  # canonical lock check
                 FakeExecuteResult(rows=[(101, 7, 42), (102, 8, 99)]),
                 FakeExecuteResult(scalar_values=[7, 8]),  # guarded entity delete
                 FakeExecuteResult(),  # search_index delete
@@ -541,6 +542,7 @@ async def test_repository_directory_delete_store_maps_note_content_snapshots() -
                 ),
                 FakeExecuteResult(),  # sorted note_content lock fence
                 FakeExecuteResult(scalar_values=[7]),  # current directory members
+                FakeExecuteResult(scalar_values=[]),  # canonical lock check
                 FakeExecuteResult(rows=[]),  # incoming relation snapshot
                 FakeExecuteResult(scalar_values=[7]),  # guarded entity delete
                 FakeExecuteResult(),  # search_index delete
@@ -580,11 +582,11 @@ async def test_repository_directory_delete_store_maps_note_content_snapshots() -
     assert delete_result == DirectoryEntityDeleteResult(
         deleted_entity_ids=frozenset({7}),
     )
-    assert len(fake_session.queries) == 8
+    assert len(fake_session.queries) == 9
     assert "FOR UPDATE" not in str(fake_session.queries[1][0])
     assert "ORDER BY note_content.entity_id" in str(fake_session.queries[2][0])
     assert "entity.file_path LIKE" in str(fake_session.queries[3][0])
-    guarded_entity_delete = str(fake_session.queries[5][0])
+    guarded_entity_delete = str(fake_session.queries[6][0])
     assert "entity.id IN" in guarded_entity_delete
     assert "entity.project_id" in guarded_entity_delete
     assert "entity.file_path LIKE" in guarded_entity_delete
@@ -601,6 +603,7 @@ async def test_repository_directory_delete_store_clears_vectors_for_deleted_enti
             [
                 FakeExecuteResult(),  # sorted note_content lock fence
                 FakeExecuteResult(scalar_values=[7, 8]),  # current directory members
+                FakeExecuteResult(scalar_values=[]),  # canonical lock check
                 FakeExecuteResult(rows=[]),  # incoming relation snapshot
                 FakeExecuteResult(scalar_values=[7, 8]),  # guarded entity delete
                 FakeExecuteResult(),  # search_index delete
@@ -642,11 +645,11 @@ async def test_repository_directory_delete_store_clears_vectors_for_deleted_enti
     )
 
     # Projection cleanup uses only ids returned by the guarded Entity mutation.
-    assert vector_calls == [(session, 3, (7, 8), 5)]
+    assert vector_calls == [(session, 3, (7, 8), 6)]
     statements = [str(query) for query, _ in fake_session.queries]
     assert "ORDER BY note_content.entity_id" in statements[0]
-    assert "DELETE FROM entity" in statements[3]
-    assert "DELETE FROM search_index" in statements[4]
+    assert "DELETE FROM entity" in statements[4]
+    assert "DELETE FROM search_index" in statements[5]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Implements the v0.24.0 locked-note scope agreed in #993: agents may set `locked: true`, but cannot use Basic Memory note APIs to edit, overwrite, delete, or unlock that note afterward. Direct filesystem edits are explicitly outside the contract.

## Scope Clarification

- `locked: true` is a one-way guard for the note-mutation API, not filesystem security.
- Imports are treated like raw file writes and are outside this lock contract. Do not add atomic import-versus-API synchronization or migrate importers into the guarded note-write path for this feature.
- Direct filesystem edits remain authoritative and may remove the lock. Deleting a file or its directory directly overrides the lock; Basic Memory must not block those deletions or restore files merely because they were locked.
- API `delete_note` and API directory deletion are explicitly bound by the lock. These filesystem exceptions do not apply to note API operations.

## What Changed

- Reject PUT, PATCH, and DELETE with HTTP 423 when the existing canonical Markdown has the YAML boolean `locked: true`.
- Reject API directory deletion before deleting any siblings when an accepted member is locked or a current local file has acquired a lock before indexing.
- Leave imports as unrestricted raw file writes; preserve direct filesystem deletion and reconciliation.
- Preserve allowed moves and their lock metadata; reads, indexing, and offline unlocking continue to work.
- Document the contract in `docs/LOCKED_NOTES.md`.

## Implementation Details

The accepted mutation runner reads the existing `NoteContent` before preparing the proposed replacement or edit. Incoming metadata, body frontmatter, or find/replace operations never authorize an unlock. Checks reuse the existing canonical mutation fence; no new database locks, identity system, privileged unlock route, or audit machinery were introduced. The local freshener reconciles direct file edits before individual note mutations.

The directory path checks accepted Markdown before any deletion. A local read-only preflight also inspects current Markdown files before accepting the bulk delete, so an offline lock does not require waiting for the watcher. Hosted runtimes retain the accepted-content check. No new locks or file-write machinery were added. Importer and FileService behavior are unchanged from the base branch.

## Testing

- `just fast-check`: passed.
- `uv run pytest test-int/test_locked_notes.py --no-cov -q`: 16 passed on SQLite.
- `uv run pytest tests/indexing/test_accepted_note_mutation_runner.py tests/indexing/test_directory_delete_runner.py tests/importers/test_importer_base.py --no-cov -q`: 64 passed.
- `uv run pytest test-int/mcp/test_delete_directory_integration.py test-int/cli/test_cli_tool_delete_note_integration.py --no-cov -q`: 14 passed.
- `BASIC_MEMORY_TEST_POSTGRES=1 uv run pytest test-int/test_locked_notes.py --no-cov -q`: 16 passed against real PostgreSQL.
- `codex review --uncommitted`: no actionable regressions; reviewer independently passed all 16 locked-note integration tests before the follow-up push.
- `just doctor`: passed.
- New tests use real APIs, files, and databases, without parameterization or mocked lock enforcement. Rejection assertions read back canonical content, file bytes, and content versions.

## Risks / Follow-ups

- This is a note-mutation contract, not filesystem security or Teams authorization. Direct file edits can remove the flag.
- Moves remain allowed and preserve protection; their normal permalink update policy is unchanged.
- Schema enforcement and team-scoped permissions from the broader #993 proposal are not implemented here.
- Native/full CI will run on the PR; local validation is not a claim that CI has finished.

