### PR TITLE
fix(core): report resolved schema identity to validation observers

### DIFF
--- a/src/basic_memory/api/v2/routers/schema_router.py
+++ b/src/basic_memory/api/v2/routers/schema_router.py
@@ -255,7 +255,7 @@ async def validate_schema(
                     schema_reference=schema_ref if isinstance(schema_ref, str) else None,
                     passed=response.passed,
                     schema_external_id=resolved.source.external_id,
-                    schema_kind="inline" if isinstance(schema_ref, dict) else "named",
+                    schema_kind=resolved.kind,
                 )
             )
 
@@ -509,7 +509,7 @@ async def _validate_note_entities(
                         schema_reference=schema_ref if isinstance(schema_ref, str) else None,
                         passed=response.passed,
                         schema_external_id=resolved.source.external_id,
-                        schema_kind="inline" if isinstance(schema_ref, dict) else "named",
+                        schema_kind=resolved.kind,
                     )
                 )
 

--- a/src/basic_memory/api/v2/routers/schema_router.py
+++ b/src/basic_memory/api/v2/routers/schema_router.py
@@ -34,7 +34,13 @@ from basic_memory.schemas.schema import (
     DriftFieldResponse,
     TypeValidationSummary,
 )
-from basic_memory.picoschema.resolver import SchemaSearchFn, resolve_schema
+from basic_memory.picoschema.resolver import (
+    ResolvedSchema,
+    SchemaCandidate,
+    SchemaSearchFn,
+    resolve_schema,
+    resolve_schema_with_source,
+)
 from basic_memory.picoschema.parser import SchemaDefinition
 from basic_memory.picoschema.validator import validate_note
 from basic_memory.services.schema_validation_hooks import (
@@ -151,6 +157,39 @@ async def _resolve_schema_for_api(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
 
+async def _resolve_note_schema(
+    session: AsyncSession,
+    entity_repository: EntityRepositoryV2ExternalDep,
+    file_service: FileServiceV2ExternalDep,
+    entity: Entity,
+    frontmatter: dict[str, Any],
+) -> ResolvedSchema[Entity] | None:
+    """Keep the selected schema entity attached to the definition we validate.
+
+    Single-note and batch validation must report the same authoritative
+    identity. Re-querying after validation can choose a different schema and
+    cannot disambiguate multiple matches from the covered type alone.
+    """
+    schema_ref = frontmatter.get("schema")
+
+    async def search_fn(query: str) -> list[SchemaCandidate[Entity]]:
+        entities = await _find_schema_entities(
+            session,
+            entity_repository,
+            query,
+            allow_reference_match=isinstance(schema_ref, str) and query == schema_ref,
+        )
+        return [
+            SchemaCandidate(await _schema_frontmatter_from_file(file_service, candidate), candidate)
+            for candidate in entities
+        ]
+
+    try:
+        return await resolve_schema_with_source(frontmatter, search_fn, inline_source=entity)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
 @router.post("/schema/validate", response_model=ValidationReport)
 async def validate_schema(
     entity_repository: EntityRepositoryV2ExternalDep,
@@ -196,20 +235,13 @@ async def validate_schema(
         frontmatter = _entity_frontmatter(entity)
         schema_ref = frontmatter.get("schema")
 
-        async def search_fn(query: str) -> list[dict[str, Any]]:
-            entities = await _find_schema_entities(
-                session,
-                entity_repository,
-                query,
-                allow_reference_match=isinstance(schema_ref, str) and query == schema_ref,
-            )
-            return [await _schema_frontmatter_from_file(file_service, e) for e in entities]
-
-        schema_def = await _resolve_schema_for_api(frontmatter, search_fn)
-        if schema_def:
+        resolved = await _resolve_note_schema(
+            session, entity_repository, file_service, entity, frontmatter
+        )
+        if resolved is not None:
             result = validate_note(
                 entity.title or entity.permalink or identifier,
-                schema_def,
+                resolved.definition,
                 _entity_observations(entity),
                 _entity_relations(entity),
                 frontmatter=frontmatter,
@@ -222,6 +254,8 @@ async def validate_schema(
                     schema_entity=response.schema_entity,
                     schema_reference=schema_ref if isinstance(schema_ref, str) else None,
                     passed=response.passed,
+                    schema_external_id=resolved.source.external_id,
+                    schema_kind="inline" if isinstance(schema_ref, dict) else "named",
                 )
             )
 
@@ -454,20 +488,13 @@ async def _validate_note_entities(
         frontmatter = _entity_frontmatter(entity)
         schema_ref = frontmatter.get("schema")
 
-        async def search_fn(query: str) -> list[dict[str, Any]]:
-            found = await _find_schema_entities(
-                session,
-                entity_repository,
-                query,
-                allow_reference_match=isinstance(schema_ref, str) and query == schema_ref,
-            )
-            return [await _schema_frontmatter_from_file(file_service, e) for e in found]
-
-        schema_def = await _resolve_schema_for_api(frontmatter, search_fn)
-        if schema_def:
+        resolved = await _resolve_note_schema(
+            session, entity_repository, file_service, entity, frontmatter
+        )
+        if resolved is not None:
             result = validate_note(
                 entity.title or entity.permalink or entity.file_path,
-                schema_def,
+                resolved.definition,
                 _entity_observations(entity),
                 _entity_relations(entity),
                 frontmatter=frontmatter,
@@ -481,6 +508,8 @@ async def _validate_note_entities(
                         schema_entity=response.schema_entity,
                         schema_reference=schema_ref if isinstance(schema_ref, str) else None,
                         passed=response.passed,
+                        schema_external_id=resolved.source.external_id,
+                        schema_kind="inline" if isinstance(schema_ref, dict) else "named",
                     )
                 )
 

--- a/src/basic_memory/picoschema/__init__.py
+++ b/src/basic_memory/picoschema/__init__.py
@@ -10,7 +10,12 @@ from basic_memory.picoschema.parser import (
     parse_picoschema,
     parse_schema_note,
 )
-from basic_memory.picoschema.resolver import resolve_schema
+from basic_memory.picoschema.resolver import (
+    ResolvedSchema,
+    SchemaCandidate,
+    resolve_schema,
+    resolve_schema_with_source,
+)
 from basic_memory.picoschema.validator import (
     FieldResult,
     ValidationResult,
@@ -39,6 +44,9 @@ __all__ = [
     "parse_schema_note",
     # Resolver
     "resolve_schema",
+    "resolve_schema_with_source",
+    "SchemaCandidate",
+    "ResolvedSchema",
     # Validator
     "FieldResult",
     "ValidationResult",

--- a/src/basic_memory/picoschema/resolver.py
+++ b/src/basic_memory/picoschema/resolver.py
@@ -12,6 +12,7 @@ data access layer.
 """
 
 from collections.abc import Callable, Awaitable
+from dataclasses import dataclass
 
 from basic_memory.picoschema.parser import (
     SchemaDefinition,
@@ -25,6 +26,24 @@ from typing import Any
 # Type alias for the search function dependency.
 # Given a query string, returns a list of frontmatter dicts from matching schema notes.
 type SchemaSearchFn = Callable[[str], Awaitable[list[dict[str, Any]]]]
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaCandidate[Source]:
+    """A schema's authored definition paired with its caller-owned source.
+
+    Keeping these together lets resolution return the source it actually used,
+    without making the schema engine depend on database entities or identities.
+    """
+
+    frontmatter: dict[str, Any]
+    source: Source
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedSchema[Source]:
+    definition: SchemaDefinition
+    source: Source
 
 
 async def resolve_schema(
@@ -48,6 +67,29 @@ async def resolve_schema(
     Returns:
         A SchemaDefinition if a schema is found, None otherwise.
     """
+
+    async def search_candidates(query: str) -> list[SchemaCandidate[None]]:
+        return [SchemaCandidate(metadata, None) for metadata in await search_fn(query)]
+
+    resolved = await resolve_schema_with_source(
+        note_frontmatter, search_candidates, inline_source=None
+    )
+    return resolved.definition if resolved is not None else None
+
+
+async def resolve_schema_with_source[Source](
+    note_frontmatter: dict[str, Any],
+    search_fn: Callable[[str], Awaitable[list[SchemaCandidate[Source]]]],
+    *,
+    inline_source: Source,
+) -> ResolvedSchema[Source] | None:
+    """Resolve once, preserving the source of the definition selected.
+
+    Callers supply their own source value, including the owner of an inline
+    schema. Named lookups retain first-match selection, and a missing explicit
+    reference still falls through to the note type. The definition-only API
+    delegates here so both entrypoints follow the same resolution rules.
+    """
     schema_value = note_frontmatter.get("schema")
 
     # --- 1. Inline schema ---
@@ -55,16 +97,17 @@ async def resolve_schema(
     # Why: inline schemas are self-contained, no lookup needed
     # Outcome: parse and return immediately
     if isinstance(schema_value, dict):
-        return _schema_from_inline(schema_value, note_frontmatter)
+        return ResolvedSchema(_schema_from_inline(schema_value, note_frontmatter), inline_source)
 
     # --- 2. Explicit reference ---
     # Trigger: schema field is a string (entity name or permalink)
     # Why: the note points to a specific schema note by name
     # Outcome: search for the referenced schema note and parse it
     if isinstance(schema_value, str):
-        result = await _schema_from_reference(schema_value, search_fn)
-        if result is not None:
-            return result
+        candidates = await search_fn(schema_value)
+        if candidates:
+            selected = candidates[0]
+            return ResolvedSchema(parse_schema_note(selected.frontmatter), selected.source)
 
     # --- 3. Implicit by type ---
     # Trigger: no schema field, but the note has a type field
@@ -72,9 +115,10 @@ async def resolve_schema(
     # Outcome: search for a schema note whose entity matches the note's type
     note_type = note_frontmatter.get("type")
     if note_type:
-        result = await _schema_from_type(note_type, search_fn)
-        if result is not None:
-            return result
+        candidates = await search_fn(note_type)
+        if candidates:
+            selected = candidates[0]
+            return ResolvedSchema(parse_schema_note(selected.frontmatter), selected.source)
 
     # --- 4. No schema ---
     return None
@@ -100,28 +144,3 @@ def _schema_from_inline(
         fields=fields,
         validation_mode=validation_mode,
     )
-
-
-async def _schema_from_reference(
-    ref: str,
-    search_fn: SchemaSearchFn,
-) -> SchemaDefinition | None:
-    """Look up a schema by entity name or permalink reference.
-
-    The search function is expected to find schema notes matching the reference.
-    """
-    results = await search_fn(ref)
-    if not results:
-        return None
-    return parse_schema_note(results[0])
-
-
-async def _schema_from_type(
-    note_type: str,
-    search_fn: SchemaSearchFn,
-) -> SchemaDefinition | None:
-    """Look up a schema implicitly by matching the note's type to a schema's entity field."""
-    results = await search_fn(note_type)
-    if not results:
-        return None
-    return parse_schema_note(results[0])

--- a/src/basic_memory/picoschema/resolver.py
+++ b/src/basic_memory/picoschema/resolver.py
@@ -20,7 +20,7 @@ from basic_memory.picoschema.parser import (
     parse_schema_note,
     parse_validation_mode,
 )
-from typing import Any
+from typing import Any, Literal
 
 
 # Type alias for the search function dependency.
@@ -44,6 +44,7 @@ class SchemaCandidate[Source]:
 class ResolvedSchema[Source]:
     definition: SchemaDefinition
     source: Source
+    kind: Literal["inline", "named"]
 
 
 async def resolve_schema(
@@ -97,7 +98,9 @@ async def resolve_schema_with_source[Source](
     # Why: inline schemas are self-contained, no lookup needed
     # Outcome: parse and return immediately
     if isinstance(schema_value, dict):
-        return ResolvedSchema(_schema_from_inline(schema_value, note_frontmatter), inline_source)
+        return ResolvedSchema(
+            _schema_from_inline(schema_value, note_frontmatter), inline_source, kind="inline"
+        )
 
     # --- 2. Explicit reference ---
     # Trigger: schema field is a string (entity name or permalink)
@@ -107,7 +110,9 @@ async def resolve_schema_with_source[Source](
         candidates = await search_fn(schema_value)
         if candidates:
             selected = candidates[0]
-            return ResolvedSchema(parse_schema_note(selected.frontmatter), selected.source)
+            return ResolvedSchema(
+                parse_schema_note(selected.frontmatter), selected.source, kind="named"
+            )
 
     # --- 3. Implicit by type ---
     # Trigger: no schema field, but the note has a type field
@@ -118,7 +123,9 @@ async def resolve_schema_with_source[Source](
         candidates = await search_fn(note_type)
         if candidates:
             selected = candidates[0]
-            return ResolvedSchema(parse_schema_note(selected.frontmatter), selected.source)
+            return ResolvedSchema(
+                parse_schema_note(selected.frontmatter), selected.source, kind="named"
+            )
 
     # --- 4. No schema ---
     return None

--- a/src/basic_memory/services/schema_validation_hooks.py
+++ b/src/basic_memory/services/schema_validation_hooks.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Literal
 
 
 @dataclass(frozen=True, slots=True)
@@ -24,20 +25,23 @@ class ValidatedNoteOutcome:
     title. What is left is what an observer can legitimately act on -- which
     schema, and whether the note satisfied it.
 
-    The two schema fields answer different questions and neither replaces the
-    other. `schema_entity` is the note type the schema covers, read from the
-    schema's own `entity:` frontmatter, so two schema notes that both cover
-    `person` report the same value. `schema_reference` is what the validated
-    note pointed at -- the string in its `schema:` frontmatter -- and is None
-    when the schema was declared inline and there was nothing to point at. An
-    observer that needs to tell two schemas for one entity apart needs the
-    reference; it is the reference as written and matched, not a stable id.
+    `schema_external_id` identifies the exact schema used by the resolver. For
+    an inline schema it is the validated note's id; for a named schema it is
+    the selected schema note's id. Observers need not repeat resolution, even
+    when several schemas cover the same type or an explicit reference misses.
+
+    The older descriptive fields remain for existing observers. `schema_entity`
+    is the covered type, and `schema_reference` is the reference as authored,
+    which may have failed before resolution fell through to the note type.
+    Neither descriptive field is a stable schema identity.
     """
 
     note_external_id: str
     schema_entity: str
     schema_reference: str | None
     passed: bool
+    schema_external_id: str
+    schema_kind: Literal["inline", "named"]
 
 
 class SchemaValidationObserver:

--- a/tests/api/v2/test_schema_validation_identity.py
+++ b/tests/api/v2/test_schema_validation_identity.py
@@ -164,3 +164,71 @@ async def test_invalid_schema_never_reports_an_identity(
     response = await client.post(f"{v2_project_url}/schema/validate", params=params)
     assert response.status_code == 400
     assert identity_observer.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope", ["type", "all"])
+async def test_mixed_batch_attributes_each_note_to_its_own_schema(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    entity_service: EntityService,
+    search_service: SearchService,
+    identity_observer: IdentityObserver,
+    scope: str,
+) -> None:
+    # A passing named note, a failing named note, and an inline note must
+    # retain their own identities and results regardless of batch ordering.
+    expected: dict[str, tuple[str, str, bool]] = {}
+    for field, passed in (("name", True), ("role", False)):
+        schema, _ = await entity_service.create_or_update_entity(
+            EntitySchema(
+                title=f"person-by-{field}",
+                directory="schemas",
+                note_type="schema",
+                entity_metadata={
+                    "entity": "person",
+                    "schema": {field: "string"},
+                    "settings": {"validation": "strict"},
+                },
+                content="A person schema.\n",
+            )
+        )
+        await search_service.index_entity(schema)
+        note, _ = await entity_service.create_or_update_entity(
+            EntitySchema(
+                title=f"Person with {field} schema",
+                directory="people",
+                note_type="person",
+                entity_metadata={"schema": schema.title},
+                content="## Observations\n- [name] Example\n",
+            )
+        )
+        await search_service.index_entity(note)
+        expected[note.external_id] = (schema.external_id, "named", passed)
+
+    inline, _ = await entity_service.create_or_update_entity(
+        EntitySchema(
+            title="Person with inline schema",
+            directory="people",
+            note_type="person",
+            entity_metadata={"schema": {"name": "string"}},
+            content="## Observations\n- [name] Example\n",
+        )
+    )
+    await search_service.index_entity(inline)
+    expected[inline.external_id] = (inline.external_id, "inline", True)
+
+    params = {"note_type": "person"} if scope == "type" else {}
+    response = await client.post(f"{v2_project_url}/schema/validate", params=params)
+    assert response.status_code == 200
+    assert response.json()["total_notes"] == 3
+    assert response.json()["valid_count"] == 2
+    assert len(identity_observer.calls) == 1
+    project_id, outcomes = identity_observer.calls[0]
+    assert project_id == test_project.external_id
+    assert len(outcomes) == 3
+    assert {
+        outcome.note_external_id: (outcome.schema_external_id, outcome.schema_kind, outcome.passed)
+        for outcome in outcomes
+    } == expected

--- a/tests/api/v2/test_schema_validation_identity.py
+++ b/tests/api/v2/test_schema_validation_identity.py
@@ -1,0 +1,166 @@
+"""Schema identity must describe the definition the real API validated."""
+
+from collections.abc import Generator, Sequence
+from typing import Literal, override
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+from basic_memory.deps.services import get_schema_validation_observer
+from basic_memory.models import Project
+from basic_memory.schemas.base import Entity as EntitySchema
+from basic_memory.services.entity_service import EntityService
+from basic_memory.services.schema_validation_hooks import (
+    SchemaValidationObserver,
+    ValidatedNoteOutcome,
+)
+from basic_memory.services.search_service import SearchService
+
+
+class IdentityObserver(SchemaValidationObserver):
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[ValidatedNoteOutcome, ...]]] = []
+
+    @override
+    async def on_notes_validated(
+        self, *, project_external_id: str, outcomes: Sequence[ValidatedNoteOutcome]
+    ) -> None:
+        self.calls.append((project_external_id, tuple(outcomes)))
+
+
+@pytest.fixture
+def identity_observer(app: FastAPI) -> Generator[IdentityObserver, None, None]:
+    observer = IdentityObserver()
+    app.dependency_overrides[get_schema_validation_observer] = lambda: observer
+    yield observer
+    app.dependency_overrides.pop(get_schema_validation_observer, None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope", ["identifier", "type", "all"])
+@pytest.mark.parametrize("reference", ["explicit", "implicit", "missing", "inline"])
+async def test_validation_identity_matches_definition_in_every_scope(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    entity_service: EntityService,
+    search_service: SearchService,
+    identity_observer: IdentityObserver,
+    scope: Literal["identifier", "type", "all"],
+    reference: Literal["explicit", "implicit", "missing", "inline"],
+) -> None:
+    # Both schemas cover person, but their required fields differ. Whichever
+    # database row is selected, the API report independently identifies its
+    # definition; a guessed id from the other candidate fails this assertion.
+    schema_fields: dict[str, str] = {}
+    explicit_title = "person-with-role"
+    for title, field in (("person-with-name", "name"), (explicit_title, "role")):
+        schema, _ = await entity_service.create_or_update_entity(
+            EntitySchema(
+                title=title,
+                directory="schemas",
+                note_type="schema",
+                entity_metadata={
+                    "entity": "person",
+                    "schema": {field: "string"},
+                    "settings": {"validation": "strict"},
+                },
+                content="A person schema.\n",
+            )
+        )
+        await search_service.index_entity(schema)
+        schema_fields[schema.external_id] = field
+
+    match reference:
+        case "explicit":
+            metadata = {"schema": explicit_title}
+        case "missing":
+            metadata = {"schema": "missing-schema-reference"}
+        case "inline":
+            metadata = {"schema": {"inline_field": "string"}}
+        case "implicit":
+            metadata = {}
+
+    note, _ = await entity_service.create_or_update_entity(
+        EntitySchema(
+            title="Identity example",
+            directory="people",
+            note_type="person",
+            entity_metadata=metadata,
+            content="## Observations\n- [name] Example\n- [inline_field] Present\n",
+        )
+    )
+    await search_service.index_entity(note)
+    match scope:
+        case "identifier":
+            params = {"identifier": note.permalink}
+        case "type":
+            params = {"note_type": "person"}
+        case "all":
+            params = {}
+
+    response = await client.post(f"{v2_project_url}/schema/validate", params=params)
+    assert response.status_code == 200
+    report = response.json()
+    assert len(identity_observer.calls) == 1
+    project_id, outcomes = identity_observer.calls[0]
+    assert project_id == test_project.external_id
+    assert len(outcomes) == len(report["results"]) == 1
+    outcome = outcomes[0]
+    assert outcome.note_external_id == note.external_id
+    assert outcome.passed == report["results"][0]["passed"]
+    fields = [field["field_name"] for field in report["results"][0]["field_results"]]
+    if reference == "inline":
+        assert outcome.schema_kind == "inline"
+        assert outcome.schema_external_id == note.external_id
+        assert fields == ["inline_field"]
+    else:
+        assert outcome.schema_kind == "named"
+        assert outcome.schema_external_id in schema_fields
+        assert fields == [schema_fields[outcome.schema_external_id]]
+        if reference == "explicit":
+            assert fields == ["role"]
+            assert outcome.passed is False
+        if reference == "missing":
+            assert outcome.schema_reference == "missing-schema-reference"
+
+    # Identity is for observers; the public validation response is unchanged.
+    assert "schema_external_id" not in report["results"][0]
+    assert "schema_kind" not in report["results"][0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope", ["identifier", "type", "all"])
+async def test_invalid_schema_never_reports_an_identity(
+    client: AsyncClient,
+    test_project: Project,
+    v2_project_url: str,
+    entity_service: EntityService,
+    search_service: SearchService,
+    identity_observer: IdentityObserver,
+    scope: str,
+) -> None:
+    note, _ = await entity_service.create_or_update_entity(
+        EntitySchema(
+            title="Invalid schema example",
+            directory="people",
+            note_type="person",
+            entity_metadata={
+                "schema": {"name": "string"},
+                "settings": {"validation": "invalid-mode"},
+            },
+            content="## Observations\n- [name] Example\n",
+        )
+    )
+    await search_service.index_entity(note)
+    params = (
+        {"identifier": note.permalink}
+        if scope == "identifier"
+        else {"note_type": "person"}
+        if scope == "type"
+        else {}
+    )
+    response = await client.post(f"{v2_project_url}/schema/validate", params=params)
+    assert response.status_code == 400
+    assert identity_observer.calls == []

--- a/tests/picoschema/test_resolver_source.py
+++ b/tests/picoschema/test_resolver_source.py
@@ -1,0 +1,58 @@
+"""Resolution retains the selected source without another lookup."""
+
+from typing import Any
+
+import pytest
+
+from basic_memory.picoschema.resolver import SchemaCandidate, resolve_schema_with_source
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("frontmatter", "queries", "expected_source"),
+    [
+        ({"schema": {"local": "string"}, "type": "person"}, [], "inline-note"),
+        ({"schema": "explicit", "type": "person"}, ["explicit"], "selected-schema"),
+        ({"schema": "missing", "type": "person"}, ["missing", "person"], "selected-schema"),
+        ({"type": "person"}, ["person"], "selected-schema"),
+        ({"schema": "missing"}, ["missing"], None),
+        ({"type": "missing"}, ["missing"], None),
+        ({}, [], None),
+    ],
+)
+async def test_source_follows_resolution(
+    frontmatter: dict[str, Any], queries: list[str], expected_source: str | None
+) -> None:
+    searched: list[str] = []
+
+    async def search(query: str) -> list[SchemaCandidate[str]]:
+        searched.append(query)
+        if query == "missing":
+            return []
+        return [
+            SchemaCandidate({"entity": "person", "schema": {"name": "string"}}, "selected-schema"),
+            SchemaCandidate({"entity": "person", "schema": {"role": "string"}}, "other-schema"),
+        ]
+
+    result = await resolve_schema_with_source(frontmatter, search, inline_source="inline-note")
+    assert searched == queries
+    if expected_source is None:
+        assert result is None
+    else:
+        assert result is not None
+        assert result.source == expected_source
+        assert result.definition.fields[0].name == (
+            "local" if expected_source == "inline-note" else "name"
+        )
+
+
+@pytest.mark.asyncio
+async def test_invalid_selected_schema_does_not_skip_to_another_source() -> None:
+    async def search(query: str) -> list[SchemaCandidate[str]]:
+        return [
+            SchemaCandidate({"entity": "person"}, "invalid-first"),
+            SchemaCandidate({"entity": "person", "schema": {"name": "string"}}, "valid-second"),
+        ]
+
+    with pytest.raises(ValueError):
+        await resolve_schema_with_source({"type": "person"}, search, inline_source="inline-note")

--- a/tests/picoschema/test_resolver_source.py
+++ b/tests/picoschema/test_resolver_source.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from basic_memory.picoschema.resolver import SchemaCandidate, resolve_schema_with_source
+from basic_memory.picoschema import ResolvedSchema, SchemaCandidate, resolve_schema_with_source
 
 
 @pytest.mark.asyncio
@@ -15,6 +15,7 @@ from basic_memory.picoschema.resolver import SchemaCandidate, resolve_schema_wit
         ({"schema": "explicit", "type": "person"}, ["explicit"], "selected-schema"),
         ({"schema": "missing", "type": "person"}, ["missing", "person"], "selected-schema"),
         ({"type": "person"}, ["person"], "selected-schema"),
+        ({"schema": 42, "type": "person"}, ["person"], "selected-schema"),
         ({"schema": "missing"}, ["missing"], None),
         ({"type": "missing"}, ["missing"], None),
         ({}, [], None),
@@ -39,7 +40,8 @@ async def test_source_follows_resolution(
     if expected_source is None:
         assert result is None
     else:
-        assert result is not None
+        assert isinstance(result, ResolvedSchema)
+        assert result.kind == ("inline" if expected_source == "inline-note" else "named")
         assert result.source == expected_source
         assert result.definition.fields[0].name == (
             "local" if expected_source == "inline-note" else "name"


### PR DESCRIPTION
Schema validation observers currently receive the covered type and the authored schema reference, neither of which identifies the exact schema used. When several schemas cover one type, or an explicit reference misses and validation falls through to type lookup, Cloud's SPEC-87 Mission 5 cannot reliably attribute the passing result and skips credit.

This change carries the selected source and inline/named kind through schema resolution and adds required `schema_external_id` and `schema_kind` fields to `ValidatedNoteOutcome`. Named schemas report the selected schema note's stable ID; inline schemas report the validated note's ID. Single-note, type-wide, and all-types validation use the same resolution adapter. The existing definition-only resolver delegates to the same selection logic, preserving resolution order and parser errors. The sourced resolver and its types are exported from `basic_memory.picoschema`. Public validation response models remain unchanged.

This is the Core prerequisite for Mission 5. Cloud must adopt the merged Core commit and consume the new identity fields before removing its repeated schema lookup and ambiguous-match skip. Cloud mission locks, rollout flags, rewards, and database schemas are unchanged. Existing observers can keep reading the old fields; code constructing outcomes must supply the two new required fields.

Validation:
- 203 SQLite Picoschema/API tests pass, including 17 identity API regressions and 9 source-resolution cases.
- 17 PostgreSQL identity API tests pass after the final changes; the broader 48 schema API tests passed before the review follow-up.
- 241 schema, MCP, CLI, and integration tests passed before the review follow-up.
- Mixed batches contain two distinct named schemas and an inline schema, with both passing and failing notes. Reusing the first note's schema ID failed both type-wide and all-types regressions; both passed after restoration.
- Deliberately swapped the selected schema source to the other candidate: the API regression failed on the mismatched validated field; all 15 identity regressions passed after restoring the implementation.
- `just fast-check`, `just doctor`, and `git diff --check` pass.

Started from Core `26439122a2c656916a39dd55cb44516aaf78869f`. This work can merge independently of Cloud #1993.
