### PR TITLE
feat(cli): add Codex plugin install command

### DIFF
--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -100,7 +100,20 @@ session.
 
 ## Install
 
-Install the plugin once from the Basic Memory repository root:
+Install the plugin once with Basic Memory and Codex CLI on your PATH:
+
+```bash
+bm install codex
+```
+
+This registers the GitHub marketplace and installs `codex@basic-memory` through
+Codex CLI. Use `--dry-run` to preview the commands or `--yes` to skip confirmation.
+For a local checkout, run `bm install codex --source /path/to/basic-memory`.
+The source must be the repository root containing `.agents/plugins/marketplace.json`.
+The default Git source uses its default branch, independently of the installed
+Basic Memory Python version. Hooks require `uv` as described above.
+
+Alternatively, install directly from the Basic Memory repository root:
 
 ```bash
 codex plugin marketplace add "$(git rev-parse --show-toplevel)"

--- a/src/basic_memory/cli/commands/install.py
+++ b/src/basic_memory/cli/commands/install.py
@@ -26,6 +26,52 @@ install_app = typer.Typer(help="Install Basic Memory resources into an agent hos
 app.add_typer(install_app, name="install")
 
 
+@install_app.command("codex")
+def install_codex(
+    source: str = typer.Option(
+        "basicmachines-co/basic-memory",
+        "--source",
+        help="Marketplace Git source or local repo root.",
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview only; no subprocesses."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Approve the displayed installation plan."),
+) -> None:
+    """Install the Basic Memory plugin through Codex's user-level marketplace."""
+    commands = [
+        ["plugin", "marketplace", "add", source],
+        ["plugin", "add", "codex@basic-memory"],
+    ]
+    typer.echo("Install the Basic Memory marketplace and plugin into Codex (user-level).")
+    for command in commands:
+        typer.echo(shell_command("codex", *command))
+    if dry_run:
+        return
+    codex = shutil.which("codex")
+    if codex is None:
+        typer.echo("Codex CLI not found on PATH. Install Codex CLI first.", err=True)
+        raise typer.Exit(1)
+    if not yes and not typer.confirm("Apply this installation plan?", default=False):
+        raise typer.Abort()
+    for command in commands:
+        try:
+            result = subprocess.run([codex, *command], check=False)
+        except OSError:
+            typer.echo("Cannot launch Codex CLI. Check its installation and permissions.", err=True)
+            raise typer.Exit(1) from None
+        # A failed marketplace registration must not install from an unrelated
+        # previously configured source with the same marketplace name.
+        if result.returncode:
+            typer.echo(
+                "Codex command failed: "
+                + shell_command("codex", *command)
+                + ". Resolve the error above and rerun bm install codex.",
+                err=True,
+            )
+            raise typer.Exit(1)
+    typer.echo("Basic Memory plugin installed. Start a new Codex thread and run $bm-setup.")
+    typer.echo("Open /hooks in Codex to review and trust the Basic Memory hooks (requires uv).")
+
+
 @dataclass(frozen=True, slots=True)
 class InstallFile:
     path: Path

--- a/tests/cli/test_install_codex.py
+++ b/tests/cli/test_install_codex.py
@@ -1,0 +1,82 @@
+"""Codex installation delegates to its CLI without initializing Basic Memory."""
+
+import subprocess
+from unittest.mock import Mock
+
+import pytest
+from typer.testing import CliRunner
+
+from basic_memory.cli.commands import install
+from basic_memory.cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def codex_run(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    monkeypatch.setattr(install.shutil, "which", lambda name: "/bin/codex")
+    run = Mock(return_value=subprocess.CompletedProcess([], 0))
+    monkeypatch.setattr(install.subprocess, "run", run)
+    monkeypatch.setattr("basic_memory.cli.app.init_cli_logging", Mock(side_effect=AssertionError))
+    return run
+
+
+def test_dry_run_without_codex(codex_run: Mock, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(install.shutil, "which", lambda name: None)
+    result = runner.invoke(app, ["install", "codex", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "codex plugin marketplace add basicmachines-co/basic-memory" in result.output
+    assert "codex plugin add codex@basic-memory" in result.output
+    codex_run.assert_not_called()
+
+
+@pytest.mark.parametrize("options,answer", [(["--yes"], None), ([], "y\n")])
+def test_install(codex_run: Mock, options: list[str], answer: str | None) -> None:
+    result = runner.invoke(app, ["install", "codex", *options], input=answer)
+    assert result.exit_code == 0, result.output
+    assert [call.args[0] for call in codex_run.call_args_list] == [
+        ["/bin/codex", "plugin", "marketplace", "add", "basicmachines-co/basic-memory"],
+        ["/bin/codex", "plugin", "add", "codex@basic-memory"],
+    ]
+    assert "$bm-setup" in result.output
+
+
+def test_local_source_is_one_argument(codex_run: Mock) -> None:
+    source = "/local checkout/basic-memory"
+    result = runner.invoke(app, ["install", "codex", "--source", source, "-y"])
+    assert result.exit_code == 0, result.output
+    assert codex_run.call_args_list[0].args[0][-1] == source
+
+
+def test_decline(codex_run: Mock) -> None:
+    result = runner.invoke(app, ["install", "codex"], input="n\n")
+    assert result.exit_code != 0
+    codex_run.assert_not_called()
+
+
+def test_missing_codex(codex_run: Mock, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(install.shutil, "which", lambda name: None)
+    result = runner.invoke(app, ["install", "codex", "-y"])
+    assert result.exit_code == 1
+    assert "Codex CLI not found" in result.output
+    codex_run.assert_not_called()
+
+
+@pytest.mark.parametrize("failed_step", [0, 1])
+def test_failure_stops_install(codex_run: Mock, failed_step: int) -> None:
+    codex_run.side_effect = [subprocess.CompletedProcess([], 0)] * failed_step + [
+        subprocess.CompletedProcess([], 2)
+    ]
+    result = runner.invoke(app, ["install", "codex", "-y"])
+    assert result.exit_code == 1
+    assert codex_run.call_count == failed_step + 1
+    assert "Codex command failed" in result.output
+    assert "plugin installed" not in result.output
+
+
+def test_launch_failure(codex_run: Mock) -> None:
+    codex_run.side_effect = OSError("launch failed")
+    result = runner.invoke(app, ["install", "codex", "-y"])
+    assert result.exit_code == 1
+    assert "Cannot launch Codex CLI" in result.output
+    assert codex_run.call_count == 1


### PR DESCRIPTION
## Why

Installing Basic Memory for Codex currently requires manually registering the marketplace and adding the plugin. Provide a discoverable `bm install codex` command alongside the existing Tau installer.

## What Changed

- Add `bm install codex` with `--dry-run`, `--yes` / `-y`, and `--source` for a Git source or local repository root.
- Document the command and the setup steps after installation.
- Cover confirmation, missing Codex CLI, local paths with spaces, subprocess failures, and dry runs without Basic Memory initialization.

## Implementation Details

Delegate to `codex plugin marketplace add basicmachines-co/basic-memory`, then `codex plugin add codex@basic-memory`. Codex owns its user-level installation and configuration. Stop on the first failure and show the failed command; dry runs launch no subprocesses. The existing install callback bypasses Basic Memory database/config initialization.

## Testing

- `uv run pytest tests/cli/test_install_codex.py tests/cli/test_install_tau.py --no-cov -q`: 20 passed.
- `just fast-check`: passed.
- `just doctor`: passed.
- `just package-check`: passed.
- `uv run bm install codex --dry-run`: displayed both expected commands.
- Checked installed Codex CLI help for marketplace and plugin command syntax.

## Risks / Follow-ups

Requires a Codex CLI version supporting plugin commands; hooks require uv. The default marketplace follows the repository's default branch independently of the installed Python package version. Actual marketplace installation is mocked in tests; no live user-level plugin installation was performed.
