### PR TITLE
feat(cli): add Claude Code plugin install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,13 +219,15 @@ output style, and `/basic-memory:bm-setup` · `:remember` · `:share` · `:statu
 
 **Connect the Basic Memory MCP server first** — see [Connect your AI
 client](#connect-your-ai-client). The plugin's hooks and skills call it, so it's a
-hard prerequisite. Then add the marketplace and install:
+hard prerequisite. Then install the plugin:
 
 ```bash
-claude plugin marketplace add basicmachines-co/basic-memory \
-  --sparse .claude-plugin plugins/claude-code
-claude plugin install basic-memory@basicmachines-co
+bm install claude-code
 ```
+
+That registers the marketplace and installs the plugin through Claude Code. Add
+`--scope project` to declare both in the repository's settings for a team, or
+`--dry-run` to see the underlying `claude plugin` commands without running them.
 
 Source: [`plugins/claude-code`](plugins/claude-code).
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -102,6 +102,31 @@ session.
 
 ## Installation
 
+Install the plugin once with Basic Memory and Claude Code on your PATH:
+
+```bash
+bm install claude-code
+```
+
+This registers the GitHub marketplace and installs `basic-memory@basicmachines-co`
+through Claude Code, sparse-checking out only the two paths the plugin needs.
+Use `--dry-run` to preview the commands or `--yes` to skip confirmation. The
+default Git source uses its default branch, independently of the installed
+Basic Memory Python version. Hooks require `uv` as described above.
+
+The install is user-level, so one install covers every project on the machine.
+Pass `--scope project` to declare the marketplace and plugin in the repository's
+`.claude/settings.json` instead — the way to hand the plugin to a whole team —
+or `--scope local` to keep it in untracked local settings. For a local checkout,
+run `bm install claude-code --source /path/to/basic-memory`; the source must be
+the repository root containing `.claude-plugin/marketplace.json`, and `--sparse`
+is omitted because Claude Code accepts it only for Git sources.
+
+Restart Claude Code after installing so it loads the plugin's skills, MCP
+configuration, and hooks.
+
+Alternatively, run the underlying commands directly:
+
 ```bash
 claude plugin marketplace add basicmachines-co/basic-memory --sparse .claude-plugin plugins/claude-code
 claude plugin install basic-memory@basicmachines-co

--- a/plugins/claude-code/docs/getting-started.md
+++ b/plugins/claude-code/docs/getting-started.md
@@ -21,9 +21,13 @@ teams are optional (see step 5).
 ## 2. Install the plugin
 
 ```bash
-claude plugin marketplace add basicmachines-co/basic-memory --sparse .claude-plugin plugins/claude-code
-claude plugin install basic-memory@basicmachines-co
+bm install claude-code
 ```
+
+This registers the marketplace and installs the plugin through Claude Code, at
+user level so one install covers every project. Use `--dry-run` to see the
+underlying `claude plugin` commands first, or `--scope project` to declare them
+in this repository's settings instead.
 
 Verify it loaded:
 
@@ -31,8 +35,9 @@ Verify it loaded:
 claude plugin details basic-memory@basicmachines-co
 ```
 
-You should see **Skills (4): remember, setup, share, status** and **Hooks (2):
-SessionStart, PreCompact**.
+You should see **Skills (8): bm-checkpoint, bm-decide, bm-orient, bm-remember,
+bm-setup, bm-share, bm-status, bm-writing** and **Hooks (2): SessionStart,
+PreCompact**.
 
 ## 3. Run setup
 

--- a/src/basic_memory/cli/commands/install.py
+++ b/src/basic_memory/cli/commands/install.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 import tomllib
 from dataclasses import dataclass
+from enum import StrEnum
 from importlib.metadata import distribution
 from pathlib import Path
 from typing import Literal
@@ -26,6 +27,58 @@ install_app = typer.Typer(help="Install Basic Memory resources into an agent hos
 app.add_typer(install_app, name="install")
 
 
+@dataclass(frozen=True, slots=True)
+class HostPlugin:
+    """A plugin install delegated to an agent host's own marketplace CLI."""
+
+    executable: str
+    display: str
+    installer: str
+    summary: str
+    steps: tuple[tuple[str, ...], ...]
+    next_steps: tuple[str, ...]
+
+
+def delegate_install(host: HostPlugin, *, dry_run: bool, yes: bool) -> None:
+    """Run a host's own plugin commands, without initializing Basic Memory.
+
+    The host owns every message, so a preview cannot reach the lines that only
+    hold once the plugin is actually installed.
+    """
+    typer.echo(host.summary)
+    for step in host.steps:
+        typer.echo(shell_command(host.executable, *step))
+    if dry_run:
+        return
+    executable = shutil.which(host.executable)
+    if executable is None:
+        typer.echo(f"{host.display} CLI not found on PATH. Install {host.display} first.", err=True)
+        raise typer.Exit(1)
+    if not yes and not typer.confirm("Apply this installation plan?", default=False):
+        raise typer.Abort()
+    for step in host.steps:
+        try:
+            result = subprocess.run([executable, *step], check=False)
+        except OSError:
+            typer.echo(
+                f"Cannot launch {host.display} CLI. Check its installation and permissions.",
+                err=True,
+            )
+            raise typer.Exit(1) from None
+        # A failed marketplace registration must not install from an unrelated
+        # previously configured source with the same marketplace name.
+        if result.returncode:
+            typer.echo(
+                f"{host.display} command failed: "
+                + shell_command(host.executable, *step)
+                + f". Resolve the error above and rerun {host.installer}.",
+                err=True,
+            )
+            raise typer.Exit(1)
+    for line in host.next_steps:
+        typer.echo(line)
+
+
 @install_app.command("codex")
 def install_codex(
     source: str = typer.Option(
@@ -37,39 +90,86 @@ def install_codex(
     yes: bool = typer.Option(False, "--yes", "-y", help="Approve the displayed installation plan."),
 ) -> None:
     """Install the Basic Memory plugin through Codex's user-level marketplace."""
-    commands = [
-        ["plugin", "marketplace", "add", source],
-        ["plugin", "add", "codex@basic-memory"],
-    ]
-    typer.echo("Install the Basic Memory marketplace and plugin into Codex (user-level).")
-    for command in commands:
-        typer.echo(shell_command("codex", *command))
-    if dry_run:
-        return
-    codex = shutil.which("codex")
-    if codex is None:
-        typer.echo("Codex CLI not found on PATH. Install Codex CLI first.", err=True)
-        raise typer.Exit(1)
-    if not yes and not typer.confirm("Apply this installation plan?", default=False):
-        raise typer.Abort()
-    for command in commands:
-        try:
-            result = subprocess.run([codex, *command], check=False)
-        except OSError:
-            typer.echo("Cannot launch Codex CLI. Check its installation and permissions.", err=True)
-            raise typer.Exit(1) from None
-        # A failed marketplace registration must not install from an unrelated
-        # previously configured source with the same marketplace name.
-        if result.returncode:
-            typer.echo(
-                "Codex command failed: "
-                + shell_command("codex", *command)
-                + ". Resolve the error above and rerun bm install codex.",
-                err=True,
-            )
-            raise typer.Exit(1)
-    typer.echo("Basic Memory plugin installed. Start a new Codex thread and run $bm-setup.")
-    typer.echo("Open /hooks in Codex to review and trust the Basic Memory hooks (requires uv).")
+    host = HostPlugin(
+        executable="codex",
+        display="Codex",
+        installer="bm install codex",
+        summary="Install the Basic Memory marketplace and plugin into Codex (user-level).",
+        steps=(
+            ("plugin", "marketplace", "add", source),
+            ("plugin", "add", "codex@basic-memory"),
+        ),
+        next_steps=(
+            "Basic Memory plugin installed. Start a new Codex thread and run $bm-setup.",
+            "Open /hooks in Codex to review and trust the Basic Memory hooks (requires uv).",
+        ),
+    )
+    delegate_install(host, dry_run=dry_run, yes=yes)
+
+
+class InstallScope(StrEnum):
+    """Claude Code's scopes for declaring a marketplace and installing a plugin."""
+
+    user = "user"
+    project = "project"
+    local = "local"
+
+
+@install_app.command("claude-code")
+def install_claude_code(
+    source: str = typer.Option(
+        "basicmachines-co/basic-memory",
+        "--source",
+        help="Marketplace Git source or local repo root.",
+    ),
+    scope: InstallScope = typer.Option(
+        InstallScope.user,
+        "--scope",
+        help="Where Claude Code declares the marketplace and plugin.",
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview only; no subprocesses."),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Approve the displayed installation plan."),
+) -> None:
+    """Install the Basic Memory plugin through Claude Code's marketplace."""
+    add = ["plugin", "marketplace", "add", source, "--scope", scope.value]
+    # Trigger: --source names a checkout on this machine instead of a Git remote.
+    # Why: --sparse configures a git sparse-checkout, and Claude Code rejects it
+    # for directory sources. Outcome: remote installs fetch only the two paths
+    # the plugin needs out of the monorepo; local installs read the checkout.
+    if not Path(source).is_dir():
+        add += ["--sparse", ".claude-plugin", "plugins/claude-code"]
+    host = HostPlugin(
+        executable="claude",
+        display="Claude Code",
+        installer="bm install claude-code",
+        summary=(
+            "Install the Basic Memory marketplace and plugin into Claude Code "
+            f"({scope.value}-level)."
+        ),
+        steps=(
+            tuple(add),
+            ("plugin", "install", "basic-memory@basicmachines-co", "--scope", scope.value),
+        ),
+        next_steps=(
+            "Basic Memory plugin installed. Restart Claude Code and run /basic-memory:bm-setup.",
+            # The plugin ships no MCP server of its own, so an unconnected server
+            # leaves every skill failing on its first tool call.
+            "Its skills call the Basic Memory MCP server; connect it if you have not: "
+            + shell_command(
+                "claude",
+                "mcp",
+                "add",
+                "basic-memory",
+                "--",
+                "uvx",
+                "--prerelease=allow",
+                "basic-memory",
+                "mcp",
+            ),
+            "The hooks run through uv; install uv first if it is not already on PATH.",
+        ),
+    )
+    delegate_install(host, dry_run=dry_run, yes=yes)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/cli/test_install_claude_code.py
+++ b/tests/cli/test_install_claude_code.py
@@ -1,0 +1,141 @@
+"""Claude Code installation delegates to its CLI without initializing Basic Memory."""
+
+import subprocess
+from unittest.mock import Mock
+
+import pytest
+from typer.testing import CliRunner
+
+from basic_memory.cli.commands import install
+from basic_memory.cli.main import app
+
+runner = CliRunner()
+
+MARKETPLACE = [
+    "/bin/claude",
+    "plugin",
+    "marketplace",
+    "add",
+    "basicmachines-co/basic-memory",
+    "--scope",
+    "user",
+    "--sparse",
+    ".claude-plugin",
+    "plugins/claude-code",
+]
+PLUGIN = [
+    "/bin/claude",
+    "plugin",
+    "install",
+    "basic-memory@basicmachines-co",
+    "--scope",
+    "user",
+]
+
+
+@pytest.fixture
+def claude_run(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    monkeypatch.setattr(install.shutil, "which", lambda name: "/bin/claude")
+    run = Mock(return_value=subprocess.CompletedProcess([], 0))
+    monkeypatch.setattr(install.subprocess, "run", run)
+    monkeypatch.setattr("basic_memory.cli.app.init_cli_logging", Mock(side_effect=AssertionError))
+    return run
+
+
+def test_dry_run_without_claude(claude_run: Mock, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(install.shutil, "which", lambda name: None)
+    result = runner.invoke(app, ["install", "claude-code", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert (
+        "claude plugin marketplace add basicmachines-co/basic-memory --scope user" in result.output
+    )
+    assert "claude plugin install basic-memory@basicmachines-co --scope user" in result.output
+    # A preview must not claim an install that never ran.
+    assert "plugin installed" not in result.output
+    claude_run.assert_not_called()
+
+
+@pytest.mark.parametrize("options,answer", [(["--yes"], None), ([], "y\n")])
+def test_install(claude_run: Mock, options: list[str], answer: str | None) -> None:
+    result = runner.invoke(app, ["install", "claude-code", *options], input=answer)
+    assert result.exit_code == 0, result.output
+    assert [call.args[0] for call in claude_run.call_args_list] == [MARKETPLACE, PLUGIN]
+    assert "/basic-memory:bm-setup" in result.output
+
+
+@pytest.mark.parametrize("scope", ["project", "local"])
+def test_scope_applies_to_both_steps(claude_run: Mock, scope: str) -> None:
+    result = runner.invoke(app, ["install", "claude-code", "--scope", scope, "-y"])
+    assert result.exit_code == 0, result.output
+    for call in claude_run.call_args_list:
+        argv = call.args[0]
+        assert argv[argv.index("--scope") + 1] == scope
+    assert f"({scope}-level)" in result.output
+
+
+def test_unknown_scope_is_rejected(claude_run: Mock) -> None:
+    result = runner.invoke(app, ["install", "claude-code", "--scope", "global", "-y"])
+    assert result.exit_code != 0
+    claude_run.assert_not_called()
+
+
+def test_local_source_is_one_argument_without_sparse(claude_run: Mock, tmp_path) -> None:
+    # Claude Code rejects --sparse for directory sources, so a checkout must not
+    # carry the sparse paths the monorepo Git source needs.
+    result = runner.invoke(app, ["install", "claude-code", "--source", str(tmp_path), "-y"])
+    assert result.exit_code == 0, result.output
+    assert claude_run.call_args_list[0].args[0] == [
+        "/bin/claude",
+        "plugin",
+        "marketplace",
+        "add",
+        str(tmp_path),
+        "--scope",
+        "user",
+    ]
+
+
+def test_missing_directory_source_keeps_sparse(claude_run: Mock, tmp_path) -> None:
+    source = str(tmp_path / "absent")
+    result = runner.invoke(app, ["install", "claude-code", "--source", source, "-y"])
+    assert result.exit_code == 0, result.output
+    assert claude_run.call_args_list[0].args[0][-3:] == [
+        "--sparse",
+        ".claude-plugin",
+        "plugins/claude-code",
+    ]
+
+
+def test_decline(claude_run: Mock) -> None:
+    result = runner.invoke(app, ["install", "claude-code"], input="n\n")
+    assert result.exit_code != 0
+    claude_run.assert_not_called()
+
+
+def test_missing_claude(claude_run: Mock, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(install.shutil, "which", lambda name: None)
+    result = runner.invoke(app, ["install", "claude-code", "-y"])
+    assert result.exit_code == 1
+    assert "Claude Code CLI not found" in result.output
+    claude_run.assert_not_called()
+
+
+@pytest.mark.parametrize("failed_step", [0, 1])
+def test_failure_stops_install(claude_run: Mock, failed_step: int) -> None:
+    claude_run.side_effect = [subprocess.CompletedProcess([], 0)] * failed_step + [
+        subprocess.CompletedProcess([], 2)
+    ]
+    result = runner.invoke(app, ["install", "claude-code", "-y"])
+    assert result.exit_code == 1
+    assert claude_run.call_count == failed_step + 1
+    assert "Claude Code command failed" in result.output
+    assert "rerun bm install claude-code" in result.output
+    assert "plugin installed" not in result.output
+
+
+def test_launch_failure(claude_run: Mock) -> None:
+    claude_run.side_effect = OSError("launch failed")
+    result = runner.invoke(app, ["install", "claude-code", "-y"])
+    assert result.exit_code == 1
+    assert "Cannot launch Claude Code CLI" in result.output
+    assert claude_run.call_count == 1

--- a/tests/cli/test_install_codex.py
+++ b/tests/cli/test_install_codex.py
@@ -27,6 +27,8 @@ def test_dry_run_without_codex(codex_run: Mock, monkeypatch: pytest.MonkeyPatch)
     assert result.exit_code == 0, result.output
     assert "codex plugin marketplace add basicmachines-co/basic-memory" in result.output
     assert "codex plugin add codex@basic-memory" in result.output
+    # A preview must not claim an install that never ran.
+    assert "plugin installed" not in result.output
     codex_run.assert_not_called()
 
 


### PR DESCRIPTION
Stacked on #1497 (`feat/install-codex`). Review that one first; this PR's diff
against it is the Claude Code half.

## What

`bm install claude-code` — the Claude Code counterpart to `bm install codex`:

```
$ bm install claude-code --dry-run
Install the Basic Memory marketplace and plugin into Claude Code (user-level).
claude plugin marketplace add basicmachines-co/basic-memory --scope user --sparse .claude-plugin plugins/claude-code
claude plugin install basic-memory@basicmachines-co --scope user
```

Same contract as the Codex installer: print the plan, confirm, delegate to the
host's own CLI, stop on the first failure, and never initialize Basic Memory's
database. `--dry-run` previews; `--yes` skips the prompt; `--source` takes a Git
source or a local repo root.

## Claude-Code-specific parts

- **`--scope user|project|local`** passes through to both steps. Claude Code
  declares marketplaces and plugins per scope, and `--scope project` writes them
  into the repository's `.claude/settings.json` — the way a team gets the plugin
  from a checkout. Defaults to `user`, matching Claude Code's own default.
- **`--sparse .claude-plugin plugins/claude-code`** on the default Git source, so
  an install fetches two paths instead of the whole monorepo. A local `--source`
  drops the flag, because Claude Code rejects it for directory sources:
  `✘ --sparse is only supported for github and git marketplace sources (got: directory)`.
- **Post-install lines** name the MCP prerequisite. The plugin ships no MCP server
  of its own, so an unconnected `basic-memory` server leaves every skill failing
  on its first tool call.

## Shared delegation path

Both installers now build a `HostPlugin` (executable, display name, plan steps,
next steps) and hand it to `delegate_install`. The Codex command keeps its exact
behavior and messages, minus two reworded strings.

Moving the messages into the host record also fixed a bug the extraction exposed:
`--dry-run` printed "Basic Memory plugin installed." for a plan it never applied.
Both test files now assert a preview never claims an install.

## Docs

Root README, `plugins/claude-code/README.md`, and the plugin's getting-started
guide lead with `bm install claude-code`; the plugin README keeps the raw
`claude plugin` commands as the alternative. Also corrected the getting-started
verification step, which still claimed `Skills (4): remember, setup, share,
status` — the plugin ships eight.

## Verification

- `just fast-check` — clean.
- `uv run pytest tests/cli` — 1027 passed, 6 skipped. 15 new tests in
  `tests/cli/test_install_claude_code.py` cover the plan, both non-default
  scopes, scope rejection, sparse on/off for remote vs. local sources, decline,
  missing CLI, per-step failure, and launch failure.
- `just package-check-claude-code` — validation passed.
- Real installs into an isolated `CLAUDE_CONFIG_DIR`, both from the GitHub source
  (sparse clone) and from a local checkout; `claude plugin details` afterward
  reports Skills (8) and Hooks (2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BrQ94iLp9pyKL1bwf9cCY
