### PR TITLE
feat(mcp): add bounded line reads and literal grep context

### DIFF
--- a/src/basic_memory/cli/commands/posix.py
+++ b/src/basic_memory/cli/commands/posix.py
@@ -332,6 +332,31 @@ def _plain_find_fields(result: dict[str, Any]) -> None:
         print(f"{row.get('file_path', '')}\t{fields_json}")
 
 
+def _display_grep_lines(result: dict[str, Any], *, plain: bool) -> None:
+    """Print bounded windows without reintroducing the search response's full body."""
+    output: list[str] = [f"Search candidates: page {result['current_page']}"]
+    for row in result["results"]:
+        path = row["file_path"]
+        output.append(f"{path}: {row['match_count']} matching line(s)")
+        for window in row["windows"]:
+            for number, line in zip(
+                range(window["start_line"], window["end_line"] + 1),
+                window["content"].split("\n"),
+                strict=True,
+            ):
+                marker = ":" if number in window["match_lines"] else "-"
+                output.append(f"{path}{marker}{number}{marker}{line}")
+        if row["next_match_line"] is not None:
+            output.append(f"… more matches; read {path} at line {row['next_match_line']}")
+    if result["has_more"]:
+        output.append(f"… more candidates; use --page {result['current_page'] + 1}")
+    text = "\n".join(output)
+    if plain:
+        print(text)
+    else:
+        console.print(Text(text))
+
+
 # --- tail rendering ---
 # tail's row shape ({type, title, permalink, file_path, created_at}) differs
 # from recent-activity's payload, so it gets its own small renderers rather
@@ -622,6 +647,22 @@ def grep(
             "--literal", "-F", help="Literal full-text matching instead of semantic search"
         ),
     ] = False,
+    context_lines: Annotated[
+        Optional[int],
+        typer.Option(
+            "-C",
+            "--context-lines",
+            min=0,
+            max=10,
+            help="Compact literal line matches with surrounding context (requires -F)",
+        ),
+    ] = None,
+    max_matches: Annotated[
+        int,
+        typer.Option(
+            "--max-matches", min=1, max=100, help="Matching lines per candidate in context mode"
+        ),
+    ] = 10,
     page: Annotated[int, typer.Option("--page", help="Page number (1-indexed)")] = 1,
     page_size: Annotated[int, typer.Option("--page-size", help="Results per page")] = 10,
     json_output: JsonOption = False,
@@ -635,6 +676,7 @@ def grep(
 
     Examples:
 
+    bm grep -F "retry" -C 3 --plain
     bm grep "auth token rotation"
     bm grep -F "BASIC_MEMORY_FORCE_LOCAL"
     bm grep "deploy checklist" --page-size 20 --json
@@ -652,6 +694,8 @@ def grep(
                 mcp_grep(
                     pattern,
                     literal=literal,
+                    context_lines=context_lines,
+                    max_matches=max_matches,
                     page=page,
                     page_size=page_size,
                     project=project,
@@ -662,6 +706,8 @@ def grep(
         mode = _resolve_output_mode(json_output, plain)
         if mode == "json":
             _print_json(result)
+        elif context_lines is not None:
+            _display_grep_lines(result, plain=mode == "plain")
         elif mode == "plain":
             _plain_search_results(result, query=pattern)
         else:

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -699,6 +699,14 @@ def write_note(
 @tool_app.command()
 def read_note(
     identifier: str,
+    start_line: Annotated[
+        Optional[int],
+        typer.Option(min=1, help="First document line, including frontmatter (1-based)"),
+    ] = None,
+    end_line: Annotated[
+        Optional[int],
+        typer.Option(min=1, help="Last document line, inclusive; omitted reads to EOF"),
+    ] = None,
     include_frontmatter: bool = typer.Option(
         False,
         "--frontmatter",
@@ -740,6 +748,7 @@ def read_note(
     bm tool read-note my-note --frontmatter
     bm tool read-note my-note --plain
     bm tool read-note my-note --json
+    bm tool read-note my-note --start-line 120 --end-line 180 --plain
     """
     # Deferred: loading the MCP tool stack at module import slows CLI startup (#886).
     from basic_memory.mcp.tools import read_note as mcp_read_note
@@ -756,6 +765,8 @@ def read_note(
                     project_id=project_id,
                     include_frontmatter=include_frontmatter,
                     output_format="json",
+                    start_line=start_line,
+                    end_line=end_line,
                 )
             )
 
@@ -776,6 +787,19 @@ def read_note(
         mode = _resolve_output_mode(json_output, plain)
         if mode == "json" or isinstance(result, str):
             _print_json(result)
+        elif "start_line" in result:
+            from basic_memory.markdown.line_scanning import format_line_read
+
+            text = format_line_read(
+                result["content"],
+                start_line=result["start_line"],
+                end_line=result["end_line"],
+                total_lines=result["total_lines"],
+            )
+            if mode == "plain":
+                print(text)
+            else:
+                console.print(Text(text))
         elif mode == "plain":
             _plain_read_note(result, include_frontmatter=include_frontmatter)
         else:

--- a/src/basic_memory/man/man1/grep(1).md
+++ b/src/basic_memory/man/man1/grep(1).md
@@ -17,6 +17,7 @@ generated: hand
 
 ```
 bm grep PATTERN [-F | --literal] [--page N] [--page-size N]
+        [-C N | --context-lines N] [--max-matches N]
         [--json | --plain] [--project NAME | --project-id UUID]
         [--local | --cloud]
 ```
@@ -29,14 +30,31 @@ matching, like real grep's fixed-strings flag. Results carry title, score,
 permalink, and the matched snippet; on a TTY they render as a table, and
 `--json` (or piped output) emits the search response with pagination.
 
+With `-F -C N`, return compact literal match windows instead. The full-text index
+selects a page of candidate notes, then their current content is checked for
+case-insensitive literal substrings. Matching line numbers include frontmatter
+and can be passed directly to `read_note(start_line=..., end_line=...)` or
+`bm cat ... --lines N-M`. Overlapping context windows merge to avoid repeated text.
+The full body and search excerpt are omitted in this mode, including JSON output.
+
+This is not an exhaustive filesystem grep: index tokenization, stemming, or edits
+can produce a candidate with zero literal matches, or omit a substring-only match.
+Pagination and totals refer to search candidates, not exact matching notes or lines.
+Each candidate reports `match_count`, `total_lines`, `windows`, and `next_match_line`
+(the first omitted matching line, or null). Use the latter for a targeted note read.
+Line positions can change if the note is edited between calls.
+
 ## OPTIONS
 
 - **-F, --literal** — literal full-text matching instead of semantic search
+- **-C, --context-lines** — opt into line scanning with 0-10 lines around each match; requires -F
+- **--max-matches** — matching lines to show per candidate in line mode, 1-100 (default 10)
 - **--page, --page-size** — result pagination (defaults 1 and 10)
 
 ## EXAMPLES
 
 ```
+bm grep -F "retry" -C 3 --max-matches 5 --plain
 bm grep "auth token rotation"
 bm grep -F "BASIC_MEMORY_FORCE_LOCAL"
 bm grep "deploy checklist" --json | jq '.results[].permalink'

--- a/src/basic_memory/man/man3/read-note(3).md
+++ b/src/basic_memory/man/man3/read-note(3).md
@@ -21,14 +21,15 @@ MCP:
 
 ```
 read_note(identifier, project=None, project_id=None, page=1, page_size=10,
-          output_format="text", include_frontmatter=False)
+          output_format="text", include_frontmatter=False, start_line=None,
+          end_line=None)
 ```
 
 CLI:
 
 ```
 bm tool read-note IDENTIFIER [--project NAME | --project-id UUID]
-                  [--page N] [--page-size N] [--frontmatter]
+                  [--start-line N] [--end-line N] [--frontmatter]
                   [--local | --cloud]
 ```
 
@@ -53,10 +54,12 @@ Accepted identifier forms (all verified):
 - **identifier** (string, required) — The title or permalink of the note to read. Can be a full memory:// URL, a permalink, a title, or search text. From the CLI this is a positional argument, not a flag.
 - **project** (string | null, optional, default: None) — Project name to read from. Optional - server will resolve using the hierarchy above. If unknown, use list_memory_projects() to discover available projects.
 - **project_id** (string | null, optional, default: None) — Project external_id (UUID). Prefer this over `project` when known — it routes to the exact project regardless of name collisions across cloud workspaces. Takes precedence over `project`. Get from list_memory_projects().
-- **page** (integer, optional, default: 1) — Page of fallback-search results to use when the identifier does not resolve to a note directly (default: 1). A direct or exact-title match always returns the full note content — page/page_size never chunk the note itself, and the title-match lookup pages through fixed-size pages of title results until an exact match is found or results are exhausted, regardless of page or page_size. Aliases: page_number.
+- **page** (integer, optional, default: 1) — Page of fallback-search results to use when the identifier does not resolve to a note directly (default: 1). A direct or exact-title match returns the note content — page/page_size never chunk the note itself, and the title-match lookup pages through fixed-size pages of title results until an exact match is found or results are exhausted, regardless of page or page_size. Aliases: page_number.
 - **page_size** (integer, optional, default: 10) — Number of fallback-search results per page (default: 10). When no match is found, this caps how many related-note suggestions are listed. Aliases: limit, per_page.
 - **output_format** (string, optional, default: "text") — "text" returns markdown content or guidance text. "json" returns a structured object with title/permalink/file_path/content/frontmatter.
-- **include_frontmatter** (boolean, optional, default: False) — When output_format="json", whether content should include the opening YAML frontmatter block; the parsed frontmatter object is returned either way. The CLI flag is --frontmatter (--include-frontmatter is a deprecated alias).
+- **include_frontmatter** (boolean, optional, default: False) — For unsliced JSON reads, include opening YAML in content; parsed frontmatter is returned either way. Explicit line ranges are never stripped. CLI: --frontmatter (--include-frontmatter is a deprecated alias).
+- **start_line** (integer | null, optional, default: None) — First document line to read (1-based, inclusive). Defaults to 1 when only end_line is given. Line scans count the full Markdown, including frontmatter, matching cat's default line coordinates.
+- **end_line** (integer | null, optional, default: None) — Last document line to read (inclusive); omitted means EOF. Out-of-file ranges return empty content; invalid/reversed ranges fail. With either bound, text output is numbered and JSON carries coordinates, has_more, and next_start_line/next_end_line. include_frontmatter does not strip an explicitly addressed range. Edits between calls may shift lines.
 
 ## MCP USAGE
 
@@ -76,6 +79,27 @@ bm tool read-note "playground/demo-cli-stdin" --project manual
 #          "frontmatter": {...}}
 ```
 
+## LINE SCANNING
+
+Pass `start_line` and/or `end_line` to read a 1-based inclusive range. An omitted
+start means line 1; an omitted end means EOF. Coordinates count the full Markdown,
+including frontmatter, regardless of `include_frontmatter`. They match literal
+grep context and `cat` with its default `include_frontmatter=True`. Cat's explicit
+`include_frontmatter=False` line reads remain body-relative.
+
+Text scans show numbered lines and the next bounded range. JSON scans return
+`content`, `start_line`, `end_line`, `total_lines`, `has_more`, `next_start_line`,
+and `next_end_line`; both next bounds are null at EOF. End bounds clamp to EOF;
+a start beyond EOF returns empty content with `end_line < start_line`. Empty
+notes have zero total lines. Bounds below 1 and reversed ranges are errors.
+Line endings normalize to LF, with CR/LF/CRLF counted consistently. A trailing
+newline does not create an extra line. Lines may move after an intervening edit.
+
+```
+read_note("runbook", start_line=120, end_line=180)
+bm tool read-note runbook --start-line 120 --end-line 180 --plain
+```
+
 ## EXAMPLES
 
 A miss returns suggestions, not an error (run against the dev project):
@@ -89,8 +113,8 @@ read_note("xyzzy definitely missing note", project="dev")
 
 ## GOTCHAS
 
-- [gotcha] Text mode always includes frontmatter; include_frontmatter only controls the json content field #output
-- [gotcha] page/page_size never chunk the note — an exact match returns the full note regardless; they only page the miss-suggestion listing #pagination
+- [gotcha] Unsliced text mode includes frontmatter; include_frontmatter controls unsliced JSON content #output
+- [gotcha] page/page_size never chunk the note — use start_line/end_line for within-note scanning; page/page_size only page the miss-suggestion listing #pagination
 - [gotcha] The CLI identifier is a positional argument, unlike write-note where everything is a flag #cli-parity
 - [gotcha] Exact-title lookup walks its own fixed-size internal pages, so a tiny page_size cannot displace an exact match out of the lookup window #pagination
 

--- a/src/basic_memory/markdown/line_scanning.py
+++ b/src/basic_memory/markdown/line_scanning.py
@@ -1,0 +1,84 @@
+"""Bounded literal-match windows over the same document lines as note slices."""
+
+from dataclasses import dataclass
+
+from basic_memory.markdown.sections import document_lines
+
+
+@dataclass(frozen=True)
+class MatchWindow:
+    start_line: int
+    end_line: int
+    match_lines: list[int]
+    content: str
+
+
+@dataclass(frozen=True)
+class LiteralLineScan:
+    total_lines: int
+    match_count: int
+    windows: list[MatchWindow]
+    next_match_line: int | None
+
+
+def scan_literal_lines(
+    content: str, pattern: str, *, context_lines: int, max_matches: int
+) -> LiteralLineScan:
+    """Find case-insensitive literal substrings; merge overlapping context windows.
+
+    Count all matching lines, but return context for only the first max_matches.
+    The next omitted match points to a useful follow-up read without copying the
+    rest of the note into the response. Inputs are validated by the tool boundary.
+    """
+    lines = document_lines(content)
+    needle = pattern.casefold()
+    matches = [number for number, line in enumerate(lines, 1) if needle in line.casefold()]
+    ranges: list[tuple[int, int, list[int]]] = []
+    for number in matches[:max_matches]:
+        first = max(1, number - context_lines)
+        last = min(len(lines), number + context_lines)
+        if ranges and first <= ranges[-1][1] + 1:
+            previous_first, previous_last, previous_matches = ranges.pop()
+            ranges.append((previous_first, max(previous_last, last), [*previous_matches, number]))
+        else:
+            ranges.append((first, last, [number]))
+    return LiteralLineScan(
+        total_lines=len(lines),
+        match_count=len(matches),
+        windows=[
+            MatchWindow(first, last, numbers, "\n".join(lines[first - 1 : last]))
+            for first, last, numbers in ranges
+        ],
+        next_match_line=matches[max_matches] if len(matches) > max_matches else None,
+    )
+
+
+def format_line_read(
+    content: str,
+    *,
+    start_line: int,
+    end_line: int,
+    total_lines: int,
+) -> str:
+    """Render a slice with copyable coordinates and a bounded continuation hint."""
+    header = f"Lines {start_line}-{end_line} of {total_lines} (document, including frontmatter)"
+    # The slice has no terminal newline. Splitting on '\n' preserves a final
+    # blank selected line; the coordinate range distinguishes it from EOF.
+    numbered = (
+        "\n".join(
+            f"{number}: {line}"
+            for number, line in zip(
+                range(start_line, end_line + 1), content.split("\n"), strict=True
+            )
+        )
+        if end_line >= start_line
+        else ""
+    )
+    if end_line < total_lines:
+        width = end_line - start_line + 1
+        header += (
+            f"; next: start_line={end_line + 1}, end_line={min(total_lines, end_line + width)}"
+        )
+    else:
+        header += "; EOF"
+    return f"{header}\n{numbered}" if numbered else header

--- a/src/basic_memory/markdown/sections.py
+++ b/src/basic_memory/markdown/sections.py
@@ -50,6 +50,18 @@ def _ends_with_terminator(text: str) -> bool:
     return text.endswith(("\n", "\r"))
 
 
+def document_lines(text: str) -> list[str]:
+    """Count physical Markdown lines, without a phantom line after a final newline.
+
+    Unlike str.splitlines(), Unicode separators inside prose do not move the
+    coordinates away from those used by the section and line-range reader.
+    """
+    if not text:
+        return []
+    lines = _split_lines(text)
+    return lines[:-1] if _ends_with_terminator(text) else lines
+
+
 @dataclass(frozen=True, slots=True)
 class MarkdownSection:
     """One heading-bounded span of a note body, addressed by its heading path.

--- a/src/basic_memory/mcp/tools/posix_tools.py
+++ b/src/basic_memory/mcp/tools/posix_tools.py
@@ -33,6 +33,7 @@ import json
 import math
 import os
 import re
+from dataclasses import asdict
 from typing import Annotated, Any, Optional
 
 from fastmcp import Context
@@ -42,6 +43,8 @@ from pydantic import BeforeValidator, TypeAdapter
 from basic_memory.config import ConfigManager
 from basic_memory.file_utils import ParseError, has_frontmatter, parse_frontmatter
 from basic_memory.man import bundled_pages, find_page, parse_page_ref, render_index
+from basic_memory.markdown.line_scanning import scan_literal_lines
+from basic_memory.markdown.sections import document_lines
 from basic_memory.mcp.container import get_container
 from basic_memory.mcp.note_reads import read_note_json_by_external_id
 from basic_memory.mcp.project_context import (
@@ -307,7 +310,7 @@ async def cat(
     if server_side_slice or (start_line is None and end_line is None):
         return qualify_note_paths(payload, route)
 
-    lines = str(payload["content"]).splitlines()
+    lines = document_lines(payload["content"])
     total_lines = len(lines)
     first = start_line or 1
     last = min(end_line, total_lines) if end_line is not None else total_lines
@@ -349,6 +352,8 @@ async def grep(
     project: Optional[str] = None,
     project_id: Optional[str] = None,
     context: Context | None = None,
+    context_lines: int | None = None,
+    max_matches: int = 10,
 ) -> dict[str, Any]:
     """Search note content, semantically by default.
 
@@ -356,13 +361,21 @@ async def grep(
         pattern: Text to search for.
         literal: Force literal full-text matching instead of semantic search.
         page: Page number (1-indexed).
-        page_size: Results per page.
+        page_size: Results per page (maximum 100 in line-scanning mode).
+        context_lines: Return compact literal match windows with 0-10 surrounding lines
+            (requires literal=True). Case-insensitive substrings, coordinates including
+            frontmatter, overlapping windows merged. Scans current content of this
+            indexed candidate page; pagination/totals count candidates, not exact matches.
+        max_matches: Maximum matching lines to show per candidate in line mode (1-100,
+            default 10). Omitted matches carry next_match_line for a targeted read_note
+            or cat read. Edits between calls can shift line positions.
         project: Project name. Required when more than one project is addressable.
         project_id: Project external_id (UUID); takes precedence over `project`.
         context: Optional FastMCP context.
 
     Returns:
-        The search response as JSON: results, pagination, and totals.
+        Normally the search response as JSON. With context_lines, only note identity,
+        match windows/counts, and candidate pagination; no full body or duplicate excerpt.
     """
     if not pattern or not pattern.strip():
         raise ValueError("pattern must not be empty")
@@ -370,6 +383,19 @@ async def grep(
         raise ValueError(f"page must be >= 1, got {page}")
     if page_size < 1:
         raise ValueError(f"page_size must be >= 1, got {page_size}")
+    if context_lines is not None:
+        if not literal:
+            raise ValueError("grep: context_lines requires literal=True")
+        if not 0 <= context_lines <= 10:
+            raise ValueError("grep: context_lines must be between 0 and 10")
+        if "\n" in pattern or "\r" in pattern:
+            raise ValueError("grep: line scanning requires a single-line pattern")
+        if page_size > 100:
+            raise ValueError("grep: line scanning page_size must be <= 100")
+    elif max_matches != 10:
+        raise ValueError("grep: max_matches requires context_lines")
+    if not 1 <= max_matches <= 100:
+        raise ValueError("grep: max_matches must be between 1 and 100")
 
     # grep's pattern is never parsed as a path — search text like "error/timeout"
     # must not be mistaken for a mount. Routing participates for the refusal rule
@@ -388,11 +414,43 @@ async def grep(
         active_project,
     ):
         # Import here to avoid circular import
-        from basic_memory.mcp.clients import SearchClient
+        from basic_memory.mcp.clients import KnowledgeClient, ResourceClient, SearchClient
 
         search_client = SearchClient(client, active_project.external_id)
         response = await search_client.search(query.model_dump(), page=page, page_size=page_size)
-        return response.model_dump(mode="json", exclude_none=True)
+        payload = response.model_dump(mode="json", exclude_none=True)
+        if context_lines is None:
+            return payload
+
+        # Search excerpts are truncated/indexed: derive coordinates from the same
+        # accepted content read_note serves. Hydrate only this bounded candidate page.
+        knowledge_client = KnowledgeClient(client, active_project.external_id)
+        resource_client = ResourceClient(client, active_project.external_id)
+        rows: list[dict[str, Any]] = []
+        for candidate in response.results:
+            if candidate.external_id is None:
+                raise ToolError("grep: line scanning requires search results with external_id")
+            note = await read_note_json_by_external_id(
+                knowledge_client=knowledge_client,
+                resource_client=resource_client,
+                entity_external_id=candidate.external_id,
+                include_frontmatter=True,
+            )
+            scan = scan_literal_lines(
+                note["content"], pattern, context_lines=context_lines, max_matches=max_matches
+            )
+            rows.append(
+                {
+                    "title": note["title"],
+                    "permalink": note["permalink"],
+                    "file_path": note["file_path"],
+                    "external_id": candidate.external_id,
+                    **asdict(scan),
+                }
+            )
+        payload["results"] = rows
+        payload["pagination_scope"] = "search_candidates"
+        return payload
 
 
 async def _project_mount_listing(

--- a/src/basic_memory/mcp/tools/read_note.py
+++ b/src/basic_memory/mcp/tools/read_note.py
@@ -11,6 +11,7 @@ from fastmcp import Context
 from pydantic import AliasChoices, Field
 
 from basic_memory.config import ConfigManager
+from basic_memory.markdown.line_scanning import format_line_read
 from basic_memory.mcp.project_context import (
     detect_project_from_identifier_prefix,
     get_project_client,
@@ -57,7 +58,7 @@ def _exact_external_id(identifier: str) -> str | None:
 
 @mcp.tool(
     title="Read Note",
-    description="Read a markdown note by title or permalink.",
+    description="Read a markdown note by title or permalink, optionally a numbered line range.",
     tags={"notes"},
     # TODO: re-enable once MCP client rendering is working
     # meta={"ui/resourceUri": "ui://basic-memory/note-preview"},
@@ -90,6 +91,8 @@ async def read_note(
     output_format: Literal["text", "json"] = "text",
     include_frontmatter: bool = False,
     context: Context | None = None,
+    start_line: int | None = None,
+    end_line: int | None = None,
 ) -> str | dict[str, Any]:
     """Return the raw markdown for a note, or guidance text if no match is found.
 
@@ -118,7 +121,7 @@ async def read_note(
                    From the CLI this is a positional argument, not a flag.
         page: Page of fallback-search results to use when the identifier does not
             resolve to a note directly (default: 1). A direct or exact-title match
-            always returns the full note content — page/page_size never chunk the
+            returns the note content — page/page_size never chunk the
             note itself, and the title-match lookup pages through fixed-size pages
             of title results until an exact match is found or results are
             exhausted, regardless of page or page_size. Aliases: page_number.
@@ -127,14 +130,21 @@ async def read_note(
             Aliases: limit, per_page.
         output_format: "text" returns markdown content or guidance text.
             "json" returns a structured object with title/permalink/file_path/content/frontmatter.
-        include_frontmatter: When output_format="json", whether content should include the
-            opening YAML frontmatter block; the parsed frontmatter object is returned either
-            way. The CLI flag is --frontmatter (--include-frontmatter is a deprecated alias).
+        include_frontmatter: For unsliced JSON reads, include opening YAML in content;
+            parsed frontmatter is returned either way. Explicit line ranges are never
+            stripped. CLI: --frontmatter (--include-frontmatter is a deprecated alias).
+        start_line: First document line to read (1-based, inclusive). Defaults to 1
+            when only end_line is given. Line scans count the full Markdown,
+            including frontmatter, matching cat's default line coordinates.
+        end_line: Last document line to read (inclusive); omitted means EOF.
+            Out-of-file ranges return empty content; invalid/reversed ranges fail.
+            With either bound, text output is numbered and JSON carries coordinates,
+            has_more, and next_start_line/next_end_line. include_frontmatter does
+            not strip an explicitly addressed range. Edits between calls may shift lines.
         context: Optional FastMCP context for performance caching.
 
     Returns:
-        The full markdown content of the note if found, or helpful guidance if not found.
-        Content includes frontmatter, observations, relations, and all markdown formatting.
+        Markdown content, a numbered line scan, or helpful guidance if not found.
 
     Examples:
         # Read by permalink
@@ -168,6 +178,13 @@ async def read_note(
         raise ValueError(f"page must be >= 1, got {page}")
     if page_size < 1:
         raise ValueError(f"page_size must be >= 1, got {page_size}")
+
+    if start_line is not None and start_line < 1:
+        raise ValueError(f"start_line must be >= 1, got {start_line}")
+    if end_line is not None and end_line < (start_line or 1):
+        raise ValueError(f"end_line must be >= start_line, got {end_line}")
+    line_scan = start_line is not None or end_line is not None
+    lines_param = f"{start_line or 1}-{'' if end_line is None else end_line}" if line_scan else None
 
     # Detect project from a memory URL or permalink prefix before routing.
     # project_id routes by external UUID, so it bypasses URL discovery entirely.
@@ -246,6 +263,33 @@ async def read_note(
             knowledge_client = KnowledgeClient(client, active_project.external_id)
             resource_client = ResourceClient(client, active_project.external_id)
 
+            async def _read_resolved_note(entity_id: str) -> str | dict[str, Any]:
+                # Only explicit line scans use the sliced API in text mode. Ordinary
+                # text reads retain their resource path; UUID JSON reads stay one GET.
+                payload = await read_note_json_by_external_id(
+                    knowledge_client=knowledge_client,
+                    resource_client=resource_client,
+                    entity_external_id=entity_id,
+                    include_frontmatter=include_frontmatter,
+                    lines=lines_param,
+                )
+                if not line_scan:
+                    return dict(payload)
+                first = payload["start_line"]
+                last = payload["end_line"]
+                total = payload["total_lines"]
+                width = last - first + 1
+                if output_format == "text":
+                    return format_line_read(
+                        payload["content"], start_line=first, end_line=last, total_lines=total
+                    )
+                return {
+                    **payload,
+                    "has_more": last < total,
+                    "next_start_line": last + 1 if last < total else None,
+                    "next_end_line": min(total, last + width) if last < total else None,
+                }
+
             def _empty_json_payload() -> dict[str, Any]:
                 return {
                     "title": None,
@@ -318,17 +362,10 @@ async def read_note(
                 value = item.get("external_id")
                 return value if isinstance(value, str) and value else None
 
-            if output_format == "json":
+            if output_format == "json" or line_scan:
                 exact_external_id = _exact_external_id(entity_path)
                 if exact_external_id is not None:
-                    return dict(
-                        await read_note_json_by_external_id(
-                            knowledge_client=knowledge_client,
-                            resource_client=resource_client,
-                            entity_external_id=exact_external_id,
-                            include_frontmatter=include_frontmatter,
-                        )
-                    )
+                    return await _read_resolved_note(exact_external_id)
 
                 try:
                     entity_id = await knowledge_client.resolve_entity(entity_path, strict=True)
@@ -339,14 +376,7 @@ async def read_note(
                         "Returning JSON read_note result from entity: {path}",
                         path=entity_path,
                     )
-                    return dict(
-                        await read_note_json_by_external_id(
-                            knowledge_client=knowledge_client,
-                            resource_client=resource_client,
-                            entity_external_id=entity_id,
-                            include_frontmatter=include_frontmatter,
-                        )
-                    )
+                    return await _read_resolved_note(entity_id)
             else:
                 # Text mode intentionally retains the resolve -> resource behavior.
                 try:
@@ -400,7 +430,7 @@ async def read_note(
                     logger.info(f"No exact title match found for: {identifier}")
                     break
 
-            if result is not None and output_format == "json":
+            if result is not None and (output_format == "json" or line_scan):
                 try:
                     entity_id = _result_external_id(result)
                     if entity_id is None and _result_permalink(result) is not None:
@@ -411,14 +441,7 @@ async def read_note(
                         logger.info(
                             f"Found note by exact title search: {_result_permalink(result)}"
                         )
-                        return dict(
-                            await read_note_json_by_external_id(
-                                knowledge_client=knowledge_client,
-                                resource_client=resource_client,
-                                entity_external_id=entity_id,
-                                include_frontmatter=include_frontmatter,
-                            )
-                        )
+                        return await _read_resolved_note(entity_id)
                 except Exception as error:  # pragma: no cover
                     logger.info(
                         "Failed to fetch content for found title match "

--- a/test-int/mcp/test_line_scanning_integration.py
+++ b/test-int/mcp/test_line_scanning_integration.py
@@ -1,0 +1,59 @@
+"""The agent-visible grep → numbered read flow over the real MCP transport."""
+
+import json
+
+import pytest
+from fastmcp import Client
+
+from basic_memory.mcp.server import set_posix_tools_visibility
+
+
+@pytest.mark.asyncio
+async def test_grep_to_read_lines_over_mcp(mcp_server, app, test_project, config_manager) -> None:
+    config = config_manager.load_config()
+    config.enable_posix_tools = True
+    config_manager.save_config(config)
+    try:
+        async with Client(mcp_server) as client:
+            await client.call_tool(
+                "write_note",
+                {
+                    "title": "Wire Scan",
+                    "directory": "test",
+                    "project": test_project.name,
+                    "content": "before\nretry the task\nafter\nremaining",
+                },
+            )
+            found = await client.call_tool(
+                "grep",
+                {
+                    "pattern": "retry",
+                    "literal": True,
+                    "context_lines": 1,
+                    "project": test_project.name,
+                },
+            )
+            block = found.content[0]
+            assert block.type == "text"
+            payload = json.loads(block.text)
+            row = payload["results"][0]
+            window = row["windows"][0]
+            assert window["content"] == "before\nretry the task\nafter"
+            read_args = {
+                "identifier": row["external_id"],
+                "project": test_project.name,
+                "start_line": window["start_line"],
+                "end_line": window["end_line"],
+            }
+            read = await client.call_tool("read_note", {**read_args, "output_format": "json"})
+            block = read.content[0]
+            assert block.type == "text"
+            selected = json.loads(block.text)
+            assert selected["content"] == window["content"]
+            assert selected["has_more"] is True
+            text_read = await client.call_tool("read_note", read_args)
+            block = text_read.content[0]
+            assert block.type == "text"
+            assert f"{window['match_lines'][0]}: retry the task" in block.text
+    finally:
+        set_posix_tools_visibility(mcp_server, False)

--- a/tests/cli/test_cli_line_scanning.py
+++ b/tests/cli/test_cli_line_scanning.py
@@ -1,0 +1,97 @@
+"""CLI scanning flags and rendered coordinates survive the MCP boundary."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from basic_memory.cli.main import app
+
+
+@pytest.mark.parametrize("mode", ["--plain", "--json", "rich"])
+def test_cli_read_lines(mode: str) -> None:
+    payload = {
+        "title": "Runbook",
+        "file_path": "runbook.md",
+        "permalink": "runbook",
+        "content": "retry [safe]\n",
+        "frontmatter": None,
+        "start_line": 4,
+        "end_line": 5,
+        "total_lines": 8,
+        "has_more": True,
+        "next_start_line": 6,
+        "next_end_line": 7,
+    }
+    tool = AsyncMock(return_value=payload)
+    with (
+        patch("basic_memory.mcp.tools.read_note", tool),
+        patch(
+            "basic_memory.cli.commands.tool._resolve_output_mode",
+            return_value=mode.removeprefix("--"),
+        ),
+    ):
+        result = CliRunner().invoke(
+            app,
+            ["tool", "read-note", "runbook", "--start-line", "4", "--end-line", "5"]
+            + ([] if mode == "rich" else [mode]),
+        )
+    assert result.exit_code == 0, result.output
+    assert tool.call_args.kwargs["start_line"] == 4
+    assert tool.call_args.kwargs["end_line"] == 5
+    if mode == "--json":
+        assert json.loads(result.stdout) == payload
+    else:
+        assert "4: retry [safe]" in result.stdout
+        assert "start_line=6" in result.stdout
+
+
+@pytest.mark.parametrize("mode", ["--plain", "--json", "rich"])
+def test_cli_grep_context(mode: str) -> None:
+    payload = {
+        "current_page": 1,
+        "page_size": 10,
+        "total": 20,
+        "has_more": True,
+        "pagination_scope": "search_candidates",
+        "results": [
+            {
+                "file_path": "runbook.md",
+                "match_count": 2,
+                "next_match_line": 20,
+                "windows": [
+                    {
+                        "start_line": 3,
+                        "end_line": 4,
+                        "match_lines": [4],
+                        "content": "context\nretry [safe]",
+                    }
+                ],
+            }
+        ],
+    }
+    tool = AsyncMock(return_value=payload)
+    with (
+        patch("basic_memory.mcp.tools.grep", tool),
+        patch(
+            "basic_memory.cli.commands.posix._resolve_output_mode",
+            return_value=mode.removeprefix("--"),
+        ),
+    ):
+        result = CliRunner().invoke(
+            app,
+            ["grep", "retry", "-F", "-C", "1", "--max-matches", "1"]
+            + ([] if mode == "rich" else [mode]),
+        )
+    assert result.exit_code == 0, result.output
+    assert tool.call_args.kwargs["literal"] is True
+    assert tool.call_args.kwargs["context_lines"] == 1
+    assert tool.call_args.kwargs["max_matches"] == 1
+    if mode == "--json":
+        assert json.loads(result.stdout) == payload
+    else:
+        assert "runbook.md-3-context" in result.stdout
+        assert "runbook.md:4:retry [safe]" in result.stdout
+        assert "line 20" in result.stdout
+        assert "--page 2" in result.stdout

--- a/tests/markdown/test_line_scanning.py
+++ b/tests/markdown/test_line_scanning.py
@@ -1,0 +1,66 @@
+"""Line coordinates and bounded match windows, including Markdown newline semantics."""
+
+import pytest
+
+from basic_memory.markdown.line_scanning import format_line_read, scan_literal_lines
+from basic_memory.markdown.sections import document_lines
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ("", []),
+        ("\n", [""]),
+        ("a\r\nb\rc\n", ["a", "b", "c"]),
+        ("a\u2028b\nc", ["a\u2028b", "c"]),
+        ("a\n\n", ["a", ""]),
+    ],
+)
+def test_document_lines(content: str, expected: list[str]) -> None:
+    assert document_lines(content) == expected
+
+
+def test_literal_windows_merge_and_limit() -> None:
+    scan = scan_literal_lines(
+        "retry\ncontext\nRETRY\nother\nother\nother\nretry\n",
+        "retry",
+        context_lines=1,
+        max_matches=2,
+    )
+    assert scan.total_lines == 7
+    assert scan.match_count == 3
+    assert scan.next_match_line == 7
+    assert len(scan.windows) == 1
+    window = scan.windows[0]
+    assert (window.start_line, window.end_line, window.match_lines) == (1, 4, [1, 3])
+    assert window.content == "retry\ncontext\nRETRY\nother"
+
+
+def test_separate_windows_casefold_and_literal_punctuation() -> None:
+    scan = scan_literal_lines(
+        "STRASSE.*\nignore\nignore\nStraße.*", "straße.*", context_lines=0, max_matches=10
+    )
+    assert [window.match_lines for window in scan.windows] == [[1], [4]]
+    assert scan.next_match_line is None
+    assert scan.match_count == 2
+
+
+@pytest.mark.parametrize("content", ["", "something else\n"])
+def test_no_literal_match(content: str) -> None:
+    scan = scan_literal_lines(content, "retry", context_lines=2, max_matches=10)
+    assert scan.windows == []
+    assert scan.match_count == 0
+    assert scan.next_match_line is None
+
+
+def test_numbered_read_preserves_blank_lines_and_bounds_continuation() -> None:
+    text = format_line_read("alpha\n", start_line=4, end_line=5, total_lines=6)
+    assert "4: alpha\n5: " in text
+    assert "next: start_line=6, end_line=6" in text
+
+
+@pytest.mark.parametrize(("first", "last", "total"), [(1, 0, 0), (20, 10, 10)])
+def test_numbered_empty_or_past_eof(first: int, last: int, total: int) -> None:
+    assert format_line_read("", start_line=first, end_line=last, total_lines=total).endswith(
+        "; EOF"
+    )

--- a/tests/mcp/test_line_scanning.py
+++ b/tests/mcp/test_line_scanning.py
@@ -1,0 +1,234 @@
+"""Exercise line reads and literal grep through real project-scoped API clients."""
+
+import json
+from typing import Any
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from basic_memory.mcp.clients import KnowledgeClient, SearchClient
+from basic_memory.mcp.tools import cat, grep, read_note, write_note
+from basic_memory.schemas.search import SearchResponse
+from basic_memory.schemas.v2 import EntityResponseV2
+
+
+@pytest.mark.asyncio
+async def test_scan_read_round_trip_and_token_savings(client, test_project) -> None:
+    body = "\n".join(
+        "retry the operation" if n in (70, 72, 180) else f"Background line {n}: " + "detail " * 15
+        for n in range(200)
+    )
+    await write_note(title="Scan Note", directory="test", content=body, project=test_project.name)
+    full = await cat("Scan Note", project=test_project.name)
+    lines = full["content"].splitlines()
+    expected_matches = [n for n, line in enumerate(lines, 1) if "retry" in line]
+
+    result = await grep(
+        "retry", literal=True, context_lines=1, max_matches=2, project=test_project.name
+    )
+    ordinary = await grep("retry", literal=True, project=test_project.name)
+    assert len(json.dumps(result)) < len(json.dumps(ordinary)) / 2
+    assert result["pagination_scope"] == "search_candidates"
+    row = result["results"][0]
+    assert "content" not in row and "matched_chunk" not in row and "frontmatter" not in row
+    assert row["match_count"] == 3
+    assert row["next_match_line"] == expected_matches[2]
+    assert len(row["windows"]) == 1
+    window = row["windows"][0]
+    assert window["match_lines"] == expected_matches[:2]
+
+    sliced = await read_note(
+        row["external_id"],
+        start_line=window["start_line"],
+        end_line=window["end_line"],
+        output_format="json",
+        project=test_project.name,
+    )
+    assert isinstance(sliced, dict)
+    assert sliced["content"] == window["content"]
+    assert sliced["total_lines"] == len(lines)
+    assert sliced["has_more"] is True
+    assert sliced["next_start_line"] == window["end_line"] + 1
+    assert sliced["next_end_line"] == window["end_line"] + len(window["content"].splitlines())
+    assert sliced["frontmatter"] is None
+    cat_slice = await cat(
+        row["file_path"],
+        start_line=window["start_line"],
+        end_line=window["end_line"],
+        project=test_project.name,
+    )
+    assert cat_slice["content"] == sliced["content"]
+    assert len(json.dumps(sliced)) < len(json.dumps(full)) / 10
+
+    numbered = await read_note(
+        "Scan Note",
+        start_line=expected_matches[0],
+        end_line=expected_matches[0],
+        project=test_project.name,
+    )
+    assert isinstance(numbered, str)
+    assert f"{expected_matches[0]}: retry the operation" in numbered
+    assert "next: start_line=" in numbered
+
+
+@pytest.mark.asyncio
+async def test_ranges_include_frontmatter_and_have_eof_metadata(client, test_project) -> None:
+    await write_note(
+        title="Bounds", directory="test", content="alpha\nbeta", project=test_project.name
+    )
+    full = await cat("Bounds", project=test_project.name)
+    lines = full["content"].splitlines()
+    opening = await read_note("Bounds", end_line=2, output_format="json", project=test_project.name)
+    assert isinstance(opening, dict)
+    assert opening["content"] == "\n".join(lines[:2])
+    assert opening["start_line"] == 1
+    for end in (None, len(lines) + 100):
+        last = await read_note(
+            "Bounds",
+            start_line=len(lines),
+            end_line=end,
+            output_format="json",
+            project=test_project.name,
+        )
+        assert isinstance(last, dict)
+        assert last["content"] == lines[-1]
+        assert last["has_more"] is False
+        assert last["next_start_line"] is None and last["next_end_line"] is None
+    empty = await read_note(
+        "Bounds", start_line=1000, output_format="json", project=test_project.name
+    )
+    assert isinstance(empty, dict)
+    assert empty["content"] == "" and empty["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_exact_uuid_line_read_is_one_sliced_get(client, test_project, monkeypatch) -> None:
+    await write_note(title="One Get", directory="test", content="alpha", project=test_project.name)
+    found = await grep("alpha", literal=True, project=test_project.name)
+    identifier = found["results"][0]["external_id"]
+    original = KnowledgeClient.get_entity
+    calls: list[tuple[str, str | None]] = []
+
+    async def record(
+        self: KnowledgeClient,
+        entity_id: str,
+        *,
+        section: str | None = None,
+        lines: str | None = None,
+        max_tokens: int | None = None,
+    ) -> EntityResponseV2:
+        calls.append((entity_id, lines))
+        return await original(self, entity_id, section=section, lines=lines, max_tokens=max_tokens)
+
+    async def refuse_resolve(*args: object, **kwargs: object) -> str:
+        raise AssertionError("UUID must not resolve")
+
+    monkeypatch.setattr(KnowledgeClient, "get_entity", record)
+    monkeypatch.setattr(KnowledgeClient, "resolve_entity", refuse_resolve)
+    await read_note(identifier, end_line=2, project=test_project.name)
+    assert calls == [(identifier, "1-2")]
+
+
+@pytest.mark.asyncio
+async def test_exact_title_fallback_keeps_line_scan(client, test_project, monkeypatch) -> None:
+    await write_note(
+        title="Exact Fallback", directory="test", content="alpha", project=test_project.name
+    )
+
+    async def refuse_resolve(*args: object, **kwargs: object) -> str:
+        raise ToolError("force title search")
+
+    monkeypatch.setattr(KnowledgeClient, "resolve_entity", refuse_resolve)
+    result = await read_note("Exact Fallback", end_line=1, project=test_project.name)
+    assert isinstance(result, str)
+    assert "1: ---" in result
+
+
+@pytest.mark.asyncio
+async def test_grep_candidate_pagination_survives_no_current_match(
+    client, test_project, monkeypatch
+) -> None:
+    for title in ("First", "Second"):
+        await write_note(title=title, directory="test", content="retry", project=test_project.name)
+    original = KnowledgeClient.get_entity
+
+    async def changed_content(self: KnowledgeClient, entity_id: str) -> EntityResponseV2:
+        entity = await original(self, entity_id)
+        # Simulate a newer accepted document while the index still matches retry.
+        return entity.model_copy(update={"content": "already fixed\n"})
+
+    monkeypatch.setattr(KnowledgeClient, "get_entity", changed_content)
+    first = await grep(
+        "retry", literal=True, context_lines=0, page_size=1, project=test_project.name
+    )
+    assert first["has_more"] is True
+    row = first["results"][0]
+    assert row["match_count"] == 0 and row["windows"] == []
+    assert row["total_lines"] == 1
+    assert row["next_match_line"] is None
+    second = await grep(
+        "retry", literal=True, context_lines=0, page=2, page_size=1, project=test_project.name
+    )
+    assert second["results"][0]["external_id"] != row["external_id"]
+
+
+@pytest.mark.asyncio
+async def test_grep_refuses_missing_candidate_identity(client, test_project, monkeypatch) -> None:
+    await write_note(title="Legacy", directory="test", content="retry", project=test_project.name)
+    original = SearchClient.search
+
+    async def old_server(
+        self: SearchClient, query: dict[str, Any], *, page: int, page_size: int
+    ) -> SearchResponse:
+        response = await original(self, query, page=page, page_size=page_size)
+        return response.model_copy(
+            update={
+                "results": [
+                    row.model_copy(update={"external_id": None}) for row in response.results
+                ]
+            }
+        )
+
+    monkeypatch.setattr(SearchClient, "search", old_server)
+    with pytest.raises(ToolError, match="external_id"):
+        await grep("retry", literal=True, context_lines=0, project=test_project.name)
+
+
+@pytest.mark.parametrize(
+    "bounds", [{"start_line": 0}, {"end_line": 0}, {"start_line": 5, "end_line": 3}]
+)
+@pytest.mark.asyncio
+async def test_invalid_read_bounds_fail_before_routing(bounds: dict[str, int]) -> None:
+    with pytest.raises(ValueError):
+        await read_note("any", start_line=bounds.get("start_line"), end_line=bounds.get("end_line"))
+
+
+@pytest.mark.parametrize(
+    ("literal", "context_lines", "max_matches", "page_size", "pattern"),
+    [
+        (False, 1, 10, 10, "retry"),
+        (True, -1, 10, 10, "retry"),
+        (True, 11, 10, 10, "retry"),
+        (True, 0, 0, 10, "retry"),
+        (True, 0, 101, 10, "retry"),
+        (True, 0, 10, 101, "retry"),
+        (True, None, 3, 10, "retry"),
+        (True, 0, 10, 10, "a\nb"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_invalid_grep_options_fail_before_routing(
+    literal: bool,
+    context_lines: int | None,
+    max_matches: int,
+    page_size: int,
+    pattern: str,
+) -> None:
+    with pytest.raises(ValueError):
+        await grep(
+            pattern,
+            literal=literal,
+            context_lines=context_lines,
+            max_matches=max_matches,
+            page_size=page_size,
+        )

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -70,7 +70,16 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "project",
         "project_id",
     ],
-    "grep": ["pattern", "literal", "page", "page_size", "project", "project_id"],
+    "grep": [
+        "pattern",
+        "literal",
+        "page",
+        "page_size",
+        "project",
+        "project_id",
+        "context_lines",
+        "max_matches",
+    ],
     "list_directory": [
         "dir_name",
         "depth",
@@ -104,6 +113,8 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "page_size",
         "output_format",
         "include_frontmatter",
+        "start_line",
+        "end_line",
     ],
     "recent_activity": [
         "type",


### PR DESCRIPTION
## Why

Agents currently retrieve a whole note to inspect a few relevant lines, while result pagination only limits the number of candidate notes. This adds a bounded search → inspect → continue workflow to reduce agent-visible response size.

Closes #1501. Complements #686.

## What Changed

- `read_note` accepts optional 1-based inclusive `start_line` / `end_line` bounds. Text output includes line numbers and a bounded continuation hint; JSON includes the range, total lines, `has_more`, and next bounds.
- `grep(..., literal=True, context_lines=3)` returns compact literal-match windows, merging overlapping context and omitting the full body and duplicate search excerpt. `max_matches` bounds matching lines returned per candidate and `next_match_line` identifies the first omitted match.
- CLI equivalents: `bm grep -F "retry" -C 3 --plain` and `bm tool read-note runbook --start-line 120 --end-line 180 --plain`.
- Document the contracts and regenerate the read-note manual page. Ordinary reads and searches keep their existing output.

## Implementation Details

Read ranges use the existing sliced knowledge API. Exact UUID reads remain one entity request. Line coordinates include frontmatter and agree with `cat`'s default reads; its existing explicit `include_frontmatter=False` body-relative behavior remains supported.

Grep uses the existing full-text search to select a bounded candidate page, then scans each candidate's current content for case-insensitive literal substrings. Pagination and totals explicitly count search candidates, not exact matches; a candidate can have zero current literal matches. This avoids inventing line coordinates from truncated or stale search excerpts.

Shared Markdown line splitting treats CR, LF, and CRLF consistently without counting Unicode separators as new physical lines. Reversed/nonpositive ranges fail, end bounds clamp to EOF, and out-of-file ranges return empty content with no continuation.

## Testing

All passed locally:

- `just fast-check` — lint, formatting, and repository-wide typecheck.
- `uv run pytest tests/mcp/test_tool_contracts.py tests/mcp/test_line_scanning.py -q --no-cov` — 22 passed.
- `just doctor` — isolated file/API/index/search/status flow.
- `just man-regen` — regenerated `read-note(3)`; manual drift tests passed.
- `uv run pytest tests/markdown/test_line_scanning.py tests/mcp/test_line_scanning.py tests/mcp/test_tool_read_note.py tests/mcp/test_read_note_request_counts.py tests/mcp/test_tool_posix.py tests/cli/test_cli_line_scanning.py tests/cli/test_cli_posix_verbs.py tests/test_man_pages.py -q --no-cov` — 521 passed at the initial compatibility checkpoint.
- `uv run pytest tests/markdown/test_line_scanning.py tests/markdown/test_sections.py tests/mcp/test_line_scanning.py tests/cli/test_cli_line_scanning.py tests/cli/test_cli_tool_json_output.py tests/cli/test_cli_tool_rich_output.py test-int/mcp/test_line_scanning_integration.py -q --no-cov` — 190 passed.
- `BASIC_MEMORY_TEST_POSTGRES=1 uv run pytest tests/mcp/test_line_scanning.py test-int/mcp/test_line_scanning_integration.py -q --no-cov` — 18 passed.
- `uv run pytest tests/markdown/test_line_scanning.py tests/mcp/test_line_scanning.py tests/cli/test_cli_line_scanning.py tests/test_man_pages.py test-int/mcp/test_line_scanning_integration.py -q --cov=src/basic_memory/markdown --cov-report=json:/tmp/bm-1501-coverage.json --cov-report=term` — 75 passed; new scanning helper has 100% statement coverage.

The large-note fixture asserts that bounded read JSON is less than 10% of the full read size and compact grep JSON is less than half the ordinary grep response size. These are fixture-specific response-size checks, not tokenizer benchmarks.

## Risks / Follow-ups

- Grep remains indexed candidate search, not exhaustive filesystem substring search. Index tokenization can omit substring-only matches; this is documented in the manual.
- Compact grep adds one content read per candidate, with page size capped at 100 in this mode. It reduces agent-visible output, not backend read volume.
- Line positions may shift after intervening edits. A long individual line can still be expensive; line windows are not a hard token budget.
- No interactive pager, snapshot/cursor system, or broader progressive-loading redesign is included.
