### PR TITLE
fix(core): preserve agent source through note materialization

### DIFF
--- a/src/basic_memory/runtime/note_object_metadata.py
+++ b/src/basic_memory/runtime/note_object_metadata.py
@@ -45,8 +45,11 @@ VALID_NOTE_OBJECT_ACTOR_KINDS: frozenset[RuntimeNoteActorKind] = frozenset(
 # extraction or ingestion-run note through the canonical note mutation path.
 # wiki_projector = the deterministic OKF projector accepting generated index
 # and log notes through that same path before materializing them as Markdown.
+# agent_runtime = a managed agent accepting a note through the canonical write
+# path; preserving it through materialization prevents recursive agent dispatch.
 VALID_NOTE_OBJECT_SOURCES: frozenset[RuntimeNoteChangeSource] = frozenset(
     {
+        "agent_runtime",
         "api",
         "collaboration_relay",
         "document_ingestion",

--- a/tests/runtime/test_agent_note_source.py
+++ b/tests/runtime/test_agent_note_source.py
@@ -1,0 +1,37 @@
+"""Agent provenance must survive the queue and object-storage boundaries."""
+
+from basic_memory.runtime.job_payloads import RuntimeNoteMaterializationJobPayload
+from basic_memory.runtime.note_content import RuntimeNoteMaterializationJobRequest
+from basic_memory.runtime.note_object_metadata import (
+    RuntimeNoteObjectMetadata,
+    RuntimeNoteObjectProvenance,
+)
+
+
+def test_agent_source_survives_materialization_payload_and_storage_metadata() -> None:
+    request = RuntimeNoteMaterializationJobRequest(
+        project_id=1,
+        entity_id=2,
+        db_version=3,
+        db_checksum="abc123",
+        actor_kind="system",
+        actor_name="Preview Agent",
+        source="agent_runtime",
+    )
+    payload = RuntimeNoteMaterializationJobPayload.from_runtime_request(request)
+    restored = RuntimeNoteMaterializationJobPayload.model_validate_json(
+        payload.model_dump_json()
+    ).to_runtime_request()
+    assert restored == request
+    metadata = RuntimeNoteObjectMetadata(
+        entity_id=restored.entity_id,
+        db_version=restored.db_version,
+        db_checksum=restored.db_checksum,
+        actor_kind=restored.actor_kind,
+        actor_name=restored.actor_name,
+        source=restored.source,
+    ).to_storage_metadata()
+    provenance = RuntimeNoteObjectProvenance.from_object_metadata(metadata)
+    assert provenance.source == "agent_runtime"
+    assert provenance.actor_kind == "system"
+    assert provenance.actor_name == "Preview Agent"


### PR DESCRIPTION
Cloud's managed agents accept notes with `source=agent_runtime`. The materialization payload currently rejects that source, leaving an accepted note at DB version 2 while Tigris remains at version 1. This was observed in the real webhook/Gateway/MCP acceptance run for basicmachines-co/basic-memory-cloud#2003.

Add `agent_runtime` to the shared source vocabulary so queue payloads and object metadata preserve the managed origin. This lets Cloud suppress recursive agent dispatch without preventing materialization.

Validation: the new payload-to-object-provenance regression failed with the observed validation error before the change; it and five materialization matching tests pass after it. Ruff and the full `uv run --extra milvus ty check src tests test-int` pass. The initial `just fast-check` reached type checking but lacked the optional Milvus dependency; the complete type check passed once that dependency was supplied. Cloud's live materialization rerun is pending the dependency update.
