### PR TITLE
fix(plugins): upgrade FastMCP to stable 4.0.3

### DIFF
--- a/plugins/claude-code/hooks/pre_compact.py
+++ b/plugins/claude-code/hooks/pre_compact.py
@@ -3,12 +3,12 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #     "basic-memory>=0.23.2",
-#     # Direct pre-release pin so old uv resolves basic-memory (which
-#     # requires this exact beta transitively) without enabling
-#     # pre-releases for basic-memory itself. Keep in lockstep with
-#     # core pyproject's fastmcp pin.
-#     "fastmcp==4.0.0b1",
+#     "fastmcp==4.0.3",
 # ]
+# [tool.uv]
+# # The released Basic Memory runtime still pins the beta. Use the stable
+# # version tested by core until the next runtime release carries this pin.
+# override-dependencies = ["fastmcp==4.0.3"]
 # ///
 """PreCompact hook — the entire hook. All logic (settings resolution, the
 extractive checkpoint note, lifecycle-envelope capture) lives in the released

--- a/plugins/claude-code/hooks/session_start.py
+++ b/plugins/claude-code/hooks/session_start.py
@@ -3,12 +3,12 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #     "basic-memory>=0.23.2",
-#     # Direct pre-release pin so old uv resolves basic-memory (which
-#     # requires this exact beta transitively) without enabling
-#     # pre-releases for basic-memory itself. Keep in lockstep with
-#     # core pyproject's fastmcp pin.
-#     "fastmcp==4.0.0b1",
+#     "fastmcp==4.0.3",
 # ]
+# [tool.uv]
+# # The released Basic Memory runtime still pins the beta. Use the stable
+# # version tested by core until the next runtime release carries this pin.
+# override-dependencies = ["fastmcp==4.0.3"]
 # ///
 """SessionStart hook — the entire hook. All logic (settings resolution, the
 context brief, lifecycle-envelope capture) lives in the released basic-memory

--- a/plugins/codex/hooks/pre_compact.py
+++ b/plugins/codex/hooks/pre_compact.py
@@ -3,11 +3,12 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@v0.23.2",
-#     # Direct pre-release pin so old uv resolves basic-memory (which
-#     # requires this exact beta transitively) without enabling
-#     # pre-releases broadly. Keep in lockstep with core pyproject.
-#     "fastmcp==4.0.0b1",
+#     "fastmcp==4.0.3",
 # ]
+# [tool.uv]
+# # The released Basic Memory runtime still pins the beta. Use the stable
+# # version tested by core until the next runtime release carries this pin.
+# override-dependencies = ["fastmcp==4.0.3"]
 # ///
 """PreCompact hook launcher backed by a pinned Basic Memory revision.
 

--- a/plugins/codex/hooks/session_start.py
+++ b/plugins/codex/hooks/session_start.py
@@ -3,11 +3,12 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #     "basic-memory @ git+https://github.com/basicmachines-co/basic-memory@v0.23.2",
-#     # Direct pre-release pin so old uv resolves basic-memory (which
-#     # requires this exact beta transitively) without enabling
-#     # pre-releases broadly. Keep in lockstep with core pyproject.
-#     "fastmcp==4.0.0b1",
+#     "fastmcp==4.0.3",
 # ]
+# [tool.uv]
+# # The released Basic Memory runtime still pins the beta. Use the stable
+# # version tested by core until the next runtime release carries this pin.
+# override-dependencies = ["fastmcp==4.0.3"]
 # ///
 """SessionStart hook launcher backed by a pinned Basic Memory revision.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "alembic>=1.14.1",
     "pillow>=11.1.0",
     "pybars3>=0.9.7",
-    "fastmcp==4.0.0b1",
+    "fastmcp==4.0.3",
     "pyjwt>=2.10.1",
     "python-dotenv>=1.1.0",
     "pytest-aio>=1.9.0",
@@ -181,9 +181,6 @@ source = "uv-dynamic-versioning"
 "integrations/pi/README.md" = "basic_memory/data/pi/package/README.md"
 "integrations/pi/SKILLS.md" = "basic_memory/data/pi/package/SKILLS.md"
 "integrations/pi/LICENSE" = "basic_memory/data/pi/package/LICENSE"
-
-[tool.uv]
-constraint-dependencies = ["fastmcp-slim==4.0.0b1"]
 
 [tool.uv-dynamic-versioning]
 vcs = "git"

--- a/scripts/validate_claude_plugin.py
+++ b/scripts/validate_claude_plugin.py
@@ -145,14 +145,8 @@ def validate_claude_plugin(plugin_dir: Path) -> None:
     for event in REQUIRED_HOOK_EVENTS:
         if event not in hooks:
             raise SystemExit(f"hooks/hooks.json: missing {event} hook")
-    # Trigger: the shims pin core's exact fastmcp beta so older uv can resolve
-    #   basic-memory (pre-release transitives are refused there) without
-    #   enabling pre-releases for basic-memory itself.
-    # Why: nothing else keeps the shim pin and core's pyproject in lockstep,
-    #   and drift makes shim resolution conflict — which the fail-open contract
-    #   turns into a silent hook no-op.
-    # Outcome: validation fails loudly when core moves its fastmcp pin without
-    #   the shims following.
+    # Both the declared dependency and effective override must follow core;
+    # a stale override silently wins over an updated direct dependency.
     core_pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     core_match = re.search(r'^\s*"fastmcp==([^"]+)",$', core_pyproject, re.MULTILINE)
     if not core_match:
@@ -178,6 +172,11 @@ def validate_claude_plugin(plugin_dir: Path) -> None:
                 f"{script}: fastmcp pin {shim_pins[0]} does not match "
                 f"core pyproject pin {core_fastmcp_pin}"
             )
+        overrides = re.findall(
+            r'^# override-dependencies = \["fastmcp==([^\"]+)"\]$', text, re.MULTILINE
+        )
+        if overrides != [core_fastmcp_pin]:
+            raise SystemExit(f"{script}: fastmcp override must match core pin {core_fastmcp_pin}")
 
     # --- Output style ---
     output_style = plugin_dir / "output-styles/basic-memory.md"

--- a/tests/test_codex_plugin_package.py
+++ b/tests/test_codex_plugin_package.py
@@ -391,12 +391,7 @@ def test_pr_create_skill_delegates_to_current_pr_workflow() -> None:
 
 
 def test_codex_hook_fastmcp_pins_match_core_pyproject() -> None:
-    """The shims pin core's exact fastmcp beta; drift breaks shim resolution.
-
-    Old uv refuses pre-release transitives, so each shim carries the pin as a
-    direct dependency. Nothing rewrites it automatically — this test is the
-    lockstep enforcement when core's pyproject moves its fastmcp pin.
-    """
+    """The direct dependency and effective override must both follow core."""
     repo_root = Path(__file__).resolve().parents[1]
     core = re.search(
         r'^\s*"fastmcp==([^"]+)",$', (repo_root / "pyproject.toml").read_text(), re.MULTILINE
@@ -406,3 +401,30 @@ def test_codex_hook_fastmcp_pins_match_core_pyproject() -> None:
         shim = (repo_root / "plugins/codex/hooks" / name).read_text()
         pins = re.findall(r'^#     "fastmcp==([^"]+)",$', shim, re.MULTILINE)
         assert pins == [core.group(1)], name
+        overrides = re.findall(
+            r'^# override-dependencies = \["fastmcp==([^\"]+)"\]$', shim, re.MULTILINE
+        )
+        assert overrides == [core.group(1)], name
+
+
+def test_claude_validator_rejects_stale_fastmcp_override(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    plugin_dir = tmp_path / "claude-code"
+    shutil.copytree(repo_root / "plugins/claude-code", plugin_dir)
+    script = plugin_dir / "hooks/session_start.py"
+    original = script.read_text()
+    script.write_text(
+        re.sub(
+            r'override-dependencies = \["fastmcp==[^\"]+"\]',
+            'override-dependencies = ["fastmcp==0.0.0"]',
+            original,
+        )
+    )
+    result = subprocess.run(
+        [sys.executable, str(repo_root / "scripts/validate_claude_plugin.py"), str(plugin_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "fastmcp override must match core pin" in result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -10,9 +10,6 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'win32'",
 ]
 
-[manifest]
-constraints = [{ name = "fastmcp-slim", specifier = "==4.0.0b1" }]
-
 [[package]]
 name = "aiofile"
 version = "3.11.1"
@@ -376,7 +373,7 @@ requires-dist = [
     { name = "dateparser", specifier = ">=1.2.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.136.1" },
     { name = "fastembed", specifier = ">=0.7.4" },
-    { name = "fastmcp", specifier = "==4.0.0b1" },
+    { name = "fastmcp", specifier = "==4.0.3" },
     { name = "filelock", specifier = ">=3.12" },
     { name = "greenlet", specifier = ">=3.1.1" },
     { name = "httpx", specifier = ">=0.28.0" },
@@ -1106,19 +1103,19 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "4.0.0b1"
+version = "4.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/fd/e513c524bb3e296203f65bd8e9e726e9236bd3b59315e7cbdeb095662c01/fastmcp-4.0.0b1.tar.gz", hash = "sha256:f98d69588a73e1672840558641d5d0f111e207baffe001f3465713a53ebb6b4c", size = 42065171, upload-time = "2026-07-28T21:18:15.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/1a/bee10aff530338f3b8982a3dd1c377c3ba5d0bc724615bf358422c4e9ecf/fastmcp-4.0.3.tar.gz", hash = "sha256:0dd50baf070105ee4436c245f087ac3c047e655c32d9e783de16d0bf15783a98", size = 42311418, upload-time = "2026-09-05T00:31:36.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/66/41b503ef852eff83f3f0c04f46cd1fc738c5374fd509384fc6b96e45918f/fastmcp-4.0.0b1-py3-none-any.whl", hash = "sha256:d66eb7b0763ffff2ae0fc573778ea25604dcb7e59769e5afaf9851a806eb1129", size = 8064, upload-time = "2026-07-28T21:18:12.688Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cb/66600db497b3be21cf141f01296308169859d48ed9b1bc8ba7c9d83279b7/fastmcp-4.0.3-py3-none-any.whl", hash = "sha256:f743f43193e1daf606e6497a9dddba5bbaad7df7957a98fd093716ecf4458b99", size = 8076, upload-time = "2026-09-05T00:31:33.957Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "4.0.0b1"
+version = "4.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mcp-types" },
@@ -1129,9 +1126,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/33/f207166aac88c6d8be1b2a82c54fecd1e04b075ef12d027aa17b3134fc0f/fastmcp_slim-4.0.0b1.tar.gz", hash = "sha256:158efb25720e0cb301711146b2d05d181de95cd91fe70e87c251ad14b123d665", size = 660081, upload-time = "2026-07-28T21:17:50.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/a9/b7b796b0d4a5e095dadef233833c82ac1136f5c110dd9947b2e9a4988518/fastmcp_slim-4.0.3.tar.gz", hash = "sha256:3ce04a82b82cc41ccb12bb3bb366cfd65b52bc797b8fee332a75da9d480f9b74", size = 685704, upload-time = "2026-09-05T00:31:12.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/5d/fbe192d2ab50bb31b284fd0eb6c72d4347df7a57d836bee4f1973ffd1d7d/fastmcp_slim-4.0.0b1-py3-none-any.whl", hash = "sha256:dd907a3db5a2f479ca958c30157e227b4f7b340a56d333eb91de95719254597a", size = 827975, upload-time = "2026-07-28T21:17:48.747Z" },
+    { url = "https://files.pythonhosted.org/packages/43/4b/6b31820d87f56d5773538860878c8634b618cd1e9044b3bfbd8a78380a0f/fastmcp_slim-4.0.3-py3-none-any.whl", hash = "sha256:3756ed4bd9f82f40adaf51974b7cdd1463ab6b9f479cf69b69b2692969312b87", size = 859717, upload-time = "2026-09-05T00:31:10.93Z" },
 ]
 
 [package.optional-dependencies]
@@ -4307,11 +4304,11 @@ wheels = [
 
 [[package]]
 name = "uncalled-for"
-version = "0.3.2"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5a/92ce0b3ea5481915f55da994c2c2c5f7a3c09949afde196ee89f8ab961aa/uncalled_for-0.4.0.tar.gz", hash = "sha256:335b95bd2422332ec210d518f314a16e4c640921c39fc8bf2ad095bd3538f4af", size = 56979, upload-time = "2026-08-10T14:51:46.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/40/97cec87c077eb3291fc7905e6633e08b7ca593c57d30238444bcb6bb3d53/uncalled_for-0.4.0-py3-none-any.whl", hash = "sha256:16c4bb3337532e4bd5569adc192285976f3ad5305402256d34c67a12b5c968bd", size = 15502, upload-time = "2026-08-10T14:51:45.068Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Installed Codex hooks exit before executing: uv cannot resolve the transitive `fastmcp-slim[client]==4.0.0b1` prerelease. This prevents startup context loading and compaction checkpoint prompts.

## What Changed

Upgrade core and the Codex/Claude Code hook launchers to stable FastMCP 4.0.3. Remove the beta-only FastMCP Slim constraint and refresh the lockfile. Package checks also enforce that the effective FastMCP overrides match core, with a regression test for stale overrides.

## Implementation Details

The hook scripts explicitly override FastMCP to 4.0.3 because their released Basic Memory runtime still requires the beta. This keeps the existing runtime references usable until a subsequent runtime release includes the stable pin. The only other lockfile upgrade is `uncalled-for` 0.3.2 → 0.4.0.

## Testing

- After adding override validation: `uv run pytest tests/test_codex_plugin_package.py --no-cov -q`: 18 passed; `just typecheck` and targeted Ruff checks passed.

- `uv run pytest tests/hooks tests/cli/test_hook_command.py tests/test_codex_plugin_package.py test-int/mcp/test_smoke_integration.py --no-cov -q`: 196 passed on the final branch based on main.
- `just typecheck`: passed on the final branch.
- Before removing the unrelated line-scanning branch ancestry, the broader suite including `tests/mcp` passed: 1,560 tests; `just package-check` and `just doctor` also passed.
- `uv run ruff check plugins/codex/hooks plugins/claude-code/hooks` and matching `ruff format --check`: passed.
- Executed the updated Codex scripts through their actual `uv run --quiet --script` commands: startup returned live memory context, PreCompact captured its event, and post-compaction startup emitted the checkpoint prompt. All exited 0 with no stderr and produced the expected local envelopes. Direct repo-environment CLI execution passed the same checks.

## Risks / Follow-ups

Plugin users need an updated plugin installation to receive these launchers. This PR does not change installed user configuration or switch hooks to a PATH-based runtime. The explicit FastMCP override bridges the older runtime's dependency pin; both runtime combinations were exercised locally.
