### PR TITLE
feat(mcp): enable POSIX tools by default

### DIFF
--- a/src/basic_memory/config_models.py
+++ b/src/basic_memory/config_models.py
@@ -611,9 +611,10 @@ class BasicMemoryConfig(BaseSettings):
     )
 
     enable_posix_tools: bool = Field(
-        default=False,
+        default=True,
         description=(
             "Register the POSIX-style read-only MCP tools (cat, grep, ls, find, tail, man). "
+            "Enabled by default; set false to hide them. "
             "Env: BASIC_MEMORY_ENABLE_POSIX_TOOLS"
         ),
     )

--- a/src/basic_memory/mcp/server.py
+++ b/src/basic_memory/mcp/server.py
@@ -111,7 +111,7 @@ async def lifespan(app: FastMCP):
     # Trigger: the enable_posix_tools config flag.
     # Why: tools register at import time; the composition root is the one place
     #      config decides what clients see (no if-checks inside tool bodies).
-    # Outcome: flag off (default) keeps the tool listing identical to today.
+    # Outcome: enabled by default; an explicit opt-out hides the POSIX group.
     set_posix_tools_visibility(app, config.enable_posix_tools)
 
     standalone_redis_url = None if container.mode.is_cloud else config.redis_url
@@ -242,6 +242,15 @@ BASIC_MEMORY_INSTRUCTIONS = (
     "Memory gives them persistent notes shared between the user and their AI, and offer to save "
     "something useful from this conversation as their first note with `write_note` — then wait "
     "for them to agree before writing anything. Do not create notes unprompted.\n\n"
+    "Read-only POSIX tools are enabled by default: `ls`, `find`, `grep`, `cat`, `tail`, "
+    'and `man`. Projects are mount points: `ls(path="/")` without a project lists '
+    'addressable projects; `ls(path="research/notes")` and '
+    '`cat(identifier="research/notes/topic.md")` route into the research project. '
+    "Use returned project-qualified paths for follow-up reads. With multiple projects, "
+    "qualify paths or pass `project` (also required for `grep` and `tail`); an explicit "
+    "project must agree with any path prefix. `cat` supports bounded line, section, and "
+    "token-budget reads; `find` can return selected metadata fields. All existing tools "
+    "remain available. Set `enable_posix_tools=false` to hide the POSIX tools.\n\n"
     "For a fuller guide, read the `memory://ai_assistant_guide` resource. The manual has a "
     "page for nearly every tool, with verified examples and gotchas: `memory://man` lists "
     "them, and `memory://man/<tool>(3)` (for example `memory://man/search-notes(3)`) is one "

--- a/src/basic_memory/mcp/server.py
+++ b/src/basic_memory/mcp/server.py
@@ -242,8 +242,10 @@ BASIC_MEMORY_INSTRUCTIONS = (
     "Memory gives them persistent notes shared between the user and their AI, and offer to save "
     "something useful from this conversation as their first note with `write_note` — then wait "
     "for them to agree before writing anything. Do not create notes unprompted.\n\n"
-    "Read-only POSIX tools are enabled by default: `ls`, `find`, `grep`, `cat`, `tail`, "
-    'and `man`. Projects are mount points: `ls(path="/")` without a project lists '
+    "When available in your tool list, use the read-only POSIX tools `ls`, `find`, "
+    "`grep`, `cat`, `tail`, and `man` for compact navigation. If they are absent, use "
+    "the existing rich tools instead. Projects are mount points: "
+    '`ls(path="/")` without a project constraint lists '
     'addressable projects; `ls(path="research/notes")` and '
     '`cat(identifier="research/notes/topic.md")` route into the research project. '
     "Use returned project-qualified paths for follow-up reads. With multiple projects, "

--- a/src/basic_memory/mcp/tools/__init__.py
+++ b/src/basic_memory/mcp/tools/__init__.py
@@ -31,7 +31,7 @@ from basic_memory.mcp.tools.project_management import (
 # ChatGPT-compatible tools
 from basic_memory.mcp.tools.chatgpt_tools import search, fetch
 
-# POSIX-style read-side tools (hidden unless enable_posix_tools is set, #1399)
+# POSIX-style read-side tools (enabled by default at server startup, #1476)
 from basic_memory.mcp.tools.posix_tools import cat, find, grep, ls, man, tail
 
 # Schema tools

--- a/src/basic_memory/mcp/tools/posix_tools.py
+++ b/src/basic_memory/mcp/tools/posix_tools.py
@@ -2,8 +2,8 @@
 
 Six familiar Unix verbs — cat, grep, ls, find, tail, man — each a thin
 translation over the same typed API clients the canonical tools use. They are
-tagged ``POSIX_TOOLS_TAG`` and hidden by default: the composition root in
-``basic_memory.mcp.server`` flips their visibility from the
+tagged ``POSIX_TOOLS_TAG`` and hidden until startup: the composition root in
+``basic_memory.mcp.server`` sets their visibility from the default-enabled
 ``enable_posix_tools`` config flag at lifespan startup, so no tool body ever
 checks config itself.
 
@@ -1431,6 +1431,6 @@ async def man(
         return response.model_dump(mode="json", exclude_none=True)
 
 
-# Default-hidden until the composition root reads config in lifespan. Keeps the
-# tool listing identical to today for any consumer that lists before startup.
+# Hidden until the composition root reads config, so importing tools never
+# bypasses an explicit opt-out before startup.
 set_posix_tools_visibility(mcp, False)

--- a/test-int/mcp/test_posix_default_integration.py
+++ b/test-int/mcp/test_posix_default_integration.py
@@ -1,0 +1,108 @@
+"""Default POSIX discovery and navigation through the MCP client transport."""
+
+import json
+
+import pytest
+from fastmcp import Client
+
+from basic_memory.mcp.server import set_posix_tools_visibility
+
+
+POSIX_TOOLS = {"cat", "grep", "ls", "find", "tail", "man"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("setting", [None, False, True])
+@pytest.mark.parametrize("mode", ["auto", "legacy"])
+async def test_posix_registration_over_mcp(mcp_server, config_manager, setting, mode) -> None:
+    # Omit the key entirely to exercise existing configs that inherit new defaults.
+    saved = json.loads(config_manager.config_file.read_text())
+    saved.pop("enable_posix_tools", None)
+    if setting is not None:
+        saved["enable_posix_tools"] = setting
+    config_manager.config_file.write_text(json.dumps(saved))
+
+    try:
+        async with Client(mcp_server, mode=mode) as client:
+            tools = {tool.name: tool for tool in await client.list_tools()}
+            assert {"read_note", "search_notes", "write_note", "build_context"} <= tools.keys()
+            if setting is False:
+                assert POSIX_TOOLS.isdisjoint(tools)
+                hidden = await client.call_tool("man", {}, raise_on_error=False)
+                assert hidden.is_error
+            else:
+                assert POSIX_TOOLS <= tools.keys()
+                for name in POSIX_TOOLS:
+                    annotations = tools[name].annotations
+                    assert annotations is not None
+                    assert annotations.read_only_hint is True
+                    assert annotations.destructive_hint is False
+                instructions = client.instructions
+                assert instructions is not None
+                assert "Projects are mount points" in instructions
+                assert 'cat(identifier="research/notes/topic.md")' in instructions
+    finally:
+        set_posix_tools_visibility(mcp_server, False)
+
+
+@pytest.mark.asyncio
+async def test_posix_default_navigation_workflow(mcp_server, app, test_project) -> None:
+    """Follow advertised mount and result paths, then scan a bounded note window."""
+    try:
+        async with Client(mcp_server) as client:
+            await client.call_tool(
+                "write_note",
+                {
+                    "title": "POSIX Runbook",
+                    "directory": "notes",
+                    "content": "# Recovery\n\nbefore\nretry the task\nafter\nremaining",
+                    "metadata": {"status": "active", "priority": 3},
+                    "project": test_project.name,
+                },
+            )
+            mounts = await client.call_tool("ls", {"path": "/"})
+            mount = next(row for row in mounts.data["nodes"] if row["name"] == test_project.name)
+            note_dir = f"{mount['directory_path']}/notes"
+            listing = await client.call_tool("ls", {"path": note_dir})
+            note_path = listing.data["nodes"][0]["file_path"]
+            full = await client.call_tool("cat", {"identifier": note_path})
+            assert "retry the task" in full.data["content"]
+
+            found = await client.call_tool("find", {"path": note_dir, "name": "*.md"})
+            assert found.data["nodes"][0]["file_path"] == note_path
+            projected = await client.call_tool(
+                "find",
+                {"path": note_dir, "meta": ["status=active"], "fields": ["priority"]},
+            )
+            row = projected.data["results"][0]
+            assert row["file_path"] == note_path
+            assert row["fields"] == {"priority": 3}
+            assert "content" not in row
+
+            matches = await client.call_tool(
+                "grep",
+                {
+                    "pattern": "retry",
+                    "literal": True,
+                    "context_lines": 1,
+                    "project": test_project.name,
+                },
+            )
+            window = matches.data["results"][0]["windows"][0]
+            sliced = await client.call_tool(
+                "cat",
+                {
+                    "identifier": note_path,
+                    "start_line": window["start_line"],
+                    "end_line": window["end_line"],
+                },
+            )
+            assert sliced.data["content"] == window["content"] == "before\nretry the task\nafter"
+            assert len(sliced.data["content"]) < len(full.data["content"])
+
+            recent = await client.call_tool("tail", {"project": test_project.name, "lines": 1})
+            assert recent.data[0]["title"] == "POSIX Runbook"
+            manual = await client.call_tool("man", {"page": "cat(1)"})
+            assert "--lines" in manual.data
+    finally:
+        set_posix_tools_visibility(mcp_server, False)

--- a/test-int/mcp/test_posix_default_integration.py
+++ b/test-int/mcp/test_posix_default_integration.py
@@ -26,6 +26,10 @@ async def test_posix_registration_over_mcp(mcp_server, config_manager, setting, 
         async with Client(mcp_server, mode=mode) as client:
             tools = {tool.name: tool for tool in await client.list_tools()}
             assert {"read_note", "search_notes", "write_note", "build_context"} <= tools.keys()
+            instructions = client.instructions
+            assert instructions is not None
+            assert "When available in your tool list" in instructions
+            assert "If they are absent, use the existing rich tools instead" in instructions
             if setting is False:
                 assert POSIX_TOOLS.isdisjoint(tools)
                 hidden = await client.call_tool("man", {}, raise_on_error=False)
@@ -37,8 +41,6 @@ async def test_posix_registration_over_mcp(mcp_server, config_manager, setting, 
                     assert annotations is not None
                     assert annotations.read_only_hint is True
                     assert annotations.destructive_hint is False
-                instructions = client.instructions
-                assert instructions is not None
                 assert "Projects are mount points" in instructions
                 assert 'cat(identifier="research/notes/topic.md")' in instructions
     finally:

--- a/tests/mcp/test_posix_tool_gate.py
+++ b/tests/mcp/test_posix_tool_gate.py
@@ -3,7 +3,7 @@
 The POSIX tools register on the shared FastMCP server at import time but stay
 hidden until the composition root reads config in lifespan. These tests drive
 both directions of the gate; visibility marks stack with the last one winning,
-so each test restores the default-hidden state it started from.
+so each test restores the pre-startup hidden state it started from.
 """
 
 import pytest
@@ -14,25 +14,24 @@ POSIX_TOOL_NAMES = {"cat", "find", "grep", "ls", "man", "tail"}
 
 
 @pytest.mark.asyncio
-async def test_posix_tools_hidden_by_default():
+async def test_posix_tools_hidden_before_startup():
     """Importing the tools must not change what clients see before startup."""
     names = {tool.name for tool in await mcp.list_tools()}
     assert names.isdisjoint(POSIX_TOOL_NAMES)
 
 
 @pytest.mark.asyncio
-async def test_posix_tools_visible_when_flag_enabled(config_manager):
+async def test_posix_tools_visible_by_default(config_manager):
     baseline = {tool.name for tool in await mcp.list_tools()}
     cfg = config_manager.load_config()
-    cfg.enable_posix_tools = True
-    config_manager.save_config(cfg)
+    assert cfg.enable_posix_tools is True
 
     try:
         async with lifespan(mcp):
             enabled = {tool.name for tool in await mcp.list_tools()}
     finally:
         # The registration singleton is shared across tests; re-hide so later
-        # tests see today's default listing (the mark appended last wins).
+        # tests see the pre-startup listing (the mark appended last wins).
         set_posix_tools_visibility(mcp, False)
 
     assert enabled == baseline | POSIX_TOOL_NAMES

--- a/tests/mcp/test_posix_tool_gate.py
+++ b/tests/mcp/test_posix_tool_gate.py
@@ -6,6 +6,9 @@ both directions of the gate; visibility marks stack with the last one winning,
 so each test restores the pre-startup hidden state it started from.
 """
 
+import subprocess
+import sys
+
 import pytest
 
 from basic_memory.mcp.server import lifespan, mcp, set_posix_tools_visibility
@@ -13,15 +16,30 @@ from basic_memory.mcp.server import lifespan, mcp, set_posix_tools_visibility
 POSIX_TOOL_NAMES = {"cat", "find", "grep", "ls", "man", "tail"}
 
 
-@pytest.mark.asyncio
-async def test_posix_tools_hidden_before_startup():
-    """Importing the tools must not change what clients see before startup."""
-    names = {tool.name for tool in await mcp.list_tools()}
-    assert names.isdisjoint(POSIX_TOOL_NAMES)
+def test_posix_tools_hidden_before_startup():
+    """A fresh interpreter proves import behavior independently of prior lifespans."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import asyncio; import basic_memory.mcp.tools; "
+            "from basic_memory.mcp.server import mcp; "
+            "names = {tool.name for tool in asyncio.run(mcp.list_tools())}; "
+            "assert 'read_note' in names; "
+            "assert names.isdisjoint({'cat', 'find', 'grep', 'ls', 'man', 'tail'})",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.asyncio
 async def test_posix_tools_visible_by_default(config_manager):
+    # Other tests may have started the singleton already; establish this test
+    # boundary explicitly rather than depending on suite order.
+    set_posix_tools_visibility(mcp, False)
     baseline = {tool.name for tool in await mcp.list_tools()}
     cfg = config_manager.load_config()
     assert cfg.enable_posix_tools is True

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -206,9 +206,9 @@ EXPECTED_TOOL_ANNOTATIONS: dict[str, dict[str, bool]] = {
 # The MCP-UI tools are disabled in tools/__init__.py but register onto the shared
 # server whenever tests import their module directly, so tolerate their presence
 # without requiring it — keeps this contract independent of test execution order.
-# The POSIX tools (#1399) are hidden unless enable_posix_tools is set, so they
-# normally don't appear in list_tools(); optional status keeps the contract
-# independent of whether a gate test has revealed them.
+# The POSIX tools are enabled by default during lifespan startup, but remain
+# hidden before config is read. Optional status keeps this direct-list contract
+# independent of whether another test has started the shared server.
 OPTIONAL_TOOL_ANNOTATIONS: dict[str, dict[str, bool]] = {
     "read_note_ui": {"readOnlyHint": True, "destructiveHint": False},
     "search_notes_ui": {"readOnlyHint": True, "destructiveHint": False},


### PR DESCRIPTION
## Why

Agents should discover compact navigation and bounded note reads without enabling an experimental flag. This completes the default-on rollout in #1476 and the first-connect project namespace guidance from #1415.

## What Changed

- Enable `cat`, `grep`, `ls`, `find`, `tail`, and `man` by default while keeping all rich tools available.
- Explain projects as mount points and project-qualified paths in server instructions.
- Preserve explicit `enable_posix_tools=false` opt-outs.

## Implementation Details

The existing lifespan composition root still applies visibility after reading configuration. Import-time hiding remains so imports cannot bypass an opt-out. Real MCP client tests cover omitted/true/false settings under modern discovery and the legacy handshake, including rejection of hidden tool calls and read-only annotations. A complete navigation workflow exercises all six verbs, metadata projections, and grep-to-cat line coordinates.

## Testing

- `uv run pytest tests/mcp/test_posix_tool_gate.py test-int/mcp/test_posix_default_integration.py tests/mcp/test_tool_posix.py tests/mcp/test_project_path_routing.py tests/mcp/test_tool_contracts.py tests/mcp/test_first_connect_onboarding.py tests/cli/test_cli_posix_verbs.py test-int/mcp/test_line_scanning_integration.py -q --no-cov`: 506 passed.
- `BASIC_MEMORY_TEST_POSTGRES=1 uv run pytest test-int/mcp/test_posix_default_integration.py -q --no-cov`: 7 passed.
- `just fast-check`: passed, including repository-wide typecheck.
- `just doctor`: passed.
- Live repo CLI: mount listing, cloud directory pagination, manual lookup, and bounded cloud reads passed. One cloud read timed out and succeeded on retry.

## Risks / Follow-ups

Persisted false values remain opt-outs, including defaults saved by older versions. Users with those configurations must set the option true or remove it to inherit the new default. This does not migrate user settings or rerun benchmarks.

Closes #1476.
