### PR TITLE
fix(cli): report missing notes with a failing exit status

### DIFF
--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -770,14 +770,11 @@ def read_note(
                 )
             )
 
-        # MCP tool returns an error field on failure in JSON mode (e.g.
-        # SECURITY_VALIDATION_ERROR on a path-traversal identifier). A genuine
-        # not-found returns null fields with no `error` key, so it still exits 0.
-        # Trigger: result carries a non-empty `error`.
-        # Why: parity with edit-note/delete-note/search-notes so a blocked read
-        #      surfaces a non-zero exit instead of looking like success.
-        # Outcome: print the error to stderr and exit non-zero.
-        if isinstance(result, dict) and result.get("error"):
+        # A missing note may carry useful suggestions. Render those in the
+        # requested mode before exiting non-zero; other failures keep the
+        # existing JSON diagnostic path.
+        not_found = isinstance(result, dict) and result.get("error") == "NOTE_NOT_FOUND"
+        if isinstance(result, dict) and result.get("error") and not not_found:
             typer.echo(f"Error: {result['error']}", err=True)
             _print_json(result)
             raise typer.Exit(1)
@@ -801,9 +798,12 @@ def read_note(
             else:
                 console.print(Text(text))
         elif mode == "plain":
-            _plain_read_note(result, include_frontmatter=include_frontmatter)
+            _plain_read_note(result, include_frontmatter=include_frontmatter and not not_found)
         else:
             _display_read_note(result, include_frontmatter=include_frontmatter)
+        if not_found:
+            typer.echo(f"Error: Note not found: {identifier}", err=True)
+            raise typer.Exit(1)
     except ValueError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/basic_memory/man/man3/read-note(3).md
+++ b/src/basic_memory/man/man3/read-note(3).md
@@ -37,10 +37,13 @@ bm tool read-note IDENTIFIER [--project NAME | --project-id UUID]
 
 Returns the raw markdown of a note. The identifier is resolved through a
 cascade: direct permalink lookup, then exact title match, then full-text
-search. If nothing matches exactly, read-note returns guidance text instead
-of an error: a ranked list of related notes, each with a copy-pasteable
+search. If nothing matches exactly, MCP text mode returns guidance:
+a ranked list of related notes, each with a copy-pasteable
 `read_note()` call, plus suggested `search_notes()` and `write_note()` next
-steps. A miss is a navigable dead end, not an exception.
+steps. JSON mode returns null note fields plus `error: "NOTE_NOT_FOUND"`,
+a message naming the identifier, and `related_results` when available.
+The CLI exits with status 1 for a missing note in every output mode, retaining
+suggestions in JSON, plain, and Rich output. An existing empty note still succeeds.
 
 Accepted identifier forms (all verified):
 
@@ -56,7 +59,7 @@ Accepted identifier forms (all verified):
 - **project_id** (string | null, optional, default: None) — Project external_id (UUID). Prefer this over `project` when known — it routes to the exact project regardless of name collisions across cloud workspaces. Takes precedence over `project`. Get from list_memory_projects().
 - **page** (integer, optional, default: 1) — Page of fallback-search results to use when the identifier does not resolve to a note directly (default: 1). A direct or exact-title match returns the note content — page/page_size never chunk the note itself, and the title-match lookup pages through fixed-size pages of title results until an exact match is found or results are exhausted, regardless of page or page_size. Aliases: page_number.
 - **page_size** (integer, optional, default: 10) — Number of fallback-search results per page (default: 10). When no match is found, this caps how many related-note suggestions are listed. Aliases: limit, per_page.
-- **output_format** (string, optional, default: "text") — "text" returns markdown content or guidance text. "json" returns a structured object with title/permalink/file_path/content/frontmatter.
+- **output_format** (string, optional, default: "text") — "text" returns markdown content or guidance text. "json" returns a structured object with title/permalink/file_path/content/frontmatter. Unresolved notes carry error="NOTE_NOT_FOUND" and a message, with related_results when suggestions are available.
 - **include_frontmatter** (boolean, optional, default: False) — For unsliced JSON reads, include opening YAML in content; parsed frontmatter is returned either way. Explicit line ranges are never stripped. CLI: --frontmatter (--include-frontmatter is a deprecated alias).
 - **start_line** (integer | null, optional, default: None) — First document line to read (1-based, inclusive). Defaults to 1 when only end_line is given. Line scans count the full Markdown, including frontmatter, matching cat's default line coordinates.
 - **end_line** (integer | null, optional, default: None) — Last document line to read (inclusive); omitted means EOF. Out-of-file ranges return empty content; invalid/reversed ranges fail. With either bound, text output is numbered and JSON carries coordinates, has_more, and next_start_line/next_end_line. include_frontmatter does not strip an explicitly addressed range. Edits between calls may shift lines.
@@ -102,7 +105,7 @@ bm tool read-note runbook --start-line 120 --end-line 180 --plain
 
 ## EXAMPLES
 
-A miss returns suggestions, not an error (run against the dev project):
+A miss in MCP text mode returns suggestions (run against the dev project):
 
 ```
 read_note("xyzzy definitely missing note", project="dev")

--- a/src/basic_memory/mcp/tools/read_note.py
+++ b/src/basic_memory/mcp/tools/read_note.py
@@ -349,7 +349,13 @@ async def read_note(
                     output_format="json",
                     context=context,
                 )
-                return cast(dict[str, object], response) if isinstance(response, dict) else {}
+                # JSON searches return a dict even when empty. Text here is a
+                # formatted search failure, not evidence that the note is absent.
+                if not isinstance(response, dict):
+                    if output_format == "json" or line_scan:
+                        raise RuntimeError(f"Fallback search failed: {response}")
+                    return {}
+                return cast(dict[str, object], response)
 
             def _result_title(item: dict[str, object]) -> str:
                 return str(item.get("title") or "")

--- a/src/basic_memory/mcp/tools/read_note.py
+++ b/src/basic_memory/mcp/tools/read_note.py
@@ -435,22 +435,16 @@ async def read_note(
                     break
 
             if result is not None and (output_format == "json" or line_scan):
-                try:
-                    entity_id = _result_external_id(result)
-                    if entity_id is None and _result_permalink(result) is not None:
-                        entity_id = await knowledge_client.resolve_entity(
-                            _result_permalink(result) or "", strict=True
-                        )
-                    if entity_id is not None:
-                        logger.info(
-                            f"Found note by exact title search: {_result_permalink(result)}"
-                        )
-                        return await _read_resolved_note(entity_id)
-                except Exception as error:  # pragma: no cover
-                    logger.info(
-                        "Failed to fetch content for found title match "
-                        f"{_result_permalink(result)}: {error}"
+                # An exact candidate identifies a note; retrieval failures must surface
+                # as operational errors instead of suggesting that it is missing.
+                entity_id = _result_external_id(result)
+                if entity_id is None and _result_permalink(result) is not None:
+                    entity_id = await knowledge_client.resolve_entity(
+                        _result_permalink(result) or "", strict=True
                     )
+                if entity_id is not None:
+                    logger.info(f"Found note by exact title search: {_result_permalink(result)}")
+                    return await _read_resolved_note(entity_id)
             elif result is not None and _result_permalink(result):
                 try:
                     entity_id = await knowledge_client.resolve_entity(

--- a/src/basic_memory/mcp/tools/read_note.py
+++ b/src/basic_memory/mcp/tools/read_note.py
@@ -8,6 +8,8 @@ import logfire
 
 from loguru import logger
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
+from httpx import HTTPStatusError
 from pydantic import AliasChoices, Field
 
 from basic_memory.config import ConfigManager
@@ -375,11 +377,32 @@ async def read_note(
             if output_format == "json" or line_scan:
                 exact_external_id = _exact_external_id(entity_path)
                 if exact_external_id is not None:
-                    return await _read_resolved_note(exact_external_id)
+                    try:
+                        return await _read_resolved_note(exact_external_id)
+                    except ToolError as error:
+                        cause = error.__cause__
+                        # Only the entity GET proves this UUID is absent. A 404
+                        # from its resource fallback is a failed content read.
+                        if (
+                            isinstance(cause, HTTPStatusError)
+                            and cause.response.status_code == 404
+                            and cause.request.url.path.endswith(
+                                f"/knowledge/entities/{exact_external_id}"
+                            )
+                        ):
+                            if output_format == "json":
+                                return _not_found_json_payload()
+                            return format_not_found_message(active_project.name, identifier)
+                        raise
 
                 try:
                     entity_id = await knowledge_client.resolve_entity(entity_path, strict=True)
-                except Exception as error:  # pragma: no cover
+                except ToolError as error:
+                    cause = error.__cause__
+                    # Search is a recovery for a confirmed lookup miss, not for
+                    # unavailable or unauthorized resolution services.
+                    if not isinstance(cause, HTTPStatusError) or cause.response.status_code != 404:
+                        raise
                     logger.info(f"Direct lookup failed for '{entity_path}': {error}")
                 else:
                     logger.info(

--- a/src/basic_memory/mcp/tools/read_note.py
+++ b/src/basic_memory/mcp/tools/read_note.py
@@ -390,6 +390,21 @@ async def read_note(
                                 f"/knowledge/entities/{exact_external_id}"
                             )
                         ):
+                            if line_scan:
+                                # The slice endpoint also uses 404 for an existing
+                                # non-Markdown entity. Confirm absence without slice
+                                # parameters before classifying this error as missing.
+                                try:
+                                    await knowledge_client.get_entity(exact_external_id)
+                                except ToolError as lookup_error:
+                                    lookup_cause = lookup_error.__cause__
+                                    if (
+                                        not isinstance(lookup_cause, HTTPStatusError)
+                                        or lookup_cause.response.status_code != 404
+                                    ):
+                                        raise
+                                else:
+                                    raise error
                             if output_format == "json":
                                 return _not_found_json_payload()
                             return format_not_found_message(active_project.name, identifier)

--- a/src/basic_memory/mcp/tools/read_note.py
+++ b/src/basic_memory/mcp/tools/read_note.py
@@ -130,6 +130,8 @@ async def read_note(
             Aliases: limit, per_page.
         output_format: "text" returns markdown content or guidance text.
             "json" returns a structured object with title/permalink/file_path/content/frontmatter.
+            Unresolved notes carry error="NOTE_NOT_FOUND" and a message, with
+            related_results when suggestions are available.
         include_frontmatter: For unsliced JSON reads, include opening YAML in content;
             parsed frontmatter is returned either way. Explicit line ranges are never
             stripped. CLI: --frontmatter (--include-frontmatter is a deprecated alias).
@@ -290,13 +292,15 @@ async def read_note(
                     "next_end_line": min(total, last + width) if last < total else None,
                 }
 
-            def _empty_json_payload() -> dict[str, Any]:
+            def _not_found_json_payload() -> dict[str, Any]:
                 return {
                     "title": None,
                     "permalink": None,
                     "file_path": None,
                     "content": None,
                     "frontmatter": None,
+                    "error": "NOTE_NOT_FOUND",
+                    "message": f"Note not found: {identifier}",
                 }
 
             def _search_results(payload: object) -> list[dict[str, object]]:
@@ -472,13 +476,13 @@ async def read_note(
             text_candidates = _search_results(text_results)
             if not text_candidates:
                 if output_format == "json":
-                    return _empty_json_payload()
+                    return _not_found_json_payload()
                 return format_not_found_message(active_project.name, identifier)
             # The fallback search is paginated server-side to page_size, so list
             # the whole returned page instead of a hardcoded cap — otherwise the
             # caller's page_size would be silently ignored past the cap.
             if output_format == "json":
-                payload = _empty_json_payload()
+                payload = _not_found_json_payload()
                 payload["related_results"] = [
                     {
                         "title": _result_title(result),

--- a/test-int/cli/test_cli_tool_delete_note_integration.py
+++ b/test-int/cli/test_cli_tool_delete_note_integration.py
@@ -36,14 +36,19 @@ def _write_note(
     return json.loads(result.stdout)
 
 
-def _read_note(identifier: str, *, project: str | None = None) -> dict[str, Any]:
+def _read_note(
+    identifier: str, *, project: str | None = None, missing: bool = False
+) -> dict[str, Any]:
     args = ["tool", "read-note", identifier]
     if project is not None:
         args.extend(["--project", project])
 
     result = runner.invoke(cli_app, args)
-    assert result.exit_code == 0, result.output
-    return json.loads(result.stdout)
+    assert result.exit_code == (1 if missing else 0), result.output
+    payload = json.loads(result.stdout)
+    if missing:
+        assert payload["error"] == "NOTE_NOT_FOUND"
+    return payload
 
 
 def _delete_note(
@@ -114,7 +119,7 @@ def test_delete_note_removes_file_database_record_and_search_result(
     }
     assert not note_path.exists()
 
-    missing = _read_note(note["permalink"])
+    missing = _read_note(note["permalink"], missing=True)
     assert missing["title"] is None
     assert missing["permalink"] is None
     assert missing["content"] is None
@@ -177,7 +182,7 @@ def test_delete_note_project_id_takes_precedence_over_wrong_project_name(
     assert exit_code == 0, output
     assert payload["deleted"] is True
     assert payload["title"] == "CLI Delete By Project ID"
-    assert _read_note(note["permalink"])["title"] is None
+    assert _read_note(note["permalink"], missing=True)["title"] is None
 
 
 def test_delete_note_memory_url_detects_project_from_identifier(
@@ -197,7 +202,7 @@ def test_delete_note_memory_url_detects_project_from_identifier(
     assert exit_code == 0, output
     assert payload["deleted"] is True
     assert payload["permalink"] == note["permalink"]
-    assert _read_note(note["permalink"], project=test_project.name)["title"] is None
+    assert _read_note(note["permalink"], project=test_project.name, missing=True)["title"] is None
 
 
 def test_delete_directory_removes_nested_files_database_records_and_search_results(
@@ -238,7 +243,7 @@ def test_delete_directory_removes_nested_files_database_records_and_search_resul
     assert not any(path.exists() for path in note_paths)
 
     for note in notes:
-        assert _read_note(note["permalink"])["title"] is None
+        assert _read_note(note["permalink"], missing=True)["title"] is None
 
     search = _search_notes("CLI Delete Directory", mode_flag="--title")
     assert search["total"] == 0

--- a/test-int/cli/test_cli_tool_json_failure_integration.py
+++ b/test-int/cli/test_cli_tool_json_failure_integration.py
@@ -6,6 +6,7 @@ error messages go to stderr, not stdout (which would break JSON parsing).
 
 import json
 
+import pytest
 from typer.testing import CliRunner
 
 from basic_memory.cli.main import app as cli_app
@@ -14,18 +15,67 @@ runner = CliRunner()
 
 
 def test_read_note_not_found(app, app_config, test_project, config_manager):
-    """read-note with non-existent identifier returns JSON with null fields."""
+    """A missing note remains machine-readable but must not report success."""
     result = runner.invoke(
         cli_app,
         ["tool", "read-note", "nonexistent-note-that-does-not-exist"],
     )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     data = json.loads(result.stdout)
-    # MCP tool returns a valid JSON payload with null fields for not-found
+    assert data["error"] == "NOTE_NOT_FOUND"
+    assert data["message"] == "Note not found: nonexistent-note-that-does-not-exist"
+    assert "Note not found" in result.stderr
     assert data["title"] is None
     assert data["permalink"] is None
     assert data["content"] is None
+
+
+@pytest.mark.parametrize("mode", ["piped", "json", "plain", "rich"])
+@pytest.mark.parametrize("related", [False, True])
+def test_read_after_delete_fails_in_every_mode(
+    app, app_config, test_project, config_manager, monkeypatch, mode, related
+):
+    """The actual write/delete/read flow must fail even when search offers alternatives."""
+    monkeypatch.setattr("basic_memory.cli.commands.tool._use_rich", lambda: mode == "rich")
+    title = "Missingneedle"
+    created = runner.invoke(
+        cli_app,
+        ["tool", "write-note", "--title", title, "--folder", "test", "--content", "original"],
+    )
+    assert created.exit_code == 0, created.output
+    deleted = runner.invoke(cli_app, ["tool", "delete-note", title])
+    assert deleted.exit_code == 0, deleted.output
+    if related:
+        alternative = runner.invoke(
+            cli_app,
+            [
+                "tool",
+                "write-note",
+                "--title",
+                "Alternative",
+                "--folder",
+                "test",
+                "--content",
+                f"This mentions {title} but is a different note.",
+            ],
+        )
+        assert alternative.exit_code == 0, alternative.output
+
+    flags = [f"--{mode}"] if mode in {"json", "plain"} else []
+    result = runner.invoke(cli_app, ["tool", "read-note", title, "--frontmatter", *flags])
+    assert result.exit_code == 1, result.output
+    assert f"Note not found: {title}" in result.stderr
+    if mode in {"piped", "json"}:
+        payload = json.loads(result.stdout)
+        assert payload["error"] == "NOTE_NOT_FOUND"
+        assert payload["content"] is None
+        if related:
+            assert payload["related_results"][0]["title"] == "Alternative"
+    else:
+        assert "Note not found" in result.stdout
+        if related:
+            assert "Alternative" in result.stdout
 
 
 def test_write_note_missing_content(app, app_config, test_project, config_manager):

--- a/test-int/cli/test_cli_tool_json_failure_integration.py
+++ b/test-int/cli/test_cli_tool_json_failure_integration.py
@@ -14,17 +14,20 @@ from basic_memory.cli.main import app as cli_app
 runner = CliRunner()
 
 
-def test_read_note_not_found(app, app_config, test_project, config_manager):
+@pytest.mark.parametrize(
+    "identifier", ["nonexistent-note-that-does-not-exist", "22222222-2222-4222-8222-222222222222"]
+)
+def test_read_note_not_found(app, app_config, test_project, config_manager, identifier):
     """A missing note remains machine-readable but must not report success."""
     result = runner.invoke(
         cli_app,
-        ["tool", "read-note", "nonexistent-note-that-does-not-exist"],
+        ["tool", "read-note", identifier],
     )
 
     assert result.exit_code == 1
     data = json.loads(result.stdout)
     assert data["error"] == "NOTE_NOT_FOUND"
-    assert data["message"] == "Note not found: nonexistent-note-that-does-not-exist"
+    assert data["message"] == f"Note not found: {identifier}"
     assert "Note not found" in result.stderr
     assert data["title"] is None
     assert data["permalink"] is None

--- a/test-int/mcp/test_read_note_missing_identifier_integration.py
+++ b/test-int/mcp/test_read_note_missing_identifier_integration.py
@@ -1,0 +1,50 @@
+"""Missing identifiers remain distinct from entities that cannot supply Markdown."""
+
+from datetime import UTC, datetime
+
+import pytest
+from fastmcp import Client
+
+from basic_memory import db
+from basic_memory.models import Entity
+from basic_memory.repository.entity_repository import EntityRepository
+
+
+@pytest.mark.asyncio
+async def test_binary_uuid_line_read_reports_content_error(
+    mcp_server, app, test_project, engine_factory
+) -> None:
+    _, session_maker = engine_factory
+    entity_repository = EntityRepository(project_id=test_project.id)
+    entity = Entity(
+        title="legacy.txt",
+        note_type="file",
+        content_type="text/plain",
+        file_path="legacy/legacy.txt",
+        checksum="seeded",
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    async with db.scoped_session(session_maker) as session:
+        entity = await entity_repository.add(session, entity)
+
+    async with Client(mcp_server) as client:
+        result = await client.call_tool(
+            "read_note",
+            {
+                "identifier": entity.external_id,
+                "project": test_project.name,
+                "output_format": "json",
+                "start_line": 1,
+                "end_line": 10,
+            },
+            raise_on_error=False,
+        )
+
+    assert result.is_error
+    block = result.content[0]
+    assert block.type == "text"
+    assert "no markdown content to slice" in block.text
+    assert "NOTE_NOT_FOUND" not in block.text
+    async with db.scoped_session(session_maker) as session:
+        assert await entity_repository.get_by_external_id(session, entity.external_id) is not None

--- a/tests/mcp/test_line_scanning.py
+++ b/tests/mcp/test_line_scanning.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 from fastmcp.exceptions import ToolError
+from httpx import HTTPStatusError, Request, Response
 
 from basic_memory.mcp.clients import KnowledgeClient, SearchClient
 from basic_memory.mcp.tools import cat, grep, read_note, write_note
@@ -136,7 +137,10 @@ async def test_exact_title_fallback_keeps_line_scan(client, test_project, monkey
     )
 
     async def refuse_resolve(*args: object, **kwargs: object) -> str:
-        raise ToolError("force title search")
+        request = Request("POST", "http://test/knowledge/resolve")
+        raise ToolError("force title search") from HTTPStatusError(
+            "Not found", request=request, response=Response(404, request=request)
+        )
 
     monkeypatch.setattr(KnowledgeClient, "resolve_entity", refuse_resolve)
     result = await read_note("Exact Fallback", end_line=1, project=test_project.name)

--- a/tests/mcp/test_read_note_request_counts.py
+++ b/tests/mcp/test_read_note_request_counts.py
@@ -155,8 +155,10 @@ async def test_permalink_json_resolves_once_then_reads_entity_once(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("fetch_fails", [False, True])
 async def test_exact_title_json_uses_search_result_external_id_without_second_resolve(
     monkeypatch: pytest.MonkeyPatch,
+    fetch_fails: bool,
 ) -> None:
     import importlib
 
@@ -178,6 +180,8 @@ async def test_exact_title_json_uses_search_result_external_id_without_second_re
         async def get_entity(self, entity_id: str) -> EntityResponseV2:
             calls["entity"] += 1
             assert entity_id == ENTITY_ID
+            if fetch_fails:
+                raise RuntimeError("entity fetch unavailable")
             return _entity()
 
     class RecordingResourceClient:
@@ -206,6 +210,12 @@ async def test_exact_title_json_uses_search_result_external_id_without_second_re
     monkeypatch.setattr(clients_module, "KnowledgeClient", RecordingKnowledgeClient)
     monkeypatch.setattr(clients_module, "ResourceClient", RecordingResourceClient)
     monkeypatch.setattr(read_note_module, "search_notes", fake_search_notes)
+
+    if fetch_fails:
+        with pytest.raises(RuntimeError, match="entity fetch unavailable"):
+            await read_note_module.read_note("Request Count", project="main", output_format="json")
+        assert calls == {"resolve": 1, "entity": 1, "resource": 0}
+        return
 
     result = await read_note_module.read_note(
         "Request Count",

--- a/tests/mcp/test_read_note_request_counts.py
+++ b/tests/mcp/test_read_note_request_counts.py
@@ -472,3 +472,36 @@ async def test_uuid_resource_404_is_a_read_error_not_a_missing_entity(
     with pytest.raises(ToolError) as raised:
         await read_note_module.read_note(ENTITY_ID, project="main", output_format="json")
     assert raised.value is error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("confirmation_status", [None, 503])
+async def test_failed_unsliced_confirmation_does_not_report_missing(
+    monkeypatch: pytest.MonkeyPatch, confirmation_status: int | None
+) -> None:
+    import importlib
+
+    read_note_module = importlib.import_module("basic_memory.mcp.tools.read_note")
+    clients_module = importlib.import_module("basic_memory.mcp.clients")
+    _patch_project_routing(monkeypatch, read_note_module)
+    request = Request("GET", f"http://test/v2/projects/{PROJECT_ID}/knowledge/entities/{ENTITY_ID}")
+    slice_error = ToolError("No Markdown content to slice")
+    slice_error.__cause__ = HTTPStatusError(
+        "No Markdown content to slice", request=request, response=Response(404, request=request)
+    )
+    confirmation_error = ToolError("Confirmation unavailable")
+    if confirmation_status is None:
+        confirmation_error.__cause__ = ReadTimeout("Timed out", request=request)
+    else:
+        confirmation_error.__cause__ = HTTPStatusError(
+            "Unavailable", request=request, response=Response(confirmation_status, request=request)
+        )
+    get_entity = AsyncMock(side_effect=[slice_error, confirmation_error])
+    monkeypatch.setattr(clients_module.KnowledgeClient, "get_entity", get_entity)
+
+    with pytest.raises(ToolError) as raised:
+        await read_note_module.read_note(
+            ENTITY_ID, project="main", output_format="json", start_line=1
+        )
+    assert raised.value is confirmation_error
+    assert get_entity.await_count == 2

--- a/tests/mcp/test_read_note_request_counts.py
+++ b/tests/mcp/test_read_note_request_counts.py
@@ -7,13 +7,22 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from httpx import Response
+from fastmcp.exceptions import ToolError
+from httpx import HTTPStatusError, ReadTimeout, Request, Response
 
 from basic_memory.mcp.note_reads import read_note_json_by_external_id
 from basic_memory.schemas.v2 import EntityResponseV2
 
 PROJECT_ID = "11111111-1111-4111-8111-111111111111"
 ENTITY_ID = "22222222-2222-4222-8222-222222222222"
+
+
+def lookup_miss() -> ToolError:
+    request = Request("POST", "http://test/knowledge/resolve")
+    response = Response(404, request=request)
+    error = ToolError("Note not found")
+    error.__cause__ = HTTPStatusError("Note not found", request=request, response=response)
+    return error
 
 
 def _entity(
@@ -176,7 +185,7 @@ async def test_exact_title_json_uses_search_result_external_id_without_second_re
             calls["resolve"] += 1
             assert identifier == "Request Count"
             assert strict is True
-            raise RuntimeError("force exact-title fallback")
+            raise lookup_miss()
 
         async def get_entity(self, entity_id: str) -> EntityResponseV2:
             calls["entity"] += 1
@@ -398,7 +407,7 @@ async def test_fallback_search_failure_is_not_reported_as_missing(
     monkeypatch.setattr(
         clients_module.KnowledgeClient,
         "resolve_entity",
-        AsyncMock(side_effect=RuntimeError("force search fallback")),
+        AsyncMock(side_effect=lookup_miss()),
     )
 
     async def search_result(*, search_type: str, **_kwargs: object) -> dict[str, object] | str:
@@ -409,3 +418,57 @@ async def test_fallback_search_failure_is_not_reported_as_missing(
     monkeypatch.setattr(read_note_module, "search_notes", search_result)
     with pytest.raises(RuntimeError, match="Search service unavailable"):
         await read_note_module.read_note("Unknown Note", project="main", output_format="json")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [None, 403, 429, 503])
+@pytest.mark.parametrize("identifier", ["Note Title", ENTITY_ID])
+async def test_operational_lookup_errors_propagate_without_search(
+    monkeypatch: pytest.MonkeyPatch, status_code: int | None, identifier: str
+) -> None:
+    import importlib
+
+    read_note_module = importlib.import_module("basic_memory.mcp.tools.read_note")
+    clients_module = importlib.import_module("basic_memory.mcp.clients")
+    _patch_project_routing(monkeypatch, read_note_module)
+    request = Request("GET", f"http://test/v2/projects/{PROJECT_ID}/knowledge/entities/{ENTITY_ID}")
+    error = ToolError("Service request failed")
+    if status_code is None:
+        error.__cause__ = ReadTimeout("Timed out", request=request)
+    else:
+        response = Response(status_code, request=request)
+        error.__cause__ = HTTPStatusError(
+            "Service request failed", request=request, response=response
+        )
+    method = "get_entity" if identifier == ENTITY_ID else "resolve_entity"
+    monkeypatch.setattr(clients_module.KnowledgeClient, method, AsyncMock(side_effect=error))
+    search = AsyncMock(return_value={"results": []})
+    monkeypatch.setattr(read_note_module, "search_notes", search)
+
+    with pytest.raises(ToolError) as raised:
+        await read_note_module.read_note(identifier, project="main", output_format="json")
+    assert raised.value is error
+    search.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_uuid_resource_404_is_a_read_error_not_a_missing_entity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib
+
+    read_note_module = importlib.import_module("basic_memory.mcp.tools.read_note")
+    clients_module = importlib.import_module("basic_memory.mcp.clients")
+    _patch_project_routing(monkeypatch, read_note_module)
+    monkeypatch.setattr(
+        clients_module.KnowledgeClient, "get_entity", AsyncMock(return_value=_entity(content=None))
+    )
+    request = Request("GET", f"http://test/v2/projects/{PROJECT_ID}/resource/{ENTITY_ID}")
+    response = Response(404, request=request)
+    error = ToolError("Content unavailable")
+    error.__cause__ = HTTPStatusError("Content unavailable", request=request, response=response)
+    monkeypatch.setattr(clients_module.ResourceClient, "read", AsyncMock(side_effect=error))
+
+    with pytest.raises(ToolError) as raised:
+        await read_note_module.read_note(ENTITY_ID, project="main", output_format="json")
+    assert raised.value is error

--- a/tests/mcp/test_read_note_request_counts.py
+++ b/tests/mcp/test_read_note_request_counts.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from httpx import Response
@@ -382,3 +383,29 @@ async def test_exact_id_helper_does_not_fabricate_frontmatter_from_entity_metada
 
     assert result["content"] == "plain body\n"
     assert result["frontmatter"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failed_search", ["title", "text"])
+async def test_fallback_search_failure_is_not_reported_as_missing(
+    monkeypatch: pytest.MonkeyPatch, failed_search: str
+) -> None:
+    import importlib
+
+    read_note_module = importlib.import_module("basic_memory.mcp.tools.read_note")
+    clients_module = importlib.import_module("basic_memory.mcp.clients")
+    _patch_project_routing(monkeypatch, read_note_module)
+    monkeypatch.setattr(
+        clients_module.KnowledgeClient,
+        "resolve_entity",
+        AsyncMock(side_effect=RuntimeError("force search fallback")),
+    )
+
+    async def search_result(*, search_type: str, **_kwargs: object) -> dict[str, object] | str:
+        if search_type == failed_search:
+            return "Search service unavailable; retry later"
+        return {"results": [], "has_more": False}
+
+    monkeypatch.setattr(read_note_module, "search_notes", search_result)
+    with pytest.raises(RuntimeError, match="Search service unavailable"):
+        await read_note_module.read_note("Unknown Note", project="main", output_format="json")

--- a/tests/mcp/test_tool_read_note.py
+++ b/tests/mcp/test_tool_read_note.py
@@ -5,12 +5,22 @@ from types import SimpleNamespace
 from textwrap import dedent
 
 import pytest
+from fastmcp.exceptions import ToolError
+from httpx import HTTPStatusError, Request, Response
 
 from basic_memory import db
 from basic_memory.mcp.tools import write_note, read_note
 from basic_memory.mcp.tools.read_note import _parse_opening_frontmatter
 from tests.mcp.conftest import ContextState, ctx
 from typing import override
+
+
+def lookup_miss() -> ToolError:
+    request = Request("POST", "http://test/knowledge/resolve")
+    response = Response(404, request=request)
+    error = ToolError("Note not found")
+    error.__cause__ = HTTPStatusError("Note not found", request=request, response=response)
+    return error
 
 
 def test_parse_opening_frontmatter_handles_crlf():
@@ -61,7 +71,7 @@ async def test_read_note_title_search_fallback_fetches_by_permalink(monkeypatch,
         async def resolve_entity(self, identifier: str, *, strict: bool = False) -> str:
             # Fail on the direct identifier to force fallback to title search
             if identifier == direct_identifier:
-                raise RuntimeError("force direct lookup failure")
+                raise lookup_miss()
             return await super().resolve_entity(identifier, strict=strict)
 
     monkeypatch.setattr(clients_mod, "KnowledgeClient", SelectiveKnowledgeClient)
@@ -112,7 +122,7 @@ async def test_read_note_returns_related_results_when_text_search_finds_matches(
     class FailingKnowledgeClient(OriginalKnowledgeClient):
         @override
         async def resolve_entity(self, identifier: str, *, strict: bool = False) -> str:
-            raise RuntimeError("force fallback")
+            raise lookup_miss()
 
     monkeypatch.setattr(clients_mod, "KnowledgeClient", FailingKnowledgeClient)
     monkeypatch.setattr(read_note_module, "search_notes", fake_search_notes_fn)
@@ -173,7 +183,7 @@ async def test_read_note_forwards_pagination_to_fallback_search(monkeypatch, app
     class FailingKnowledgeClient(OriginalKnowledgeClient):
         @override
         async def resolve_entity(self, identifier: str, *, strict: bool = False) -> str:
-            raise RuntimeError("force fallback")
+            raise lookup_miss()
 
     monkeypatch.setattr(clients_mod, "KnowledgeClient", FailingKnowledgeClient)
     monkeypatch.setattr(read_note_module, "search_notes", fake_search_notes_fn)
@@ -216,7 +226,7 @@ async def test_read_note_title_fallback_finds_exact_match_on_later_page(
         async def resolve_entity(self, identifier: str, *, strict: bool = False) -> str:
             # Fail on the direct identifier to force fallback to title search
             if identifier == direct_identifier:
-                raise RuntimeError("force direct lookup failure")
+                raise lookup_miss()
             return await super().resolve_entity(identifier, strict=strict)
 
     monkeypatch.setattr(clients_mod, "KnowledgeClient", SelectiveKnowledgeClient)
@@ -261,7 +271,7 @@ async def test_read_note_title_fallback_finds_exact_match_with_small_page_size(
         async def resolve_entity(self, identifier: str, *, strict: bool = False) -> str:
             # Fail on the direct identifier to force fallback to title search
             if identifier == direct_identifier:
-                raise RuntimeError("force direct lookup failure")
+                raise lookup_miss()
             return await super().resolve_entity(identifier, strict=strict)
 
     monkeypatch.setattr(clients_mod, "KnowledgeClient", SelectiveKnowledgeClient)
@@ -325,7 +335,7 @@ async def test_read_note_title_fallback_pages_past_higher_ranked_fuzzy_titles(
         async def resolve_entity(self, identifier: str, *, strict: bool = False) -> str:
             # Fail on the direct identifier to force fallback to title search
             if identifier == direct_identifier:
-                raise RuntimeError("force direct lookup failure")
+                raise lookup_miss()
             return await super().resolve_entity(identifier, strict=strict)
 
     monkeypatch.setattr(clients_mod, "KnowledgeClient", SelectiveKnowledgeClient)
@@ -371,7 +381,7 @@ async def test_read_note_title_lookup_stops_at_page_cap(monkeypatch, app, test_p
     class FailingKnowledgeClient(OriginalKnowledgeClient):
         @override
         async def resolve_entity(self, identifier: str, *, strict: bool = False) -> str:
-            raise RuntimeError("force fallback")
+            raise lookup_miss()
 
     monkeypatch.setattr(clients_mod, "KnowledgeClient", FailingKnowledgeClient)
     monkeypatch.setattr(read_note_module, "search_notes", fake_search_notes_fn)
@@ -412,7 +422,7 @@ async def test_read_note_related_results_list_full_search_page(monkeypatch, app,
     class FailingKnowledgeClient(OriginalKnowledgeClient):
         @override
         async def resolve_entity(self, identifier: str, *, strict: bool = False) -> str:
-            raise RuntimeError("force fallback")
+            raise lookup_miss()
 
     monkeypatch.setattr(clients_mod, "KnowledgeClient", FailingKnowledgeClient)
     monkeypatch.setattr(read_note_module, "search_notes", fake_search_notes_fn)
@@ -449,7 +459,7 @@ async def test_read_note_title_fallback_requires_exact_title_match(monkeypatch, 
         @override
         async def resolve_entity(self, identifier: str, *, strict: bool = False) -> str:
             if strict:
-                raise RuntimeError("force strict direct lookup failure")
+                raise lookup_miss()
             return await super().resolve_entity(identifier, strict=strict)
 
     async def fake_search_notes_fn(*, query, search_type, **kwargs):
@@ -962,7 +972,7 @@ async def test_read_note_memory_url_fallback_uses_search_tool_normalization(
         @override
         async def resolve_entity(self, identifier: str, *, strict: bool = False) -> str:
             if strict and identifier.endswith("test/memory-url-fallback-note"):
-                raise RuntimeError("force direct lookup failure")
+                raise lookup_miss()
             return await super().resolve_entity(identifier, strict=strict)
 
     async def fake_search_notes_fn(*, query, search_type, project, **kwargs):
@@ -1318,3 +1328,15 @@ class TestReadNoteSecurityEdgeCases:
             if ".." in attack_identifier.strip() or "~" in attack_identifier.strip():
                 assert "# Error" in result
                 assert "paths must stay within project boundaries" in result
+
+
+@pytest.mark.asyncio
+async def test_missing_uuid_line_scan_returns_not_found_guidance(app, test_project) -> None:
+    result = await read_note(
+        "22222222-2222-4222-8222-222222222222",
+        project=test_project.name,
+        start_line=1,
+        end_line=10,
+    )
+    assert isinstance(result, str)
+    assert "Note Not Found" in result


### PR DESCRIPTION
## Why

A read after deleting a note returned null fields and exit status 0, so scripts and agents could not distinguish a missing note from success.

## What Changed

Unresolved JSON reads now include `error: "NOTE_NOT_FOUND"` and an identifier-specific message. The CLI exits 1 in JSON, piped, plain, and Rich modes while retaining related-note suggestions. Missing UUIDs receive the same structured result. Successful reads and ordinary MCP text guidance retain their behavior.

## Implementation Details

Only confirmed resolution misses enter title/text fallback. Authorization, timeout, retrieval, and fallback-search failures propagate instead of being classified as absence. A resource 404 behind an existing entity remains a read error. Because a sliced entity GET also returns 404 for an existing non-Markdown entity, that error path confirms absence with an unsliced GET; successful UUID line reads still use one request.

The CLI renders the not-found result in the requested mode before signaling failure, including when `--frontmatter` is requested. The manual documents the contract.

## Testing

- `uv run pytest tests/mcp/test_read_note_request_counts.py tests/mcp/test_tool_read_note.py tests/mcp/test_line_scanning.py test-int/cli/test_cli_tool_json_failure_integration.py test-int/mcp/test_line_scanning_integration.py test-int/mcp/test_read_note_missing_identifier_integration.py -q --no-cov`: 98 passed.
- `BASIC_MEMORY_TEST_POSTGRES=1 uv run pytest test-int/cli/test_cli_tool_json_failure_integration.py test-int/mcp/test_read_note_missing_identifier_integration.py -q --no-cov`: 14 passed.
- `uv run pytest tests/test_man_pages.py -q --no-cov`: 39 passed.
- `just fast-check` and `just doctor`: passed.
- Tests cover actual write/delete/read operations in four output modes, missing UUIDs, related suggestions, failed resolution/search/content reads, and a real MCP/API read of an unsliceable entity.

## Risks / Follow-ups

Scripts that treated missing notes as successful reads now receive exit status 1. JSON retains the existing null fields and adds error/message fields. A failed UUID line read may make one additional request to distinguish a missing entity from missing Markdown content.

Closes #1495.
