### PR TITLE
perf(core): avoid hashing files before the first index

### DIFF
--- a/src/basic_memory/index/local_project.py
+++ b/src/basic_memory/index/local_project.py
@@ -317,6 +317,12 @@ class LocalProjectIndexObservedFileSource(ProjectIndexObservedFileSource):
             if self.indexed_stat_source is not None
             else {}
         )
+        # With a confirmed empty index, every discovered path is new. Hashes
+        # cannot identify changes or moves yet; the batch reader computes them
+        # when indexing content. Status can therefore count files without reads.
+        if self.indexed_stat_source is not None and not indexed_stats:
+            return tuple(RuntimeObservedIndexFile(path=path) for path in file_paths)
+
         observed_files: list[RuntimeObservedIndexFile] = []
         for file_path in file_paths:
             try:

--- a/src/basic_memory/index/local_project.py
+++ b/src/basic_memory/index/local_project.py
@@ -317,18 +317,15 @@ class LocalProjectIndexObservedFileSource(ProjectIndexObservedFileSource):
             if self.indexed_stat_source is not None
             else {}
         )
-        # With a confirmed empty index, every discovered path is new. Hashes
-        # cannot identify changes or moves yet; the batch reader computes them
-        # when indexing content. Status can therefore count files without reads.
-        if self.indexed_stat_source is not None and not indexed_stats:
-            return tuple(RuntimeObservedIndexFile(path=path) for path in file_paths)
-
         observed_files: list[RuntimeObservedIndexFile] = []
         for file_path in file_paths:
             try:
                 metadata = await self.file_service.get_file_metadata(file_path)
                 checksum = self._reuse_indexed_checksum(file_path, metadata, indexed_stats)
-                if checksum is None:
+                # A confirmed empty index has no changed or moved files to
+                # compare. Keep stat metadata, but let the batch reader hash
+                # new content when indexing rather than during status.
+                if checksum is None and (self.indexed_stat_source is None or indexed_stats):
                     checksum = await self.file_service.compute_checksum(file_path)
             except (OSError, FileError, FileOperationError) as exc:
                 # Trigger: a path the walk just listed fails stat/checksum

--- a/test-int/cli/test_status_wait_integration.py
+++ b/test-int/cli/test_status_wait_integration.py
@@ -67,6 +67,6 @@ def test_unindexed_status_counts_files_without_hashing(
     files = next(stage for stage in data["readiness"]["stages"] if stage["name"] == "files")
     assert files["pending"] == files["total"] == 2
     assert {item["path"]: item["size"] for item in data["observed_files"]} == {
-        "notes/new.md": len(b"# New\n"),
-        "asset.txt": len(b"unindexed asset"),
+        "notes/new.md": (root / "notes" / "new.md").stat().st_size,
+        "asset.txt": (root / "asset.txt").stat().st_size,
     }

--- a/test-int/cli/test_status_wait_integration.py
+++ b/test-int/cli/test_status_wait_integration.py
@@ -35,3 +35,34 @@ def test_status_wait_returns_once_indexed(app, app_config, test_project, config_
     data = json.loads(result.output[start:])
     assert data["total_files"] == 1
     assert data["observed_files"][0]["path"] == "test-notes/Wait Test Note.md"
+
+
+def test_unindexed_status_counts_files_without_hashing(
+    app, app_config, test_project, config_manager, monkeypatch
+) -> None:
+    """First status walks eligible paths without reading their contents."""
+    from pathlib import Path
+
+    from basic_memory.services import FileService
+
+    root = Path(test_project.path)
+    (root / "notes").mkdir()
+    (root / "notes" / "new.md").write_text("# New\n", encoding="utf-8")
+    (root / "asset.txt").write_text("unindexed asset", encoding="utf-8")
+    (root / ".hidden.md").write_text("hidden", encoding="utf-8")
+
+    async def unexpected_checksum(self: FileService, path: str) -> str:
+        raise AssertionError(f"Unindexed status must not hash {path}")
+
+    monkeypatch.setattr(FileService, "compute_checksum", unexpected_checksum)
+    result = runner.invoke(cli_app, ["status", "--json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert data["total_files"] == 2
+    assert {item["path"] for item in data["observed_files"]} == {"notes/new.md", "asset.txt"}
+    assert all(item["checksum"] is None for item in data["observed_files"])
+    assert data["readiness"]["phase"] == "never_indexed"
+    assert data["readiness"]["indexed_entities"] == 0
+    files = next(stage for stage in data["readiness"]["stages"] if stage["name"] == "files")
+    assert files["pending"] == files["total"] == 2

--- a/test-int/cli/test_status_wait_integration.py
+++ b/test-int/cli/test_status_wait_integration.py
@@ -66,3 +66,7 @@ def test_unindexed_status_counts_files_without_hashing(
     assert data["readiness"]["indexed_entities"] == 0
     files = next(stage for stage in data["readiness"]["stages"] if stage["name"] == "files")
     assert files["pending"] == files["total"] == 2
+    assert {item["path"]: item["size"] for item in data["observed_files"]} == {
+        "notes/new.md": len(b"# New\n"),
+        "asset.txt": len(b"unindexed asset"),
+    }


### PR DESCRIPTION
## Why

The first `bm status` on a project with no indexed rows read every file to compute checksums, even though every discovered path was already known to be unindexed.

## What Changed

An observation backed by a confirmed empty index now returns the eligible file paths without reading file contents. Status still reports the file count, `never_indexed`, and all files pending.

## Implementation Details

The local observed-file source reuses its existing indexed-stat query to identify the empty-index case. A source without database evidence continues hashing. Projects with indexed rows retain stat-based checksum reuse, changed-file hashing, and move detection. The indexing batch reader computes checksums when it reads new files, so this also avoids redundant reads before a first index pass.

## Testing

- After preserving file-size metadata: `uv run pytest test-int/cli/test_status_wait_integration.py tests/index/test_local_project_index.py tests/index/test_local_project_scan_parity.py tests/api/v2/test_project_router.py -q --no-cov`: 86 passed; `just fast-check`: passed.

- `uv run pytest test-int/cli/test_status_wait_integration.py tests/index/test_local_project_index.py tests/index/test_local_project_scan_parity.py -q --no-cov`: 54 passed.
- `uv run pytest test-int/cli/test_status_wait_integration.py -q --no-cov`: 2 passed, including readiness assertions.
- `BASIC_MEMORY_TEST_POSTGRES=1 uv run pytest test-int/cli/test_status_wait_integration.py tests/index/test_local_project_index.py -q --no-cov`: 46 passed.
- `just fast-check` and `just doctor`: passed.
- The CLI regression makes any checksum call fail and verifies the actual status response, including hidden-file filtering.

## Risks / Follow-ups

An empty-index observation carries null checksums until indexing reads the content; file sizes remain available from stat metadata. The filesystem count remains a snapshot and converges on subsequent observations if files or indexed rows change concurrently.

Closes #1446.
