### PR TITLE
docs(plugins): diagnose Codex Desktop WSL hook prerequisites

### DIFF
--- a/plugins/codex/README.md
+++ b/plugins/codex/README.md
@@ -95,8 +95,53 @@ ref. All refs are updated together with
   - Windows: `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"`
 
 Disclosure: uv installs the pinned Basic Memory Git ref on first run and reuses
-its cache afterward. Every failure path exits 0 — the hooks never disrupt a
-session.
+its cache afterward. The Python hook scripts exit 0 on failure so they do not
+disrupt a session. If the host cannot find `uv`, those scripts never start; a
+successful interactive-shell probe does not prove that Desktop can launch them.
+
+## Troubleshooting Desktop hooks on WSL
+
+`uv` must be available on the **hook process's PATH**, not just installed in the
+WSL distribution. Codex Desktop can launch hooks with a different PATH from
+`codex-tui` or an interactive terminal. In [#1499](https://github.com/basicmachines-co/basic-memory/issues/1499),
+the documented installer put uv at `~/.local/bin/uv`, but Desktop's hook PATH
+included `/usr/local/bin` and omitted `~/.local/bin`.
+
+First check the installation inside the WSL distribution used by the project:
+
+```bash
+command -v uv
+"$HOME/.local/bin/uv" --version
+```
+
+These commands establish shell visibility and the default installer location.
+To diagnose Desktop, inspect the failing hook's output and actual PATH. A
+`uv: command not found` launcher error means Basic Memory's Python hook never
+ran. Compare the manifest command with an absolute-path invocation of uv using
+the same hook payload and environment. Empty output or exit status 0 alone is
+not proof of successful context loading.
+
+For the confirmed WSL case where uv exists at `~/.local/bin/uv` and Desktop
+includes `/usr/local/bin`, the reporter recovered by adding a symlink:
+
+```bash
+sudo ln -s "$HOME/.local/bin/uv" /usr/local/bin/uv
+```
+
+Do not replace an existing `/usr/local/bin/uv`; inspect it first if `ln` reports
+that it exists. If uv is installed elsewhere, use its verified absolute path.
+This is a WSL/Linux workaround, not a native Windows installation command.
+
+Fully quit and restart Codex Desktop, then create a new task in the WSL project.
+Verify both outcomes:
+
+1. Startup includes Basic Memory session context, with the hooks enabled and trusted.
+2. After compaction, the resumed turn receives the `bm-checkpoint` instruction
+   and creates an actual checkpoint note with `trigger: compact` in the configured
+   project. `checkpointOnCompact` must be enabled.
+
+A successful TUI run, a lifecycle inbox event, or a successful hook exit is not
+a substitute for these Desktop checks.
 
 ## Install
 

--- a/plugins/codex/skills/bm-status/SKILL.md
+++ b/plugins/codex/skills/bm-status/SKILL.md
@@ -39,7 +39,18 @@ Gather a concise diagnostic. Do not over-investigate.
    - treat the command's settings resolution as canonical for hook behavior; if
      it disagrees with the manually read config, show the mismatch
 
-4. Hook files:
+4. Hook files and launcher visibility:
+   - check `uv --version` in the current environment independently of CLI
+     reachability; uv is a required hook prerequisite
+   - distinguish "uv missing from this shell" from "Desktop hook runtime
+     verified"; shell success does not establish the Desktop hook process's PATH
+   - when Desktop/WSL hooks fail while TUI works, inspect the actual hook
+     launch error and PATH; `uv: command not found` occurs before the Python
+     script can emit a diagnostic
+   - consult `../../README.md` under "Troubleshooting Desktop hooks on WSL"
+     for the default-location probe and conditional symlink workaround
+   - only report Desktop hook execution as verified when startup context and a
+     post-compaction checkpoint note were observed; otherwise label it unverified
    - confirm `plugins/codex/hooks/hooks.json` exists if running from this repo
    - remind the user that Codex plugin hooks must be reviewed and trusted before
      they run
@@ -75,7 +86,8 @@ Basic Memory for Codex
 - Shared pending envelopes: <count or unavailable>
 - Shared archived envelopes: <count or unavailable>
 - Last flush: <timestamp, never, or unavailable>
-- Hook runtime: basic-memory <version>; uv <version or missing>
+- Hook runtime in this environment: basic-memory <version>; uv <version or missing>
+- Desktop hook execution: <verified from context and checkpoint | unverified>
 - Recent checkpoints: <count across coding_session and codex_session>
 - Active tasks: <count>
 - Open decisions: <count>


### PR DESCRIPTION
## Why

Codex Desktop on WSL may omit the documented uv install directory from its hook PATH. An interactive shell can run uv while Desktop never starts the Python hook.

## What Changed

Document the WSL diagnosis, the confirmed `/usr/local/bin` symlink workaround, restart steps, and the two observable success criteria: startup context and an authored post-compaction checkpoint. The status skill now distinguishes shell runtime visibility from verified Desktop hook execution.

## Implementation Details

The README explains that Python's fail-open behavior cannot cover failure to launch uv. The workaround is conditional on the actual install location and Desktop PATH and does not replace an existing executable. uv remains a prerequisite.

## Testing

- `just package-check-codex`: passed; optional external scaffold validator was not configured.
- `just package-check`: passed for all consolidated packages.

## Risks / Follow-ups

No launcher behavior changes. Actual Codex Desktop on WSL verification is still required; this environment is macOS. This documents the recovery path and improves diagnostic instructions without claiming the host-specific problem is fully fixed.

Refs #1499.
