### PR TITLE
fix(mcp): retry gateway rate limits

### DIFF
--- a/src/basic_memory/mcp/tools/utils.py
+++ b/src/basic_memory/mcp/tools/utils.py
@@ -256,7 +256,7 @@ def _parse_retry_after(response: Response) -> tuple[str, float] | None:
             len(normalized_delay) == len(max_wait_text) and normalized_delay > max_wait_text
         ):
             return raw_retry_after, float("inf")
-        return raw_retry_after, float(int(retry_after))
+        return raw_retry_after, float(int(normalized_delay))
 
     try:
         retry_at = parsedate_to_datetime(retry_after)

--- a/src/basic_memory/mcp/tools/utils.py
+++ b/src/basic_memory/mcp/tools/utils.py
@@ -4,7 +4,12 @@ These functions provide a consistent interface for making HTTP requests
 to the Basic Memory API, with improved error handling and logging.
 """
 
+import asyncio
+import random
 import typing
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Any, Optional
 
 import logfire
@@ -33,6 +38,13 @@ from loguru import logger
 from fastmcp.exceptions import ToolError
 
 from basic_memory.config import ConfigManager
+
+_RATE_LIMIT_MAX_ATTEMPTS = 3
+_RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS = 30.0
+_RATE_LIMIT_JITTER_MIN_SECONDS = 0.05
+_RATE_LIMIT_JITTER_MAX_SECONDS = 0.25
+
+type _RequestCall = Callable[[], Awaitable[Response]]
 
 
 def _classify_http_outcome(status_code: int) -> str:
@@ -225,6 +237,123 @@ def _resolve_error_message(
     return get_error_message(status_code, url, method)
 
 
+def _utc_now() -> datetime:
+    """Return the current UTC time for HTTP-date Retry-After values."""
+    return datetime.now(timezone.utc)
+
+
+def _parse_retry_after(response: Response) -> tuple[str, float] | None:
+    """Parse a Retry-After delay-seconds or HTTP-date header."""
+    raw_retry_after = response.headers.get("Retry-After")
+    if raw_retry_after is None:
+        return None
+
+    retry_after = raw_retry_after.strip()
+    if retry_after.isascii() and retry_after.isdigit():
+        normalized_delay = retry_after.lstrip("0") or "0"
+        max_wait_text = str(int(_RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS))
+        if len(normalized_delay) > len(max_wait_text) or (
+            len(normalized_delay) == len(max_wait_text) and normalized_delay > max_wait_text
+        ):
+            return raw_retry_after, float("inf")
+        return raw_retry_after, float(int(retry_after))
+
+    try:
+        retry_at = parsedate_to_datetime(retry_after)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+    if retry_at.tzinfo is None:
+        return None
+
+    delay_seconds = (retry_at.astimezone(timezone.utc) - _utc_now()).total_seconds()
+    return raw_retry_after, max(0.0, delay_seconds)
+
+
+def _request_body_is_replayable(
+    content: RequestContent | None,
+    files: RequestFiles | None,
+) -> bool:
+    """Return whether httpx can safely rebuild the request body for another attempt."""
+    return files is None and (content is None or isinstance(content, (str, bytes)))
+
+
+def _with_rate_limit_context(message: str, context: str) -> str:
+    """Preserve the server detail while adding actionable retry context."""
+    separator = "" if message.endswith((".", "!", "?")) else "."
+    return f"{message}{separator} {context}"
+
+
+async def _request_with_rate_limit_retry(
+    request: _RequestCall,
+    *,
+    method: str,
+    url: URL | str,
+    replayable: bool,
+) -> tuple[Response, str | None]:
+    """Retry Basic Memory gateway 429 responses within an explicit wait budget.
+
+    The gateway rejects rate-limited requests before application processing, so replayable
+    writes are safe to retry. This is a cumulative sleep budget, not an end-to-end request
+    deadline; each individual HTTP attempt retains the caller's configured timeout.
+    """
+    total_wait_seconds = 0.0
+
+    for attempt in range(1, _RATE_LIMIT_MAX_ATTEMPTS + 1):
+        response = await request()
+        if response.status_code != 429:
+            return response, None
+
+        response_data = _extract_response_data(response)
+        error_message = _resolve_error_message(429, url, method, response_data)
+        retry_boundary = _parse_retry_after(response)
+
+        if retry_boundary is None:
+            return response, _with_rate_limit_context(
+                error_message,
+                "Automatic retry skipped because Retry-After is missing or invalid.",
+            )
+
+        raw_retry_after, server_delay_seconds = retry_boundary
+        boundary_text = f"Server Retry-After: {raw_retry_after}."
+
+        if not replayable:
+            return response, _with_rate_limit_context(
+                error_message,
+                "Automatic retry skipped because the request body cannot be safely replayed. "
+                f"{boundary_text}",
+            )
+
+        if attempt == _RATE_LIMIT_MAX_ATTEMPTS:
+            return response, _with_rate_limit_context(
+                error_message,
+                f"Rate-limit retry exhausted after {attempt} attempts. {boundary_text}",
+            )
+
+        jitter_seconds = random.uniform(
+            _RATE_LIMIT_JITTER_MIN_SECONDS,
+            _RATE_LIMIT_JITTER_MAX_SECONDS,
+        )
+        wait_seconds = server_delay_seconds + jitter_seconds
+        if total_wait_seconds + wait_seconds > _RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS:
+            return response, _with_rate_limit_context(
+                error_message,
+                "Rate-limit retry wait budget exhausted before the next attempt "
+                f"(maximum cumulative wait {_RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS:g}s). "
+                f"{boundary_text}",
+            )
+
+        logger.warning(
+            f"Rate limit exceeded: {method} {url}; retrying in {wait_seconds:.3f}s "
+            f"(attempt {attempt + 1}/{_RATE_LIMIT_MAX_ATTEMPTS})"
+        )
+        await response.aclose()
+        await asyncio.sleep(wait_seconds)
+        total_wait_seconds += wait_seconds
+
+    raise AssertionError("rate-limit retry loop exhausted without returning")  # pragma: no cover
+
+
 async def call_get(
     client: AsyncClient,
     url: URL | str,
@@ -274,15 +403,20 @@ async def call_get(
             has_query=bool(params),
             has_body=False,
         ) as request_span:
-            response = await client.get(
-                url,
-                params=params,
-                headers=_request_headers(headers),
-                cookies=cookies,
-                auth=auth,
-                follow_redirects=follow_redirects,
-                timeout=timeout,
-                extensions=extensions,
+            response, rate_limit_error_message = await _request_with_rate_limit_retry(
+                lambda: client.get(
+                    url,
+                    params=params,
+                    headers=_request_headers(headers),
+                    cookies=cookies,
+                    auth=auth,
+                    follow_redirects=follow_redirects,
+                    timeout=timeout,
+                    extensions=extensions,
+                ),
+                method="GET",
+                url=url,
+                replayable=True,
             )
             request_span.set_attributes(_response_span_attrs(response))
 
@@ -292,7 +426,9 @@ async def call_get(
         # Handle different status codes differently
         status_code = response.status_code
         response_data = _extract_response_data(response)
-        error_message = _resolve_error_message(status_code, url, "GET", response_data)
+        error_message = rate_limit_error_message or _resolve_error_message(
+            status_code, url, "GET", response_data
+        )
 
         # Log at appropriate level based on status code
         if 400 <= status_code < 500:
@@ -379,19 +515,24 @@ async def call_put(
             has_query=bool(params),
             has_body=any(value is not None for value in (content, data, files, json)),
         ) as request_span:
-            response = await client.put(
-                url,
-                content=content,
-                data=data,
-                files=files,
-                json=json,
-                params=params,
-                headers=_request_headers(headers),
-                cookies=cookies,
-                auth=auth,
-                follow_redirects=follow_redirects,
-                timeout=timeout,
-                extensions=extensions,
+            response, rate_limit_error_message = await _request_with_rate_limit_retry(
+                lambda: client.put(
+                    url,
+                    content=content,
+                    data=data,
+                    files=files,
+                    json=json,
+                    params=params,
+                    headers=_request_headers(headers),
+                    cookies=cookies,
+                    auth=auth,
+                    follow_redirects=follow_redirects,
+                    timeout=timeout,
+                    extensions=extensions,
+                ),
+                method="PUT",
+                url=url,
+                replayable=_request_body_is_replayable(content, files),
             )
             request_span.set_attributes(_response_span_attrs(response))
 
@@ -402,7 +543,9 @@ async def call_put(
         status_code = response.status_code
 
         response_data = _extract_response_data(response)
-        error_message = _resolve_error_message(status_code, url, "PUT", response_data)
+        error_message = rate_limit_error_message or _resolve_error_message(
+            status_code, url, "PUT", response_data
+        )
 
         # Log at appropriate level based on status code
         if 400 <= status_code < 500:
@@ -475,6 +618,7 @@ async def call_patch(
         ToolError: If the request fails with an appropriate error message
     """
     logger.debug(f"Calling PATCH '{url}'")
+    error_message = None
     request_span: logfire.LogfireSpan | None = None
 
     try:
@@ -488,19 +632,24 @@ async def call_patch(
             has_query=bool(params),
             has_body=any(value is not None for value in (content, data, files, json)),
         ) as request_span:
-            response = await client.patch(
-                url,
-                content=content,
-                data=data,
-                files=files,
-                json=json,
-                params=params,
-                headers=_request_headers(headers),
-                cookies=cookies,
-                auth=auth,
-                follow_redirects=follow_redirects,
-                timeout=timeout,
-                extensions=extensions,
+            response, rate_limit_error_message = await _request_with_rate_limit_retry(
+                lambda: client.patch(
+                    url,
+                    content=content,
+                    data=data,
+                    files=files,
+                    json=json,
+                    params=params,
+                    headers=_request_headers(headers),
+                    cookies=cookies,
+                    auth=auth,
+                    follow_redirects=follow_redirects,
+                    timeout=timeout,
+                    extensions=extensions,
+                ),
+                method="PATCH",
+                url=url,
+                replayable=_request_body_is_replayable(content, files),
             )
             request_span.set_attributes(_response_span_attrs(response))
 
@@ -511,7 +660,9 @@ async def call_patch(
         status_code = response.status_code
 
         response_data = _extract_response_data(response)
-        error_message = _resolve_error_message(status_code, url, "PATCH", response_data)
+        error_message = rate_limit_error_message or _resolve_error_message(
+            status_code, url, "PATCH", response_data
+        )
 
         # Log at appropriate level based on status code
         if 400 <= status_code < 500:
@@ -529,10 +680,10 @@ async def call_patch(
         return response  # This line will never execute, but it satisfies the type checker  # pragma: no cover
 
     except HTTPStatusError as e:
-        status_code = e.response.status_code
-
-        response_data = _extract_response_data(e.response)
-        error_message = _resolve_error_message(status_code, url, "PATCH", response_data)
+        if error_message is None:
+            status_code = e.response.status_code
+            response_data = _extract_response_data(e.response)
+            error_message = _resolve_error_message(status_code, url, "PATCH", response_data)
 
         raise ToolError(error_message) from e
     except TransportError as e:
@@ -603,19 +754,24 @@ async def call_post(
             has_query=bool(params),
             has_body=any(value is not None for value in (content, data, files, json)),
         ) as request_span:
-            response = await client.post(
+            response, rate_limit_error_message = await _request_with_rate_limit_retry(
+                lambda: client.post(
+                    url=url,
+                    content=content,
+                    data=data,
+                    files=files,
+                    json=json,
+                    params=params,
+                    headers=_request_headers(headers),
+                    cookies=cookies,
+                    auth=auth,
+                    follow_redirects=follow_redirects,
+                    timeout=timeout,
+                    extensions=extensions,
+                ),
+                method="POST",
                 url=url,
-                content=content,
-                data=data,
-                files=files,
-                json=json,
-                params=params,
-                headers=_request_headers(headers),
-                cookies=cookies,
-                auth=auth,
-                follow_redirects=follow_redirects,
-                timeout=timeout,
-                extensions=extensions,
+                replayable=_request_body_is_replayable(content, files),
             )
             request_span.set_attributes(_response_span_attrs(response))
         logger.debug(f"response: {_extract_response_data(response)}")
@@ -626,7 +782,9 @@ async def call_post(
         # Handle different status codes differently
         status_code = response.status_code
         response_data = _extract_response_data(response)
-        error_message = _resolve_error_message(status_code, url, "POST", response_data)
+        error_message = rate_limit_error_message or _resolve_error_message(
+            status_code, url, "POST", response_data
+        )
 
         # Log at appropriate level based on status code
         if 400 <= status_code < 500:
@@ -691,20 +849,25 @@ async def call_query(
             has_query=bool(params),
             has_body=any(value is not None for value in (content, data, files, json)),
         ) as request_span:
-            response = await client.request(
-                "QUERY",
+            response, rate_limit_error_message = await _request_with_rate_limit_retry(
+                lambda: client.request(
+                    "QUERY",
+                    url=url,
+                    content=content,
+                    data=data,
+                    files=files,
+                    json=json,
+                    params=params,
+                    headers=_request_headers(headers),
+                    cookies=cookies,
+                    auth=auth,
+                    follow_redirects=follow_redirects,
+                    timeout=timeout,
+                    extensions=extensions,
+                ),
+                method="QUERY",
                 url=url,
-                content=content,
-                data=data,
-                files=files,
-                json=json,
-                params=params,
-                headers=_request_headers(headers),
-                cookies=cookies,
-                auth=auth,
-                follow_redirects=follow_redirects,
-                timeout=timeout,
-                extensions=extensions,
+                replayable=_request_body_is_replayable(content, files),
             )
             request_span.set_attributes(_response_span_attrs(response))
 
@@ -713,7 +876,9 @@ async def call_query(
 
         status_code = response.status_code
         response_data = _extract_response_data(response)
-        error_message = _resolve_error_message(status_code, url, "QUERY", response_data)
+        error_message = rate_limit_error_message or _resolve_error_message(
+            status_code, url, "QUERY", response_data
+        )
 
         if 400 <= status_code < 500:
             if status_code == 429:  # pragma: no cover
@@ -819,15 +984,20 @@ async def call_delete(
             has_query=bool(params),
             has_body=False,
         ) as request_span:
-            response = await client.delete(
+            response, rate_limit_error_message = await _request_with_rate_limit_retry(
+                lambda: client.delete(
+                    url=url,
+                    params=params,
+                    headers=_request_headers(headers),
+                    cookies=cookies,
+                    auth=auth,
+                    follow_redirects=follow_redirects,
+                    timeout=timeout,
+                    extensions=extensions,
+                ),
+                method="DELETE",
                 url=url,
-                params=params,
-                headers=_request_headers(headers),
-                cookies=cookies,
-                auth=auth,
-                follow_redirects=follow_redirects,
-                timeout=timeout,
-                extensions=extensions,
+                replayable=True,
             )
             request_span.set_attributes(_response_span_attrs(response))
 
@@ -837,7 +1007,9 @@ async def call_delete(
         # Handle different status codes differently
         status_code = response.status_code
         response_data = _extract_response_data(response)
-        error_message = _resolve_error_message(status_code, url, "DELETE", response_data)
+        error_message = rate_limit_error_message or _resolve_error_message(
+            status_code, url, "DELETE", response_data
+        )
 
         # Log at appropriate level based on status code
         if 400 <= status_code < 500:

--- a/tests/mcp/test_tool_utils_rate_limit.py
+++ b/tests/mcp/test_tool_utils_rate_limit.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from datetime import datetime, timezone
 from email.utils import format_datetime
 from io import BytesIO
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -32,6 +32,24 @@ _CALL_HELPERS: tuple[tuple[CallHelper, dict[str, Any]], ...] = (
     (call_query, {"json": {"value": "same request"}}),
     (call_delete, {}),
 )
+
+
+def test_utc_now_returns_the_current_aware_utc_time() -> None:
+    before = datetime.now(timezone.utc)
+    current = utils_module._utc_now()
+    after = datetime.now(timezone.utc)
+
+    assert current.tzinfo is timezone.utc
+    assert before <= current <= after
+
+
+def test_parse_retry_after_rejects_a_date_without_timezone() -> None:
+    response = httpx.Response(
+        429,
+        headers={"Retry-After": "Sun, 06 Nov 1994 08:49:37"},
+    )
+
+    assert utils_module._parse_retry_after(response) is None
 
 
 @pytest.mark.asyncio
@@ -357,6 +375,39 @@ async def test_call_post_does_not_retry_async_request_content() -> None:
     assert "quota detail" in str(exc.value)
     assert "request body cannot be safely replayed" in str(exc.value)
     assert "Server Retry-After: 1" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_call_patch_preserves_error_detail_from_a_response() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"detail": "patch detail"})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://cloud.invalid") as client:
+        with pytest.raises(ToolError, match="patch detail"):
+            await call_patch(client, "/v2/resource", json={"value": "replacement"})
+
+
+@pytest.mark.asyncio
+async def test_call_patch_rebuilds_detail_when_client_raises_status_error() -> None:
+    class DirectStatusErrorClient:
+        async def patch(self, *args: Any, **kwargs: Any) -> httpx.Response:
+            request = httpx.Request("PATCH", "https://cloud.invalid/v2/resource")
+            response = httpx.Response(
+                409,
+                request=request,
+                json={"detail": "direct patch detail"},
+            )
+            raise httpx.HTTPStatusError(
+                "conflict",
+                request=request,
+                response=response,
+            )
+
+    client = cast(httpx.AsyncClient, DirectStatusErrorClient())
+
+    with pytest.raises(ToolError, match="direct patch detail"):
+        await call_patch(client, "/v2/resource", json={"value": "replacement"})
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_tool_utils_rate_limit.py
+++ b/tests/mcp/test_tool_utils_rate_limit.py
@@ -237,6 +237,41 @@ async def test_call_get_does_not_truncate_retry_after_to_wait_budget(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("retry_after", "expected_delay"),
+    [("0" * 5000, 0.125), ("0" * 5000 + "1", 1.125)],
+)
+async def test_call_get_accepts_long_zero_padded_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+    retry_after: str,
+    expected_delay: float,
+) -> None:
+    calls = 0
+    sleep_delays: list[float] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(429, headers={"Retry-After": retry_after})
+        return httpx.Response(200)
+
+    async def record_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(random, "uniform", lambda _start, _end: 0.125)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://cloud.invalid") as client:
+        response = await call_get(client, "/v2/resource")
+
+    assert response.status_code == 200
+    assert calls == 2
+    assert sleep_delays == [expected_delay]
+
+
+@pytest.mark.asyncio
 async def test_call_get_limits_cumulative_retry_wait(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = 0
     sleep_delays: list[float] = []

--- a/tests/mcp/test_tool_utils_rate_limit.py
+++ b/tests/mcp/test_tool_utils_rate_limit.py
@@ -1,0 +1,353 @@
+"""Rate-limit retry coverage for the shared MCP HTTP helpers."""
+
+import asyncio
+import random
+from collections.abc import AsyncIterator, Awaitable, Callable
+from datetime import datetime, timezone
+from email.utils import format_datetime
+from io import BytesIO
+from typing import Any
+
+import httpx
+import pytest
+from fastmcp.exceptions import ToolError
+
+from basic_memory.mcp.tools import utils as utils_module
+from basic_memory.mcp.tools.utils import (
+    call_delete,
+    call_get,
+    call_patch,
+    call_post,
+    call_put,
+    call_query,
+)
+
+type CallHelper = Callable[..., Awaitable[httpx.Response]]
+
+_CALL_HELPERS: tuple[tuple[CallHelper, dict[str, Any]], ...] = (
+    (call_get, {}),
+    (call_put, {"json": {"value": "same request"}}),
+    (call_patch, {"json": {"value": "same request"}}),
+    (call_post, {"json": {"value": "same request"}}),
+    (call_query, {"json": {"value": "same request"}}),
+    (call_delete, {}),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("call_helper,request_kwargs", _CALL_HELPERS)
+async def test_call_helpers_retry_replayable_requests_after_rate_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    call_helper: CallHelper,
+    request_kwargs: dict[str, Any],
+) -> None:
+    """The Basic Memory gateway rejects 429 requests before processing them (#1378)."""
+    calls = 0
+    sleep_delays: list[float] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(
+                429,
+                headers={"Retry-After": "0"},
+                json={"detail": "gateway rate limit"},
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    async def record_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(random, "uniform", lambda _start, _end: 0.125)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://cloud.invalid") as client:
+        response = await call_helper(client, "/v2/resource", **request_kwargs)
+
+    assert response.json() == {"ok": True}
+    assert calls == 2
+    assert sleep_delays == [0.125]
+
+
+@pytest.mark.asyncio
+async def test_call_get_accepts_http_date_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+    sleep_delays: list[float] = []
+    now = datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc)
+    retry_at = datetime(2026, 9, 8, 12, 0, 2, tzinfo=timezone.utc)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(
+                429, headers={"Retry-After": format_datetime(retry_at, usegmt=True)}
+            )
+        return httpx.Response(200)
+
+    async def record_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(utils_module, "_utc_now", lambda: now)
+    monkeypatch.setattr(asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(random, "uniform", lambda _start, _end: 0.125)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://cloud.invalid") as client:
+        response = await call_get(client, "/v2/resource")
+
+    assert response.status_code == 200
+    assert calls == 2
+    assert sleep_delays == [2.125]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("retry_after", [None, "later", "-1", "1.5"])
+async def test_call_get_does_not_retry_without_valid_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+    retry_after: str | None,
+) -> None:
+    calls = 0
+    sleep_delays: list[float] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        headers = {"Retry-After": retry_after} if retry_after is not None else {}
+        return httpx.Response(429, headers=headers, json={"detail": "quota detail"})
+
+    async def record_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", record_sleep)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://cloud.invalid") as client:
+        with pytest.raises(ToolError) as exc:
+            await call_get(client, "/v2/resource")
+
+    assert calls == 1
+    assert sleep_delays == []
+    assert "quota detail" in str(exc.value)
+    assert "Retry-After is missing or invalid" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_call_get_stops_after_three_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+    sleep_delays: list[float] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            429,
+            headers={"Retry-After": "0"},
+            json={"detail": "quota detail"},
+        )
+
+    async def record_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(random, "uniform", lambda _start, _end: 0.125)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://cloud.invalid") as client:
+        with pytest.raises(ToolError) as exc:
+            await call_get(client, "/v2/resource")
+
+    assert calls == 3
+    assert sleep_delays == [0.125, 0.125]
+    assert "quota detail" in str(exc.value)
+    assert "exhausted after 3 attempts" in str(exc.value)
+    assert "Server Retry-After: 0" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_call_get_reports_the_final_rate_limit_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(
+                429,
+                headers={"Retry-After": "0"},
+                json={"detail": "first boundary"},
+            )
+        return httpx.Response(429, json={"detail": "final boundary"})
+
+    async def no_wait(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", no_wait)
+    monkeypatch.setattr(random, "uniform", lambda _start, _end: 0.125)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://cloud.invalid") as client:
+        with pytest.raises(ToolError) as exc:
+            await call_get(client, "/v2/resource")
+
+    assert calls == 2
+    assert "final boundary" in str(exc.value)
+    assert "first boundary" not in str(exc.value)
+    assert "Retry-After is missing or invalid" in str(exc.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("retry_after", ["31", "9" * 400, "9" * 5000])
+async def test_call_get_does_not_truncate_retry_after_to_wait_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    retry_after: str,
+) -> None:
+    calls = 0
+    sleep_delays: list[float] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            429,
+            headers={"Retry-After": retry_after},
+            json={"detail": "quota detail"},
+        )
+
+    async def record_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(random, "uniform", lambda _start, _end: 0.125)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://cloud.invalid") as client:
+        with pytest.raises(ToolError) as exc:
+            await call_get(client, "/v2/resource")
+
+    assert calls == 1
+    assert sleep_delays == []
+    assert "quota detail" in str(exc.value)
+    assert "maximum cumulative wait 30s" in str(exc.value)
+    assert f"Server Retry-After: {retry_after}" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_call_get_limits_cumulative_retry_wait(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+    sleep_delays: list[float] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            429,
+            headers={"Retry-After": "15"},
+            json={"detail": "quota detail"},
+        )
+
+    async def record_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(random, "uniform", lambda _start, _end: 0.125)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://cloud.invalid") as client:
+        with pytest.raises(ToolError) as exc:
+            await call_get(client, "/v2/resource")
+
+    assert calls == 2
+    assert sleep_delays == [15.125]
+    assert "maximum cumulative wait 30s" in str(exc.value)
+    assert "Server Retry-After: 15" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_call_get_does_not_retry_transport_failure_after_rate_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+    sleep_delays: list[float] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(429, headers={"Retry-After": "0"})
+        raise httpx.ConnectError("connection refused", request=request)
+
+    async def record_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(random, "uniform", lambda _start, _end: 0.125)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://cloud.invalid") as client:
+        with pytest.raises(ToolError, match="Connection failed.*connection refused"):
+            await call_get(client, "/v2/resource")
+
+    assert calls == 2
+    assert sleep_delays == [0.125]
+
+
+@pytest.mark.asyncio
+async def test_call_post_does_not_retry_async_request_content() -> None:
+    calls = 0
+
+    async def one_shot_content() -> AsyncIterator[bytes]:
+        yield b"payload"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        assert await request.aread() == b"payload"
+        return httpx.Response(
+            429,
+            headers={"Retry-After": "1"},
+            json={"detail": "quota detail"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://cloud.invalid") as client:
+        with pytest.raises(ToolError) as exc:
+            await call_post(client, "/v2/resource", content=one_shot_content())
+
+    assert calls == 1
+    assert "quota detail" in str(exc.value)
+    assert "request body cannot be safely replayed" in str(exc.value)
+    assert "Server Retry-After: 1" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_call_post_does_not_retry_file_uploads() -> None:
+    calls = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        assert b"payload" in await request.aread()
+        return httpx.Response(
+            429,
+            headers={"Retry-After": "1"},
+            json={"detail": "quota detail"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://cloud.invalid") as client:
+        with pytest.raises(ToolError) as exc:
+            await call_post(
+                client,
+                "/v2/resource",
+                files={"file": ("payload.txt", BytesIO(b"payload"))},
+            )
+
+    assert calls == 1
+    assert "quota detail" in str(exc.value)
+    assert "request body cannot be safely replayed" in str(exc.value)
+    assert "Server Retry-After: 1" in str(exc.value)


### PR DESCRIPTION
## Why

The shared MCP API helpers currently surface a gateway `429` immediately, even when the server
provides a valid `Retry-After` boundary and a later attempt would succeed. This exposes transient
Basic Memory gateway rate limits to every MCP operation instead of honoring the gateway's
pre-processing rejection contract.

## What Changed

- Route all six Basic Memory MCP HTTP wrappers (`GET`, `PUT`, `PATCH`, `POST`, `DELETE`, and
  `QUERY`) through one rate-limit retry helper.
- Honor valid `Retry-After` delay-seconds and HTTP-date values, with at most three total attempts,
  positive jitter, and a 30-second cumulative sleep budget.
- Retry writes only when their request bodies are replayable. Streaming content and file uploads
  remain one-shot.
- Preserve the final server detail and `Retry-After` boundary when retrying is skipped, exceeds
  the wait budget, or exhausts all attempts.

## Implementation Details

- Retries are limited to HTTP `429` responses with a valid standard `Retry-After` header; missing
  or malformed headers, transport failures, timeouts, and non-429 responses are not retried.
- The server delay is never shortened to fit the local budget. A next attempt is skipped when its
  server delay plus jitter would exceed the remaining 30-second cumulative sleep budget.
- Each completed 429 response is closed before sleeping. Cancellation continues to propagate,
  and each attempt retains the caller's existing HTTP timeout.
- Existing public wrapper signatures, request parameters and workspace headers, telemetry
  attributes, and ordinary error paths—including `PATCH`—are preserved.

## Testing

- `uv run pytest --no-cov -q tests/mcp/test_tool_utils_rate_limit.py` — **26 passed in 0.24s**
  on final HEAD `c004638a1d713be8517409fa8af6c19437942f84`.
- `COVERAGE_FILE=/home/admindawn/auto_pr/repros/basic-memory-1378/.coverage-focused-final/.coverage uv run coverage run --branch -m pytest -q tests/mcp/test_tool_utils.py tests/mcp/test_tool_utils_cloud_auth.py tests/mcp/test_tool_telemetry.py tests/mcp/test_tool_utils_rate_limit.py`
  — **65 passed in 12.41s**. A line/arc comparison against base
  `c50ed118809e0ffff5bfb2e65698f05913148ae2` found all **78/78 added executable lines** and
  **20/20 added branch arcs** covered; this is changed-code coverage, not whole-module coverage.
- `just check` — passed on final HEAD (`ruff check`, `ruff format`, and full `ty check`).
- `just doctor` — passed on production-equivalent HEAD `9cfee2136c33452e06d6b04e0f453d2dae23b895`;
  the final commit only adds tests.
- `TZ=UTC RAYON_NUM_THREADS=1 just test` on final HEAD:
  - SQLite unit: **7,223 passed, 49 skipped**.
  - SQLite integration: **552 passed, 15 skipped, 34 deselected**.
  - PostgreSQL unit: **7,204 passed, 68 skipped**.
  - PostgreSQL integration: **557 passed, 10 skipped, 34 deselected, 1,347 warnings in
    1,478.38s**. Its original pytest process continued after the 600-second outer wrapper had
    reported `error: recipe test-int-postgres failed with exit code 1`, and later produced this
    passing summary. All four pytest stages therefore have passing summaries, but the overall
    `just test` command itself exited unsuccessfully and is not reported green.
- FastMCP 4.0.3 compatibility was checked with an isolated overlay containing exactly the three
  packages changed by upstream #1506 (`fastmcp==4.0.3`, `fastmcp-slim==4.0.3`, and
  `uncalled-for==0.4.0`) over the existing locked environment:
  - Both scripts were run from the repository after setting the required overlay environment:

    ```bash
    export PYTHONPATH=/home/admindawn/auto_pr/repros/basic-memory-1378/fastmcp-4.0.3-compat-c004638/overlay:/home/admindawn/auto_pr/repos/basic-memory/src:/home/admindawn/auto_pr/repos/basic-memory/tests
    export BM1378_COMPAT_METADATA=/home/admindawn/auto_pr/repros/basic-memory-1378/fastmcp-4.0.3-compat-c004638/metadata
    export BM1378_COMPAT_OVERLAY=/home/admindawn/auto_pr/repros/basic-memory-1378/fastmcp-4.0.3-compat-c004638/overlay
    export TZ=UTC
    export RAYON_NUM_THREADS=1
    cd /home/admindawn/auto_pr/repos/basic-memory
    ```

  - `.venv/bin/python /home/admindawn/auto_pr/repros/basic-memory-1378/fastmcp-4.0.3-compat-c004638/run_focused_pytest.py`
    — **59 passed, 2 warnings in 0.23s** for the rate-limit and existing utils tests, with the
    overlay versions and loaded module paths asserted in-process.
  - `.venv/bin/python /home/admindawn/auto_pr/repros/basic-memory-1378/fastmcp-4.0.3-compat-c004638/compat_runtime_check.py`
    — in-process FastMCP calls made exactly three HTTP attempts for each of the default
    `ToolError` and `raise_on_error=False` paths, preserving the gateway detail and retry boundary.
  - This was a three-package overlay check, not a complete fresh environment or full-suite run on
    upstream's new lock. The branch's full-suite run uses locked FastMCP 4.0.0b1.
- A prior native Asia/Shanghai MCP suite on implementation HEAD `20999286` produced **1,385 passed
  and 2 failed**; both naive-datetime failures reproduce unchanged on base `c50ed118`.
- One PDF subprocess test initially hit a host Rayon resource-limit error and failed identically on
  base `c50ed118`; the isolated test passed with command-local `RAYON_NUM_THREADS=1`.

## Risks / Follow-ups

- No live model/provider API or external Basic Memory gateway was called. HTTP retry behavior was
  exercised with `httpx.MockTransport` plus the in-process FastMCP client smoke.
- A full suite has not been completed under upstream's FastMCP 4.0.3 lock; the bounded overlay
  result does not replace that validation.
- The four pytest stages produced passing summaries, but the PostgreSQL integration process
  outlived the recipe's 600-second wrapper. Because that wrapper exited with code 1, the overall
  `just test` command is not counted as green despite the later passing child-process summary.

Fixes #1378
