### PR TITLE
feat(mcp): add compact search discovery results

### DIFF
--- a/src/basic_memory/man/man3/search-notes(3).md
+++ b/src/basic_memory/man/man3/search-notes(3).md
@@ -77,6 +77,8 @@ their content-length/truncation fields. Identifiers, metadata, relation targets,
 scores, temporal assertions, and pagination are retained. It works with JSON or
 text output and with `search_all_projects=True`. Read selected notes afterward
 with `read_note`; a search hit is discovery, not full content verification.
+Observation titles use their category and their permalinks use the owning file
+path instead of repeating observation prose; IDs remain unchanged.
 This reduces the MCP response, not the underlying API query or database work.
 It is not a hard token budget: titles and metadata can still be large.
 

--- a/src/basic_memory/man/man3/search-notes(3).md
+++ b/src/basic_memory/man/man3/search-notes(3).md
@@ -26,7 +26,7 @@ search_notes(query=None, project=None, project_id=None,
              entity_types=None, categories=None, after_date=None,
              metadata_filters=None, tags=None, status=None,
              min_similarity=None, valid_at=None, valid_overlaps=None,
-             time_kind=None)
+             time_kind=None, compact=False)
 ```
 
 CLI:
@@ -72,6 +72,14 @@ query. Because one note can carry several assertions that disagree, these
 queries return observation-level results, each carrying the assertion that
 matched.
 
+**Compact discovery** (`compact=True`) omits `content`, `matched_chunk`, and
+their content-length/truncation fields. Identifiers, metadata, relation targets,
+scores, temporal assertions, and pagination are retained. It works with JSON or
+text output and with `search_all_projects=True`. Read selected notes afterward
+with `read_note`; a search hit is discovery, not full content verification.
+This reduces the MCP response, not the underlying API query or database work.
+It is not a hard token budget: titles and metadata can still be large.
+
 ## PARAMETERS
 
 - **query** (string | null, optional, default: None) — Optional search query string (supports boolean operators, phrases, patterns). Omit or pass None for filter-only searches using metadata_filters, tags, or status.
@@ -93,6 +101,7 @@ matched.
 - **valid_at** (string | null, optional, default: None) — Optional date ("2026-07-28") or RFC 3339 instant ("2026-07-28T09:00:00Z"; a timestamp with no offset is read as UTC). Returns sources whose authored valid range contains it. Sources with no temporal qualifier are excluded. Aliases: as_of, valid_on.
 - **valid_overlaps** (string | null, optional, default: None) — Optional PostgreSQL-style range literal ("[2026-06-10,2026-07-27)", "(,2026-07-27]", "[2026-06-10,)"). Returns sources whose authored valid range overlaps it. Mutually exclusive with valid_at; also excludes undated sources. Aliases: overlaps, valid_during.
 - **time_kind** (string | null, optional, default: None) — Optional kind of valid time to narrow to: "effective", "valid", "occurred", "due", or "mentioned". Valid on its own. Alias: kind.
+- **compact** (boolean, optional, default: False) — Omit note bodies and matched excerpts from results. Keep identifiers, metadata, relation targets, scores and pagination for discovery, then read selected notes.
 
 ## MCP USAGE
 

--- a/src/basic_memory/mcp/tools/search.py
+++ b/src/basic_memory/mcp/tools/search.py
@@ -573,14 +573,10 @@ def _qualify_results_for_project(
         else:
             result_data = dict(result)
         project = project_ref.get("project")
-        if (
-            compact
-            and result_data.get("type") == SearchItemType.OBSERVATION
-            and project
-            and "/" in project
-        ):
+        if compact and result_data.get("type") == SearchItemType.OBSERVATION and project:
             # This is an exact file read target, not a generated permalink:
-            # retain its extension, spaces, and case under the workspace route.
+            # retain its extension, spaces, and case under the local project or
+            # workspace/project route.
             result_data["permalink"] = (
                 f"{project.strip('/')}/{result_data['file_path'].lstrip('/')}"
             )

--- a/src/basic_memory/mcp/tools/search.py
+++ b/src/basic_memory/mcp/tools/search.py
@@ -55,6 +55,14 @@ def _compact_search_response(response: SearchResponse) -> SearchResponse:
                         "matched_chunk": None,
                         "content_length": None,
                         "content_truncated": None,
+                        # Observation labels embed excerpts too. Keep owner-file
+                        # navigation and IDs without duplicating source prose.
+                        "title": (result.category or "observation")
+                        if result.type == SearchItemType.OBSERVATION
+                        else result.title,
+                        "permalink": result.file_path
+                        if result.type == SearchItemType.OBSERVATION
+                        else result.permalink,
                     }
                 )
                 for result in response.results

--- a/src/basic_memory/mcp/tools/search.py
+++ b/src/basic_memory/mcp/tools/search.py
@@ -562,6 +562,8 @@ def _qualify_permalink_for_project(permalink: object, project: str | None) -> ob
 def _qualify_results_for_project(
     results: list[SearchResult | dict[str, Any]],
     project_ref: dict[str, str | None],
+    *,
+    compact: bool = False,
 ) -> list[dict[str, Any]]:
     """Attach the searched workspace/project prefix to each result permalink."""
     qualified: list[dict[str, Any]] = []
@@ -570,10 +572,22 @@ def _qualify_results_for_project(
             result_data = result.model_dump()
         else:
             result_data = dict(result)
-        result_data["permalink"] = _qualify_permalink_for_project(
-            result_data.get("permalink"),
-            project_ref.get("project"),
-        )
+        project = project_ref.get("project")
+        if (
+            compact
+            and result_data.get("type") == SearchItemType.OBSERVATION
+            and project
+            and "/" in project
+        ):
+            # This is an exact file read target, not a generated permalink:
+            # retain its extension, spaces, and case under the workspace route.
+            result_data["permalink"] = (
+                f"{project.strip('/')}/{result_data['file_path'].lstrip('/')}"
+            )
+        else:
+            result_data["permalink"] = _qualify_permalink_for_project(
+                result_data.get("permalink"), project
+            )
         qualified.append(result_data)
     return qualified
 
@@ -694,6 +708,9 @@ async def _search_all_projects(
                 time_kind=time_kind,
                 search_all_projects=False,
                 context=context,
+                # Project qualification below must run after compact replaces
+                # observation excerpt permalinks with their owning file paths.
+                compact=compact,
             )
         except Exception as exc:
             logger.warning(
@@ -719,7 +736,9 @@ async def _search_all_projects(
         total += _result_total(results, raw_results)
         total_is_exact = total_is_exact and _result_total_is_exact(results)
         any_project_has_more = any_project_has_more or results.get("has_more") is True
-        merged_results.extend(_qualify_results_for_project(raw_results, project_ref))
+        merged_results.extend(
+            _qualify_results_for_project(raw_results, project_ref, compact=compact)
+        )
 
     # Trigger: a valid-time filter was requested and not one project answered.
     # Why: each leg confirms the filter through SearchClient or is refused by it, and a
@@ -758,8 +777,6 @@ async def _search_all_projects(
         }
     )
 
-    if compact:
-        response = _compact_search_response(response)
     if output_format == "json":
         return response.model_dump(mode="json", exclude_none=True)
     return _format_search_markdown(response, "all projects", query)

--- a/src/basic_memory/mcp/tools/search.py
+++ b/src/basic_memory/mcp/tools/search.py
@@ -44,6 +44,25 @@ from basic_memory.temporal import TemporalQualifierError, parse_temporal_filter
 _SERVICE_UNAVAILABLE_HEADING = "# Search Failed - Service Temporarily Unavailable"
 
 
+def _compact_search_response(response: SearchResponse) -> SearchResponse:
+    """Keep discovery identities and pagination without repeating source prose."""
+    return response.model_copy(
+        update={
+            "results": [
+                result.model_copy(
+                    update={
+                        "content": None,
+                        "matched_chunk": None,
+                        "content_length": None,
+                        "content_truncated": None,
+                    }
+                )
+                for result in response.results
+            ]
+        }
+    )
+
+
 def _default_search_type() -> str:
     """Pick default search mode from config, falling back to auto-detection.
 
@@ -588,6 +607,7 @@ async def _search_all_projects(
     valid_overlaps: str | None,
     time_kind: str | None,
     context: Context | None,
+    compact: bool = False,
 ) -> dict[str, Any] | str:
     """Search every accessible project when the caller explicitly opts in."""
     requested_page = max(page, 1)
@@ -730,6 +750,8 @@ async def _search_all_projects(
         }
     )
 
+    if compact:
+        response = _compact_search_response(response)
     if output_format == "json":
         return response.model_dump(mode="json", exclude_none=True)
     return _format_search_markdown(response, "all projects", query)
@@ -873,6 +895,11 @@ async def search_notes(
         "source carrying an assertion of that kind.",
     ] = None,
     context: Context | None = None,
+    compact: Annotated[
+        bool,
+        "Omit note bodies and matched excerpts from results. Keep identifiers, metadata, "
+        "relation targets, scores and pagination for discovery, then read selected notes.",
+    ] = False,
 ) -> dict[str, Any] | str:
     """Search across all content in the knowledge base with comprehensive syntax support.
 
@@ -1063,6 +1090,8 @@ async def search_notes(
         time_kind: Optional kind of valid time to narrow to: "effective", "valid",
                  "occurred", "due", or "mentioned". Valid on its own. Alias: kind.
         context: Optional FastMCP context for performance caching.
+        compact: Omit content and matched excerpts in either output format. Defaults to False.
+                 Use returned note identifiers with read_note for content verification.
 
     Returns:
         Formatted markdown text (output_format="text"), dict (output_format="json"),
@@ -1249,6 +1278,7 @@ async def search_notes(
             valid_overlaps=valid_overlaps,
             time_kind=time_kind,
             context=context,
+            compact=compact,
         )
         return all_projects_result
 
@@ -1434,6 +1464,8 @@ async def search_notes(
                     # Don't treat this as an error, but the user might want guidance
                     # We return the empty result as normal - the user can decide if they need help
 
+                if compact:
+                    result = _compact_search_response(result)
                 if output_format == "json":
                     return result.model_dump(mode="json", exclude_none=True)
 

--- a/test-int/mcp/test_compact_search_integration.py
+++ b/test-int/mcp/test_compact_search_integration.py
@@ -1,0 +1,62 @@
+"""Compact discovery preserves ranked note identities without source prose."""
+
+import json
+
+import pytest
+from fastmcp import Client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("all_projects", [False, True])
+async def test_compact_search_can_discover_then_read_notes(
+    mcp_server, app, test_project, all_projects
+):
+    body = "CompactNeedle " + "This is source prose for a long note. " * 250
+    async with Client(mcp_server) as client:
+        await client.call_tool(
+            "write_note",
+            {
+                "title": "CompactNeedle",
+                "content": body,
+                "directory": "search",
+                "project": test_project.name,
+            },
+        )
+        arguments: dict[str, object] = {
+            "query": "CompactNeedle",
+            "search_type": "text",
+            "output_format": "json",
+        }
+        if all_projects:
+            arguments["search_all_projects"] = True
+        else:
+            arguments["project"] = test_project.name
+        full_result = await client.call_tool("search_notes", arguments)
+        compact_result = await client.call_tool("search_notes", {**arguments, "compact": True})
+        full = json.loads(full_result.content[0].text)
+        compact = json.loads(compact_result.content[0].text)
+        assert full["results"]
+        assert "content" in full["results"][0]
+        omitted = {"content", "matched_chunk", "content_length", "content_truncated"}
+        expected = {
+            **full,
+            "results": [
+                {key: value for key, value in row.items() if key not in omitted}
+                for row in full["results"]
+            ],
+        }
+        assert compact == expected
+        assert len(json.dumps(compact)) < len(json.dumps(full)) / 3
+
+        selected = compact["results"][0]
+        read = await client.call_tool(
+            "read_note",
+            {"identifier": selected["external_id"], "project": test_project.name},
+        )
+        assert body in read.content[0].text
+
+        text_result = await client.call_tool(
+            "search_notes", {**arguments, "compact": True, "output_format": "text"}
+        )
+        assert "CompactNeedle" in text_result.content[0].text
+        assert "This is source prose" not in text_result.content[0].text

--- a/test-int/mcp/test_compact_search_integration.py
+++ b/test-int/mcp/test_compact_search_integration.py
@@ -8,10 +8,13 @@ from fastmcp import Client
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("all_projects", [False, True])
+@pytest.mark.parametrize("observations", [False, True])
 async def test_compact_search_can_discover_then_read_notes(
-    mcp_server, app, test_project, all_projects
+    mcp_server, app, test_project, all_projects, observations
 ):
     body = "CompactNeedle " + "This is source prose for a long note. " * 250
+    if observations:
+        body = "- [fact] " + body
     async with Client(mcp_server) as client:
         await client.call_tool(
             "write_note",
@@ -26,6 +29,7 @@ async def test_compact_search_can_discover_then_read_notes(
             "query": "CompactNeedle",
             "search_type": "text",
             "output_format": "json",
+            "entity_types": ["observation"] if observations else ["entity"],
         }
         if all_projects:
             arguments["search_all_projects"] = True
@@ -45,6 +49,10 @@ async def test_compact_search_can_discover_then_read_notes(
                 for row in full["results"]
             ],
         }
+        if observations:
+            for row in expected["results"]:
+                row["title"] = row["category"]
+                row["permalink"] = row["file_path"]
         assert compact == expected
         assert len(json.dumps(compact)) < len(json.dumps(full)) / 3
 
@@ -58,5 +66,6 @@ async def test_compact_search_can_discover_then_read_notes(
         text_result = await client.call_tool(
             "search_notes", {**arguments, "compact": True, "output_format": "text"}
         )
-        assert "CompactNeedle" in text_result.content[0].text
+        assert ("fact" if observations else "CompactNeedle") in text_result.content[0].text
         assert "This is source prose" not in text_result.content[0].text
+        assert "this-is-source-prose" not in text_result.content[0].text

--- a/test-int/mcp/test_compact_search_integration.py
+++ b/test-int/mcp/test_compact_search_integration.py
@@ -52,14 +52,18 @@ async def test_compact_search_can_discover_then_read_notes(
         if observations:
             for row in expected["results"]:
                 row["title"] = row["category"]
-                row["permalink"] = row["file_path"]
+                row["permalink"] = (
+                    f"{test_project.name}/{row['file_path']}" if all_projects else row["file_path"]
+                )
         assert compact == expected
         assert len(json.dumps(compact)) < len(json.dumps(full)) / 3
 
         selected = compact["results"][0]
         read = await client.call_tool(
             "read_note",
-            {"identifier": selected["external_id"], "project": test_project.name},
+            {"identifier": selected["permalink"]}
+            if all_projects and observations
+            else {"identifier": selected["external_id"], "project": test_project.name},
         )
         assert body in read.content[0].text
 

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -150,6 +150,7 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "valid_at",
         "valid_overlaps",
         "time_kind",
+        "compact",
     ],
     "tail": ["timeframe", "lines", "project", "project_id"],
     "view_note": ["identifier", "project", "project_id"],

--- a/tests/mcp/tools/test_search_notes_multi_project.py
+++ b/tests/mcp/tools/test_search_notes_multi_project.py
@@ -39,8 +39,10 @@ def local_routing(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("compact", [False, True])
+@pytest.mark.parametrize("observations", [False, True])
 async def test_search_notes_search_all_projects_qualifies_result_permalinks(
-    monkeypatch, cloud_routing
+    monkeypatch, cloud_routing, compact, observations
 ):
     """Multi-project search belongs to search_notes and keeps result ids routable."""
     clients_mod = importlib.import_module("basic_memory.mcp.clients")
@@ -91,9 +93,12 @@ async def test_search_notes_search_all_projects_qualifies_result_permalinks(
                         title=title,
                         permalink="main/tests/mcp-test-note",
                         content="MCP content",
-                        type=SearchItemType.ENTITY,
+                        type=SearchItemType.OBSERVATION if observations else SearchItemType.ENTITY,
+                        category="fact" if observations else None,
                         score=score,
-                        file_path="/main/tests/mcp-test-note.md",
+                        file_path="tests/Exact Note.md"
+                        if observations
+                        else "/main/tests/mcp-test-note.md",
                     )
                 ],
                 current_page=page,
@@ -110,6 +115,7 @@ async def test_search_notes_search_all_projects_qualifies_result_permalinks(
         query="MCP Test Note",
         search_all_projects=True,
         output_format="json",
+        compact=compact,
     )
 
     assert isinstance(result, dict)
@@ -117,10 +123,13 @@ async def test_search_notes_search_all_projects_qualifies_result_permalinks(
         ("personal/main", "11111111-1111-1111-1111-111111111111"),
         ("team-paul/main", "22222222-2222-2222-2222-222222222222"),
     ]
+    path = "tests/Exact Note.md" if compact and observations else "tests/mcp-test-note"
     assert [item["permalink"] for item in result["results"]] == [
-        "team-paul/main/tests/mcp-test-note",
-        "personal/main/tests/mcp-test-note",
+        f"team-paul/main/{path}",
+        f"personal/main/{path}",
     ]
+    if compact:
+        assert all("content" not in item for item in result["results"])
     assert result["total_is_exact"] is True
 
 

--- a/tests/mcp/tools/test_search_notes_multi_project.py
+++ b/tests/mcp/tools/test_search_notes_multi_project.py
@@ -381,7 +381,10 @@ async def test_search_notes_search_all_projects_propagates_retryable_service_out
 
 
 @pytest.mark.asyncio
-async def test_search_notes_search_all_projects_local_omits_project_id(monkeypatch, local_routing):
+@pytest.mark.parametrize("compact_observations", [False, True])
+async def test_search_notes_search_all_projects_local_omits_project_id(
+    monkeypatch, local_routing, compact_observations
+):
     """Without a cloud route, fan-out must address each project by name only.
 
     project_id (external UUID) routes through the cloud v2 API path, which
@@ -431,7 +434,9 @@ async def test_search_notes_search_all_projects_local_omits_project_id(monkeypat
                         title=f"Note in {self.project_id or 'local'}",
                         permalink="notes/example",
                         content="",
-                        type=SearchItemType.ENTITY,
+                        type=SearchItemType.OBSERVATION
+                        if compact_observations
+                        else SearchItemType.ENTITY,
                         score=0.5,
                         file_path="/notes/example.md",
                     )
@@ -450,6 +455,7 @@ async def test_search_notes_search_all_projects_local_omits_project_id(monkeypat
         query="anything",
         search_all_projects=True,
         output_format="json",
+        compact=compact_observations,
     )
 
     assert isinstance(result, dict)
@@ -459,3 +465,8 @@ async def test_search_notes_search_all_projects_local_omits_project_id(monkeypat
     )
     assert result["total"] == 2
     assert result["total_is_exact"] is True
+    if compact_observations:
+        assert [item["permalink"] for item in result["results"]] == [
+            "alpha/notes/example.md",
+            "beta/notes/example.md",
+        ]


### PR DESCRIPTION
## Why

#686 reports excessive search response size when agents only need to discover relevant notes. JSON results can include both note content and a matched excerpt before the agent decides what to read.

Refs #686. This is the search-discovery slice; compact graph traversal remains separate.

## What Changed

Add opt-in `search_notes(compact=True)` for both JSON and text output, including all-project searches. It omits `content`, `matched_chunk`, `content_length`, and `content_truncated` while preserving ranked identifiers, metadata, relation fields, temporal assertions, and pagination. Observation titles use their category and permalinks use their owning file path, so labels do not repeat source prose. Agents can read selected notes afterward using their stable identifiers.

## Implementation Details

Apply a typed response projection after each project retrieval, before workspace qualification and account-wide merging. Normal responses remain unchanged and source response objects are not mutated. Compact observation read paths preserve case, spaces and extensions beneath the workspace/project prefix. The generated manual documents the parameter and the discovery/read workflow.

## Testing

- `uv run pytest test-int/mcp/test_compact_search_integration.py tests/mcp/test_tool_search.py tests/mcp/tools/test_search_notes_multi_project.py -q --no-cov`: **79 passed**.
- `BASIC_MEMORY_TEST_POSTGRES=1 uv run pytest test-int/mcp/test_compact_search_integration.py -q --no-cov`: **4 passed**.
- Real MCP scenarios exercise project-scoped and all-project search, compare every retained field, read the selected note, and check text output omits excerpts. The long-note fixture's compact JSON is less than one-third the full JSON size; this is a fixture measurement, not a general token-saving claim.
- `just man-regen`, `just fast-check`, and `just doctor`: passed.

## Risks / Follow-ups

This reduces the model-visible MCP response, not API transfer or database retrieval work. It is not a hard token budget: titles and metadata can still be large. It does not add observation-summary levels or compact `build_context` responses, and does not change the default search output.
