### PR TITLE
feat(mcp): add compact graph context discovery

### DIFF
--- a/src/basic_memory/man/man3/build-context(3).md
+++ b/src/basic_memory/man/man3/build-context(3).md
@@ -21,7 +21,8 @@ MCP:
 
 ```
 build_context(url, project=None, project_id=None, depth=1, timeframe="7d",
-              page=1, page_size=10, max_related=10, output_format="json")
+              page=1, page_size=10, max_related=10, output_format="json",
+              compact=False)
 ```
 
 CLI:
@@ -43,6 +44,12 @@ URL forms: `"folder/note"`, `"memory://folder/note"`, and patterns
 (`"folder/*"` — but see GOTCHAS for cloud projects). Each traversal step
 costs two depth levels internally (relation, then entity).
 
+Use `compact=True` for graph discovery without note or observation bodies.
+JSON keeps the graph shape, identifiers, categories, short observation titles,
+relations and pagination; text omits the observation section and note bodies.
+Read selected notes with `read_note`. The default response is unchanged.
+This reduces MCP output, not API traversal work, and is not a fixed token limit.
+
 ## PARAMETERS
 
 - **url** (string, required) — memory:// URI pointing to discussion content (e.g. memory://specs/search), or a bare permalink path.
@@ -54,6 +61,7 @@ costs two depth levels internally (relation, then entity).
 - **page_size** (integer, optional, default: 10) — Number of primary results to return per page (default: 10, maximum: 50)
 - **max_related** (integer, optional, default: 10) — Maximum total related results to return (default: 10, maximum: 100)
 - **output_format** (string, optional, default: "json") — Response format - "json" for structured JSON dict, "text" for compact markdown text
+- **compact** (boolean, optional, default: False) — Omit note and observation bodies for graph discovery. Preserve identifiers, relation targets and pagination; use read_note for selected content. This reduces response size, not traversal work or a guaranteed token budget.
 
 ## MCP USAGE
 

--- a/src/basic_memory/man/man3/build-context(3).md
+++ b/src/basic_memory/man/man3/build-context(3).md
@@ -45,8 +45,10 @@ URL forms: `"folder/note"`, `"memory://folder/note"`, and patterns
 costs two depth levels internally (relation, then entity).
 
 Use `compact=True` for graph discovery without note or observation bodies.
-JSON keeps the graph shape, identifiers, categories, short observation titles,
+JSON keeps the graph shape, identifiers, categories,
 relations and pagination; text omits the observation section and note bodies.
+Observation titles become their categories and their content-derived permalinks
+become owning-file paths, which can be passed to `read_note`.
 Read selected notes with `read_note`. The default response is unchanged.
 This reduces MCP output, not API traversal work, and is not a fixed token limit.
 

--- a/src/basic_memory/mcp/tools/build_context.py
+++ b/src/basic_memory/mcp/tools/build_context.py
@@ -29,7 +29,7 @@ from basic_memory.schemas.memory import (
 )
 
 
-def _format_entity_block(result: ContextResult) -> str:
+def _format_entity_block(result: ContextResult, *, compact: bool = False) -> str:
     """Format a single context result as a markdown block."""
     primary = result.primary_result
     lines = []
@@ -39,12 +39,12 @@ def _format_entity_block(result: ContextResult) -> str:
     if primary.permalink:
         lines.append(f"permalink: {primary.permalink}")
     # RelationSummary has no content field; Entity/Observation do
-    if not isinstance(primary, RelationSummary) and primary.content:
+    if not compact and not isinstance(primary, RelationSummary) and primary.content:
         lines.append("")
         lines.append(primary.content)
 
     # --- Observations ---
-    if result.observations:
+    if result.observations and not compact:
         lines.append("")
         lines.append("### Observations")
         for obs in result.observations:
@@ -77,7 +77,7 @@ def _format_entity_block(result: ContextResult) -> str:
     return "\n".join(lines)
 
 
-def _format_context_markdown(graph: GraphContext, project: str) -> str:
+def _format_context_markdown(graph: GraphContext, project: str, *, compact: bool = False) -> str:
     """Format GraphContext as compact markdown text.
 
     Produces a human-readable markdown representation that is much smaller
@@ -101,7 +101,7 @@ def _format_context_markdown(graph: GraphContext, project: str) -> str:
     parts.append("")
 
     # --- Entity blocks separated by --- ---
-    entity_blocks = [_format_entity_block(result) for result in graph.results]
+    entity_blocks = [_format_entity_block(result, compact=compact) for result in graph.results]
     parts.append("\n\n---\n\n".join(entity_blocks))
 
     # --- Footer ---
@@ -187,6 +187,12 @@ async def build_context(
     ] = DEFAULT_CONTEXT_RELATED_RESULTS,
     output_format: Literal["json", "text"] = "json",
     context: Context | None = None,
+    compact: Annotated[
+        bool,
+        "Omit note and observation bodies for graph discovery. Preserve identifiers, "
+        "relation targets and pagination; use read_note for selected content. "
+        "This reduces response size, not traversal work or a guaranteed token budget.",
+    ] = False,
 ) -> dict[str, Any] | str:
     """Get context needed to continue a discussion within a specific project.
 
@@ -215,6 +221,7 @@ async def build_context(
         output_format: Response format - "json" for structured JSON dict,
             "text" for compact markdown text
         context: Optional FastMCP context for performance caching.
+        compact: Omit note and observation bodies while retaining navigation summaries.
 
     Returns:
         dict (output_format="json"): Structured JSON with internal fields excluded
@@ -341,6 +348,21 @@ async def build_context(
             )
 
             if output_format == "text":
-                return _format_context_markdown(graph, active_project.name)
+                return _format_context_markdown(graph, active_project.name, compact=compact)
+
+            # Discovery keeps the same graph and pagination, but leaves source prose
+            # for an explicit read. Exclude at serialization to preserve API models.
+            if compact:
+                return graph.model_dump(
+                    exclude={
+                        "results": {
+                            "__all__": {
+                                "primary_result": {"content"},
+                                "observations": {"__all__": {"content"}},
+                                "related_results": {"__all__": {"content"}},
+                            }
+                        }
+                    }
+                )
 
             return graph.model_dump()

--- a/src/basic_memory/mcp/tools/build_context.py
+++ b/src/basic_memory/mcp/tools/build_context.py
@@ -29,6 +29,39 @@ from basic_memory.schemas.memory import (
 )
 
 
+def _compact_observation(observation: ObservationSummary) -> ObservationSummary:
+    """Navigate to the owning file without repeating content-derived labels."""
+    return observation.model_copy(
+        update={"title": observation.category, "permalink": observation.file_path}
+    )
+
+
+def _compact_context_labels(graph: GraphContext) -> GraphContext:
+    # Observation titles and permalinks embed source prose. Use the category and
+    # owning file for discovery; keep numeric and external IDs unchanged.
+    return graph.model_copy(
+        update={
+            "results": [
+                result.model_copy(
+                    update={
+                        "primary_result": _compact_observation(result.primary_result)
+                        if isinstance(result.primary_result, ObservationSummary)
+                        else result.primary_result,
+                        "observations": [_compact_observation(obs) for obs in result.observations],
+                        "related_results": [
+                            _compact_observation(item)
+                            if isinstance(item, ObservationSummary)
+                            else item
+                            for item in result.related_results
+                        ],
+                    }
+                )
+                for result in graph.results
+            ]
+        }
+    )
+
+
 def _format_entity_block(result: ContextResult, *, compact: bool = False) -> str:
     """Format a single context result as a markdown block."""
     primary = result.primary_result
@@ -346,6 +379,9 @@ async def build_context(
                 f"related_count={graph.metadata.related_count or 0} "
                 f"output_format={output_format}"
             )
+
+            if compact:
+                graph = _compact_context_labels(graph)
 
             if output_format == "text":
                 return _format_context_markdown(graph, active_project.name, compact=compact)

--- a/test-int/mcp/test_compact_context_integration.py
+++ b/test-int/mcp/test_compact_context_integration.py
@@ -1,0 +1,58 @@
+"""Graph discovery can omit prose and retain usable note identities."""
+
+import json
+
+import pytest
+from fastmcp import Client
+
+
+@pytest.mark.asyncio
+async def test_compact_context_preserves_graph_navigation(mcp_server, app, test_project):
+    body = "Long context body. " * 500 + "\n- [fact] " + "Detailed observation. " * 100
+    async with Client(mcp_server) as client:
+        for title, content in [
+            ("Context Target", "Target body"),
+            ("Context Source", body + "\n- relates_to [[Context Target]]"),
+        ]:
+            await client.call_tool(
+                "write_note",
+                {
+                    "title": title,
+                    "content": content,
+                    "directory": "context",
+                    "project": test_project.name,
+                },
+            )
+        arguments = {
+            "url": "context/context-source",
+            "project": test_project.name,
+            "depth": 2,
+        }
+        full_result = await client.call_tool("build_context", arguments)
+        compact_result = await client.call_tool("build_context", {**arguments, "compact": True})
+        full = json.loads(full_result.content[0].text)
+        compact = json.loads(compact_result.content[0].text)
+        assert full["results"]
+        assert full["results"][0]["observations"]
+        assert any(row["type"] == "relation" for row in full["results"][0]["related_results"])
+        # Request-time timestamps vary between calls; graph and page data must not.
+        for field in ("generated_at", "timeframe"):
+            full["metadata"].pop(field, None)
+            compact["metadata"].pop(field, None)
+        for result in full["results"]:
+            result["primary_result"].pop("content", None)
+            for item in [*result["observations"], *result["related_results"]]:
+                item.pop("content", None)
+        assert compact == full
+        assert len(compact_result.content[0].text) < len(full_result.content[0].text) / 2
+        selected = compact["results"][0]["primary_result"]
+        read = await client.call_tool(
+            "read_note", {"identifier": selected["external_id"], "project": test_project.name}
+        )
+        assert body in read.content[0].text
+        text_result = await client.call_tool(
+            "build_context", {**arguments, "compact": True, "output_format": "text"}
+        )
+        assert "Context Source" in text_result.content[0].text
+        assert "Long context body" not in text_result.content[0].text
+        assert "### Observations" not in text_result.content[0].text

--- a/test-int/mcp/test_compact_context_integration.py
+++ b/test-int/mcp/test_compact_context_integration.py
@@ -43,13 +43,23 @@ async def test_compact_context_preserves_graph_navigation(mcp_server, app, test_
             result["primary_result"].pop("content", None)
             for item in [*result["observations"], *result["related_results"]]:
                 item.pop("content", None)
+                if item["type"] == "observation":
+                    item["permalink"] = item["file_path"]
+                    item["title"] = item["category"]
         assert compact == full
+        assert "detailed-observation" not in compact_result.content[0].text.lower()
+        assert "Detailed observation" not in compact_result.content[0].text
         assert len(compact_result.content[0].text) < len(full_result.content[0].text) / 2
         selected = compact["results"][0]["primary_result"]
         read = await client.call_tool(
             "read_note", {"identifier": selected["external_id"], "project": test_project.name}
         )
         assert body in read.content[0].text
+        observation = compact["results"][0]["observations"][0]
+        observed_note = await client.call_tool(
+            "read_note", {"identifier": observation["permalink"], "project": test_project.name}
+        )
+        assert body in observed_note.content[0].text
         text_result = await client.call_tool(
             "build_context", {**arguments, "compact": True, "output_format": "text"}
         )

--- a/tests/mcp/test_compact_context_labels.py
+++ b/tests/mcp/test_compact_context_labels.py
@@ -1,0 +1,39 @@
+"""Content-derived observation labels must not reintroduce omitted prose."""
+
+from datetime import UTC, datetime
+
+from basic_memory.mcp.tools.build_context import _compact_context_labels, _format_context_markdown
+from basic_memory.schemas.memory import (
+    ContextResult,
+    GraphContext,
+    MemoryMetadata,
+    ObservationSummary,
+)
+
+
+def test_compact_observation_navigation_uses_owning_file_without_mutating_graph():
+    observation = ObservationSummary(
+        observation_id=12,
+        entity_external_id="source-uuid",
+        title="fact: Private source prose",
+        file_path="notes/Source.md",
+        permalink="notes/source/observations/fact/private-source-prose",
+        category="fact",
+        content="Private source prose",
+        created_at=datetime.now(UTC),
+    )
+    graph = GraphContext(
+        results=[ContextResult(primary_result=observation, related_results=[observation])],
+        metadata=MemoryMetadata(depth=1),
+    )
+    compact = _compact_context_labels(graph)
+    for item in [compact.results[0].primary_result, *compact.results[0].related_results]:
+        assert isinstance(item, ObservationSummary)
+        assert item.title == "fact"
+        assert item.permalink == "notes/Source.md"
+        assert item.entity_external_id == "source-uuid"
+        assert item.observation_id == 12
+    text = _format_context_markdown(compact, "project", compact=True)
+    assert "notes/Source.md" in text
+    assert "private" not in text.lower()
+    assert graph.results[0].primary_result.title == "fact: Private source prose"

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -24,6 +24,7 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "page_size",
         "max_related",
         "output_format",
+        "compact",
     ],
     "cat": [
         "identifier",


### PR DESCRIPTION
## Why

Graph discovery currently returns note and observation bodies before an agent chooses which notes to read. Refs #686; complements compact search in #1515.

## What Changed

Adds opt-in `build_context(compact=True)`. JSON omits content fields while preserving graph identities, observation categories, relation targets, counts and pagination. Observation labels use categories and their permalinks point to the owning file instead of repeating source prose. Text omits note bodies and the observation section. The default response remains unchanged.

## Implementation Details

JSON uses Pydantic serialization exclusions at the MCP boundary, keeping API models and traversal unchanged. The existing Markdown formatter accepts the same compact flag. The manual and tool-signature contract describe the new argument.

## Testing

- `uv run pytest test-int/mcp/test_compact_context_integration.py tests/mcp/test_tool_contracts.py tests/mcp/test_tool_build_context.py -q --no-cov`: 17 passed.
- `BASIC_MEMORY_TEST_POSTGRES=1 uv run pytest test-int/mcp/test_compact_context_integration.py -q --no-cov`: 1 passed.
- `uv run pytest tests/mcp/test_compact_context_labels.py -q --no-cov`: 1 passed; primary and related observation labels preserve owner navigation without mutating the original graph.
- The real MCP scenario creates linked notes and a long observation, compares graph/page data, verifies a response below half the original size on that fixture, and reads the selected note by returned UUID.
- `just man-regen`, `just fast-check`, `just doctor`, and `git diff --check`: passed.

## Risks / Follow-ups

This reduces MCP output, not API/database work. Titles and graph size still contribute tokens; it is not a fixed token budget. This does not implement all proposed L0/L1/L2 tiers or change defaults, so #686 remains open. CLI exposure is a separate follow-up.
