### PR TITLE
feat(cli): expose compact search and context discovery

### DIFF
--- a/docs/COMPACT_DISCOVERY.md
+++ b/docs/COMPACT_DISCOVERY.md
@@ -1,0 +1,23 @@
+# Compact discovery
+
+Use compact results to choose notes before reading their bodies:
+
+```sh
+bm tool search-notes "deployment" --compact --json
+bm tool build-context "notes/deployment" --compact --json
+bm tool read-note "notes/deployment" --start-line 20 --end-line 60 --plain
+```
+
+`--compact` also works with `--plain` and the interactive Rich display. Output
+format selection is unchanged: pipes default to JSON, while `--plain` explicitly
+requests text. Omit `--compact` to retain ordinary content-bearing responses.
+
+Search omits note bodies and matched excerpts. Context omits note and observation
+bodies; observation labels become categories and their read targets become owning
+file paths. IDs, relation targets, and pagination remain available in JSON.
+
+MCP clients use `search_notes(compact=True)` and `build_context(compact=True)`.
+These options reduce model-visible output, not database search or traversal work.
+They do not impose a fixed token limit: titles, metadata, and the number of graph
+items still affect response size. Use pagination and targeted note reads to bound
+the rest of the workflow.

--- a/src/basic_memory/cli/commands/tool.py
+++ b/src/basic_memory/cli/commands/tool.py
@@ -970,6 +970,9 @@ def edit_note(
 @tool_app.command()
 def build_context(
     url: str,
+    compact: Annotated[
+        bool, typer.Option("--compact", help="Omit note and observation bodies for discovery")
+    ] = False,
     depth: Optional[int] = typer.Option(1, "--depth", help="Depth of context to build"),
     timeframe: Optional[str] = typer.Option(
         "7d", "--timeframe", help="Timeframe filter (e.g., '7d', '1 week')"
@@ -1032,6 +1035,7 @@ def build_context(
                     page_size=page_size,
                     max_related=max_related,
                     output_format="json",
+                    compact=compact,
                 )
             )
 
@@ -1146,6 +1150,9 @@ def search_notes(
         Optional[str],
         typer.Argument(help="Search query string (optional when using metadata filters)"),
     ] = "",
+    compact: Annotated[
+        bool, typer.Option("--compact", help="Omit note bodies and matched excerpts for discovery")
+    ] = False,
     permalink: Annotated[bool, typer.Option("--permalink", help="Search permalink values")] = False,
     title: Annotated[bool, typer.Option("--title", help="Search title values")] = False,
     vector: Annotated[bool, typer.Option("--vector", help="Use vector retrieval")] = False,
@@ -1304,6 +1311,7 @@ def search_notes(
                     metadata_filters=metadata_filters,
                     tags=tags,
                     status=status,
+                    compact=compact,
                 )
             )
 

--- a/src/basic_memory/man/man3/build-context(3).md
+++ b/src/basic_memory/man/man3/build-context(3).md
@@ -21,7 +21,8 @@ MCP:
 
 ```
 build_context(url, project=None, project_id=None, depth=1, timeframe="7d",
-              page=1, page_size=10, max_related=10, output_format="json")
+              page=1, page_size=10, max_related=10, output_format="json",
+              compact=False)
 ```
 
 CLI:
@@ -43,6 +44,12 @@ URL forms: `"folder/note"`, `"memory://folder/note"`, and patterns
 (`"folder/*"` — but see GOTCHAS for cloud projects). Each traversal step
 costs two depth levels internally (relation, then entity).
 
+Use `compact=True` for graph discovery without note or observation bodies.
+JSON keeps the graph shape, identifiers, categories, short observation titles,
+relations and pagination; text omits the observation section and note bodies.
+Read selected notes with `read_note`. The default response is unchanged.
+This reduces MCP output, not API traversal work, and is not a fixed token limit.
+
 ## PARAMETERS
 
 - **url** (string, required) — memory:// URI pointing to discussion content (e.g. memory://specs/search), or a bare permalink path.
@@ -54,6 +61,7 @@ costs two depth levels internally (relation, then entity).
 - **page_size** (integer, optional, default: 10) — Number of primary results to return per page (default: 10, maximum: 50)
 - **max_related** (integer, optional, default: 10) — Maximum total related results to return (default: 10, maximum: 100)
 - **output_format** (string, optional, default: "json") — Response format - "json" for structured JSON dict, "text" for compact markdown text
+- **compact** (boolean, optional, default: False) — Omit note and observation bodies for graph discovery. Preserve identifiers, relation targets and pagination; use read_note for selected content. This reduces response size, not traversal work or a guaranteed token budget.
 
 ## MCP USAGE
 

--- a/src/basic_memory/man/man3/build-context(3).md
+++ b/src/basic_memory/man/man3/build-context(3).md
@@ -45,8 +45,10 @@ URL forms: `"folder/note"`, `"memory://folder/note"`, and patterns
 costs two depth levels internally (relation, then entity).
 
 Use `compact=True` for graph discovery without note or observation bodies.
-JSON keeps the graph shape, identifiers, categories, short observation titles,
+JSON keeps the graph shape, identifiers, categories,
 relations and pagination; text omits the observation section and note bodies.
+Observation titles become their categories and their content-derived permalinks
+become owning-file paths, which can be passed to `read_note`.
 Read selected notes with `read_note`. The default response is unchanged.
 This reduces MCP output, not API traversal work, and is not a fixed token limit.
 

--- a/src/basic_memory/man/man3/search-notes(3).md
+++ b/src/basic_memory/man/man3/search-notes(3).md
@@ -77,6 +77,8 @@ their content-length/truncation fields. Identifiers, metadata, relation targets,
 scores, temporal assertions, and pagination are retained. It works with JSON or
 text output and with `search_all_projects=True`. Read selected notes afterward
 with `read_note`; a search hit is discovery, not full content verification.
+Observation titles use their category and their permalinks use the owning file
+path instead of repeating observation prose; IDs remain unchanged.
 This reduces the MCP response, not the underlying API query or database work.
 It is not a hard token budget: titles and metadata can still be large.
 

--- a/src/basic_memory/man/man3/search-notes(3).md
+++ b/src/basic_memory/man/man3/search-notes(3).md
@@ -26,7 +26,7 @@ search_notes(query=None, project=None, project_id=None,
              entity_types=None, categories=None, after_date=None,
              metadata_filters=None, tags=None, status=None,
              min_similarity=None, valid_at=None, valid_overlaps=None,
-             time_kind=None)
+             time_kind=None, compact=False)
 ```
 
 CLI:
@@ -72,6 +72,14 @@ query. Because one note can carry several assertions that disagree, these
 queries return observation-level results, each carrying the assertion that
 matched.
 
+**Compact discovery** (`compact=True`) omits `content`, `matched_chunk`, and
+their content-length/truncation fields. Identifiers, metadata, relation targets,
+scores, temporal assertions, and pagination are retained. It works with JSON or
+text output and with `search_all_projects=True`. Read selected notes afterward
+with `read_note`; a search hit is discovery, not full content verification.
+This reduces the MCP response, not the underlying API query or database work.
+It is not a hard token budget: titles and metadata can still be large.
+
 ## PARAMETERS
 
 - **query** (string | null, optional, default: None) — Optional search query string (supports boolean operators, phrases, patterns). Omit or pass None for filter-only searches using metadata_filters, tags, or status.
@@ -93,6 +101,7 @@ matched.
 - **valid_at** (string | null, optional, default: None) — Optional date ("2026-07-28") or RFC 3339 instant ("2026-07-28T09:00:00Z"; a timestamp with no offset is read as UTC). Returns sources whose authored valid range contains it. Sources with no temporal qualifier are excluded. Aliases: as_of, valid_on.
 - **valid_overlaps** (string | null, optional, default: None) — Optional PostgreSQL-style range literal ("[2026-06-10,2026-07-27)", "(,2026-07-27]", "[2026-06-10,)"). Returns sources whose authored valid range overlaps it. Mutually exclusive with valid_at; also excludes undated sources. Aliases: overlaps, valid_during.
 - **time_kind** (string | null, optional, default: None) — Optional kind of valid time to narrow to: "effective", "valid", "occurred", "due", or "mentioned". Valid on its own. Alias: kind.
+- **compact** (boolean, optional, default: False) — Omit note bodies and matched excerpts from results. Keep identifiers, metadata, relation targets, scores and pagination for discovery, then read selected notes.
 
 ## MCP USAGE
 

--- a/src/basic_memory/mcp/tools/build_context.py
+++ b/src/basic_memory/mcp/tools/build_context.py
@@ -29,7 +29,7 @@ from basic_memory.schemas.memory import (
 )
 
 
-def _format_entity_block(result: ContextResult) -> str:
+def _format_entity_block(result: ContextResult, *, compact: bool = False) -> str:
     """Format a single context result as a markdown block."""
     primary = result.primary_result
     lines = []
@@ -39,12 +39,12 @@ def _format_entity_block(result: ContextResult) -> str:
     if primary.permalink:
         lines.append(f"permalink: {primary.permalink}")
     # RelationSummary has no content field; Entity/Observation do
-    if not isinstance(primary, RelationSummary) and primary.content:
+    if not compact and not isinstance(primary, RelationSummary) and primary.content:
         lines.append("")
         lines.append(primary.content)
 
     # --- Observations ---
-    if result.observations:
+    if result.observations and not compact:
         lines.append("")
         lines.append("### Observations")
         for obs in result.observations:
@@ -77,7 +77,7 @@ def _format_entity_block(result: ContextResult) -> str:
     return "\n".join(lines)
 
 
-def _format_context_markdown(graph: GraphContext, project: str) -> str:
+def _format_context_markdown(graph: GraphContext, project: str, *, compact: bool = False) -> str:
     """Format GraphContext as compact markdown text.
 
     Produces a human-readable markdown representation that is much smaller
@@ -101,7 +101,7 @@ def _format_context_markdown(graph: GraphContext, project: str) -> str:
     parts.append("")
 
     # --- Entity blocks separated by --- ---
-    entity_blocks = [_format_entity_block(result) for result in graph.results]
+    entity_blocks = [_format_entity_block(result, compact=compact) for result in graph.results]
     parts.append("\n\n---\n\n".join(entity_blocks))
 
     # --- Footer ---
@@ -187,6 +187,12 @@ async def build_context(
     ] = DEFAULT_CONTEXT_RELATED_RESULTS,
     output_format: Literal["json", "text"] = "json",
     context: Context | None = None,
+    compact: Annotated[
+        bool,
+        "Omit note and observation bodies for graph discovery. Preserve identifiers, "
+        "relation targets and pagination; use read_note for selected content. "
+        "This reduces response size, not traversal work or a guaranteed token budget.",
+    ] = False,
 ) -> dict[str, Any] | str:
     """Get context needed to continue a discussion within a specific project.
 
@@ -215,6 +221,7 @@ async def build_context(
         output_format: Response format - "json" for structured JSON dict,
             "text" for compact markdown text
         context: Optional FastMCP context for performance caching.
+        compact: Omit note and observation bodies while retaining navigation summaries.
 
     Returns:
         dict (output_format="json"): Structured JSON with internal fields excluded
@@ -341,6 +348,21 @@ async def build_context(
             )
 
             if output_format == "text":
-                return _format_context_markdown(graph, active_project.name)
+                return _format_context_markdown(graph, active_project.name, compact=compact)
+
+            # Discovery keeps the same graph and pagination, but leaves source prose
+            # for an explicit read. Exclude at serialization to preserve API models.
+            if compact:
+                return graph.model_dump(
+                    exclude={
+                        "results": {
+                            "__all__": {
+                                "primary_result": {"content"},
+                                "observations": {"__all__": {"content"}},
+                                "related_results": {"__all__": {"content"}},
+                            }
+                        }
+                    }
+                )
 
             return graph.model_dump()

--- a/src/basic_memory/mcp/tools/build_context.py
+++ b/src/basic_memory/mcp/tools/build_context.py
@@ -29,6 +29,39 @@ from basic_memory.schemas.memory import (
 )
 
 
+def _compact_observation(observation: ObservationSummary) -> ObservationSummary:
+    """Navigate to the owning file without repeating content-derived labels."""
+    return observation.model_copy(
+        update={"title": observation.category, "permalink": observation.file_path}
+    )
+
+
+def _compact_context_labels(graph: GraphContext) -> GraphContext:
+    # Observation titles and permalinks embed source prose. Use the category and
+    # owning file for discovery; keep numeric and external IDs unchanged.
+    return graph.model_copy(
+        update={
+            "results": [
+                result.model_copy(
+                    update={
+                        "primary_result": _compact_observation(result.primary_result)
+                        if isinstance(result.primary_result, ObservationSummary)
+                        else result.primary_result,
+                        "observations": [_compact_observation(obs) for obs in result.observations],
+                        "related_results": [
+                            _compact_observation(item)
+                            if isinstance(item, ObservationSummary)
+                            else item
+                            for item in result.related_results
+                        ],
+                    }
+                )
+                for result in graph.results
+            ]
+        }
+    )
+
+
 def _format_entity_block(result: ContextResult, *, compact: bool = False) -> str:
     """Format a single context result as a markdown block."""
     primary = result.primary_result
@@ -346,6 +379,9 @@ async def build_context(
                 f"related_count={graph.metadata.related_count or 0} "
                 f"output_format={output_format}"
             )
+
+            if compact:
+                graph = _compact_context_labels(graph)
 
             if output_format == "text":
                 return _format_context_markdown(graph, active_project.name, compact=compact)

--- a/src/basic_memory/mcp/tools/search.py
+++ b/src/basic_memory/mcp/tools/search.py
@@ -573,14 +573,10 @@ def _qualify_results_for_project(
         else:
             result_data = dict(result)
         project = project_ref.get("project")
-        if (
-            compact
-            and result_data.get("type") == SearchItemType.OBSERVATION
-            and project
-            and "/" in project
-        ):
+        if compact and result_data.get("type") == SearchItemType.OBSERVATION and project:
             # This is an exact file read target, not a generated permalink:
-            # retain its extension, spaces, and case under the workspace route.
+            # retain its extension, spaces, and case under the local project or
+            # workspace/project route.
             result_data["permalink"] = (
                 f"{project.strip('/')}/{result_data['file_path'].lstrip('/')}"
             )

--- a/src/basic_memory/mcp/tools/search.py
+++ b/src/basic_memory/mcp/tools/search.py
@@ -55,6 +55,14 @@ def _compact_search_response(response: SearchResponse) -> SearchResponse:
                         "matched_chunk": None,
                         "content_length": None,
                         "content_truncated": None,
+                        # Observation labels embed excerpts too. Keep owner-file
+                        # navigation and IDs without duplicating source prose.
+                        "title": (result.category or "observation")
+                        if result.type == SearchItemType.OBSERVATION
+                        else result.title,
+                        "permalink": result.file_path
+                        if result.type == SearchItemType.OBSERVATION
+                        else result.permalink,
                     }
                 )
                 for result in response.results

--- a/src/basic_memory/mcp/tools/search.py
+++ b/src/basic_memory/mcp/tools/search.py
@@ -562,6 +562,8 @@ def _qualify_permalink_for_project(permalink: object, project: str | None) -> ob
 def _qualify_results_for_project(
     results: list[SearchResult | dict[str, Any]],
     project_ref: dict[str, str | None],
+    *,
+    compact: bool = False,
 ) -> list[dict[str, Any]]:
     """Attach the searched workspace/project prefix to each result permalink."""
     qualified: list[dict[str, Any]] = []
@@ -570,10 +572,22 @@ def _qualify_results_for_project(
             result_data = result.model_dump()
         else:
             result_data = dict(result)
-        result_data["permalink"] = _qualify_permalink_for_project(
-            result_data.get("permalink"),
-            project_ref.get("project"),
-        )
+        project = project_ref.get("project")
+        if (
+            compact
+            and result_data.get("type") == SearchItemType.OBSERVATION
+            and project
+            and "/" in project
+        ):
+            # This is an exact file read target, not a generated permalink:
+            # retain its extension, spaces, and case under the workspace route.
+            result_data["permalink"] = (
+                f"{project.strip('/')}/{result_data['file_path'].lstrip('/')}"
+            )
+        else:
+            result_data["permalink"] = _qualify_permalink_for_project(
+                result_data.get("permalink"), project
+            )
         qualified.append(result_data)
     return qualified
 
@@ -694,6 +708,9 @@ async def _search_all_projects(
                 time_kind=time_kind,
                 search_all_projects=False,
                 context=context,
+                # Project qualification below must run after compact replaces
+                # observation excerpt permalinks with their owning file paths.
+                compact=compact,
             )
         except Exception as exc:
             logger.warning(
@@ -719,7 +736,9 @@ async def _search_all_projects(
         total += _result_total(results, raw_results)
         total_is_exact = total_is_exact and _result_total_is_exact(results)
         any_project_has_more = any_project_has_more or results.get("has_more") is True
-        merged_results.extend(_qualify_results_for_project(raw_results, project_ref))
+        merged_results.extend(
+            _qualify_results_for_project(raw_results, project_ref, compact=compact)
+        )
 
     # Trigger: a valid-time filter was requested and not one project answered.
     # Why: each leg confirms the filter through SearchClient or is refused by it, and a
@@ -758,8 +777,6 @@ async def _search_all_projects(
         }
     )
 
-    if compact:
-        response = _compact_search_response(response)
     if output_format == "json":
         return response.model_dump(mode="json", exclude_none=True)
     return _format_search_markdown(response, "all projects", query)

--- a/src/basic_memory/mcp/tools/search.py
+++ b/src/basic_memory/mcp/tools/search.py
@@ -44,6 +44,25 @@ from basic_memory.temporal import TemporalQualifierError, parse_temporal_filter
 _SERVICE_UNAVAILABLE_HEADING = "# Search Failed - Service Temporarily Unavailable"
 
 
+def _compact_search_response(response: SearchResponse) -> SearchResponse:
+    """Keep discovery identities and pagination without repeating source prose."""
+    return response.model_copy(
+        update={
+            "results": [
+                result.model_copy(
+                    update={
+                        "content": None,
+                        "matched_chunk": None,
+                        "content_length": None,
+                        "content_truncated": None,
+                    }
+                )
+                for result in response.results
+            ]
+        }
+    )
+
+
 def _default_search_type() -> str:
     """Pick default search mode from config, falling back to auto-detection.
 
@@ -588,6 +607,7 @@ async def _search_all_projects(
     valid_overlaps: str | None,
     time_kind: str | None,
     context: Context | None,
+    compact: bool = False,
 ) -> dict[str, Any] | str:
     """Search every accessible project when the caller explicitly opts in."""
     requested_page = max(page, 1)
@@ -730,6 +750,8 @@ async def _search_all_projects(
         }
     )
 
+    if compact:
+        response = _compact_search_response(response)
     if output_format == "json":
         return response.model_dump(mode="json", exclude_none=True)
     return _format_search_markdown(response, "all projects", query)
@@ -873,6 +895,11 @@ async def search_notes(
         "source carrying an assertion of that kind.",
     ] = None,
     context: Context | None = None,
+    compact: Annotated[
+        bool,
+        "Omit note bodies and matched excerpts from results. Keep identifiers, metadata, "
+        "relation targets, scores and pagination for discovery, then read selected notes.",
+    ] = False,
 ) -> dict[str, Any] | str:
     """Search across all content in the knowledge base with comprehensive syntax support.
 
@@ -1063,6 +1090,8 @@ async def search_notes(
         time_kind: Optional kind of valid time to narrow to: "effective", "valid",
                  "occurred", "due", or "mentioned". Valid on its own. Alias: kind.
         context: Optional FastMCP context for performance caching.
+        compact: Omit content and matched excerpts in either output format. Defaults to False.
+                 Use returned note identifiers with read_note for content verification.
 
     Returns:
         Formatted markdown text (output_format="text"), dict (output_format="json"),
@@ -1249,6 +1278,7 @@ async def search_notes(
             valid_overlaps=valid_overlaps,
             time_kind=time_kind,
             context=context,
+            compact=compact,
         )
         return all_projects_result
 
@@ -1434,6 +1464,8 @@ async def search_notes(
                     # Don't treat this as an error, but the user might want guidance
                     # We return the empty result as normal - the user can decide if they need help
 
+                if compact:
+                    result = _compact_search_response(result)
                 if output_format == "json":
                     return result.model_dump(mode="json", exclude_none=True)
 

--- a/test-int/cli/test_compact_discovery_integration.py
+++ b/test-int/cli/test_compact_discovery_integration.py
@@ -1,0 +1,33 @@
+"""CLI compact discovery keeps identifiers without loading source prose."""
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from basic_memory.cli.main import app as cli_app
+
+
+@pytest.mark.parametrize("command", ["search-notes", "build-context"])
+@pytest.mark.parametrize("mode", ["--json", "--plain"])
+def test_compact_cli_discovery(app, app_config, test_project, config_manager, command, mode):
+    runner = CliRunner()
+    body = "Source prose that should be omitted. " * 100
+    written = runner.invoke(
+        cli_app,
+        ["tool", "write-note", "--title", "CompactCli", "--folder", "notes"],
+        input=body,
+    )
+    assert written.exit_code == 0, written.output
+    note = json.loads(written.stdout)
+    query = "CompactCli" if command == "search-notes" else note["permalink"]
+    result = runner.invoke(cli_app, ["tool", command, query, "--compact", mode])
+    assert result.exit_code == 0, result.output
+    assert "CompactCli" in result.stdout
+    assert "Source prose" not in result.stdout
+    if mode == "--json":
+        data = json.loads(result.stdout)
+        assert data["results"]
+    full = runner.invoke(cli_app, ["tool", command, query, mode])
+    assert full.exit_code == 0, full.output
+    assert "Source prose" in full.stdout

--- a/test-int/mcp/test_compact_context_integration.py
+++ b/test-int/mcp/test_compact_context_integration.py
@@ -1,0 +1,58 @@
+"""Graph discovery can omit prose and retain usable note identities."""
+
+import json
+
+import pytest
+from fastmcp import Client
+
+
+@pytest.mark.asyncio
+async def test_compact_context_preserves_graph_navigation(mcp_server, app, test_project):
+    body = "Long context body. " * 500 + "\n- [fact] " + "Detailed observation. " * 100
+    async with Client(mcp_server) as client:
+        for title, content in [
+            ("Context Target", "Target body"),
+            ("Context Source", body + "\n- relates_to [[Context Target]]"),
+        ]:
+            await client.call_tool(
+                "write_note",
+                {
+                    "title": title,
+                    "content": content,
+                    "directory": "context",
+                    "project": test_project.name,
+                },
+            )
+        arguments = {
+            "url": "context/context-source",
+            "project": test_project.name,
+            "depth": 2,
+        }
+        full_result = await client.call_tool("build_context", arguments)
+        compact_result = await client.call_tool("build_context", {**arguments, "compact": True})
+        full = json.loads(full_result.content[0].text)
+        compact = json.loads(compact_result.content[0].text)
+        assert full["results"]
+        assert full["results"][0]["observations"]
+        assert any(row["type"] == "relation" for row in full["results"][0]["related_results"])
+        # Request-time timestamps vary between calls; graph and page data must not.
+        for field in ("generated_at", "timeframe"):
+            full["metadata"].pop(field, None)
+            compact["metadata"].pop(field, None)
+        for result in full["results"]:
+            result["primary_result"].pop("content", None)
+            for item in [*result["observations"], *result["related_results"]]:
+                item.pop("content", None)
+        assert compact == full
+        assert len(compact_result.content[0].text) < len(full_result.content[0].text) / 2
+        selected = compact["results"][0]["primary_result"]
+        read = await client.call_tool(
+            "read_note", {"identifier": selected["external_id"], "project": test_project.name}
+        )
+        assert body in read.content[0].text
+        text_result = await client.call_tool(
+            "build_context", {**arguments, "compact": True, "output_format": "text"}
+        )
+        assert "Context Source" in text_result.content[0].text
+        assert "Long context body" not in text_result.content[0].text
+        assert "### Observations" not in text_result.content[0].text

--- a/test-int/mcp/test_compact_context_integration.py
+++ b/test-int/mcp/test_compact_context_integration.py
@@ -43,13 +43,23 @@ async def test_compact_context_preserves_graph_navigation(mcp_server, app, test_
             result["primary_result"].pop("content", None)
             for item in [*result["observations"], *result["related_results"]]:
                 item.pop("content", None)
+                if item["type"] == "observation":
+                    item["permalink"] = item["file_path"]
+                    item["title"] = item["category"]
         assert compact == full
+        assert "detailed-observation" not in compact_result.content[0].text.lower()
+        assert "Detailed observation" not in compact_result.content[0].text
         assert len(compact_result.content[0].text) < len(full_result.content[0].text) / 2
         selected = compact["results"][0]["primary_result"]
         read = await client.call_tool(
             "read_note", {"identifier": selected["external_id"], "project": test_project.name}
         )
         assert body in read.content[0].text
+        observation = compact["results"][0]["observations"][0]
+        observed_note = await client.call_tool(
+            "read_note", {"identifier": observation["permalink"], "project": test_project.name}
+        )
+        assert body in observed_note.content[0].text
         text_result = await client.call_tool(
             "build_context", {**arguments, "compact": True, "output_format": "text"}
         )

--- a/test-int/mcp/test_compact_search_integration.py
+++ b/test-int/mcp/test_compact_search_integration.py
@@ -1,0 +1,62 @@
+"""Compact discovery preserves ranked note identities without source prose."""
+
+import json
+
+import pytest
+from fastmcp import Client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("all_projects", [False, True])
+async def test_compact_search_can_discover_then_read_notes(
+    mcp_server, app, test_project, all_projects
+):
+    body = "CompactNeedle " + "This is source prose for a long note. " * 250
+    async with Client(mcp_server) as client:
+        await client.call_tool(
+            "write_note",
+            {
+                "title": "CompactNeedle",
+                "content": body,
+                "directory": "search",
+                "project": test_project.name,
+            },
+        )
+        arguments: dict[str, object] = {
+            "query": "CompactNeedle",
+            "search_type": "text",
+            "output_format": "json",
+        }
+        if all_projects:
+            arguments["search_all_projects"] = True
+        else:
+            arguments["project"] = test_project.name
+        full_result = await client.call_tool("search_notes", arguments)
+        compact_result = await client.call_tool("search_notes", {**arguments, "compact": True})
+        full = json.loads(full_result.content[0].text)
+        compact = json.loads(compact_result.content[0].text)
+        assert full["results"]
+        assert "content" in full["results"][0]
+        omitted = {"content", "matched_chunk", "content_length", "content_truncated"}
+        expected = {
+            **full,
+            "results": [
+                {key: value for key, value in row.items() if key not in omitted}
+                for row in full["results"]
+            ],
+        }
+        assert compact == expected
+        assert len(json.dumps(compact)) < len(json.dumps(full)) / 3
+
+        selected = compact["results"][0]
+        read = await client.call_tool(
+            "read_note",
+            {"identifier": selected["external_id"], "project": test_project.name},
+        )
+        assert body in read.content[0].text
+
+        text_result = await client.call_tool(
+            "search_notes", {**arguments, "compact": True, "output_format": "text"}
+        )
+        assert "CompactNeedle" in text_result.content[0].text
+        assert "This is source prose" not in text_result.content[0].text

--- a/test-int/mcp/test_compact_search_integration.py
+++ b/test-int/mcp/test_compact_search_integration.py
@@ -8,10 +8,13 @@ from fastmcp import Client
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("all_projects", [False, True])
+@pytest.mark.parametrize("observations", [False, True])
 async def test_compact_search_can_discover_then_read_notes(
-    mcp_server, app, test_project, all_projects
+    mcp_server, app, test_project, all_projects, observations
 ):
     body = "CompactNeedle " + "This is source prose for a long note. " * 250
+    if observations:
+        body = "- [fact] " + body
     async with Client(mcp_server) as client:
         await client.call_tool(
             "write_note",
@@ -26,6 +29,7 @@ async def test_compact_search_can_discover_then_read_notes(
             "query": "CompactNeedle",
             "search_type": "text",
             "output_format": "json",
+            "entity_types": ["observation"] if observations else ["entity"],
         }
         if all_projects:
             arguments["search_all_projects"] = True
@@ -45,6 +49,10 @@ async def test_compact_search_can_discover_then_read_notes(
                 for row in full["results"]
             ],
         }
+        if observations:
+            for row in expected["results"]:
+                row["title"] = row["category"]
+                row["permalink"] = row["file_path"]
         assert compact == expected
         assert len(json.dumps(compact)) < len(json.dumps(full)) / 3
 
@@ -58,5 +66,6 @@ async def test_compact_search_can_discover_then_read_notes(
         text_result = await client.call_tool(
             "search_notes", {**arguments, "compact": True, "output_format": "text"}
         )
-        assert "CompactNeedle" in text_result.content[0].text
+        assert ("fact" if observations else "CompactNeedle") in text_result.content[0].text
         assert "This is source prose" not in text_result.content[0].text
+        assert "this-is-source-prose" not in text_result.content[0].text

--- a/test-int/mcp/test_compact_search_integration.py
+++ b/test-int/mcp/test_compact_search_integration.py
@@ -52,14 +52,18 @@ async def test_compact_search_can_discover_then_read_notes(
         if observations:
             for row in expected["results"]:
                 row["title"] = row["category"]
-                row["permalink"] = row["file_path"]
+                row["permalink"] = (
+                    f"{test_project.name}/{row['file_path']}" if all_projects else row["file_path"]
+                )
         assert compact == expected
         assert len(json.dumps(compact)) < len(json.dumps(full)) / 3
 
         selected = compact["results"][0]
         read = await client.call_tool(
             "read_note",
-            {"identifier": selected["external_id"], "project": test_project.name},
+            {"identifier": selected["permalink"]}
+            if all_projects and observations
+            else {"identifier": selected["external_id"], "project": test_project.name},
         )
         assert body in read.content[0].text
 

--- a/tests/mcp/test_compact_context_labels.py
+++ b/tests/mcp/test_compact_context_labels.py
@@ -1,0 +1,39 @@
+"""Content-derived observation labels must not reintroduce omitted prose."""
+
+from datetime import UTC, datetime
+
+from basic_memory.mcp.tools.build_context import _compact_context_labels, _format_context_markdown
+from basic_memory.schemas.memory import (
+    ContextResult,
+    GraphContext,
+    MemoryMetadata,
+    ObservationSummary,
+)
+
+
+def test_compact_observation_navigation_uses_owning_file_without_mutating_graph():
+    observation = ObservationSummary(
+        observation_id=12,
+        entity_external_id="source-uuid",
+        title="fact: Private source prose",
+        file_path="notes/Source.md",
+        permalink="notes/source/observations/fact/private-source-prose",
+        category="fact",
+        content="Private source prose",
+        created_at=datetime.now(UTC),
+    )
+    graph = GraphContext(
+        results=[ContextResult(primary_result=observation, related_results=[observation])],
+        metadata=MemoryMetadata(depth=1),
+    )
+    compact = _compact_context_labels(graph)
+    for item in [compact.results[0].primary_result, *compact.results[0].related_results]:
+        assert isinstance(item, ObservationSummary)
+        assert item.title == "fact"
+        assert item.permalink == "notes/Source.md"
+        assert item.entity_external_id == "source-uuid"
+        assert item.observation_id == 12
+    text = _format_context_markdown(compact, "project", compact=True)
+    assert "notes/Source.md" in text
+    assert "private" not in text.lower()
+    assert graph.results[0].primary_result.title == "fact: Private source prose"

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -24,6 +24,7 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "page_size",
         "max_related",
         "output_format",
+        "compact",
     ],
     "cat": [
         "identifier",

--- a/tests/mcp/test_tool_contracts.py
+++ b/tests/mcp/test_tool_contracts.py
@@ -150,6 +150,7 @@ EXPECTED_TOOL_SIGNATURES: dict[str, list[str]] = {
         "valid_at",
         "valid_overlaps",
         "time_kind",
+        "compact",
     ],
     "tail": ["timeframe", "lines", "project", "project_id"],
     "view_note": ["identifier", "project", "project_id"],

--- a/tests/mcp/tools/test_search_notes_multi_project.py
+++ b/tests/mcp/tools/test_search_notes_multi_project.py
@@ -39,8 +39,10 @@ def local_routing(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("compact", [False, True])
+@pytest.mark.parametrize("observations", [False, True])
 async def test_search_notes_search_all_projects_qualifies_result_permalinks(
-    monkeypatch, cloud_routing
+    monkeypatch, cloud_routing, compact, observations
 ):
     """Multi-project search belongs to search_notes and keeps result ids routable."""
     clients_mod = importlib.import_module("basic_memory.mcp.clients")
@@ -91,9 +93,12 @@ async def test_search_notes_search_all_projects_qualifies_result_permalinks(
                         title=title,
                         permalink="main/tests/mcp-test-note",
                         content="MCP content",
-                        type=SearchItemType.ENTITY,
+                        type=SearchItemType.OBSERVATION if observations else SearchItemType.ENTITY,
+                        category="fact" if observations else None,
                         score=score,
-                        file_path="/main/tests/mcp-test-note.md",
+                        file_path="tests/Exact Note.md"
+                        if observations
+                        else "/main/tests/mcp-test-note.md",
                     )
                 ],
                 current_page=page,
@@ -110,6 +115,7 @@ async def test_search_notes_search_all_projects_qualifies_result_permalinks(
         query="MCP Test Note",
         search_all_projects=True,
         output_format="json",
+        compact=compact,
     )
 
     assert isinstance(result, dict)
@@ -117,10 +123,13 @@ async def test_search_notes_search_all_projects_qualifies_result_permalinks(
         ("personal/main", "11111111-1111-1111-1111-111111111111"),
         ("team-paul/main", "22222222-2222-2222-2222-222222222222"),
     ]
+    path = "tests/Exact Note.md" if compact and observations else "tests/mcp-test-note"
     assert [item["permalink"] for item in result["results"]] == [
-        "team-paul/main/tests/mcp-test-note",
-        "personal/main/tests/mcp-test-note",
+        f"team-paul/main/{path}",
+        f"personal/main/{path}",
     ]
+    if compact:
+        assert all("content" not in item for item in result["results"])
     assert result["total_is_exact"] is True
 
 

--- a/tests/mcp/tools/test_search_notes_multi_project.py
+++ b/tests/mcp/tools/test_search_notes_multi_project.py
@@ -381,7 +381,10 @@ async def test_search_notes_search_all_projects_propagates_retryable_service_out
 
 
 @pytest.mark.asyncio
-async def test_search_notes_search_all_projects_local_omits_project_id(monkeypatch, local_routing):
+@pytest.mark.parametrize("compact_observations", [False, True])
+async def test_search_notes_search_all_projects_local_omits_project_id(
+    monkeypatch, local_routing, compact_observations
+):
     """Without a cloud route, fan-out must address each project by name only.
 
     project_id (external UUID) routes through the cloud v2 API path, which
@@ -431,7 +434,9 @@ async def test_search_notes_search_all_projects_local_omits_project_id(monkeypat
                         title=f"Note in {self.project_id or 'local'}",
                         permalink="notes/example",
                         content="",
-                        type=SearchItemType.ENTITY,
+                        type=SearchItemType.OBSERVATION
+                        if compact_observations
+                        else SearchItemType.ENTITY,
                         score=0.5,
                         file_path="/notes/example.md",
                     )
@@ -450,6 +455,7 @@ async def test_search_notes_search_all_projects_local_omits_project_id(monkeypat
         query="anything",
         search_all_projects=True,
         output_format="json",
+        compact=compact_observations,
     )
 
     assert isinstance(result, dict)
@@ -459,3 +465,8 @@ async def test_search_notes_search_all_projects_local_omits_project_id(monkeypat
     )
     assert result["total"] == 2
     assert result["total_is_exact"] is True
+    if compact_observations:
+        assert [item["permalink"] for item in result["results"]] == [
+            "alpha/notes/example.md",
+            "beta/notes/example.md",
+        ]


### PR DESCRIPTION
## Why

Shell agents need access to the same compact discovery options as MCP clients. Refs #686.

## What Changed

Adds `--compact` to `bm tool search-notes` and `bm tool build-context`, forwarding to the MCP implementations. JSON, plain text and Rich output selection remain unchanged. Adds a short discovery-then-read guide in `docs/COMPACT_DISCOVERY.md`.

## Implementation Details

Stacked on #1516 and includes the search implementation from #1515. Land both prerequisites before retargeting this PR to main. The new CLI change only forwards the option; it shares the MCP projection and uses existing renderers.

## Testing

- `uv run pytest test-int/cli/test_compact_discovery_integration.py -q --no-cov`: 4 passed, covering both commands in JSON/plain modes and ordinary output without the flag.
- `BASIC_MEMORY_TEST_POSTGRES=1 uv run pytest test-int/cli/test_compact_discovery_integration.py -q --no-cov`: 4 passed.
- `uv run pytest tests/cli/test_cli_tools.py tests/cli/test_cli_tool_rich_output.py tests/cli/test_cli_tool_json_output.py tests/cli/test_cli_tool_exit.py -q --no-cov`: 93 passed.
- `just fast-check`, `just doctor`, `git diff --check`: passed.

## Risks / Follow-ups

Opt-in, with no default change. Compact output reduces payload size rather than database work or a fixed token budget. The broader progressive-loading issue remains open.
