### PR TITLE
feat(core): retain extraction page maps in document provenance

### DIFF
--- a/docs/DOCUMENT_CITATIONS.md
+++ b/docs/DOCUMENT_CITATIONS.md
@@ -50,9 +50,33 @@ retrieve a historical version or automatically detect replacement of the PDF.
 ## Scope and prior art
 
 This implements page-level addressing for #1366 and the citation convention from
-the amended SPEC-89. It does not implement an extraction offset map, quote
+the amended SPEC-89. It does not implement quote
 highlighting, generic OKF conformance (#1246), evidence watermarks, or contradiction
 detection. Cloud prompt adoption and viewer routing are separate integration work.
+
+## Extraction page map
+
+New pdf-inspector extractions retain `extraction.page_map` on both the document
+and ingestion-run note. Each entry has a one-based physical `page` and half-open
+`start`/`end` offsets measured in Unicode code points, as in Python string slices.
+The ranges partition the normalized raw Markdown body, including page markers;
+inter-page separators belong to the preceding page. OCR-only pages retain a
+range for their marker. Offsets exclude frontmatter and include the canonical
+final newline.
+
+The map carries `body_length` and a SHA-256 checksum of that body's UTF-8 bytes.
+`DocumentPageMapV1.resolve_span(body, start=..., end=...)` verifies the exact body
+before returning the physical pages intersecting a nonempty span. It rejects
+rewritten text and invalid bounds. After enrichment the map still describes the
+raw extraction revision, never the new agent-written body. Retrieve that raw
+revision before resolving a span; the source PDF checksum identifies a different
+artifact and cannot substitute for the body checksum.
+
+Older extractions omit the optional map and retain their serialized shape. The
+pdf-inspector extraction profile is now `pdf-inspector-v2`, yielding a new run
+identity when the same PDF is explicitly re-extracted; existing notes are not
+backfilled automatically. Other extraction providers may supply the same
+parser-neutral map contract.
 
 - [RFC 8118, section 3](https://www.rfc-editor.org/rfc/rfc8118.html#section-3)
   defines the PDF `page=N` fragment with one-based page numbering.

--- a/src/basic_memory/document_ingestion/pdf_inspector.py
+++ b/src/basic_memory/document_ingestion/pdf_inspector.py
@@ -17,6 +17,8 @@ from enum import StrEnum
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from basic_memory.schemas.document_page_map import DocumentPageMapV1
+
 PDF_INSPECTOR_ENGINE = "firecrawl/pdf-inspector"
 PDF_INSPECTOR_WORKER_MODULE = "basic_memory.document_ingestion.pdf_inspector_worker"
 
@@ -57,6 +59,7 @@ class PdfInspectorOutput(BaseModel):
     page_count: int = Field(gt=0)
     extracted_page_count: int = Field(ge=0)
     pages_needing_ocr: tuple[int, ...] = ()
+    page_map: DocumentPageMapV1 | None = None
     confidence: float = Field(ge=0.0, le=1.0)
     processing_time_ms: int = Field(ge=0)
     is_complex_layout: bool
@@ -67,6 +70,12 @@ class PdfInspectorOutput(BaseModel):
     @model_validator(mode="after")
     def validate_page_diagnostics(self) -> PdfInspectorOutput:
         """Keep page diagnostics within the document and internally consistent."""
+        if self.page_map is not None:
+            if len(self.page_map.pages) != self.page_count:
+                raise ValueError("page map must contain every physical page")
+            body = self.markdown.replace("\r\n", "\n").replace("\r", "\n").strip("\n")
+            body = body + "\n" if body else ""
+            self.page_map.resolve_span(body, start=0, end=len(body))
         page_lists = (
             self.pages_needing_ocr,
             self.pages_with_tables,

--- a/src/basic_memory/document_ingestion/pdf_inspector_worker.py
+++ b/src/basic_memory/document_ingestion/pdf_inspector_worker.py
@@ -9,6 +9,7 @@ PDF cannot exhaust the parent process.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.metadata
 import sys
 
@@ -27,6 +28,7 @@ from basic_memory.document_ingestion.pdf_inspector import (
     PdfInspectorOutput,
     PdfInspectorPdfType,
 )
+from basic_memory.schemas.document_page_map import DocumentPageMapV1, DocumentPageRangeV1
 
 
 def _normalized_pages(pages: list[int], *, page_count: int) -> tuple[int, ...]:
@@ -73,6 +75,29 @@ def inspect_pdf_bytes(
             continue
         markdown_parts.append(f"<!-- Page {page_number} -->\n\n{page.markdown.strip()}")
     markdown = "\n\n".join(markdown_parts).strip()
+    # Canonical note assembly normalizes line endings and adds one final newline.
+    # Record offsets against those stored body characters, not native bytes or
+    # frontmatter. Separators belong to the preceding page; OCR markers retain
+    # their physical page even when no text could be extracted.
+    page_ranges: list[DocumentPageRangeV1] = []
+    body_parts: list[str] = []
+    offset = 0
+    for index, part in enumerate(markdown_parts):
+        normalized = part.replace("\r\n", "\n").replace("\r", "\n")
+        normalized = (
+            normalized + "\n\n" if index < len(markdown_parts) - 1 else normalized.rstrip() + "\n"
+        )
+        body_parts.append(normalized)
+        page_ranges.append(
+            DocumentPageRangeV1(page=index + 1, start=offset, end=offset + len(normalized))
+        )
+        offset += len(normalized)
+    canonical_body = "".join(body_parts)
+    page_map = DocumentPageMapV1(
+        body_checksum="sha256:" + hashlib.sha256(canonical_body.encode("utf-8")).hexdigest(),
+        body_length=len(canonical_body),
+        pages=tuple(page_ranges),
+    )
     if len(markdown.encode("utf-8")) > max_output_bytes:
         raise ValueError("PDF extraction exceeds the configured output byte limit")
 
@@ -90,6 +115,7 @@ def inspect_pdf_bytes(
         engine_version=engine_version,
         pdf_type=PdfInspectorPdfType(result.pdf_type),
         markdown=markdown,
+        page_map=page_map,
         title=result.title,
         page_count=result.page_count,
         extracted_page_count=sum(not page.needs_ocr for page in page_result.pages),

--- a/src/basic_memory/document_ingestion/raw_document.py
+++ b/src/basic_memory/document_ingestion/raw_document.py
@@ -52,7 +52,9 @@ from basic_memory.schemas.document import (
 # Actor source recorded on generated notes; see VALID_NOTE_OBJECT_SOURCES.
 DOCUMENT_INGESTION_SOURCE = "document_ingestion"
 PDF_RAW_PIPELINE_VERSION = "pdf-inspector-raw-v1"
-PDF_RAW_EXTRACTION_PROFILE = "pdf-inspector-v1"
+# Page-map provenance changes the accepted envelope; a new profile prevents
+# idempotent writers from reusing a prior run that lacks the map.
+PDF_RAW_EXTRACTION_PROFILE = "pdf-inspector-v2"
 
 
 class DocumentSourceChangedError(RuntimeError):
@@ -237,6 +239,7 @@ def build_raw_document_artifacts(
         requires_ocr=bool(extracted.pages_needing_ocr),
         ocr_page_count=len(extracted.pages_needing_ocr),
         pages_needing_ocr=extracted.pages_needing_ocr,
+        page_map=extracted.page_map,
         confidence=extracted.confidence,
         has_encoding_issues=extracted.has_encoding_issues,
         has_tables=bool(extracted.pages_with_tables),

--- a/src/basic_memory/document_ingestion/raw_document.py
+++ b/src/basic_memory/document_ingestion/raw_document.py
@@ -198,6 +198,12 @@ def build_raw_document_artifacts(
     extracted_at: datetime,
 ) -> RawDocumentArtifacts:
     """Map native extraction output into Core's portable document contract."""
+    # Older adapters can still supply the optional, map-less output contract.
+    # Preserve their v1 identity; only mapped output earns the v2 provenance
+    # profile, so a later mapped extraction cannot reuse a map-less run.
+    extraction_profile = (
+        PDF_RAW_EXTRACTION_PROFILE if extracted.page_map is not None else "pdf-inspector-v1"
+    )
     options_hash = extraction_options_checksum(limits)
     run_id = UUID(
         derive_document_ingestion_run_id(
@@ -206,7 +212,7 @@ def build_raw_document_artifacts(
             pipeline_version=PDF_RAW_PIPELINE_VERSION,
             extractor_engine=extracted.engine,
             extractor_version=extracted.engine_version,
-            extraction_profile=PDF_RAW_EXTRACTION_PROFILE,
+            extraction_profile=extraction_profile,
             extraction_options_hash=options_hash,
             prompt_version=None,
         )
@@ -224,7 +230,7 @@ def build_raw_document_artifacts(
     extraction = DocumentExtractionV1(
         engine=extracted.engine,
         engine_version=extracted.engine_version,
-        profile=PDF_RAW_EXTRACTION_PROFILE,
+        profile=extraction_profile,
         options_hash=options_hash,
         classification=extracted.pdf_type.value,
         status=(

--- a/src/basic_memory/schemas/document.py
+++ b/src/basic_memory/schemas/document.py
@@ -31,6 +31,7 @@ from pydantic import (
 )
 
 from basic_memory.file_utils import dump_frontmatter, parse_frontmatter, remove_frontmatter
+from basic_memory.schemas.document_page_map import DocumentPageMapV1
 
 if TYPE_CHECKING:  # pragma: no cover - static import only
     from basic_memory.markdown.entity_parser import EntityContent
@@ -132,6 +133,7 @@ class DocumentExtractionV1(_DocumentContractModel):
     requires_ocr: StrictBool
     ocr_page_count: int = Field(ge=0, strict=True)
     pages_needing_ocr: tuple[StrictInt, ...] = ()
+    page_map: DocumentPageMapV1 | None = None
     confidence: float | None = Field(default=None, ge=0.0, le=1.0, strict=True)
     has_encoding_issues: StrictBool = False
     has_tables: StrictBool = False
@@ -144,6 +146,8 @@ class DocumentExtractionV1(_DocumentContractModel):
 
     @model_validator(mode="after")
     def validate_page_diagnostics(self) -> "DocumentExtractionV1":
+        if self.page_map is not None and len(self.page_map.pages) != self.page_count:
+            raise ValueError("page map must contain every physical page")
         if self.extracted_page_count > self.page_count:
             raise ValueError("extracted_page_count cannot exceed page_count")
         if self.ocr_page_count != len(self.pages_needing_ocr):

--- a/src/basic_memory/schemas/document_page_map.py
+++ b/src/basic_memory/schemas/document_page_map.py
@@ -1,0 +1,57 @@
+"""Page provenance for exact raw extraction text, independent of PDF parsers."""
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class DocumentPageRangeV1(BaseModel):
+    """Half-open Unicode code-point offsets in the raw extraction body."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    page: int = Field(ge=1, strict=True)
+    start: int = Field(ge=0, strict=True)
+    end: int = Field(ge=0, strict=True)
+
+    @model_validator(mode="after")
+    def require_ordered_offsets(self) -> "DocumentPageRangeV1":
+        if self.end < self.start:
+            raise ValueError("page range end cannot precede start")
+        return self
+
+
+class DocumentPageMapV1(BaseModel):
+    """Ordered page ranges bound to one exact raw Markdown body checksum.
+
+    This remains extraction provenance after enrichment; offsets never address
+    the rewritten agent body or the frontmatter of a serialized note.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    unit: Literal["unicode_code_point"] = "unicode_code_point"
+    body_checksum: str = Field(strict=True, pattern=r"^sha256:[0-9a-f]{64}$")
+    body_length: int = Field(ge=0, strict=True)
+    pages: tuple[DocumentPageRangeV1, ...]
+
+    @model_validator(mode="after")
+    def require_complete_partition(self) -> "DocumentPageMapV1":
+        end = 0
+        for number, page in enumerate(self.pages, start=1):
+            if page.page != number or page.start != end:
+                raise ValueError("page map must cover ordered consecutive pages without gaps")
+            end = page.end
+        if end != self.body_length:
+            raise ValueError("page map must cover the entire raw body")
+        return self
+
+    def resolve_span(self, body: str, *, start: int, end: int) -> tuple[int, ...]:
+        """Resolve a nonempty raw-body span, rejecting stale or rewritten text."""
+        checksum = "sha256:" + hashlib.sha256(body.encode("utf-8")).hexdigest()
+        if len(body) != self.body_length or checksum != self.body_checksum:
+            raise ValueError("body does not match extraction page map")
+        if not 0 <= start < end <= self.body_length:
+            raise ValueError("span must be nonempty and within the raw body")
+        return tuple(page.page for page in self.pages if page.start < end and start < page.end)

--- a/tests/document_ingestion/test_pdf_inspector_worker.py
+++ b/tests/document_ingestion/test_pdf_inspector_worker.py
@@ -5,14 +5,27 @@ from __future__ import annotations
 import io
 import sys
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import Mock
+from uuid import UUID
 
 import pytest
 
 from basic_memory.document_ingestion import pdf_inspector_worker
 from basic_memory.document_ingestion.pdf_inspector import PDF_INSPECTOR_ENGINE, PdfInspectorOutput
+from basic_memory.document_ingestion.pdf_inspector import PdfInspectorLimits
+from basic_memory.document_ingestion.raw_document import (
+    DocumentSourceEntity,
+    DocumentSourceSnapshot,
+    build_raw_document_artifacts,
+    build_raw_ingestion_run_markdown,
+)
+from basic_memory.schemas.document import (
+    parse_document_markdown,
+    parse_document_ingestion_run_markdown,
+)
 
 
 @dataclass(frozen=True)
@@ -69,6 +82,52 @@ def test_inspect_pdf_bytes_maps_native_output(monkeypatch: pytest.MonkeyPatch) -
     assert result.extracted_page_count == 1
     assert result.pages_needing_ocr == (2,)
     assert result.markdown == "<!-- Page 1 -->\n\n# Page one\n\n<!-- Page 2: OCR required -->"
+
+
+def test_page_map_survives_document_and_run_serialization(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = fake_engine(pages=(FakePage(0, False, "é🙂\r\nQuote"), FakePage(1, True, "")))
+    monkeypatch.setattr(pdf_inspector_worker, "pdf_inspector", engine)
+    extracted = pdf_inspector_worker.inspect_pdf_bytes(
+        b"%PDF-test", max_pages=10, max_output_bytes=10_000
+    )
+    now = datetime.now(UTC)
+    artifacts = build_raw_document_artifacts(
+        DocumentSourceSnapshot(
+            entity=DocumentSourceEntity(
+                entity_id=1,
+                external_id=UUID("11111111-1111-1111-1111-111111111111"),
+                file_path="report.pdf",
+                media_type="application/pdf",
+            ),
+            content=b"%PDF-test",
+            checksum="sha256:" + "a" * 64,
+            size_bytes=9,
+            storage_etag="source-version",
+        ),
+        extracted,
+        limits=PdfInspectorLimits(),
+        started_at=now,
+        extracted_at=now,
+    )
+    document = parse_document_markdown(artifacts.document_markdown)
+    run = parse_document_ingestion_run_markdown(
+        build_raw_ingestion_run_markdown(
+            artifacts, raw_checksum="sha256:" + "b" * 64, raw_created_at=now
+        )
+    )
+    assert run.frontmatter.extraction == document.frontmatter.extraction
+    page_map = document.frontmatter.extraction.page_map
+    assert page_map is not None
+    assert page_map == extracted.page_map
+    start = document.body.index("é🙂")
+    assert page_map.resolve_span(document.body, start=start, end=start + 2) == (1,)
+    start = document.body.index("OCR required")
+    assert page_map.resolve_span(document.body, start=start, end=start + 3) == (2,)
+    with pytest.raises(ValueError, match="every physical page"):
+        PdfInspectorOutput.model_validate({**extracted.model_dump(), "page_count": 3})
+    extraction = document.frontmatter.extraction
+    with pytest.raises(ValueError, match="every physical page"):
+        type(extraction).model_validate({**extraction.model_dump(), "page_count": 3})
 
 
 @pytest.mark.parametrize(

--- a/tests/document_ingestion/test_pdf_inspector_worker.py
+++ b/tests/document_ingestion/test_pdf_inspector_worker.py
@@ -110,6 +110,7 @@ def test_page_map_survives_document_and_run_serialization(monkeypatch: pytest.Mo
         extracted_at=now,
     )
     document = parse_document_markdown(artifacts.document_markdown)
+    assert document.frontmatter.extraction.profile == "pdf-inspector-v2"
     run = parse_document_ingestion_run_markdown(
         build_raw_ingestion_run_markdown(
             artifacts, raw_checksum="sha256:" + "b" * 64, raw_created_at=now

--- a/tests/document_ingestion/test_raw_document.py
+++ b/tests/document_ingestion/test_raw_document.py
@@ -105,7 +105,7 @@ def test_build_raw_document_artifacts_is_typed_and_deterministic() -> None:
     assert parsed.frontmatter.type == "document"
     assert parsed.frontmatter.source.storage_etag == "etag-1"
     assert parsed.frontmatter.extraction.status is DocumentExtractionStatus.complete
-    assert parsed.frontmatter.extraction.profile == "pdf-inspector-v1"
+    assert parsed.frontmatter.extraction.profile == "pdf-inspector-v2"
     assert parsed.frontmatter.extraction.options_hash == extraction_options_checksum(limits)
     assert parsed.frontmatter.extraction.classification == "text_based"
     assert parsed.frontmatter.extraction.duration_ms == 12

--- a/tests/document_ingestion/test_raw_document.py
+++ b/tests/document_ingestion/test_raw_document.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import hashlib
 from datetime import UTC, datetime
 from typing import override
 from uuid import UUID
 
 import pytest
+
+from basic_memory.schemas.document_page_map import DocumentPageMapV1, DocumentPageRangeV1
 
 from basic_memory.document_ingestion.pdf_inspector import (
     PdfInspector,
@@ -105,7 +108,7 @@ def test_build_raw_document_artifacts_is_typed_and_deterministic() -> None:
     assert parsed.frontmatter.type == "document"
     assert parsed.frontmatter.source.storage_etag == "etag-1"
     assert parsed.frontmatter.extraction.status is DocumentExtractionStatus.complete
-    assert parsed.frontmatter.extraction.profile == "pdf-inspector-v2"
+    assert parsed.frontmatter.extraction.profile == "pdf-inspector-v1"
     assert parsed.frontmatter.extraction.options_hash == extraction_options_checksum(limits)
     assert parsed.frontmatter.extraction.classification == "text_based"
     assert parsed.frontmatter.extraction.duration_ms == 12
@@ -116,6 +119,29 @@ def test_build_raw_document_artifacts_is_typed_and_deterministic() -> None:
 
 def test_engine_version_is_part_of_run_identity() -> None:
     assert artifacts().run_id != artifacts(engine_version="1.17.0").run_id
+
+
+def test_mapped_extraction_cannot_reuse_a_legacy_run() -> None:
+    output = extraction_output()
+    page_map = DocumentPageMapV1(
+        body_checksum="sha256:" + hashlib.sha256(output.markdown.encode()).hexdigest(),
+        body_length=len(output.markdown),
+        pages=(DocumentPageRangeV1(page=1, start=0, end=len(output.markdown)),),
+    )
+    mapped = build_raw_document_artifacts(
+        source_snapshot(),
+        output.model_copy(update={"page_map": page_map}),
+        limits=PdfInspectorLimits(),
+        started_at=STARTED_AT,
+        extracted_at=EXTRACTED_AT,
+    )
+    legacy = artifacts()
+    assert mapped.run_id != legacy.run_id
+    assert mapped.document_external_id == legacy.document_external_id
+    assert mapped.extraction.profile == "pdf-inspector-v2"
+    assert legacy.extraction.profile == "pdf-inspector-v1"
+    with pytest.raises(RuntimeError, match="deterministic run identity"):
+        require_matching_raw_document(accepted_document(legacy), mapped)
 
 
 def test_raw_run_note_references_the_accepted_document_checksum() -> None:

--- a/tests/schemas/test_document_page_map.py
+++ b/tests/schemas/test_document_page_map.py
@@ -1,0 +1,44 @@
+"""Exact-text page resolution must not silently cite a different revision."""
+
+import hashlib
+
+import pytest
+from pydantic import ValidationError
+
+from basic_memory.schemas.document_page_map import DocumentPageMapV1, DocumentPageRangeV1
+
+
+def test_unicode_spans_resolve_pages_and_reject_drift() -> None:
+    body = "é🙂\nsecond"
+    page_map = DocumentPageMapV1(
+        body_checksum="sha256:" + hashlib.sha256(body.encode()).hexdigest(),
+        body_length=len(body),
+        pages=(
+            DocumentPageRangeV1(page=1, start=0, end=3),
+            DocumentPageRangeV1(page=2, start=3, end=len(body)),
+        ),
+    )
+    assert page_map.resolve_span(body, start=0, end=2) == (1,)
+    assert page_map.resolve_span(body, start=3, end=len(body)) == (2,)
+    assert page_map.resolve_span(body, start=1, end=4) == (1, 2)
+    with pytest.raises(ValueError, match="does not match"):
+        page_map.resolve_span(body.replace("second", "edited"), start=0, end=1)
+    for start, end in [(-1, 1), (0, 0), (0, len(body) + 1)]:
+        with pytest.raises(ValueError, match="nonempty"):
+            page_map.resolve_span(body, start=start, end=end)
+
+
+@pytest.mark.parametrize(
+    "pages",
+    [
+        [{"page": 1, "start": 1, "end": 3}],
+        [{"page": 2, "start": 0, "end": 3}],
+        [{"page": 1, "start": 0, "end": 2}],
+        [{"page": 1, "start": 2, "end": 1}],
+    ],
+)
+def test_invalid_page_partitions_are_rejected(pages: list[dict[str, int]]) -> None:
+    with pytest.raises(ValidationError):
+        DocumentPageMapV1.model_validate(
+            {"body_checksum": "sha256:" + "a" * 64, "body_length": 3, "pages": pages}
+        )


### PR DESCRIPTION
## Why

#1366 already has page-level observation citations, but extraction discarded the offset-to-page map. A later consumer could not resolve raw text spans without parsing the PDF again.

## What Changed

Persist an optional parser-neutral `extraction.page_map` on document and ingestion-run provenance. New pdf-inspector runs capture every physical page, including OCR markers, while assembling Markdown. `resolve_span` verifies the exact raw body checksum before returning intersecting pages.

## Implementation Details

Ranges use half-open Unicode code-point offsets over the canonical raw body, excluding frontmatter and including the final newline. Separators belong to the preceding page. Ordered contiguous ranges, physical page count, body length, and SHA-256 constrain the map. Enrichment retains extraction provenance; offsets continue to address the raw revision, not rewritten prose.

The extraction profile advances to `pdf-inspector-v2` so deterministic run reuse cannot return an older envelope without a map. Existing notes without maps retain their serialized shape. No source PDF bytes or extracted prose are rewritten by this feature.

## Testing

- `uv run pytest tests/document_ingestion tests/schemas/test_document.py tests/schemas/test_document_page_map.py test-int/test_document_page_citations.py -q --no-cov`: **139 passed**.
- Tests cover Unicode spans, cross-page spans, changed-body rejection, invalid ranges, OCR pages, CRLF normalization, and document/run serialization. The existing native subprocess extraction and citation suites also pass.
- `just fast-check`, final `just typecheck`, `just doctor`, and `git diff --check`: passed.

## Risks / Follow-ups

Refs #1366. This provides extraction provenance and a resolver, not quote highlighting or a Cloud viewer. Consumers must retrieve the exact raw extraction revision. Existing documents are not automatically backfilled; an explicit new extraction gets the new profile/run identity.
