### PR TITLE
fix(integrations): flag unverified Hermes save claims

### DIFF
--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -82,6 +82,27 @@ Plus automatic capture:
 
 A bundled skill (`skill:view basic-memory:basic-memory`) gives the agent a longer reference doc on top of the always-on `system_prompt_block`.
 
+### Save confirmations
+
+When `memory.provider` is `basic-memory`, the plugin checks direct English save
+confirmations against successful `bm_write` or `bm_edit` events in the same turn.
+Without an observed successful write it appends:
+
+> Basic Memory verification: no successful Basic Memory write was observed in this turn. The save claim above is unverified.
+
+This is a bounded heuristic: it recognizes confirmations such as “Saved to Basic
+Memory” and “I've saved it” after a remember request. It skips quoted and fenced
+examples. It does not verify the contents of a successful write, recognize every
+paraphrase or language, or observe writes made through a shell or another client.
+Automatic transcript capture does not count as saving the requested note.
+
+The guard requires Hermes to dispatch `pre_llm_call` and `post_tool_call` with
+session/turn IDs, plus `transform_llm_output` before final-response delivery. Older
+hosts without hook registration log an upgrade warning. Host contract tests below
+verify the installed Hermes source; they pass against released Hermes v0.21.1
+(`v2026.9.7`). Use that release or newer for save-claim verification; the older
+prerequisite above covers the ordinary memory tools.
+
 ## Slash commands
 
 For direct, in-session use without going through the agent (requires Hermes ≥ v0.11.0):
@@ -210,7 +231,9 @@ hermes plugins remove basic-memory     # then revert memory.provider in config.y
 
 ## Development
 
-The plugin is a single-file Python module at `__init__.py`. The Hermes plugin loader expects `register(ctx)` and grep-detects either `register_memory_provider` or `MemoryProvider` in the file.
+The plugin entrypoint is `__init__.py`; `save_claims.py` owns turn-scoped write
+evidence and confirmation detection. The Hermes plugin loader expects `register(ctx)`
+and grep-detects either `register_memory_provider` or `MemoryProvider` in the entrypoint.
 
 For local development (point Hermes at your working tree instead of going through `hermes plugins install`):
 
@@ -239,6 +262,16 @@ BM_INTEGRATION=1 uv run --with pytest --with mcp pytest tests/test_integration.p
 The unit suite stubs out Hermes-internal imports (`agent.memory_provider`, `tools.registry`) so it runs without a Hermes install. `mcp` is optional at unit-test time — its absence just makes `is_available()` return False, which the tests verify.
 
 Integration tests require `BM_INTEGRATION=1`, `bm` CLI on PATH, and `mcp` Python package importable. Each session creates a unique throwaway BM project (under `tempfile.mkdtemp`) and removes it on teardown, so they never touch your real BM projects.
+
+To verify hook loading, tool-result status, and final-response replacement against
+a Hermes checkout, run from that checkout with its test environment:
+
+```bash
+scripts/run_tests.sh /absolute/path/to/basic-memory/integrations/hermes/host_tests/test_save_claims.py -q
+```
+
+These tests use the real memory-provider loader, hook dispatcher, and turn finalizer
+with temporary configuration. They make no model or Basic Memory server requests.
 
 ## License
 

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -39,6 +39,8 @@ from typing import Any, Callable
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
 
+from .save_claims import SaveClaimGuard
+
 __version__ = "0.23.2"
 
 logger = logging.getLogger("hermes.memory.basic-memory")
@@ -2036,6 +2038,32 @@ def register(ctx: Any) -> None:
     provider = BasicMemoryProvider()
     _active_providers.append(provider)
     ctx.register_memory_provider(provider)
+
+    # Hook discovery can instantiate a second, inactive provider. Select the
+    # configured backend at the turn boundary instead of closing over that
+    # instance's initialization state, which would disable the guard on reload.
+    if hasattr(ctx, "register_hook"):
+        guard = SaveClaimGuard()
+
+        def begin_memory_turn(
+            *, session_id: str = "", turn_id: str = "", user_message: str = "", **_: object
+        ) -> None:
+            from hermes_cli.config import cfg_get, load_config_readonly
+
+            if cfg_get(load_config_readonly(), "memory", "provider") == PROVIDER_NAME:
+                guard.begin_turn(session_id=session_id, turn_id=turn_id, user_message=user_message)
+            else:
+                guard.end_session(session_id=session_id)
+
+        ctx.register_hook("pre_llm_call", begin_memory_turn)
+        ctx.register_hook("post_tool_call", guard.observe_tool)
+        ctx.register_hook("transform_llm_output", guard.transform)
+        ctx.register_hook("on_session_end", guard.end_session)
+    else:
+        logger.warning(
+            "basic-memory: this Hermes host does not expose plugin hooks; "
+            "save-claim verification requires a Hermes upgrade"
+        )
 
     # Bundle the user-facing skill so `hermes plugins install` wires it up
     # with the rest of the plugin. The skill is opt-in via

--- a/integrations/hermes/host_tests/pytest.ini
+++ b/integrations/hermes/host_tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -ra

--- a/integrations/hermes/host_tests/test_save_claims.py
+++ b/integrations/hermes/host_tests/test_save_claims.py
@@ -1,0 +1,71 @@
+"""Local host-contract proof; no model or Basic Memory server calls."""
+
+import logging
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+import hermes_cli.plugins as plugins
+from agent.turn_finalizer import _apply_output_hooks
+from model_tools import _emit_post_tool_call_hook
+from plugins.memory import _load_provider_from_dir
+
+
+@pytest.mark.parametrize(
+    "result, corrected",
+    [(None, True), ('{"error":"offline"}', True), ('{"permalink":"notes/test"}', False)],
+)
+@pytest.mark.parametrize("active", [True, False])
+@pytest.mark.parametrize(
+    "confirmation",
+    ["Saved to Basic Memory.", "Got it. I have recorded that:\n- The date is October 3rd."],
+)
+def test_real_dispatch_and_finalizer(
+    tmp_path, monkeypatch, result, corrected, active, confirmation
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    directory = tmp_path / "plugins" / "basic-memory"
+    directory.mkdir(parents=True)
+    shutil.copyfile(
+        Path(__file__).parents[1] / "save_claims.py",
+        directory / "save_claims.py",
+    )
+    source = Path(__file__).parents[1]
+    for filename in ["__init__.py", "plugin.yaml"]:
+        shutil.copyfile(source / filename, directory / filename)
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "plugins": {"enabled": ["basic-memory"]},
+                "memory": {"provider": "basic-memory" if active else "builtin"},
+            }
+        )
+    )
+    manager = plugins.PluginManager()
+    monkeypatch.setattr(plugins, "_plugin_manager", manager)
+    manager.discover_and_load()
+    provider = _load_provider_from_dir(directory)
+    assert provider is not None
+    assert manager.has_hook("transform_llm_output")
+    manager.invoke_hook("pre_llm_call", session_id="s1", turn_id="t1", user_message="Remember this")
+    if result is not None:
+        _emit_post_tool_call_hook(
+            function_name="bm_write", function_args={}, result=result, session_id="s1", turn_id="t1"
+        )
+    response, transformed, original = _apply_output_hooks(
+        SimpleNamespace(session_id="s1", model="test"),
+        confirmation,
+        logging.getLogger(__name__),
+        platform="cli",
+        effective_task_id="task",
+        turn_id="t1",
+        original_user_message="Remember this",
+        messages=[],
+    )
+    corrected = corrected and active
+    assert transformed is corrected
+    assert ("unverified" in response) is corrected
+    assert original == (confirmation if corrected else None)

--- a/integrations/hermes/save_claims.py
+++ b/integrations/hermes/save_claims.py
@@ -16,8 +16,11 @@ _MEMORY_REQUEST = re.compile(r"\bremember\b", re.IGNORECASE)
 _MEMORY_NAME = re.compile(r"\bbasic[- ]memory\b", re.IGNORECASE)
 _QUALIFIED_CLAIM = re.compile(r"\b(?:not|never|nothing|none|zero|no)\b|\?", re.IGNORECASE)
 _OTHER_DESTINATION = re.compile(
-    r"\blocally\b|\b(?:to|on|in)\s+(?:(?:the|my|your|local)\s+)?"
-    r"(?:disk|filesystem|file system|desktop|downloads|clipboard)\b",
+    r"\blocally\b|\b(?:to|on|in)\s+\S",
+    re.IGNORECASE,
+)
+_HISTORICAL_SAVE = re.compile(
+    r"\b(?:yesterday|previously|earlier|already|last\s+(?:time|week|month|year|session))\b",
     re.IGNORECASE,
 )
 _CORRECTION = (
@@ -41,12 +44,15 @@ def claims_memory_save(response: str, *, memory_requested: bool) -> bool:
             match = _SAVE_CLAIM.search(sentence)
             if match is None:
                 continue
-            claim = sentence[match.start() :]
+            claim = re.sub(r"^[,:;—–]\s+", "", sentence[match.start() :])
+            claim = re.split(r"[;,]\s+(?!but\b|however\b|yet\b)", claim, flags=re.IGNORECASE)[0]
             names_memory = bool(_MEMORY_NAME.search(claim))
             if not memory_requested and not names_memory:
                 continue
             # A greeting or later question cannot qualify this save clause.
             if _QUALIFIED_CLAIM.search(claim):
+                continue
+            if _HISTORICAL_SAVE.search(claim):
                 continue
             if not names_memory and _OTHER_DESTINATION.search(claim):
                 continue

--- a/integrations/hermes/save_claims.py
+++ b/integrations/hermes/save_claims.py
@@ -13,7 +13,7 @@ _SAVE_CLAIM = re.compile(
     re.IGNORECASE,
 )
 _MEMORY_REQUEST = re.compile(r"\bremember\b", re.IGNORECASE)
-_MEMORY_NAME = re.compile(r"\bbasic[- ]memory\b", re.IGNORECASE)
+_MEMORY_NAME = re.compile(r"\bbasic[- ]memory\b|\bmemory://", re.IGNORECASE)
 _QUALIFIED_CLAIM = re.compile(r"\b(?:not|never|nothing|none|zero|no)\b|\?", re.IGNORECASE)
 _OTHER_DESTINATION = re.compile(
     r"\blocally\b|\b(?:to|on|in)\s+\S",
@@ -40,6 +40,7 @@ def claims_memory_save(response: str, *, memory_requested: bool) -> bool:
         if in_code or stripped.startswith((">", '"', "'")):
             continue
         plain = stripped.replace("**", "").replace("__", "")
+        plain = re.sub(r"^(?:[-+*]|\d+[.)])\s+", "", plain)
         for sentence in re.split(r"(?<=[.!?])\s+", plain):
             match = _SAVE_CLAIM.search(sentence)
             if match is None:

--- a/integrations/hermes/save_claims.py
+++ b/integrations/hermes/save_claims.py
@@ -13,7 +13,10 @@ _SAVE_CLAIM = re.compile(
     re.IGNORECASE,
 )
 _MEMORY_REQUEST = re.compile(r"\bremember\b", re.IGNORECASE)
-_MEMORY_NAME = re.compile(r"\bbasic[- ]memory\b|\bmemory://", re.IGNORECASE)
+_CAPTURE_REQUEST = re.compile(r"\b(?:save|record|note)\s+", re.IGNORECASE)
+_MEMORY_DESTINATION = re.compile(
+    r"\b(?:to|in|on|into)\s+(?:basic[- ]memory\b|memory://)", re.IGNORECASE
+)
 _QUALIFIED_CLAIM = re.compile(r"\b(?:not|never|nothing|none|zero|no)\b|\?", re.IGNORECASE)
 _OTHER_DESTINATION = re.compile(
     r"\blocally\b|\b(?:to|on|in)\s+\S",
@@ -47,7 +50,7 @@ def claims_memory_save(response: str, *, memory_requested: bool) -> bool:
                 continue
             claim = re.sub(r"^[,:;—–]\s+", "", sentence[match.start() :])
             claim = re.split(r"[;,]\s+(?!but\b|however\b|yet\b)", claim, flags=re.IGNORECASE)[0]
-            names_memory = bool(_MEMORY_NAME.search(claim))
+            names_memory = bool(_MEMORY_DESTINATION.search(claim))
             if not memory_requested and not names_memory:
                 continue
             # A greeting or later question cannot qualify this save clause.
@@ -84,10 +87,15 @@ class SaveClaimGuard:
     ) -> None:
         if not session_id or not turn_id:
             return
-        # Generic save requests also cover images and files outside Basic Memory.
-        # Only an explicit memory destination or remember request supplies context
-        # for a destination-free confirmation such as "I've saved it."
-        requested = bool(_MEMORY_REQUEST.search(user_message) or _MEMORY_NAME.search(user_message))
+        # Capture verbs establish context unless they explicitly target another destination.
+        requested = bool(
+            _MEMORY_REQUEST.search(user_message)
+            or _MEMORY_DESTINATION.search(user_message)
+            or (
+                _CAPTURE_REQUEST.search(user_message)
+                and not _OTHER_DESTINATION.search(user_message)
+            )
+        )
         with self._lock:
             self._turns[session_id] = TurnEvidence(turn_id, requested)
 

--- a/integrations/hermes/save_claims.py
+++ b/integrations/hermes/save_claims.py
@@ -9,7 +9,8 @@ from dataclasses import dataclass, replace
 
 _SAVE_CLAIM = re.compile(
     r"(?:^|[.!?]\s+)(?:I(?:['’]ve| have)?\s+)?"
-    r"(?:saved|stored|recorded|remembered|added|updated)\b",
+    r"(?:saved|stored|recorded|remembered)\b"
+    r"(?!\s+(?:nothing|none|no|not|zero)\b)",
     re.IGNORECASE,
 )
 _MEMORY_REQUEST = re.compile(r"\bremember\b", re.IGNORECASE)

--- a/integrations/hermes/save_claims.py
+++ b/integrations/hermes/save_claims.py
@@ -8,14 +8,18 @@ from dataclasses import dataclass, replace
 
 
 _SAVE_CLAIM = re.compile(
-    r"(?:^|[.!?]\s+)(?:I(?:['’]ve| have)?\s+)?"
-    r"(?:saved|stored|recorded|remembered)\b"
-    r"(?!\s+(?:nothing|none|no|not|zero)\b)",
+    r"(?:^|[,:;—–]\s+)(?:I(?:['’]ve| have)?\s+)?"
+    r"(?:saved|stored|recorded|remembered)\b",
     re.IGNORECASE,
 )
 _MEMORY_REQUEST = re.compile(r"\bremember\b", re.IGNORECASE)
 _MEMORY_NAME = re.compile(r"\bbasic[- ]memory\b", re.IGNORECASE)
 _QUALIFIED_CLAIM = re.compile(r"\b(?:not|never|nothing|none|zero|no)\b|\?", re.IGNORECASE)
+_OTHER_DESTINATION = re.compile(
+    r"\blocally\b|\b(?:to|on|in)\s+(?:(?:the|my|your|local)\s+)?"
+    r"(?:disk|filesystem|file system|desktop|downloads|clipboard)\b",
+    re.IGNORECASE,
+)
 _CORRECTION = (
     "Basic Memory verification: no successful Basic Memory write was observed in this turn. "
     "The save claim above is unverified."
@@ -33,11 +37,19 @@ def claims_memory_save(response: str, *, memory_requested: bool) -> bool:
         if in_code or stripped.startswith((">", '"', "'")):
             continue
         plain = stripped.replace("**", "").replace("__", "")
-        # A later denial can qualify the apparent confirmation at the start.
-        # Prefer missing an ambiguous claim to contradicting an explicit denial.
-        if _QUALIFIED_CLAIM.search(plain):
-            continue
-        if _SAVE_CLAIM.search(plain) and (memory_requested or _MEMORY_NAME.search(plain)):
+        for sentence in re.split(r"(?<=[.!?])\s+", plain):
+            match = _SAVE_CLAIM.search(sentence)
+            if match is None:
+                continue
+            claim = sentence[match.start() :]
+            names_memory = bool(_MEMORY_NAME.search(claim))
+            if not memory_requested and not names_memory:
+                continue
+            # A greeting or later question cannot qualify this save clause.
+            if _QUALIFIED_CLAIM.search(claim):
+                continue
+            if not names_memory and _OTHER_DESTINATION.search(claim):
+                continue
             return True
     return False
 

--- a/integrations/hermes/save_claims.py
+++ b/integrations/hermes/save_claims.py
@@ -15,13 +15,14 @@ _SAVE_CLAIM = re.compile(
 _MEMORY_REQUEST = re.compile(r"\bremember\b", re.IGNORECASE)
 _CAPTURE_REQUEST = re.compile(r"\b(?:save|record|note)\s+", re.IGNORECASE)
 _MEMORY_DESTINATION = re.compile(
-    r"\b(?:to|in|on|into)\s+(?:basic[- ]memory\b|memory://)", re.IGNORECASE
+    r"\b(?:to|in|on|into)\s+`?(?:basic[- ]memory\b|memory://)", re.IGNORECASE
 )
 _QUALIFIED_CLAIM = re.compile(r"\b(?:not|never|nothing|none|zero|no)\b|\?", re.IGNORECASE)
 _OTHER_DESTINATION = re.compile(
-    r"\blocally\b|\b(?:to|on|in)\s+\S",
+    r"\blocally\b|\b(?:to|on|in|into)\s+\S",
     re.IGNORECASE,
 )
+_CONTENT_CLAUSE = re.compile(r"\bthat\s+.+?\b(?:is|are|was|were|will|has|have)\b", re.IGNORECASE)
 _HISTORICAL_SAVE = re.compile(
     r"\b(?:yesterday|previously|earlier|already|last\s+(?:time|week|month|year|session))\b",
     re.IGNORECASE,
@@ -50,7 +51,10 @@ def claims_memory_save(response: str, *, memory_requested: bool) -> bool:
                 continue
             claim = re.sub(r"^[,:;—–]\s+", "", sentence[match.start() :])
             claim = re.split(r"[;,]\s+(?!but\b|however\b|yet\b)", claim, flags=re.IGNORECASE)[0]
-            names_memory = bool(_MEMORY_DESTINATION.search(claim))
+            # A reported proposition can contain locations that are not storage destinations.
+            # Keep noun objects such as "that photo to Google Drive" in the save clause.
+            destination_clause = _CONTENT_CLAUSE.split(claim, maxsplit=1)[0]
+            names_memory = bool(_MEMORY_DESTINATION.search(destination_clause))
             if not memory_requested and not names_memory:
                 continue
             # A greeting or later question cannot qualify this save clause.
@@ -58,7 +62,7 @@ def claims_memory_save(response: str, *, memory_requested: bool) -> bool:
                 continue
             if _HISTORICAL_SAVE.search(claim):
                 continue
-            if not names_memory and _OTHER_DESTINATION.search(claim):
+            if not names_memory and _OTHER_DESTINATION.search(destination_clause):
                 continue
             return True
     return False
@@ -88,12 +92,13 @@ class SaveClaimGuard:
         if not session_id or not turn_id:
             return
         # Capture verbs establish context unless they explicitly target another destination.
+        destination_clause = _CONTENT_CLAUSE.split(user_message, maxsplit=1)[0]
         requested = bool(
             _MEMORY_REQUEST.search(user_message)
-            or _MEMORY_DESTINATION.search(user_message)
+            or _MEMORY_DESTINATION.search(destination_clause)
             or (
                 _CAPTURE_REQUEST.search(user_message)
-                and not _OTHER_DESTINATION.search(user_message)
+                and not _OTHER_DESTINATION.search(destination_clause)
             )
         )
         with self._lock:

--- a/integrations/hermes/save_claims.py
+++ b/integrations/hermes/save_claims.py
@@ -1,0 +1,98 @@
+"""Turn-scoped evidence for correcting unsupported Basic Memory save claims."""
+
+from __future__ import annotations
+
+import re
+import threading
+from dataclasses import dataclass, replace
+
+
+_SAVE_CLAIM = re.compile(
+    r"(?:^|[.!?]\s+)(?:I(?:['’]ve| have)?\s+)?"
+    r"(?:saved|stored|recorded|remembered|added|updated)\b",
+    re.IGNORECASE,
+)
+_MEMORY_REQUEST = re.compile(r"\bremember\b", re.IGNORECASE)
+_MEMORY_NAME = re.compile(r"\bbasic[- ]memory\b", re.IGNORECASE)
+_CORRECTION = (
+    "Basic Memory verification: no successful Basic Memory write was observed in this turn. "
+    "The save claim above is unverified."
+)
+
+
+def claims_memory_save(response: str, *, memory_requested: bool) -> bool:
+    """Recognize direct English save confirmations outside quotes and code blocks."""
+    in_code = False
+    for line in response.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("```", "~~~")):
+            in_code = not in_code
+            continue
+        if in_code or stripped.startswith((">", '"', "'")):
+            continue
+        plain = stripped.replace("**", "").replace("__", "")
+        if _SAVE_CLAIM.search(plain) and (memory_requested or _MEMORY_NAME.search(plain)):
+            return True
+    return False
+
+
+@dataclass(frozen=True)
+class TurnEvidence:
+    turn_id: str
+    memory_requested: bool
+    write_observed: bool = False
+
+
+class SaveClaimGuard:
+    """Correlate observer hooks without borrowing writes from other turns/sessions.
+
+    Hermes serializes turns within a session. The explicit turn ID on tool
+    events also rejects late completion events from a prior interrupted turn.
+    """
+
+    def __init__(self) -> None:
+        self._turns: dict[str, TurnEvidence] = {}
+        self._lock = threading.Lock()
+
+    def begin_turn(
+        self, *, session_id: str = "", turn_id: str = "", user_message: str = "", **_: object
+    ) -> None:
+        if not session_id or not turn_id:
+            return
+        # Generic save requests also cover images and files outside Basic Memory.
+        # Only an explicit memory destination or remember request supplies context
+        # for a destination-free confirmation such as "I've saved it."
+        requested = bool(_MEMORY_REQUEST.search(user_message) or _MEMORY_NAME.search(user_message))
+        with self._lock:
+            self._turns[session_id] = TurnEvidence(turn_id, requested)
+
+    def observe_tool(
+        self,
+        *,
+        session_id: str = "",
+        turn_id: str = "",
+        tool_name: str = "",
+        status: str = "",
+        **_: object,
+    ) -> None:
+        if tool_name not in {"bm_write", "bm_edit"} or status != "ok":
+            return
+        with self._lock:
+            current = self._turns.get(session_id)
+            if current is not None and current.turn_id == turn_id:
+                self._turns[session_id] = replace(current, write_observed=True)
+
+    def transform(
+        self, *, session_id: str = "", response_text: str = "", **_: object
+    ) -> str | None:
+        with self._lock:
+            current = self._turns.pop(session_id, None)
+        if current is None or current.write_observed:
+            return None
+        if claims_memory_save(response_text, memory_requested=current.memory_requested):
+            return f"{response_text}\n\n{_CORRECTION}"
+        return None
+
+    def end_session(self, *, session_id: str = "", **_: object) -> None:
+        with self._lock:
+            self._turns.pop(session_id, None)

--- a/integrations/hermes/save_claims.py
+++ b/integrations/hermes/save_claims.py
@@ -15,6 +15,7 @@ _SAVE_CLAIM = re.compile(
 )
 _MEMORY_REQUEST = re.compile(r"\bremember\b", re.IGNORECASE)
 _MEMORY_NAME = re.compile(r"\bbasic[- ]memory\b", re.IGNORECASE)
+_QUALIFIED_CLAIM = re.compile(r"\b(?:not|never|nothing|none|zero|no)\b|\?", re.IGNORECASE)
 _CORRECTION = (
     "Basic Memory verification: no successful Basic Memory write was observed in this turn. "
     "The save claim above is unverified."
@@ -32,6 +33,10 @@ def claims_memory_save(response: str, *, memory_requested: bool) -> bool:
         if in_code or stripped.startswith((">", '"', "'")):
             continue
         plain = stripped.replace("**", "").replace("__", "")
+        # A later denial can qualify the apparent confirmation at the start.
+        # Prefer missing an ambiguous claim to contradicting an explicit denial.
+        if _QUALIFIED_CLAIM.search(plain):
+            continue
         if _SAVE_CLAIM.search(plain) and (memory_requested or _MEMORY_NAME.search(plain)):
             return True
     return False

--- a/integrations/hermes/tests/conftest.py
+++ b/integrations/hermes/tests/conftest.py
@@ -49,6 +49,7 @@ _PLUGIN_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "__init_
 _spec = importlib.util.spec_from_file_location("hermes_basic_memory_plugin", _PLUGIN_PATH)
 assert _spec is not None and _spec.loader is not None
 _plugin = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _plugin
 _spec.loader.exec_module(_plugin)
 
 

--- a/integrations/hermes/tests/test_save_claims.py
+++ b/integrations/hermes/tests/test_save_claims.py
@@ -98,6 +98,8 @@ def test_only_the_save_clause_supplies_qualifications() -> None:
         "I've saved it to Basic Memory; no other settings were changed.",
         "I've saved it, no problem.",
         "Saved it to memory://notes/renewal.",
+        "Saved to `memory://notes/renewal`.",
+        "I've saved that the meeting is in Paris.",
         "- Saved to Basic Memory.",
         "1. Saved to Basic Memory.",
         "* **Saved to Basic Memory.**",
@@ -110,6 +112,8 @@ def test_only_the_save_clause_supplies_qualifications() -> None:
         "Stored it in Dropbox.",
         "Sure, I saved it to Google Drive.",
         "Saved the Basic Memory config to Google Drive.",
+        "Saved into Google Drive.",
+        "Saved that photo to Google Drive.",
     ]:
         assert not _module.claims_memory_save(response, memory_requested=True)
 

--- a/integrations/hermes/tests/test_save_claims.py
+++ b/integrations/hermes/tests/test_save_claims.py
@@ -1,0 +1,97 @@
+"""A save confirmation must not borrow tool evidence from another turn."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+_spec = importlib.util.spec_from_file_location(
+    "bm_save_claims", Path(__file__).parents[1] / "save_claims.py"
+)
+assert _spec is not None and _spec.loader is not None
+_module = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _module
+_spec.loader.exec_module(_module)
+
+
+def test_guard_correlates_successful_writes_with_current_turn() -> None:
+    guard = _module.SaveClaimGuard()
+    guard.begin_turn(session_id="a", turn_id="1", user_message="Remember this")
+    guard.begin_turn(session_id="b", turn_id="1", user_message="Remember this")
+    guard.observe_tool(session_id="a", turn_id="1", tool_name="bm_write", status="ok")
+    assert guard.transform(session_id="a", response_text="Saved to Basic Memory.") is None
+    assert "unverified" in guard.transform(session_id="b", response_text="Saved to Basic Memory.")
+    guard.begin_turn(session_id="a", turn_id="2", user_message="Remember this too")
+    guard.observe_tool(session_id="a", turn_id="1", tool_name="bm_write", status="ok")
+    guard.observe_tool(session_id="a", turn_id="2", tool_name="bm_edit", status="error")
+    assert "unverified" in guard.transform(session_id="a", response_text="I've saved it.")
+
+
+def test_guard_ignores_examples_and_non_claims() -> None:
+    for response in [
+        "I will save it.",
+        "I have not saved it.",
+        "> Saved to Basic Memory.",
+        "```text\nSaved to Basic Memory.\n```",
+        "Saved the image to disk.",
+    ]:
+        guard = _module.SaveClaimGuard()
+        guard.begin_turn(session_id="a", turn_id="1", user_message="Hello")
+        assert guard.transform(session_id="a", response_text=response) is None
+    guard = _module.SaveClaimGuard()
+    guard.begin_turn(session_id="a", turn_id="1", user_message="Remember this")
+    guard.end_session(session_id="a")
+    assert guard.transform(session_id="a", response_text="Saved it.") is None
+
+
+def test_generic_file_save_does_not_imply_basic_memory() -> None:
+    guard = _module.SaveClaimGuard()
+    guard.begin_turn(session_id="a", turn_id="1", user_message="Save the image to disk")
+    assert guard.transform(session_id="a", response_text="Saved the image to disk.") is None
+    guard.begin_turn(session_id="a", turn_id="2", user_message="Save this to Basic Memory")
+    assert "unverified" in guard.transform(session_id="a", response_text="I've saved it.")
+
+
+def test_missing_turn_identity_does_not_create_evidence() -> None:
+    guard = _module.SaveClaimGuard()
+    guard.begin_turn(session_id="a", user_message="Remember this")
+    assert guard.transform(session_id="a", response_text="Saved to Basic Memory.") is None
+
+
+def test_reported_hermes_acknowledgment_is_corrected() -> None:
+    guard = _module.SaveClaimGuard()
+    guard.begin_turn(
+        session_id="a", turn_id="1", user_message="Remember this: the renewal date is October 3rd."
+    )
+    response = "Got it. I have recorded that:\n- The renewal date is October 3rd."
+    corrected = guard.transform(session_id="a", response_text=response)
+    assert corrected.startswith(response)
+    assert "unverified" in corrected
+
+
+def test_registered_hooks_follow_configured_provider(bm, monkeypatch) -> None:
+    config = {"memory": {"provider": "basic-memory"}}
+    config_module = ModuleType("hermes_cli.config")
+    config_module.load_config_readonly = lambda: config
+    config_module.cfg_get = lambda value, *keys: value[keys[0]][keys[1]]
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", config_module)
+    hooks = {}
+    ctx = SimpleNamespace(
+        register_memory_provider=lambda provider: None,
+        register_hook=lambda name, callback: hooks.setdefault(name, callback),
+        register_command=lambda *args, **kwargs: None,
+        register_skill=lambda *args, **kwargs: None,
+    )
+    bm.register(ctx)
+    hooks["pre_llm_call"](session_id="a", turn_id="1", user_message="Remember this")
+    assert "unverified" in hooks["transform_llm_output"](
+        session_id="a", response_text="Saved to Basic Memory."
+    )
+    hooks["pre_llm_call"](session_id="a", turn_id="2", user_message="Remember this")
+    config["memory"]["provider"] = "builtin"
+    hooks["pre_llm_call"](session_id="a", turn_id="3", user_message="Remember this")
+    assert (
+        hooks["transform_llm_output"](session_id="a", response_text="Saved to Basic Memory.")
+        is None
+    )

--- a/integrations/hermes/tests/test_save_claims.py
+++ b/integrations/hermes/tests/test_save_claims.py
@@ -53,6 +53,20 @@ def test_generic_file_save_does_not_imply_basic_memory() -> None:
     assert "unverified" in guard.transform(session_id="a", response_text="I've saved it.")
 
 
+def test_memory_request_does_not_turn_a_denial_into_a_save_claim() -> None:
+    for response in [
+        "I have saved nothing to Basic Memory.",
+        "Saved no notes to Basic Memory.",
+        "I recorded none of this in Basic Memory.",
+        "I stored zero notes.",
+        "I updated my response, but did not save it.",
+        "I added a suggestion to my response, not a note.",
+    ]:
+        guard = _module.SaveClaimGuard()
+        guard.begin_turn(session_id="a", turn_id="1", user_message="Remember this")
+        assert guard.transform(session_id="a", response_text=response) is None
+
+
 def test_missing_turn_identity_does_not_create_evidence() -> None:
     guard = _module.SaveClaimGuard()
     guard.begin_turn(session_id="a", user_message="Remember this")

--- a/integrations/hermes/tests/test_save_claims.py
+++ b/integrations/hermes/tests/test_save_claims.py
@@ -75,6 +75,17 @@ def test_missing_turn_identity_does_not_create_evidence() -> None:
     assert guard.transform(session_id="a", response_text="Saved to Basic Memory.") is None
 
 
+def test_only_the_save_clause_supplies_qualifications() -> None:
+    for response in [
+        "No problem, I've saved it to Basic Memory.",
+        "I've saved it. Do you need anything else?",
+        "Sure, I saved it in Basic Memory.",
+        "Done — I've recorded it.",
+    ]:
+        assert _module.claims_memory_save(response, memory_requested=True)
+    assert not _module.claims_memory_save("Saved the image to disk.", memory_requested=True)
+
+
 def test_reported_hermes_acknowledgment_is_corrected() -> None:
     guard = _module.SaveClaimGuard()
     guard.begin_turn(

--- a/integrations/hermes/tests/test_save_claims.py
+++ b/integrations/hermes/tests/test_save_claims.py
@@ -53,6 +53,20 @@ def test_generic_file_save_does_not_imply_basic_memory() -> None:
     assert "unverified" in guard.transform(session_id="a", response_text="I've saved it.")
 
 
+def test_named_capture_requests_require_write_evidence() -> None:
+    for request in [
+        "Please save my favorite color for later",
+        "Please record that",
+        "Please note that",
+    ]:
+        guard = _module.SaveClaimGuard()
+        guard.begin_turn(session_id="a", turn_id="1", user_message=request)
+        assert "unverified" in guard.transform(session_id="a", response_text="I've recorded it.")
+    guard = _module.SaveClaimGuard()
+    guard.begin_turn(session_id="a", turn_id="1", user_message="Save the image to disk")
+    assert guard.transform(session_id="a", response_text="I've saved it.") is None
+
+
 def test_memory_request_does_not_turn_a_denial_into_a_save_claim() -> None:
     for response in [
         "I have saved nothing to Basic Memory.",
@@ -95,6 +109,7 @@ def test_only_the_save_clause_supplies_qualifications() -> None:
         "Saved the photo to Google Drive.",
         "Stored it in Dropbox.",
         "Sure, I saved it to Google Drive.",
+        "Saved the Basic Memory config to Google Drive.",
     ]:
         assert not _module.claims_memory_save(response, memory_requested=True)
 

--- a/integrations/hermes/tests/test_save_claims.py
+++ b/integrations/hermes/tests/test_save_claims.py
@@ -81,9 +81,18 @@ def test_only_the_save_clause_supplies_qualifications() -> None:
         "I've saved it. Do you need anything else?",
         "Sure, I saved it in Basic Memory.",
         "Done — I've recorded it.",
+        "I've saved it to Basic Memory; no other settings were changed.",
+        "I've saved it, no problem.",
     ]:
         assert _module.claims_memory_save(response, memory_requested=True)
     assert not _module.claims_memory_save("Saved the image to disk.", memory_requested=True)
+    for response in [
+        "I saved it to Basic Memory yesterday.",
+        "Saved the photo to Google Drive.",
+        "Stored it in Dropbox.",
+        "Sure, I saved it to Google Drive.",
+    ]:
+        assert not _module.claims_memory_save(response, memory_requested=True)
 
 
 def test_reported_hermes_acknowledgment_is_corrected() -> None:

--- a/integrations/hermes/tests/test_save_claims.py
+++ b/integrations/hermes/tests/test_save_claims.py
@@ -83,6 +83,10 @@ def test_only_the_save_clause_supplies_qualifications() -> None:
         "Done — I've recorded it.",
         "I've saved it to Basic Memory; no other settings were changed.",
         "I've saved it, no problem.",
+        "Saved it to memory://notes/renewal.",
+        "- Saved to Basic Memory.",
+        "1. Saved to Basic Memory.",
+        "* **Saved to Basic Memory.**",
     ]:
         assert _module.claims_memory_save(response, memory_requested=True)
     assert not _module.claims_memory_save("Saved the image to disk.", memory_requested=True)

--- a/integrations/hermes/tests/test_save_claims.py
+++ b/integrations/hermes/tests/test_save_claims.py
@@ -61,6 +61,8 @@ def test_memory_request_does_not_turn_a_denial_into_a_save_claim() -> None:
         "I stored zero notes.",
         "I updated my response, but did not save it.",
         "I added a suggestion to my response, not a note.",
+        "I saved it locally, but did not store it in Basic Memory.",
+        "Saved? No, I did not.",
     ]:
         guard = _module.SaveClaimGuard()
         guard.begin_turn(session_id="a", turn_id="1", user_message="Remember this")


### PR DESCRIPTION
## Why

Hermes can answer “Got it. I have recorded that” without calling a write tool (#1341). Prompt guidance already asks for real writes; this adds a visible correction when the observed turn has no successful write.

Refs #1341 (Hermes slice; OpenClaw remains open).

## What Changed

- Append an unverified-save correction to recognized English confirmations when no successful `bm_write` or `bm_edit` event occurred in that session and turn.
- Keep successful saves and sessions configured for another memory backend unchanged.
- Add hermetic regression tests and separately runnable tests against Hermes's real provider loader, tool observer, dispatcher, and finalizer.

## Implementation Details

`pre_llm_call` starts turn evidence, `post_tool_call` records successful writes, and `transform_llm_output` appends the correction before the host returns its final response. Turn IDs reject late events from earlier turns; session IDs prevent evidence crossing sessions. Session-end cleanup discards pending evidence. Automatic transcript capture is not proof of the requested write.

Hook discovery can create an inactive provider instance, so the turn hook checks the configured backend rather than that instance's initialization state. The detector recognizes saved/stored/recorded/remembered confirmations, evaluates denials in the matched save clause, and skips quoted/fenced examples and explicit non-memory destinations such as disk. Conversational prefaces and unrelated follow-up questions do not hide a confirmation; it covers the actual “Got it. I have recorded that” report.

## Testing

- `just package-check`: passed all agent-package checks before the final wording regression was added.
- `just package-check-hermes`: final 281 passed, 12 live-server tests skipped. Capture-verb and external-destination regressions failed before the fixes.
- From Hermes release `v2026.9.7` (v0.21.1), `HERMES_PYTHON=<Basic Memory .venv/bin/python> scripts/run_tests.sh <Basic Memory>/integrations/hermes/host_tests/test_save_claims.py -q`: 12 passed. These exercise actual loading and final-response transformation for no write, failed write, and successful write, with active/inactive backends and both confirmation forms.
- `just typecheck`: passed.
- Ruff check on all changed Python files, Ruff format check, and `git diff --check`: passed. A broader Ruff scan found five preexisting findings in untouched Hermes tests.

## Risks / Follow-ups

This is a bounded English heuristic, not verification of arbitrary natural language or the contents of a successful write. Shell/other-client writes are not observed. Use Hermes v0.21.1 (`v2026.9.7`) or newer for the guard; older hosts may lack the required hook contract. Tests verify the host finalizer, not live Discord/Telegram delivery or a live model conversation. OpenClaw enforcement remains separate work under #1341.
