### PR TITLE
fix(mcp): refuse overwrites resolving to another path

### DIFF
--- a/src/basic_memory/man/man3/write-note(3).md
+++ b/src/basic_memory/man/man3/write-note(3).md
@@ -56,7 +56,7 @@ prepends, or edits sections in place without rewriting the file.
 - **tags** (array | string | null, optional, default: None) — Tags to categorize the note. Can be a list of strings, a comma-separated string, or None. Note: If passing from external MCP clients, use a string format (e.g. "tag1,tag2,tag3")
 - **note_type** (string, optional, default: "note") — Type of note to create (stored in frontmatter `type:`). Defaults to "note". Can be "guide", "report", "config", "person", etc. The CLI flag is --type. A `type:` in content frontmatter takes precedence over this parameter, and this is what schema validation keys on.
 - **metadata** (object | null, optional, default: None) — Optional dict of extra frontmatter fields merged into entity_metadata. Useful for schema notes or any note that needs custom YAML frontmatter beyond title/type/tags. Nested dicts are supported. Not available from the CLI.
-- **overwrite** (boolean | null, optional, default: None) — If True, replace existing note on conflict. If False, error on conflict. If None (default), consult write_note_overwrite_default config setting.
+- **overwrite** (boolean | null, optional, default: None) — If True, replace existing note on conflict. If False, error on conflict. If None (default), consult write_note_overwrite_default config setting. Refuses when the requested path resolves to a note at a different path; inspect or edit the returned note identity instead.
 - **output_format** (string, optional, default: "text") — "text" returns the existing markdown summary. "json" returns machine-readable metadata; on conflict it returns action: "conflict" with an error code instead of raising.
 
 ## MCP USAGE

--- a/src/basic_memory/mcp/tools/write_note.py
+++ b/src/basic_memory/mcp/tools/write_note.py
@@ -298,6 +298,8 @@ async def write_note(
                   beyond title/type/tags. Nested dicts are supported. Not available from the CLI.
         overwrite: If True, replace existing note on conflict. If False, error on conflict.
                    If None (default), consult write_note_overwrite_default config setting.
+                   Refuses when the requested path resolves to a note at a different path;
+                   inspect or edit the returned note identity instead.
         output_format: "text" returns the existing markdown summary. "json" returns
                        machine-readable metadata; on conflict it returns action: "conflict"
                        with an error code instead of raising.
@@ -438,6 +440,37 @@ async def write_note(
 
             # Use typed KnowledgeClient for API calls
             knowledge_client = KnowledgeClient(client, active_project.external_id)
+
+            # A retained permalink can outlive its original filename after a move.
+            # Refuse that identity/path mismatch before optimistic create can mint a shadow.
+            if effective_overwrite:
+                requested_path = Path(entity.file_path).as_posix()
+                try:
+                    existing = await knowledge_client.resolve_entity_response(
+                        requested_path, strict=True
+                    )
+                except ToolError as error:
+                    cause = error.__cause__
+                    if not isinstance(cause, HTTPStatusError) or cause.response.status_code != 404:
+                        raise
+                    existing = None
+                if existing is not None and existing.file_path != requested_path:
+                    if output_format == "json":
+                        return {
+                            "title": title,
+                            "permalink": existing.permalink,
+                            "file_path": existing.file_path,
+                            "checksum": None,
+                            "action": "conflict",
+                            "error": "NOTE_PATH_CONFLICT",
+                        }
+                    return (
+                        "# Error: Note exists at a different path\n\n"
+                        f"The requested note resolves to `{existing.file_path}`. "
+                        "Nothing was written.\n\n"
+                        f"Read or edit `{existing.external_id}` to update that note, "
+                        "or choose a distinct title for a new note."
+                    )
 
             # Try to create the entity first (optimistic create)
             logger.debug(f"Attempting to create entity permalink={entity.permalink}")

--- a/src/basic_memory/services/link_resolver.py
+++ b/src/basic_memory/services/link_resolver.py
@@ -89,6 +89,7 @@ class LinkResolver:
     """Service for resolving markdown links to permalinks.
 
     Uses a combination of exact matching and search-based resolution:
+    Strict .md paths select their current file owner before generated permalink candidates.
     1. Try exact permalink match (fastest)
     2. Try exact title match
     3. Try exact file path match
@@ -408,6 +409,20 @@ class LinkResolver:
                 else:
                     # Multiple candidates - pick closest to source
                     return self._find_closest_entity(candidates, source_path)
+
+        # Strict explicit paths name the current file owner before generated aliases
+        # from moved notes (#1479). Preserve verbatim custom permalink precedence.
+        if strict and clean_text.casefold().endswith(".md"):
+            exact_file = await entity_repository.get_by_file_path(
+                session, clean_text, load_relations=load_relations
+            )
+            if exact_file is not None:
+                exact_permalink = await entity_repository.get_by_permalink(
+                    session, permalink_candidates[0], load_relations=load_relations
+                )
+                if exact_permalink is not None:
+                    return exact_permalink
+                return exact_file
 
         # Standard resolution (no source context): permalink first, then title.
         #

--- a/test-int/mcp/test_moved_note_overwrite.py
+++ b/test-int/mcp/test_moved_note_overwrite.py
@@ -1,0 +1,55 @@
+"""An overwrite must not silently create a shadow of a renamed note."""
+
+import json
+from pathlib import Path
+
+import pytest
+from fastmcp import Client
+from basic_memory.config import ConfigManager
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("output_format", ["text", "json"])
+async def test_overwrite_after_rename_refuses_without_changing_files(
+    mcp_server, app, test_project, app_config, output_format
+):
+    app_config.update_permalinks_on_move = False
+    ConfigManager().save_config(app_config)
+    async with Client(mcp_server) as client:
+        arguments = {
+            "project": test_project.name,
+            "title": "song-sketching",
+            "directory": "app/probe",
+            "content": "# original\nfirst body",
+        }
+        await client.call_tool("write_note", arguments)
+        await client.call_tool(
+            "move_note",
+            {
+                "project": test_project.name,
+                "identifier": "song-sketching",
+                "destination_path": "app/probe/SKILL.md",
+            },
+        )
+        moved = Path(test_project.path) / "app/probe/SKILL.md"
+        original = moved.read_bytes()
+        result = await client.call_tool(
+            "write_note",
+            {
+                **arguments,
+                "content": "# replacement\nsecond body",
+                "overwrite": True,
+                "output_format": output_format,
+            },
+        )
+        assert result.content[0].type == "text"
+        if output_format == "json":
+            payload = json.loads(result.content[0].text)
+            assert payload["action"] == "conflict"
+            assert payload["error"] == "NOTE_PATH_CONFLICT"
+            assert payload["file_path"] == "app/probe/SKILL.md"
+        else:
+            assert "different path" in result.content[0].text
+            assert "app/probe/SKILL.md" in result.content[0].text
+        assert moved.read_bytes() == original
+        assert sorted(path.name for path in moved.parent.glob("*.md")) == ["SKILL.md"]

--- a/test-int/mcp/test_moved_note_overwrite.py
+++ b/test-int/mcp/test_moved_note_overwrite.py
@@ -53,3 +53,40 @@ async def test_overwrite_after_rename_refuses_without_changing_files(
             assert "app/probe/SKILL.md" in result.content[0].text
         assert moved.read_bytes() == original
         assert sorted(path.name for path in moved.parent.glob("*.md")) == ["SKILL.md"]
+
+
+@pytest.mark.asyncio
+async def test_overwrite_prefers_replacement_at_exact_path(
+    mcp_server, app, test_project, app_config
+):
+    app_config.update_permalinks_on_move = False
+    ConfigManager().save_config(app_config)
+    async with Client(mcp_server) as client:
+        arguments = {
+            "project": test_project.name,
+            "title": "song-sketching",
+            "directory": "app/probe",
+            "content": "Original moved body",
+            "output_format": "json",
+        }
+        await client.call_tool("write_note", arguments)
+        await client.call_tool(
+            "move_note",
+            {
+                "project": test_project.name,
+                "identifier": "song-sketching",
+                "destination_path": "app/probe/SKILL.md",
+            },
+        )
+        moved = Path(test_project.path) / "app/probe/SKILL.md"
+        original = moved.read_bytes()
+        await client.call_tool(
+            "write_note", {**arguments, "content": "Replacement", "overwrite": False}
+        )
+        result = await client.call_tool(
+            "write_note", {**arguments, "content": "Updated replacement", "overwrite": True}
+        )
+        assert result.content[0].type == "text"
+        assert json.loads(result.content[0].text)["action"] == "updated"
+        assert moved.read_bytes() == original
+        assert "Updated replacement" in (moved.parent / "song-sketching.md").read_text()

--- a/tests/services/test_link_resolver_path_owner.py
+++ b/tests/services/test_link_resolver_path_owner.py
@@ -1,0 +1,38 @@
+"""Strict file ownership must not change verbatim custom permalink resolution."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from basic_memory import db
+from basic_memory.models.knowledge import Entity
+from basic_memory.services.link_resolver import LinkResolver
+
+
+@pytest.mark.asyncio
+async def test_literal_markdown_permalink_keeps_precedence(
+    entity_repository, search_service, session_maker, app_config
+):
+    now = datetime.now(timezone.utc)
+    async with db.scoped_session(session_maker) as session:
+        for title, path, permalink in [
+            ("Custom identity", "archive/original.md", "notes/current.md"),
+            ("File owner", "notes/current.md", "notes/replacement"),
+        ]:
+            await entity_repository.add(
+                session,
+                Entity(
+                    title=title,
+                    note_type="note",
+                    content_type="text/markdown",
+                    file_path=path,
+                    permalink=permalink,
+                    created_at=now,
+                    updated_at=now,
+                    project_id=entity_repository.project_id,
+                ),
+            )
+    resolver = LinkResolver(entity_repository, search_service, session_maker, app_config)
+    result = await resolver.resolve_link("notes/current.md", strict=True)
+    assert result is not None
+    assert result.file_path == "archive/original.md"


### PR DESCRIPTION
## Why

Refs #1479. With the default retained permalink, renaming a note leaves its old identity live while its title-derived file path is free. `write_note(overwrite=True)` currently creates a second file instead of updating or refusing.

This draft makes **option B (refuse and return the current location)** concrete for policy review. The choice between refusal and following a move is still open; this PR does not authorize landing that choice.

## What Changed

Before an overwrite-enabled create, resolve the requested path strictly. If that identity resolves to a different current path, return `NOTE_PATH_CONFLICT` in JSON or an actionable text refusal naming the path and stable note ID. No file is written. Normal creates and same-path overwrites retain their existing behavior.

## Implementation Details

Uses the existing project-routed typed resolver; no fuzzy search, title guessing, or new API contract. Only a real HTTP 404 permits creation to continue; operational errors propagate. A retained permalink makes the reported rename discoverable. Moves that deliberately update permalinks are outside this identity-based guard.

Strict explicit Markdown paths select the current file owner before generated permalink aliases. This lets a replacement at a vacated path be overwritten without touching the moved note. Verbatim custom permalinks retain their existing precedence.

The preflight adds one resolution request to overwrite-enabled calls. It is not a transaction or a concurrent-move guarantee. The implementation preserves the existing canonical write safeguards and does not follow a moved target automatically.

## Testing

- Real MCP text/JSON reproduction on main: both fail by returning Created and creating the duplicate.
- `uv run pytest test-int/mcp/test_moved_note_overwrite.py --no-cov -q`: 2 passed after fix; unchanged moved-file bytes and no second Markdown file.
- Existing write unit/integration coverage: 79 passed.
- Final resolver and moved-note SQLite suite: 59 passed, including replacement ownership and literal custom permalink precedence.
- Final moved-note and custom permalink PostgreSQL regressions: 4 passed.
- `BASIC_MEMORY_TEST_POSTGRES=1 uv run pytest test-int/mcp/test_moved_note_overwrite.py test-int/mcp/test_write_note_integration.py --no-cov -q`: 17 passed.
- `just fast-check`, `just doctor`, `just man-regen`, and `git diff --check`: passed.

## Risks / Follow-ups

Policy approval is still required before marking this draft ready to land. Strict resolution can conservatively refuse aliases that resolve to another path; it never writes to that alternate path. Explicit `overwrite=False` remains ordinary create/conflict behavior. No claim is made that arbitrary same-title notes or changed permalinks identify a moved note.
