### PR TITLE
fix(mcp): report never-indexed projects instead of a silent empty search

### DIFF
--- a/tests/mcp/test_tool_recent_activity.py
+++ b/tests/mcp/test_tool_recent_activity.py
@@ -695,3 +695,53 @@ async def test_recent_activity_entity_rows_include_external_id(client, test_grap
     assert any(re.search(uuid_pattern, line) for line in entity_lines), (
         f"entity rows missing external_id: {entity_lines!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_recent_activity_never_indexed_says_so(
+    client, test_project, session_maker, config_home
+):
+    """A never-indexed project must not report an ordinary empty activity feed (#1534)."""
+    from sqlalchemy import text as sa_text
+
+    from basic_memory import db
+
+    # Trigger: files exist on disk but no index pass has ever completed.
+    notes_dir = config_home / "notes"
+    notes_dir.mkdir(exist_ok=True)
+    (notes_dir / "unindexed-note.md").write_text("# Unindexed Note\n\nNot yet indexed.\n")
+    async with db.scoped_session(session_maker) as session:
+        await session.execute(
+            sa_text("UPDATE project SET last_indexed_at = NULL WHERE id = :id"),
+            {"id": test_project.id},
+        )
+
+    result = await recent_activity(project=test_project.name, timeframe="7d")
+
+    assert isinstance(result, str)
+    assert "never been indexed" in result
+    assert "bm project index" in result
+
+
+@pytest.mark.asyncio
+async def test_recent_activity_indexed_empty_keeps_onboarding(
+    client, test_project, session_maker, config_home
+):
+    """An indexed-but-quiet project keeps the original onboarding copy (#1534)."""
+    from datetime import datetime
+
+    from sqlalchemy import text as sa_text
+
+    from basic_memory import db
+
+    async with db.scoped_session(session_maker) as session:
+        await session.execute(
+            sa_text("UPDATE project SET last_indexed_at = :now WHERE id = :id"),
+            {"now": datetime.now(), "id": test_project.id},
+        )
+
+    result = await recent_activity(project=test_project.name, timeframe="7d")
+
+    assert isinstance(result, str)
+    assert "No recent activity" in result
+    assert "never been indexed" not in result

--- a/tests/mcp/test_tool_search.py
+++ b/tests/mcp/test_tool_search.py
@@ -2281,3 +2281,112 @@ def test_search_notes_parse_str_list_rejects_non_string_list_elements_in_place()
     # All-string lists still work correctly.
     assert parse_str_list(["note", "task"]) == ["note", "task"]
     assert parse_str_list(["note,task"]) == ["note", "task"]
+
+
+@pytest.mark.asyncio
+async def test_search_never_indexed_text_says_so(client, test_project, session_maker, config_home):
+    """A never-indexed project must not report an ordinary empty result (#1534)."""
+    from sqlalchemy import text as sa_text
+
+    from basic_memory import db
+
+    # Trigger: files exist on disk but no index pass has ever completed.
+    notes_dir = config_home / "notes"
+    notes_dir.mkdir(exist_ok=True)
+    (notes_dir / "unindexed-note.md").write_text(
+        "# Unindexed Note\n\nNothing about this file can be found by search.\n"
+    )
+    async with db.scoped_session(session_maker) as session:
+        await session.execute(
+            sa_text("UPDATE project SET last_indexed_at = NULL WHERE id = :id"),
+            {"id": test_project.id},
+        )
+
+    response = await search_notes(
+        project=test_project.name,
+        query="unindexed-note-xyzzy",
+        search_type="text",
+        output_format="text",
+    )
+
+    assert isinstance(response, str)
+    assert "never been indexed" in response
+    assert "bm project index" in response
+    assert "Try broader or different terms" not in response
+
+
+@pytest.mark.asyncio
+async def test_search_never_indexed_json_carries_phase(
+    client, test_project, session_maker, config_home
+):
+    """The structured search path carries index_phase on a never-indexed miss (#1534)."""
+    from sqlalchemy import text as sa_text
+
+    from basic_memory import db
+
+    notes_dir = config_home / "notes"
+    notes_dir.mkdir(exist_ok=True)
+    (notes_dir / "unindexed-note.md").write_text("# Unindexed Note\n\nNo index covers this.\n")
+    async with db.scoped_session(session_maker) as session:
+        await session.execute(
+            sa_text("UPDATE project SET last_indexed_at = NULL WHERE id = :id"),
+            {"id": test_project.id},
+        )
+
+    response = await search_notes(
+        project=test_project.name,
+        query="unindexed-note-xyzzy",
+        search_type="text",
+        output_format="json",
+    )
+
+    assert isinstance(response, dict)
+    assert response["results"] == []
+    assert response["index_phase"] == "never_indexed"
+
+
+@pytest.mark.asyncio
+async def test_search_indexed_miss_keeps_original_copy(
+    client, test_project, session_maker, config_home
+):
+    """An indexed project with genuinely no match keeps the plain-miss copy (#1534)."""
+    from datetime import datetime
+
+    from sqlalchemy import text as sa_text
+
+    from basic_memory import db
+    from basic_memory.mcp.tools import write_note as write_note_tool
+
+    async with db.scoped_session(session_maker) as session:
+        await session.execute(
+            sa_text("UPDATE project SET last_indexed_at = :now WHERE id = :id"),
+            {"now": datetime.now(), "id": test_project.id},
+        )
+
+    created = await write_note_tool(
+        project=test_project.name,
+        title="Indexed Note",
+        directory="notes",
+        content="# Indexed Note\n\nSearchable content about telescopes.\n",
+    )
+    assert created
+
+    miss = await search_notes(
+        project=test_project.name,
+        query="nothing-matches-this-xyzzy",
+        search_type="text",
+        output_format="text",
+    )
+    assert isinstance(miss, str)
+    assert "Try broader or different terms" in miss
+    assert "never been indexed" not in miss
+
+    hit = await search_notes(
+        project=test_project.name,
+        query="telescopes",
+        search_type="text",
+        output_format="json",
+    )
+    assert isinstance(hit, dict)
+    assert len(hit["results"]) > 0
+    assert "index_phase" not in hit


### PR DESCRIPTION
## What

On a project that has never been indexed (`project.last_indexed_at IS NULL`), the MCP tools reported an ordinary empty result that is indistinguishable from an honest "no match" on an indexed project:

- `search_notes` returned `results: []` plus `No results found for '<q>' in project '<p>'. Try broader or different terms, ...`
- `recent_activity` (project-scoped) was empty and said nothing about the index.

Both are vacuous negatives: files exist on disk, but nothing was ever searched. This defeats the "search before creating" convention agents rely on, and it is the state of every fresh install before the first index pass.

## Why

The signal already exists — `ProjectIndexPhase.NEVER_INDEXED` and `ProjectIndexReadiness.describe()` — and the CLI already uses it (`bm status`, `bm project add`). Nothing under `src/basic_memory/mcp/` read `last_indexed_at`, so the MCP surface — the one agents actually read through — never asked.

## How

- `src/basic_memory/mcp/tools/search.py`: on the **zero-result path only**, read readiness through the existing typed client (`ProjectClient.get_status`). When the phase is `NEVER_INDEXED`, `_format_search_markdown` returns an honest sentence that reuses `ProjectIndexReadiness.describe(...)` (so it cannot drift from `bm status`). The structured path carries `index_phase` in the returned payload.
- `src/basic_memory/mcp/tools/recent_activity.py`: the same guard for the project-scoped empty page, replacing the "you have no notes yet" onboarding (which would misread "never looked" as "no notes") with the never-indexed state.
- If readiness cannot be read, both paths fall back to today's copy — this is a reporting courtesy, not a hard failure.
- No schema, router, client, or CLI changes; no new dependencies. An indexed project pays nothing (the readiness read happens only on the empty path).

## Tests

Added 3 tests (`tests/mcp/test_tool_search.py`, `tests/mcp/test_tool_recent_activity.py`) that set up a project whose `last_indexed_at` is `None` with a note on disk:

- `search_notes` text output names the never-indexed state and the `bm project index` remedy
- `search_notes(output_format="json")` carries `index_phase == "never_indexed"`
- `recent_activity` text reports the never-indexed state

Results:

```
uv run pytest tests/mcp/test_tool_search.py tests/mcp/test_tool_recent_activity.py -q --no-cov
88 passed, 2 failed
```

Both failures (`test_search_with_date_filter`, `test_recent_activity_format_relative_time_and_truncate_helpers`) are **pre-existing on clean `main`** — confirmed by stashing this change and re-running them (same 2 failures), and they are unrelated to the touched code.

`uv run ruff check` and `uv run ruff format --check` pass on all changed files.

## Mutation check

Disabling the readiness read (`index_readiness = None`) makes all 3 new tests fail, and restoring it makes them pass — the tests genuinely guard the fix.

## Notes

- Commits carry a DCO `Signed-off-by` line.
- This is my first PR here, so the `license/cla` check will need my one-time CLA acceptance from the GitHub bot link; the DCO check should pass on its own.

Fixes #1534
