### PR TITLE
fix(core): honor the gitignore \# escape when loading ignore patterns

### DIFF
--- a/src/basic_memory/ignore_utils.py
+++ b/src/basic_memory/ignore_utils.py
@@ -68,6 +68,21 @@ DEFAULT_IGNORE_PATTERNS = {
 }
 
 
+def _parse_ignore_pattern_line(raw_line: str) -> str | None:
+    """Return the pattern for one gitignore-style line, or None to skip it.
+
+    Blank lines and comments (leading ``#``) are skipped. A leading backslash
+    escapes a pattern that itself begins with ``#`` (gitignore rule), so
+    ``\\#*#`` yields the pattern ``#*#``.
+    """
+    line = raw_line.strip()
+    if not line or line.startswith("#"):
+        return None
+    if line.startswith("\\#"):
+        return line[1:]
+    return line
+
+
 def get_bmignore_path() -> Path:
     """Get path to .bmignore file.
 
@@ -170,10 +185,9 @@ def load_bmignore_patterns() -> Set[str]:
     try:
         with bmignore_path.open("r", encoding="utf-8") as f:
             for line in f:
-                line = line.strip()
-                # Skip empty lines and comments
-                if line and not line.startswith("#"):
-                    patterns.add(line)
+                pattern = _parse_ignore_pattern_line(line)
+                if pattern:
+                    patterns.add(pattern)
     except Exception:  # pragma: no cover
         # If we can't read .bmignore, fall back to defaults
         return set(DEFAULT_IGNORE_PATTERNS)  # pragma: no cover
@@ -209,10 +223,9 @@ def load_gitignore_patterns(base_path: Path, use_gitignore: bool = True) -> Set[
             try:
                 with gitignore_file.open("r", encoding="utf-8") as f:
                     for line in f:
-                        line = line.strip()
-                        # Skip empty lines and comments
-                        if line and not line.startswith("#"):
-                            patterns.add(line)
+                        pattern = _parse_ignore_pattern_line(line)
+                        if pattern:
+                            patterns.add(pattern)
             except Exception:
                 # If we can't read .gitignore, just use default patterns
                 pass

--- a/tests/cli/test_ignore_utils.py
+++ b/tests/cli/test_ignore_utils.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from basic_memory.ignore_utils import (
     DEFAULT_IGNORE_PATTERNS,
     get_bmignore_path,
+    load_bmignore_patterns,
     load_gitignore_patterns,
     should_ignore_path,
     filter_files,
@@ -330,3 +331,35 @@ temp_*
         assert len(filtered_files) == 2
         assert set(filtered_files) == set(expected_kept)
         assert ignored_count == 2  # debug.log, temp_file.txt
+
+
+def test_bmignore_escaped_hash_pattern_loads(tmp_path, monkeypatch):
+    """Regression for #1539: an escaped hash pattern loads without the backslash."""
+    monkeypatch.setenv("BASIC_MEMORY_CONFIG_DIR", str(tmp_path))
+    (tmp_path / ".bmignore").write_text("# a comment\n\\#*#\n*~\n")
+
+    patterns = load_bmignore_patterns()
+
+    assert "#*#" in patterns
+    assert "\\#*#" not in patterns
+    assert "# a comment" not in patterns
+    assert should_ignore_path(tmp_path / "notes" / "#note.md#", tmp_path, patterns) is True
+
+
+def test_bmignore_bare_hash_is_still_a_comment(tmp_path, monkeypatch):
+    """A bare leading hash is still a comment, so it never becomes a pattern."""
+    monkeypatch.setenv("BASIC_MEMORY_CONFIG_DIR", str(tmp_path))
+    (tmp_path / ".bmignore").write_text("#*#\n")
+
+    assert "#*#" not in load_bmignore_patterns()
+
+
+def test_gitignore_escaped_hash_pattern_loads(tmp_path, monkeypatch):
+    """Same \\# escape fix applies to project .gitignore files."""
+    monkeypatch.setenv("BASIC_MEMORY_CONFIG_DIR", str(tmp_path))
+    (tmp_path / ".gitignore").write_text("\\#*#\n")
+
+    patterns = load_gitignore_patterns(tmp_path)
+
+    assert "#*#" in patterns
+    assert should_ignore_path(tmp_path / "#note.md#", tmp_path, patterns) is True


### PR DESCRIPTION
## What

`.bmignore` (and project `.gitignore`) could not express **any** pattern beginning with `#`.

## Why

Both loaders used a naive line filter that skipped every line starting with `#` and never
unescaped a leading backslash:

- `#*#` was silently dropped as a comment.
- `\#*#` was stored **literally**, and `should_ignore_path()` matches with `fnmatch`, which
  has no escape syntax — so it matched nothing.

The failure mode is silent and misleading: the pattern looks right in `.bmignore` and
simply never loads. It makes Emacs autosave files (`#file#`) impossible to ignore through
the documented gitignore-style syntax, even though the shipped defaults already cover
`*~`, `*.swp` and `*.swo`. As the issue notes, the matcher itself handles `#*#` correctly
(it `fnmatch`es each path part) — only the loader was broken.

## How

Added one small module-level helper, `_parse_ignore_pattern_line()`, and routed both the
`.bmignore` and `.gitignore` read loops through it:

- blank lines and comments (leading `#`) are still skipped;
- a line starting with `\#` now yields the pattern with **one leading backslash stripped**,
  per the gitignore rule *"Put a backslash in front of the first hash for patterns that
  begin with a hash"* — so `\#*#` loads as `#*#` and matches.

`should_ignore_path()` is unchanged, `DEFAULT_IGNORE_PATTERNS` is unchanged (adding a
default `#*#` would be a separate product decision), and no dependency was added
(no `pathspec`).

## Tests

Three regression tests in `tests/cli/test_ignore_utils.py`:

- `test_bmignore_escaped_hash_pattern_loads` — `\#*#` in `.bmignore` loads as `#*#`, the
  comment line is still skipped, and `should_ignore_path("notes/#note.md#")` is `True`.
- `test_bmignore_bare_hash_is_still_a_comment` — a bare `#*#` remains a comment.
- `test_gitignore_escaped_hash_pattern_loads` — same escape handling for a project
  `.gitignore`.

```
$ .venv/bin/python -m pytest tests/cli/test_ignore_utils.py -q
17 passed
$ ruff check  (both files)         -> All checks passed!
$ ruff format --check (both files) -> 2 files already formatted
```

## Mutation check

Reverting only the escape handling in `_parse_ignore_pattern_line()` (the `\#` branch
removed, everything else intact) fails exactly the two tests that guard the fix:

```
FAILED tests/cli/test_ignore_utils.py::test_bmignore_escaped_hash_pattern_loads
FAILED tests/cli/test_ignore_utils.py::test_gitignore_escaped_hash_pattern_loads
2 failed, 1 passed, 14 deselected
```

Restoring the fix → `17 passed`.

Fixes #1539
